### PR TITLE
feat: OAuth 凭据接入(连接 Gitee/GitHub/GitLab/自建)

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/httpapi"
 	"github.com/huangchengsir/pipewright/internal/mask"
 	"github.com/huangchengsir/pipewright/internal/notify"
+	"github.com/huangchengsir/pipewright/internal/oauth"
 	"github.com/huangchengsir/pipewright/internal/pipeline"
 	"github.com/huangchengsir/pipewright/internal/project"
 	"github.com/huangchengsir/pipewright/internal/run"
@@ -194,9 +195,15 @@ func main() {
 	// 服务器跳过(不误报)。复用已装配的 targetSvc(采集),无新顶层依赖;无 init 副作用/不起轮询。
 	anomalySvc := anomaly.New(st.DB, httpapi.NewAnomalyCollector(targetSvc))
 
+	// 装配多 provider OAuth 凭据接入服务(连接 Gitee/GitHub/GitLab/自建):复用 vault secretbox 加密
+	// OAuth 应用 client_secret(密文入库);OAuth 拿到的 access_token 经 vault.Create 存成 git_token 凭据,
+	// 之后克隆/构建直接复用(无需改克隆逻辑)。Exchange 兑换用带超时的注入 HTTP 客户端(~10s);
+	// state CSRF 短期内存绑会话。master key 未配置时涉及密钥的操作降级为明确错误(不 panic)。
+	oauthSvc := oauth.New(st.DB, credVault, &http.Client{Timeout: 10 * time.Second})
+
 	srv := &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithServers(targetSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc)),
+		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithServers(targetSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc)),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		// WriteTimeout 置 0:SSE 长连接(/api/runs/{id}/events)不可被写超时切断;

--- a/internal/httpapi/oauth.go
+++ b/internal/httpapi/oauth.go
@@ -1,0 +1,249 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/oauth"
+	"github.com/huangchengsir/pipewright/internal/vault"
+)
+
+// ---- OAuth 应用配置 DTO(冻结契约;camelCase;client_secret 仅掩码,绝无明文) ----
+
+// oauthAppDTO 是 GET /api/oauth/apps 列表项与 PUT 响应体(冻结契约)。
+// clientSecret 只暴露掩码 maskedSecret + configured 标志,绝无明文。
+type oauthAppDTO struct {
+	Provider     string  `json:"provider"`
+	ClientID     string  `json:"clientId"`
+	BaseURL      string  `json:"baseUrl"`
+	Enabled      bool    `json:"enabled"`
+	MaskedSecret string  `json:"maskedSecret"`
+	Configured   bool    `json:"configured"`
+	UpdatedAt    *string `json:"updatedAt"`
+}
+
+// toOAuthAppDTO 把领域 AppConfig 转契约 DTO(secret 仅掩码;updatedAt 未设为 null)。
+func toOAuthAppDTO(c oauth.AppConfig) oauthAppDTO {
+	dto := oauthAppDTO{
+		Provider:     c.Provider,
+		ClientID:     c.ClientID,
+		BaseURL:      c.BaseURL,
+		Enabled:      c.Enabled,
+		MaskedSecret: c.MaskedSecret,
+		Configured:   c.Configured,
+	}
+	if c.UpdatedAt != nil {
+		s := c.UpdatedAt.UTC().Format(time.RFC3339)
+		dto.UpdatedAt = &s
+	}
+	return dto
+}
+
+// writeOAuthError 把领域错误映射为契约错误码/状态码;绝不回显 client_secret 明文/密文。
+func writeOAuthError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, oauth.ErrInvalidProvider):
+		writeError(w, http.StatusUnprocessableEntity, "invalid_provider", "provider 只能为 gitee、github、gitlab 或 custom")
+	case errors.Is(err, oauth.ErrBaseURLRequired):
+		writeError(w, http.StatusUnprocessableEntity, "base_url_required", "自建(custom)provider 必须配置 baseUrl")
+	case errors.Is(err, oauth.ErrClientIDRequired):
+		writeError(w, http.StatusUnprocessableEntity, "client_id_required", "clientId 不能为空")
+	case errors.Is(err, oauth.ErrClientSecretRequired):
+		writeError(w, http.StatusUnprocessableEntity, "client_secret_required", "该 provider 需要配置 client secret")
+	case errors.Is(err, oauth.ErrAppNotConfigured):
+		writeError(w, http.StatusUnprocessableEntity, "app_not_configured", "该 provider 的 OAuth 应用未配置或未启用")
+	case errors.Is(err, oauth.ErrVaultUnconfigured):
+		writeError(w, http.StatusServiceUnavailable, "vault_unconfigured", "保险库未配置 master key,无法加密或读取 client secret")
+	default:
+		writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+	}
+}
+
+// makeListOAuthAppsHandler 返回 GET /api/oauth/apps handler(认证)。
+// 返回所有已配置 provider 的应用视图(secret 仅掩码)。svc 为 nil → 503。
+func makeListOAuthAppsHandler(svc oauth.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "OAuth 服务未初始化")
+			return
+		}
+		apps, err := svc.ListApps(r.Context())
+		if err != nil {
+			writeOAuthError(w, err)
+			return
+		}
+		out := make([]oauthAppDTO, 0, len(apps))
+		for _, a := range apps {
+			out = append(out, toOAuthAppDTO(a))
+		}
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+// makeSaveOAuthAppHandler 返回 PUT /api/oauth/apps/{provider} handler(认证 + CSRF)。
+// clientSecret 只写:省略/空保留既有,非空轮换(加密)。绝不在响应回明文。校验失败 → 422 定位。
+func makeSaveOAuthAppHandler(svc oauth.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "OAuth 服务未初始化")
+			return
+		}
+		provider := chi.URLParam(r, "provider")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+		var req struct {
+			ClientID string `json:"clientId"`
+			BaseURL  string `json:"baseUrl"`
+			// ClientSecret 用指针区分「省略(nil)」与「显式空串」;两者均保留既有。
+			ClientSecret *string `json:"clientSecret"`
+			Enabled      bool    `json:"enabled"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		cfg, err := svc.SaveApp(r.Context(), oauth.SaveAppInput{
+			Provider:     provider,
+			ClientID:     req.ClientID,
+			BaseURL:      req.BaseURL,
+			ClientSecret: req.ClientSecret,
+			Enabled:      req.Enabled,
+		})
+		if err != nil {
+			writeOAuthError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, toOAuthAppDTO(*cfg))
+	}
+}
+
+// vaultCreator 抽象 OAuth 把 token 存成 git_token 凭据所需的 vault 能力(便于测试)。
+type vaultCreator interface {
+	Create(in vault.CreateInput) (*vault.Credential, error)
+}
+
+// makeOAuthAuthorizeHandler 返回 GET /api/oauth/{provider}/authorize handler(认证)。
+// 生成绑定当前会话的 state → 302 跳 provider 授权页;redirect_uri = {请求 origin}/api/oauth/{provider}/callback。
+// 该 provider 未配置/未启用 → 422(JSON);state 生成失败 → 500。
+func makeOAuthAuthorizeHandler(svc oauth.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "OAuth 服务未初始化")
+			return
+		}
+		provider := chi.URLParam(r, "provider")
+		sess, ok := sessionFromContext(r.Context())
+		if !ok || sess == nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "请先登录")
+			return
+		}
+		// 用会话 token 作绑定身份(state 与发起授权的会话绑死,防 CSRF)。
+		state, err := svc.IssueState(sess.Token)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+			return
+		}
+		redirectURI := requestOrigin(r) + "/api/oauth/" + url.PathEscape(provider) + "/callback"
+		authURL, err := svc.AuthorizeURL(r.Context(), provider, state, redirectURI)
+		if err != nil {
+			writeOAuthError(w, err)
+			return
+		}
+		http.Redirect(w, r, authURL, http.StatusFound)
+	}
+}
+
+// makeOAuthCallbackHandler 返回 GET /api/oauth/{provider}/callback handler(认证;豁免 CSRF,靠 state 校验)。
+// 验 state(绑会话)→ Exchange(code→token→login)→ vault.Create 存 git_token 凭据 →
+// 302 跳回 /settings/vault?connected={provider}&account={login};任一步失败 → 跳回 oauth_error(人读,无 secret)。
+func makeOAuthCallbackHandler(svc oauth.Service, v vaultCreator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		provider := chi.URLParam(r, "provider")
+		if svc == nil {
+			redirectVaultError(w, r, provider, "oauth_unavailable")
+			return
+		}
+		sess, ok := sessionFromContext(r.Context())
+		if !ok || sess == nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "请先登录")
+			return
+		}
+		q := r.URL.Query()
+		code := q.Get("code")
+		state := q.Get("state")
+
+		// state CSRF 校验:必须匹配本会话发起的 state(一次性消费),否则拒绝。
+		if !svc.ConsumeState(state, sess.Token) {
+			redirectVaultError(w, r, provider, "invalid_state")
+			return
+		}
+		if code == "" {
+			redirectVaultError(w, r, provider, "missing_code")
+			return
+		}
+
+		redirectURI := requestOrigin(r) + "/api/oauth/" + url.PathEscape(provider) + "/callback"
+		res, err := svc.Exchange(r.Context(), provider, code, redirectURI)
+		if err != nil {
+			redirectVaultError(w, r, provider, oauthErrorReason(err))
+			return
+		}
+
+		if v == nil {
+			redirectVaultError(w, r, provider, "vault_unavailable")
+			return
+		}
+		// 把 access_token 存成 git_token 凭据(name = {provider}:{login})。token 绝不回显/日志。
+		_, cerr := v.Create(vault.CreateInput{
+			Name:   provider + ":" + res.Login,
+			Type:   vault.TypeGitToken,
+			Scope:  "global",
+			Secret: res.AccessToken,
+		})
+		if cerr != nil {
+			if errors.Is(cerr, vault.ErrVaultUnconfigured) {
+				redirectVaultError(w, r, provider, "vault_unavailable")
+				return
+			}
+			redirectVaultError(w, r, provider, "store_failed")
+			return
+		}
+
+		dest := "/settings/vault?connected=" + url.QueryEscape(provider) + "&account=" + url.QueryEscape(res.Login)
+		http.Redirect(w, r, dest, http.StatusFound)
+	}
+}
+
+// oauthErrorReason 把领域错误映射为人读、无 secret 的跳回原因码。
+func oauthErrorReason(err error) string {
+	switch {
+	case errors.Is(err, oauth.ErrAppNotConfigured):
+		return "app_not_configured"
+	case errors.Is(err, oauth.ErrVaultUnconfigured):
+		return "vault_unavailable"
+	case errors.Is(err, oauth.ErrInvalidProvider):
+		return "invalid_provider"
+	default:
+		return "exchange_failed"
+	}
+}
+
+// redirectVaultError 302 跳回保险库设置页并带人读、无 secret 的 oauth_error 原因码。
+func redirectVaultError(w http.ResponseWriter, r *http.Request, provider, reason string) {
+	dest := "/settings/vault?oauth_error=" + url.QueryEscape(reason) + "&provider=" + url.QueryEscape(provider)
+	http.Redirect(w, r, dest, http.StatusFound)
+}
+
+// requestOrigin 据请求推导来源 origin(scheme://host),用于构造 OAuth redirect_uri。
+// scheme 取 TLS 在场判定(直连);host 取 r.Host(信任反代设置的 Host)。绝不信 X-Forwarded-*
+// 拼 redirect_uri(可被伪造致开放重定向 / 把授权码导到攻击者域)。
+func requestOrigin(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return scheme + "://" + r.Host
+}

--- a/internal/httpapi/oauth_test.go
+++ b/internal/httpapi/oauth_test.go
@@ -1,0 +1,262 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/auth"
+	"github.com/huangchengsir/pipewright/internal/oauth"
+	"github.com/huangchengsir/pipewright/internal/vault"
+)
+
+// setupOAuthServer 构造带 auth + vault + oauth 的测试 server;oauth 用注入 client(默认 http.DefaultClient)。
+// 返回 server、已登录 client、csrf token、底层 vault(供断言凭据已存)。
+func setupOAuthServer(t *testing.T, client *http.Client) (*httptest.Server, *http.Client, string, vault.Vault) {
+	t.Helper()
+	st := testStoreAuth(t)
+	svc := auth.NewService(st.DB, nil)
+	if err := svc.Bootstrap("admin", "testpass"); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	v := vault.New(st.DB, testMasterKey())
+	if client == nil {
+		client = http.DefaultClient
+	}
+	oauthSvc := oauth.New(st.DB, v, client)
+	srv := httptest.NewServer(New(testWebFSAuth(), svc, WithVault(v), WithOAuth(oauthSvc)))
+	t.Cleanup(srv.Close)
+
+	c := newTestClient(t)
+	csrf := loginWithClient(t, c, srv.URL)
+	return srv, c, csrf, v
+}
+
+// TestOAuthAppPutMaskedNoPlaintext 验证 PUT apps/{provider} secret 只写 + 响应仅掩码无明文。
+func TestOAuthAppPutMaskedNoPlaintext(t *testing.T) {
+	srv, client, csrf, _ := setupOAuthServer(t, nil)
+	body := `{"clientId":"iv1.abc","clientSecret":"SECRET-PLAINTEXT-xyz","enabled":true}`
+	resp := doJSON(t, client, http.MethodPut, srv.URL+"/api/oauth/apps/github", csrf, body)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("PUT status = %d, body=%s", resp.StatusCode, raw)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(raw), "PLAINTEXT") {
+		t.Fatalf("响应不应含明文 client_secret: %s", raw)
+	}
+	var dto map[string]any
+	_ = json.Unmarshal(raw, &dto)
+	if dto["provider"] != "github" || dto["configured"] != true || dto["enabled"] != true {
+		t.Fatalf("响应字段不符: %s", raw)
+	}
+	if dto["clientId"] != "iv1.abc" {
+		t.Fatalf("clientId 应回显: %s", raw)
+	}
+	if ms, _ := dto["maskedSecret"].(string); ms == "" || strings.Contains(ms, "PLAINTEXT") {
+		t.Fatalf("maskedSecret 不应为空/含明文: %q", ms)
+	}
+}
+
+// TestOAuthAppPutInvalidProvider 验证非法 provider → 422。
+func TestOAuthAppPutInvalidProvider(t *testing.T) {
+	srv, client, csrf, _ := setupOAuthServer(t, nil)
+	resp := doJSON(t, client, http.MethodPut, srv.URL+"/api/oauth/apps/bitbucket", csrf, `{"clientId":"x","clientSecret":"y","enabled":true}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", resp.StatusCode)
+	}
+}
+
+// TestOAuthAppPutRequiresCSRF 验证 PUT 缺 CSRF token → 403。
+func TestOAuthAppPutRequiresCSRF(t *testing.T) {
+	srv, client, _, _ := setupOAuthServer(t, nil)
+	// 故意传错 csrf。
+	resp := doJSON(t, client, http.MethodPut, srv.URL+"/api/oauth/apps/github", "wrong-csrf", `{"clientId":"x","clientSecret":"y","enabled":true}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 (csrf)", resp.StatusCode)
+	}
+}
+
+// TestOAuthListApps 验证 GET apps 列表返回已配项(掩码)。
+func TestOAuthListApps(t *testing.T) {
+	srv, client, csrf, _ := setupOAuthServer(t, nil)
+	_ = doJSON(t, client, http.MethodPut, srv.URL+"/api/oauth/apps/gitee", csrf, `{"clientId":"g","clientSecret":"SECRET-PLAINTEXT","enabled":true}`).Body.Close()
+
+	resp := doJSON(t, client, http.MethodGet, srv.URL+"/api/oauth/apps", csrf, "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(raw), "PLAINTEXT") {
+		t.Fatalf("列表泄漏明文: %s", raw)
+	}
+	var arr []map[string]any
+	_ = json.Unmarshal(raw, &arr)
+	if len(arr) != 1 || arr[0]["provider"] != "gitee" {
+		t.Fatalf("列表内容不符: %s", raw)
+	}
+}
+
+// TestOAuthAuthorizeUnconfigured 验证未配置 provider 发起 authorize → 422。
+func TestOAuthAuthorizeUnconfigured(t *testing.T) {
+	srv, client, _, _ := setupOAuthServer(t, nil)
+	resp, err := client.Get(srv.URL + "/api/oauth/github/authorize")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", resp.StatusCode)
+	}
+}
+
+// TestOAuthAuthorizeRedirects 验证已配 provider 发起 authorize → 302 跳授权页带 state/redirect_uri。
+func TestOAuthAuthorizeRedirects(t *testing.T) {
+	srv, client, csrf, _ := setupOAuthServer(t, nil)
+	_ = doJSON(t, client, http.MethodPut, srv.URL+"/api/oauth/apps/github", csrf, `{"clientId":"CID","clientSecret":"s","enabled":true}`).Body.Close()
+
+	resp, err := client.Get(srv.URL + "/api/oauth/github/authorize")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("status = %d, want 302", resp.StatusCode)
+	}
+	loc := resp.Header.Get("Location")
+	u, _ := url.Parse(loc)
+	if u.Host != "github.com" {
+		t.Fatalf("authorize redirect host = %q (%s)", u.Host, loc)
+	}
+	q := u.Query()
+	if q.Get("client_id") != "CID" || q.Get("state") == "" {
+		t.Fatalf("authorize params: %v", q)
+	}
+	if !strings.HasSuffix(q.Get("redirect_uri"), "/api/oauth/github/callback") {
+		t.Fatalf("redirect_uri: %q", q.Get("redirect_uri"))
+	}
+}
+
+// TestOAuthCallbackBadState 验证 callback state 不匹配 → 跳回 oauth_error=invalid_state(不 Exchange)。
+func TestOAuthCallbackBadState(t *testing.T) {
+	srv, client, csrf, v := setupOAuthServer(t, nil)
+	_ = doJSON(t, client, http.MethodPut, srv.URL+"/api/oauth/apps/github", csrf, `{"clientId":"CID","clientSecret":"s","enabled":true}`).Body.Close()
+
+	resp, err := client.Get(srv.URL + "/api/oauth/github/callback?code=somecode&state=forged-state")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("status = %d, want 302", resp.StatusCode)
+	}
+	loc := resp.Header.Get("Location")
+	if !strings.Contains(loc, "oauth_error=invalid_state") {
+		t.Fatalf("应跳回 invalid_state: %q", loc)
+	}
+	// 未存任何凭据。
+	creds, _ := v.List()
+	if len(creds) != 0 {
+		t.Fatalf("state 不匹配不应存凭据,got %d", len(creds))
+	}
+}
+
+// TestOAuthCallbackSuccessStoresCredential 走完整 authorize→callback,经 mock provider 换 token、
+// 存成 git_token 凭据、跳回 connected。custom provider 指向本地 mock。
+func TestOAuthCallbackSuccessStoresCredential(t *testing.T) {
+	// mock provider:/oauth/token 回 token;/api/v4/user 回 login。
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if r.FormValue("client_secret") != "the-secret" {
+			t.Errorf("provider 未收到正确 client_secret")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"glpat-FAKE-TOKEN","token_type":"bearer"}`))
+	})
+	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"username":"alice","id":7}`))
+	})
+	mock := httptest.NewServer(mux)
+	t.Cleanup(mock.Close)
+
+	srv, client, csrf, v := setupOAuthServer(t, mock.Client())
+
+	// 配 custom provider 指向 mock。
+	body := `{"clientId":"cid","clientSecret":"the-secret","baseUrl":"` + mock.URL + `","enabled":true}`
+	if r := doJSON(t, client, http.MethodPut, srv.URL+"/api/oauth/apps/custom", csrf, body); r.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		t.Fatalf("save custom app status=%d body=%s", r.StatusCode, raw)
+	}
+
+	// 发起 authorize 拿到合法 state(从 Location 提取)。
+	authResp, err := client.Get(srv.URL + "/api/oauth/custom/authorize")
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	_ = authResp.Body.Close()
+	if authResp.StatusCode != http.StatusFound {
+		t.Fatalf("authorize status = %d, want 302", authResp.StatusCode)
+	}
+	au, _ := url.Parse(authResp.Header.Get("Location"))
+	state := au.Query().Get("state")
+	if state == "" {
+		t.Fatal("authorize 未带 state")
+	}
+
+	// callback 带合法 code + state(同会话 client)。
+	cbResp, err := client.Get(srv.URL + "/api/oauth/custom/callback?code=valid-code&state=" + url.QueryEscape(state))
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	defer cbResp.Body.Close()
+	if cbResp.StatusCode != http.StatusFound {
+		raw, _ := io.ReadAll(cbResp.Body)
+		t.Fatalf("callback status = %d body=%s", cbResp.StatusCode, raw)
+	}
+	loc := cbResp.Header.Get("Location")
+	if !strings.Contains(loc, "connected=custom") || !strings.Contains(loc, "account=alice") {
+		t.Fatalf("应跳回 connected=custom&account=alice: %q", loc)
+	}
+
+	// 验证已存成 git_token 凭据 name=custom:alice,且可解密回 token。
+	creds, err := v.List()
+	if err != nil {
+		t.Fatalf("vault.List: %v", err)
+	}
+	if len(creds) != 1 || creds[0].Name != "custom:alice" || creds[0].Type != vault.TypeGitToken {
+		t.Fatalf("凭据未正确创建: %+v", creds)
+	}
+	tok, err := v.Reveal(creds[0].ID)
+	if err != nil || tok != "glpat-FAKE-TOKEN" {
+		t.Fatalf("token 解密不符: tok=%q err=%v", tok, err)
+	}
+	// 跳回 URL 绝不含 token。
+	if strings.Contains(loc, "glpat-FAKE-TOKEN") {
+		t.Fatalf("跳回 URL 泄漏 token: %q", loc)
+	}
+}
+
+// TestOAuthEndpoints401WithoutLogin 验证未登录访问 oauth 端点 → 401。
+func TestOAuthEndpoints401WithoutLogin(t *testing.T) {
+	srv, _, _, _ := setupOAuthServer(t, nil)
+	anon := newTestClient(t)
+	resp, err := anon.Get(srv.URL + "/api/oauth/apps")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -22,6 +22,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/auth"
 	"github.com/huangchengsir/pipewright/internal/deploy"
 	"github.com/huangchengsir/pipewright/internal/notify"
+	"github.com/huangchengsir/pipewright/internal/oauth"
 	"github.com/huangchengsir/pipewright/internal/pipeline"
 	"github.com/huangchengsir/pipewright/internal/project"
 	"github.com/huangchengsir/pipewright/internal/run"
@@ -65,6 +66,7 @@ type options struct {
 	notifications    notify.Service
 	deployer         deploy.Service
 	anomaly          anomaly.Service
+	oauth            oauth.Service
 }
 
 // WithVault 注入凭据保险库,挂载 /api/credentials* 路由。
@@ -195,6 +197,19 @@ func WithNotifications(s notify.Service) Option {
 // 不传则相关端点返回 503(服务未初始化)。
 func WithAnomaly(s anomaly.Service) Option {
 	return func(o *options) { o.anomaly = s }
+}
+
+// WithOAuth 注入多 provider OAuth 凭据接入服务,挂载 /api/oauth/* 路由:
+//   - GET  /api/oauth/apps(auth):列已配 OAuth 应用(secret 掩码)。
+//   - PUT  /api/oauth/apps/{provider}(auth+CSRF):upsert 应用配置(clientSecret 只写)。
+//   - GET  /api/oauth/{provider}/authorize(auth):生成 state → 302 跳 provider 授权页。
+//   - GET  /api/oauth/{provider}/callback(auth;豁免 CSRF——GET 回跳,靠 state 校验):
+//     验 state → Exchange → 把 access_token 经 vault.Create 存成 git_token 凭据 → 302 跳回。
+//
+// 复用已注入的 vault(o.vault)存 token 凭据。client_secret/access_token 经 vault 密文,
+// 响应/错误/日志绝无明文。不传则相关端点返回 503。
+func WithOAuth(s oauth.Service) Option {
+	return func(o *options) { o.oauth = s }
 }
 
 // New 构建 HTTP 处理器:健康端点 + Auth API + (可选)凭据 API + 内嵌 SPA 静态托管。
@@ -451,6 +466,18 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		ar.Delete("/anomaly/rules/{id}", makeDeleteAnomalyRuleHandler(an))
 		ar.Post("/anomaly/check", makeAnomalyCheckHandler(an))
 		ar.Get("/anomaly/alerts", makeListAnomalyAlertsHandler(an))
+
+		// 多 provider OAuth 凭据接入(连接 Gitee/GitHub/GitLab/自建)。oa 为 nil → handler 503。
+		// apps 列表/upsert:GET 过 auth;PUT 写方法过 auth + CSRF(clientSecret 只写、加密入库、响应仅掩码)。
+		// authorize/callback 均为 GET(过 auth、豁免 CSRF):authorize 生成绑会话 state → 302 跳授权页;
+		// callback 验 state(CSRF 防护)→ Exchange → 经已注入 vault(v)把 access_token 存成 git_token
+		// 凭据 → 302 跳回 /settings/vault。token/client_secret 经 vault 密文,响应/错误绝无明文。
+		// 字面段 apps 优先于 {provider},/oauth/{provider}/authorize 不会被 /oauth/apps 吞。
+		oa := o.oauth
+		ar.Get("/oauth/apps", makeListOAuthAppsHandler(oa))
+		ar.Put("/oauth/apps/{provider}", makeSaveOAuthAppHandler(oa))
+		ar.Get("/oauth/{provider}/authorize", makeOAuthAuthorizeHandler(oa))
+		ar.Get("/oauth/{provider}/callback", makeOAuthCallbackHandler(oa, v))
 
 		// 后续 story 在此挂载其他 API 路由。
 	})

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -1,0 +1,397 @@
+package oauth
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/huangchengsir/pipewright/internal/vault"
+)
+
+// 领域错误(续 provider.go)。错误体永不含 client_secret / access_token 明文。
+var (
+	// ErrClientIDRequired 表示保存配置缺 client_id。
+	ErrClientIDRequired = errors.New("oauth: client id required")
+	// ErrClientSecretRequired 表示该 provider 既无既有 secret 又无新 secret。
+	ErrClientSecretRequired = errors.New("oauth: client secret required")
+	// ErrVaultUnconfigured 表示保险库未配置 master key,无法加密/读取 client_secret 或存 token。
+	ErrVaultUnconfigured = errors.New("oauth: vault unconfigured")
+	// ErrAppNotConfigured 表示该 provider 的 OAuth 应用未配置/未启用,无法发起授权。
+	ErrAppNotConfigured = errors.New("oauth: provider app not configured or disabled")
+	// ErrExchangeFailed 表示 code→token 兑换或取用户信息失败(人读,绝无 secret/token)。
+	ErrExchangeFailed = errors.New("oauth: exchange failed")
+)
+
+// AppConfig 是对外可见的 OAuth 应用配置视图:client_secret 仅掩码 + configured 标志,绝无明文。
+type AppConfig struct {
+	Provider     string
+	ClientID     string
+	BaseURL      string
+	Enabled      bool
+	MaskedSecret string
+	Configured   bool
+	UpdatedAt    *time.Time
+}
+
+// SaveAppInput 是 upsert OAuth 应用配置的入参。
+// ClientSecret 为**只写**指针:nil/空串 = 保留既有 secret(不清空);非空 = 轮换为新 secret。
+type SaveAppInput struct {
+	Provider     string
+	ClientID     string
+	BaseURL      string
+	ClientSecret *string
+	Enabled      bool
+}
+
+// TokenResult 是 Exchange 的产出:access_token + 解析出的登录名。
+// access_token 仅供调用方立即经 vault.Create 存成凭据,绝不回显/日志。
+type TokenResult struct {
+	AccessToken string
+	Login       string
+}
+
+// Service 定义 OAuth 领域对外接口。
+type Service interface {
+	// ListApps 返回所有已配置 provider 的应用视图(client_secret 仅掩码)。
+	ListApps(ctx context.Context) ([]AppConfig, error)
+	// SaveApp 校验并 upsert 单个 provider 的 OAuth 应用配置;
+	// clientSecret 省略/空保留旧密文、非空轮换(vault.SealSecret 加密)。返回更新后视图(掩码)。
+	SaveApp(ctx context.Context, in SaveAppInput) (*AppConfig, error)
+	// AuthorizeURL 据已配置的 client_id + provider 端点 + scope + state + redirectURI 构造授权 URL。
+	// 该 provider 未配置/未启用 → ErrAppNotConfigured。
+	AuthorizeURL(ctx context.Context, provider, state, redirectURI string) (string, error)
+	// Exchange 用 code 经 provider tokenURL 换 access_token(server-to-server,注入 http.Client),
+	// 再用 token 拉 userURL 取登录名。client_secret 绝不出现在错误/日志/响应。
+	Exchange(ctx context.Context, provider, code, redirectURI string) (*TokenResult, error)
+	// IssueState 生成绑定 sessionID 的随机 state(CSRF;放进 authorize URL)。
+	IssueState(sessionID string) (string, error)
+	// ConsumeState 校验并一次性消费 callback 带回的 state(存在+未过期+绑定会话匹配)。
+	ConsumeState(state, sessionID string) bool
+}
+
+// service 是 store + vault + 注入 http.Client + 内存 state 存储支撑的 Service 实现。
+type service struct {
+	db     *sql.DB
+	vault  vault.Vault
+	client *http.Client
+	states *stateStore
+}
+
+// New 构造 Service。
+//   - db:经参数化 SQL 触库。
+//   - v:凭据保险库,复用其 secretbox(master key)加解密 client_secret;并经 v.Create 存 token。
+//   - client:Exchange 兑换/取用户用的 HTTP 客户端(应带超时);为 nil 时回退默认带超时客户端。
+//     单测可注入指向 httptest mock provider 的 client。
+func New(db *sql.DB, v vault.Vault, client *http.Client) Service {
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &service{db: db, vault: v, client: client, states: newStateStore()}
+}
+
+func (s *service) IssueState(sessionID string) (string, error) { return s.states.issue(sessionID) }
+
+func (s *service) ConsumeState(state, sessionID string) bool {
+	return s.states.consume(state, sessionID)
+}
+
+func (s *service) ListApps(ctx context.Context) ([]AppConfig, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT provider, client_id, client_secret_ciphertext, base_url, enabled, updated_at
+		 FROM oauth_apps ORDER BY provider`)
+	if err != nil {
+		return nil, fmt.Errorf("oauth: list apps: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	apps := make([]AppConfig, 0)
+	for rows.Next() {
+		var (
+			provider   string
+			clientID   string
+			sealed     []byte
+			baseURL    string
+			enabledInt int
+			updatedStr string
+		)
+		if err := rows.Scan(&provider, &clientID, &sealed, &baseURL, &enabledInt, &updatedStr); err != nil {
+			return nil, fmt.Errorf("oauth: scan app: %w", err)
+		}
+		apps = append(apps, s.toAppConfig(provider, clientID, baseURL, enabledInt != 0, sealed, updatedStr))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("oauth: iterate apps: %w", err)
+	}
+	return apps, nil
+}
+
+func (s *service) SaveApp(ctx context.Context, in SaveAppInput) (*AppConfig, error) {
+	provider, err := normalizeProvider(in.Provider)
+	if err != nil {
+		return nil, err
+	}
+	clientID := strings.TrimSpace(in.ClientID)
+	if clientID == "" {
+		return nil, ErrClientIDRequired
+	}
+	baseURL := strings.TrimSpace(in.BaseURL)
+	// 自建必填 baseUrl,且须能推导端点(否则 authorize/exchange 必失败)。
+	if provider == ProviderCustom {
+		if _, derr := customProvider(baseURL); derr != nil {
+			return nil, derr
+		}
+	}
+
+	// 读既有行以实现 client_secret 保留语义。
+	_, _, existingSealed, _, _, _, err := s.loadApp(ctx, provider)
+	if err != nil {
+		return nil, err
+	}
+
+	// client_secret 保留语义:nil/空 → 沿用既有密文;非空 → 轮换(SealSecret 加密)。
+	sealed := existingSealed
+	if in.ClientSecret != nil && *in.ClientSecret != "" {
+		if s.vault == nil {
+			return nil, ErrVaultUnconfigured
+		}
+		newSealed, serr := s.vault.SealSecret([]byte(*in.ClientSecret))
+		if serr != nil {
+			if errors.Is(serr, vault.ErrVaultUnconfigured) {
+				return nil, ErrVaultUnconfigured
+			}
+			return nil, fmt.Errorf("oauth: seal client secret: %w", serr)
+		}
+		sealed = newSealed
+	}
+	if len(sealed) == 0 {
+		return nil, ErrClientSecretRequired
+	}
+
+	enabled := 0
+	if in.Enabled {
+		enabled = 1
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO oauth_apps
+		   (provider, client_id, client_secret_ciphertext, base_url, enabled, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(provider) DO UPDATE SET
+		   client_id = excluded.client_id,
+		   client_secret_ciphertext = excluded.client_secret_ciphertext,
+		   base_url = excluded.base_url,
+		   enabled = excluded.enabled,
+		   updated_at = excluded.updated_at`,
+		provider, clientID, sealed, baseURL, enabled, now, now,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("oauth: upsert app: %w", err)
+	}
+
+	cfg := s.toAppConfig(provider, clientID, baseURL, in.Enabled, sealed, now)
+	return &cfg, nil
+}
+
+func (s *service) AuthorizeURL(ctx context.Context, provider, state, redirectURI string) (string, error) {
+	prov, clientID, sealed, baseURL, enabled, _, err := s.loadApp(ctx, provider)
+	if err != nil {
+		return "", err
+	}
+	// 未配置(无 client_id/secret)或未启用 → 不可发起授权。
+	if clientID == "" || len(sealed) == 0 || !enabled {
+		return "", ErrAppNotConfigured
+	}
+	endpoints, err := resolveProvider(prov, baseURL)
+	if err != nil {
+		return "", err
+	}
+
+	u, err := url.Parse(endpoints.AuthorizeURL)
+	if err != nil {
+		return "", ErrAppNotConfigured
+	}
+	q := u.Query()
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("response_type", "code")
+	q.Set("scope", endpoints.scope())
+	q.Set("state", state)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func (s *service) Exchange(ctx context.Context, provider, code, redirectURI string) (*TokenResult, error) {
+	prov, clientID, sealed, baseURL, _, _, err := s.loadApp(ctx, provider)
+	if err != nil {
+		return nil, err
+	}
+	if clientID == "" || len(sealed) == 0 {
+		return nil, ErrAppNotConfigured
+	}
+	if strings.TrimSpace(code) == "" {
+		return nil, ErrExchangeFailed
+	}
+	endpoints, err := resolveProvider(prov, baseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// 解密 client_secret(进程内即用即弃,绝不日志/回显)。
+	secret, err := s.openSecret(sealed)
+	if err != nil {
+		return nil, err
+	}
+
+	accessToken, err := s.requestToken(ctx, endpoints, clientID, secret, code, redirectURI)
+	// 明文 secret 用完即弃。
+	secret = ""
+	if err != nil {
+		return nil, err
+	}
+
+	login, err := s.requestUser(ctx, endpoints, accessToken)
+	if err != nil {
+		return nil, err
+	}
+	return &TokenResult{AccessToken: accessToken, Login: login}, nil
+}
+
+// requestToken POST code→token 到 provider tokenURL,取回 access_token(绝不日志 secret/token)。
+func (s *service) requestToken(ctx context.Context, p Provider, clientID, clientSecret, code, redirectURI string) (string, error) {
+	form := url.Values{}
+	form.Set("client_id", clientID)
+	form.Set("client_secret", clientSecret)
+	form.Set("code", code)
+	form.Set("grant_type", "authorization_code")
+	form.Set("redirect_uri", redirectURI)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", ErrExchangeFailed
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	// GitHub 默认回表单编码,显式要 JSON;其余平台本就回 JSON,加这头无害。
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", ErrExchangeFailed
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", ErrExchangeFailed
+	}
+
+	var parsed struct {
+		AccessToken string `json:"access_token"`
+		Error       string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", ErrExchangeFailed
+	}
+	if parsed.AccessToken == "" {
+		// 兑换失败(如 code 失效):人读错误,绝不回 provider 原文(可能含敏感细节)。
+		return "", ErrExchangeFailed
+	}
+	return parsed.AccessToken, nil
+}
+
+// requestUser 用 access_token 拉 userURL 取登录名(绝不日志 token)。
+func (s *service) requestUser(ctx context.Context, p Provider, accessToken string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.UserURL, nil)
+	if err != nil {
+		return "", ErrExchangeFailed
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", ErrExchangeFailed
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", ErrExchangeFailed
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		return "", ErrExchangeFailed
+	}
+	login := p.parseLogin(m)
+	if login == "" {
+		return "", ErrExchangeFailed
+	}
+	return login, nil
+}
+
+// loadApp 读单个 provider 的应用行;返回 (provider, clientID, sealedSecret, baseURL, enabled, updatedAt, err)。
+// 无行 → 返回空默认(clientID="" / sealed=nil / enabled=false),无错误。
+func (s *service) loadApp(ctx context.Context, provider string) (string, string, []byte, string, bool, string, error) {
+	prov, err := normalizeProvider(provider)
+	if err != nil {
+		return "", "", nil, "", false, "", err
+	}
+	var (
+		clientID   string
+		sealed     []byte
+		baseURL    string
+		enabledInt int
+		updatedStr string
+	)
+	err = s.db.QueryRowContext(ctx,
+		`SELECT client_id, client_secret_ciphertext, base_url, enabled, updated_at
+		 FROM oauth_apps WHERE provider = ?`, prov,
+	).Scan(&clientID, &sealed, &baseURL, &enabledInt, &updatedStr)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return prov, "", nil, "", false, "", nil
+		}
+		return "", "", nil, "", false, "", fmt.Errorf("oauth: load app: %w", err)
+	}
+	return prov, clientID, sealed, baseURL, enabledInt != 0, updatedStr, nil
+}
+
+// openSecret 解密既有 client_secret 密文返回明文(供 Exchange 取用,用完即弃)。
+func (s *service) openSecret(sealed []byte) (string, error) {
+	if s.vault == nil {
+		return "", ErrVaultUnconfigured
+	}
+	plain, err := s.vault.OpenSecret(sealed)
+	if err != nil {
+		if errors.Is(err, vault.ErrVaultUnconfigured) {
+			return "", ErrVaultUnconfigured
+		}
+		// 解密失败(错误 master key / 篡改):按未配置态处理,不泄漏细节。
+		return "", ErrVaultUnconfigured
+	}
+	return string(plain), nil
+}
+
+// toAppConfig 组装对外视图:client_secret 仅掩码,绝无明文。
+// 掩码不解密(无需明文):有密文即回固定掩码 ••••••,configured = 有 clientID + 有密文。
+func (s *service) toAppConfig(provider, clientID, baseURL string, enabled bool, sealed []byte, updatedStr string) AppConfig {
+	cfg := AppConfig{
+		Provider:   provider,
+		ClientID:   clientID,
+		BaseURL:    baseURL,
+		Enabled:    enabled,
+		Configured: clientID != "" && len(sealed) > 0,
+	}
+	if len(sealed) > 0 {
+		cfg.MaskedSecret = "••••••"
+	}
+	if t, perr := time.Parse(time.RFC3339, updatedStr); perr == nil {
+		cfg.UpdatedAt = &t
+	}
+	return cfg
+}

--- a/internal/oauth/oauth_test.go
+++ b/internal/oauth/oauth_test.go
@@ -1,0 +1,374 @@
+package oauth
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/store"
+	"github.com/huangchengsir/pipewright/internal/vault"
+)
+
+// testMasterKey 返回确定性测试用 master key。
+func testMasterKey() *[32]byte {
+	var k [32]byte
+	for i := range k {
+		k[i] = byte(i + 7)
+	}
+	return &k
+}
+
+// testDB 打开临时 SQLite(含全部迁移),返回 *sql.DB 与库文件路径(供整库 dump 验明文)。
+func testDB(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st.DB, dbPath
+}
+
+func newService(t *testing.T, client *http.Client) (Service, vault.Vault, *sql.DB, string) {
+	t.Helper()
+	db, path := testDB(t)
+	v := vault.New(db, testMasterKey())
+	return New(db, v, client), v, db, path
+}
+
+func ctx() context.Context { return context.Background() }
+
+// ---- provider URL 构造 -------------------------------------------------
+
+func TestResolveProviderPresets(t *testing.T) {
+	cases := []struct {
+		name      string
+		authorize string
+		token     string
+		user      string
+		scopeHas  string
+	}{
+		{ProviderGitee, "https://gitee.com/oauth/authorize", "https://gitee.com/oauth/token", "https://gitee.com/api/v5/user", "projects"},
+		{ProviderGitHub, "https://github.com/login/oauth/authorize", "https://github.com/login/oauth/access_token", "https://api.github.com/user", "repo"},
+		{ProviderGitLab, "https://gitlab.com/oauth/authorize", "https://gitlab.com/oauth/token", "https://gitlab.com/api/v4/user", "read_repository"},
+	}
+	for _, c := range cases {
+		p, err := resolveProvider(c.name, "")
+		if err != nil {
+			t.Fatalf("%s resolve: %v", c.name, err)
+		}
+		if p.AuthorizeURL != c.authorize || p.TokenURL != c.token || p.UserURL != c.user {
+			t.Fatalf("%s endpoints mismatch: %+v", c.name, p)
+		}
+		if !strings.Contains(p.scope(), c.scopeHas) {
+			t.Fatalf("%s scope %q missing %q", c.name, p.scope(), c.scopeHas)
+		}
+	}
+}
+
+func TestResolveCustomDerivesEndpoints(t *testing.T) {
+	p, err := resolveProvider(ProviderCustom, "https://git.internal.example.com/")
+	if err != nil {
+		t.Fatalf("custom resolve: %v", err)
+	}
+	if p.AuthorizeURL != "https://git.internal.example.com/oauth/authorize" {
+		t.Fatalf("custom authorize: %q", p.AuthorizeURL)
+	}
+	if p.TokenURL != "https://git.internal.example.com/oauth/token" {
+		t.Fatalf("custom token: %q", p.TokenURL)
+	}
+	if p.UserURL != "https://git.internal.example.com/api/v4/user" {
+		t.Fatalf("custom user: %q", p.UserURL)
+	}
+}
+
+func TestResolveCustomRequiresBaseURL(t *testing.T) {
+	if _, err := resolveProvider(ProviderCustom, ""); err != ErrBaseURLRequired {
+		t.Fatalf("custom no baseURL err = %v, want ErrBaseURLRequired", err)
+	}
+}
+
+func TestNormalizeProviderRejectsUnknown(t *testing.T) {
+	if _, err := normalizeProvider("bitbucket"); err != ErrInvalidProvider {
+		t.Fatalf("unknown provider err = %v, want ErrInvalidProvider", err)
+	}
+}
+
+// ---- app 配置:secret 只写 + 掩码 + configured ------------------------
+
+func TestSaveAppMaskedNoPlaintextAndConfigured(t *testing.T) {
+	svc, _, _, dbPath := newService(t, http.DefaultClient)
+	cfg, err := svc.SaveApp(ctx(), SaveAppInput{
+		Provider:     ProviderGitHub,
+		ClientID:     "iv1.client",
+		ClientSecret: strp("super-secret-PLAINTEXT"),
+		Enabled:      true,
+	})
+	if err != nil {
+		t.Fatalf("SaveApp: %v", err)
+	}
+	if !cfg.Configured || !cfg.Enabled {
+		t.Fatalf("应 configured/enabled=true: %+v", cfg)
+	}
+	if cfg.MaskedSecret == "" || strings.Contains(cfg.MaskedSecret, "PLAINTEXT") {
+		t.Fatalf("maskedSecret 不应含明文: %q", cfg.MaskedSecret)
+	}
+	// 整库 dump 绝无明文 secret(裸断言)。
+	raw, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatalf("read db: %v", err)
+	}
+	if strings.Contains(string(raw), "super-secret-PLAINTEXT") {
+		t.Fatalf("DB dump 含明文 client_secret!")
+	}
+}
+
+func TestSaveAppSecretWriteOnlyPreservesOnOmit(t *testing.T) {
+	svc, v, _, _ := newService(t, http.DefaultClient)
+	if _, err := svc.SaveApp(ctx(), SaveAppInput{
+		Provider: ProviderGitee, ClientID: "cid1", ClientSecret: strp("secret-1"), Enabled: true,
+	}); err != nil {
+		t.Fatalf("save 1: %v", err)
+	}
+	// 第二次保存省略 clientSecret(nil)→ 保留旧 secret;改 clientID/enabled。
+	if _, err := svc.SaveApp(ctx(), SaveAppInput{
+		Provider: ProviderGitee, ClientID: "cid2", ClientSecret: nil, Enabled: false,
+	}); err != nil {
+		t.Fatalf("save 2: %v", err)
+	}
+	// 省略 secret 的二次保存未报 ErrClientSecretRequired,且 ListApps 仍 configured=true、
+	// clientID 已更新、enabled 已更新 —— 证明旧 secret 被保留(未清空)、其余字段已轮换。
+	apps, err := svc.ListApps(ctx())
+	if err != nil || len(apps) != 1 {
+		t.Fatalf("ListApps: %v len=%d", err, len(apps))
+	}
+	a := apps[0]
+	if !a.Configured {
+		t.Fatalf("省略 secret 后应仍 configured(旧 secret 保留): %+v", a)
+	}
+	if a.ClientID != "cid2" || a.Enabled {
+		t.Fatalf("clientID/enabled 应已更新: %+v", a)
+	}
+	_ = v
+}
+
+func TestSaveAppRejectsEmptyClientID(t *testing.T) {
+	svc, _, _, _ := newService(t, http.DefaultClient)
+	if _, err := svc.SaveApp(ctx(), SaveAppInput{Provider: ProviderGitee, ClientID: "  ", ClientSecret: strp("s")}); err != ErrClientIDRequired {
+		t.Fatalf("empty clientID err = %v, want ErrClientIDRequired", err)
+	}
+}
+
+func TestSaveAppFirstTimeRequiresSecret(t *testing.T) {
+	svc, _, _, _ := newService(t, http.DefaultClient)
+	if _, err := svc.SaveApp(ctx(), SaveAppInput{Provider: ProviderGitee, ClientID: "cid", ClientSecret: nil}); err != ErrClientSecretRequired {
+		t.Fatalf("first save no secret err = %v, want ErrClientSecretRequired", err)
+	}
+}
+
+func TestSaveAppCustomRequiresBaseURL(t *testing.T) {
+	svc, _, _, _ := newService(t, http.DefaultClient)
+	if _, err := svc.SaveApp(ctx(), SaveAppInput{Provider: ProviderCustom, ClientID: "cid", ClientSecret: strp("s")}); err != ErrBaseURLRequired {
+		t.Fatalf("custom no baseURL err = %v, want ErrBaseURLRequired", err)
+	}
+}
+
+func TestListAppsMaskedOnly(t *testing.T) {
+	svc, _, _, _ := newService(t, http.DefaultClient)
+	_, _ = svc.SaveApp(ctx(), SaveAppInput{Provider: ProviderGitee, ClientID: "g", ClientSecret: strp("sec-PLAINTEXT"), Enabled: true})
+	apps, err := svc.ListApps(ctx())
+	if err != nil {
+		t.Fatalf("ListApps: %v", err)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("want 1 app, got %d", len(apps))
+	}
+	if strings.Contains(apps[0].MaskedSecret, "PLAINTEXT") {
+		t.Fatalf("masked secret leaks plaintext: %q", apps[0].MaskedSecret)
+	}
+}
+
+// ---- AuthorizeURL ------------------------------------------------------
+
+func TestAuthorizeURLUnconfiguredProviderErrors(t *testing.T) {
+	svc, _, _, _ := newService(t, http.DefaultClient)
+	if _, err := svc.AuthorizeURL(ctx(), ProviderGitHub, "st", "https://x/cb"); err != ErrAppNotConfigured {
+		t.Fatalf("unconfigured authorize err = %v, want ErrAppNotConfigured", err)
+	}
+}
+
+func TestAuthorizeURLBuildsParams(t *testing.T) {
+	svc, _, _, _ := newService(t, http.DefaultClient)
+	_, _ = svc.SaveApp(ctx(), SaveAppInput{Provider: ProviderGitHub, ClientID: "CID123", ClientSecret: strp("s"), Enabled: true})
+	raw, err := svc.AuthorizeURL(ctx(), ProviderGitHub, "STATE-XYZ", "https://app.example/api/oauth/github/callback")
+	if err != nil {
+		t.Fatalf("AuthorizeURL: %v", err)
+	}
+	u, _ := url.Parse(raw)
+	if u.Host != "github.com" {
+		t.Fatalf("authorize host = %q", u.Host)
+	}
+	q := u.Query()
+	if q.Get("client_id") != "CID123" || q.Get("state") != "STATE-XYZ" {
+		t.Fatalf("params mismatch: %v", q)
+	}
+	if q.Get("redirect_uri") != "https://app.example/api/oauth/github/callback" {
+		t.Fatalf("redirect_uri mismatch: %q", q.Get("redirect_uri"))
+	}
+	if q.Get("response_type") != "code" || !strings.Contains(q.Get("scope"), "repo") {
+		t.Fatalf("response_type/scope mismatch: %v", q)
+	}
+}
+
+// ---- Exchange(httptest mock provider)---------------------------------
+
+// mockProvider 返回一个假冒 provider:/token 回 access_token、/user 回 login;
+// 记录是否收到 client_secret(验证 server-to-server 真带上了 secret),但绝不要求回显它。
+func mockProvider(t *testing.T, wantSecret string) (*httptest.Server, *bool) {
+	t.Helper()
+	gotSecret := new(bool)
+	mux := http.NewServeMux()
+	// custom provider 据 baseURL 推导端点为 /oauth/token 与 /api/v4/user。
+	mux.HandleFunc("/oauth/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if r.FormValue("client_secret") == wantSecret {
+			*gotSecret = true
+		}
+		if r.Header.Get("Accept") != "application/json" {
+			t.Errorf("token request missing Accept: application/json")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"gho_FAKE_TOKEN_123","token_type":"bearer"}`))
+	})
+	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer gho_FAKE_TOKEN_123" {
+			t.Errorf("user request bad auth header: %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"login":"octocat","username":"octocat","id":1}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, gotSecret
+}
+
+func TestExchangeViaCustomProviderStoresToken(t *testing.T) {
+	mock, gotSecret := mockProvider(t, "the-client-secret")
+	svc, v, _, _ := newService(t, mock.Client())
+
+	// custom 据 mock baseURL 推导端点;但 mock 端点路径是 /token、/user,
+	// customProvider 推导为 /oauth/token、/api/v4/user。改用直接覆盖端点的方式不便,
+	// 故注册 mock 在这两条路径上。
+	if _, err := svc.SaveApp(ctx(), SaveAppInput{
+		Provider: ProviderCustom, ClientID: "cid", ClientSecret: strp("the-client-secret"),
+		BaseURL: mock.URL, Enabled: true,
+	}); err != nil {
+		t.Fatalf("SaveApp: %v", err)
+	}
+
+	res, err := svc.Exchange(ctx(), ProviderCustom, "auth-code-xyz", mock.URL+"/cb")
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if res.AccessToken != "gho_FAKE_TOKEN_123" || res.Login != "octocat" {
+		t.Fatalf("exchange result: %+v", res)
+	}
+	if !*gotSecret {
+		t.Fatalf("provider 未收到 client_secret(server-to-server 应带上)")
+	}
+
+	// 经 vault.Create 存成 git_token 凭据,验证可解密回 token。
+	cred, err := v.Create(vault.CreateInput{
+		Name: ProviderCustom + ":" + res.Login, Type: vault.TypeGitToken, Scope: "global", Secret: res.AccessToken,
+	})
+	if err != nil {
+		t.Fatalf("vault.Create: %v", err)
+	}
+	got, err := v.Reveal(cred.ID)
+	if err != nil {
+		t.Fatalf("Reveal: %v", err)
+	}
+	if got != "gho_FAKE_TOKEN_123" {
+		t.Fatalf("stored token mismatch: %q", got)
+	}
+}
+
+func TestExchangeUnconfiguredProviderErrors(t *testing.T) {
+	svc, _, _, _ := newService(t, http.DefaultClient)
+	if _, err := svc.Exchange(ctx(), ProviderGitee, "code", "https://x/cb"); err != ErrAppNotConfigured {
+		t.Fatalf("unconfigured exchange err = %v, want ErrAppNotConfigured", err)
+	}
+}
+
+func TestExchangeProviderErrorMapsToExchangeFailed(t *testing.T) {
+	// provider /token 回 4xx → ErrExchangeFailed(绝不泄漏 provider 原文)。
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth/token", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"bad_verification_code","secret_leak":"the-client-secret"}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	svc, _, _, _ := newService(t, srv.Client())
+	_, _ = svc.SaveApp(ctx(), SaveAppInput{Provider: ProviderCustom, ClientID: "cid", ClientSecret: strp("the-client-secret"), BaseURL: srv.URL, Enabled: true})
+
+	_, err := svc.Exchange(ctx(), ProviderCustom, "stale-code", srv.URL+"/cb")
+	if err != ErrExchangeFailed {
+		t.Fatalf("exchange err = %v, want ErrExchangeFailed", err)
+	}
+	if strings.Contains(err.Error(), "the-client-secret") || strings.Contains(err.Error(), "bad_verification_code") {
+		t.Fatalf("错误体泄漏了 provider 原文/secret: %v", err)
+	}
+}
+
+// ---- state CSRF --------------------------------------------------------
+
+func TestStateRoundTrip(t *testing.T) {
+	svc, _, _, _ := newService(t, http.DefaultClient)
+	st, err := svc.IssueState("session-A")
+	if err != nil {
+		t.Fatalf("IssueState: %v", err)
+	}
+	if st == "" {
+		t.Fatal("state empty")
+	}
+	if !svc.ConsumeState(st, "session-A") {
+		t.Fatal("匹配会话应消费成功")
+	}
+	// 一次性:重复消费应失败(防重放)。
+	if svc.ConsumeState(st, "session-A") {
+		t.Fatal("state 应一次性,重复消费应拒")
+	}
+}
+
+func TestStateWrongSessionRejected(t *testing.T) {
+	svc, _, _, _ := newService(t, http.DefaultClient)
+	st, _ := svc.IssueState("session-A")
+	if svc.ConsumeState(st, "session-B") {
+		t.Fatal("不同会话的 state 应拒(CSRF 防护)")
+	}
+	// 即便会话错被拒,state 也已被消费,正确会话再用也应失败。
+	if svc.ConsumeState(st, "session-A") {
+		t.Fatal("被错误会话触碰后 state 应已失效")
+	}
+}
+
+func TestStateUnknownRejected(t *testing.T) {
+	svc, _, _, _ := newService(t, http.DefaultClient)
+	if svc.ConsumeState("never-issued", "session-A") {
+		t.Fatal("未签发的 state 应拒")
+	}
+	if svc.ConsumeState("", "session-A") {
+		t.Fatal("空 state 应拒")
+	}
+}
+
+func strp(s string) *string { return &s }

--- a/internal/oauth/provider.go
+++ b/internal/oauth/provider.go
@@ -1,0 +1,164 @@
+// Package oauth 是「多 provider OAuth 凭据接入」的领域层。
+//
+// 运营者一次性配置各 git 平台(gitee|github|gitlab|custom)的 OAuth 应用(client_id +
+// client_secret〔加密〕+ base_url〔自建用〕),用户在页面点「连接」→ 跳 git 平台授权 →
+// 平台回跳带 code → 后端用 client_id/client_secret 换 access_token → 拉登录名 → 把 token
+// 经 vault.Create 存成 git_token 凭据。之后克隆/构建直接复用该凭据(BasicAuth token)。
+//
+// 安全铁律:client_secret 经 vault secretbox(master key)加密后仅以密文入库;access_token /
+// client_secret 绝不出现在错误体/日志/响应。state CSRF 防伪造授权码注入。
+package oauth
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+)
+
+// provider 枚举(DB 存小写字串;路由 path 同名)。
+const (
+	// ProviderGitee 表示码云 gitee.com。
+	ProviderGitee = "gitee"
+	// ProviderGitHub 表示 github.com。
+	ProviderGitHub = "github"
+	// ProviderGitLab 表示 gitlab.com。
+	ProviderGitLab = "gitlab"
+	// ProviderCustom 表示自建实例(据 base_url 推导 GitLab/Gitea 风格端点)。
+	ProviderCustom = "custom"
+)
+
+// 领域错误。错误体永不含 client_secret / access_token 明文。
+var (
+	// ErrInvalidProvider 表示 provider 枚举非法(非 gitee|github|gitlab|custom)。
+	ErrInvalidProvider = errors.New("oauth: invalid provider")
+	// ErrBaseURLRequired 表示 custom provider 缺 base_url(无从推导端点)。
+	ErrBaseURLRequired = errors.New("oauth: base url required for custom provider")
+)
+
+// userInfo 是从 provider user API 解析出的用户信息(仅取登录名)。
+type userInfo struct {
+	Login string
+}
+
+// Provider 描述一个 OAuth provider 的端点与解析策略。
+// 内置预设为不可变模板;custom 经 resolve(baseURL) 据基址推导端点。
+type Provider struct {
+	// Name 是 provider 枚举值(gitee|github|gitlab|custom)。
+	Name string
+	// AuthorizeURL 是授权页地址(用户浏览器跳转目标)。
+	AuthorizeURL string
+	// TokenURL 是 code→token 兑换地址(后端 server-to-server POST)。
+	TokenURL string
+	// UserURL 是取当前用户信息的 API 地址(带 access_token)。
+	UserURL string
+	// DefaultScopes 是申请的最小权限(含仓库读)。
+	DefaultScopes []string
+	// parseLogin 从 user API 的 JSON map 解析登录名(各平台字段不同)。
+	parseLogin func(m map[string]any) string
+}
+
+// scope 把 DefaultScopes 以空格连接(OAuth2 标准 scope 串)。
+func (p Provider) scope() string { return strings.Join(p.DefaultScopes, " ") }
+
+// presets 是内置 provider 预设注册表(map 注册,设计可扩展)。
+// custom 不在此(需 base_url 动态推导),经 resolveProvider 单独处理。
+var presets = map[string]Provider{
+	ProviderGitee: {
+		Name:          ProviderGitee,
+		AuthorizeURL:  "https://gitee.com/oauth/authorize",
+		TokenURL:      "https://gitee.com/oauth/token",
+		UserURL:       "https://gitee.com/api/v5/user",
+		DefaultScopes: []string{"user_info", "projects"},
+		parseLogin:    parseLoginField("login"),
+	},
+	ProviderGitHub: {
+		Name:          ProviderGitHub,
+		AuthorizeURL:  "https://github.com/login/oauth/authorize",
+		TokenURL:      "https://github.com/login/oauth/access_token",
+		UserURL:       "https://api.github.com/user",
+		DefaultScopes: []string{"repo", "read:user"},
+		parseLogin:    parseLoginField("login"),
+	},
+	ProviderGitLab: {
+		Name:          ProviderGitLab,
+		AuthorizeURL:  "https://gitlab.com/oauth/authorize",
+		TokenURL:      "https://gitlab.com/oauth/token",
+		UserURL:       "https://gitlab.com/api/v4/user",
+		DefaultScopes: []string{"read_repository", "read_user"},
+		parseLogin:    parseLoginField("username"),
+	},
+}
+
+// parseLoginField 返回一个从 JSON map 取字符串字段(回退 "id" 数字)的解析器。
+func parseLoginField(field string) func(map[string]any) string {
+	return func(m map[string]any) string {
+		if v, ok := m[field].(string); ok && v != "" {
+			return v
+		}
+		// 回退:部分实例可能只回 id(数字)。
+		if v, ok := m["username"].(string); ok && v != "" {
+			return v
+		}
+		if v, ok := m["login"].(string); ok && v != "" {
+			return v
+		}
+		return ""
+	}
+}
+
+// normalizeProvider 校验并归一 provider 枚举(空串非法)。
+func normalizeProvider(p string) (string, error) {
+	switch strings.TrimSpace(p) {
+	case ProviderGitee:
+		return ProviderGitee, nil
+	case ProviderGitHub:
+		return ProviderGitHub, nil
+	case ProviderGitLab:
+		return ProviderGitLab, nil
+	case ProviderCustom:
+		return ProviderCustom, nil
+	default:
+		return "", ErrInvalidProvider
+	}
+}
+
+// resolveProvider 据 provider 名 + 配置的 baseURL 返回可用的 Provider 端点模板。
+//   - gitee/github/gitlab:返回内置预设(忽略 baseURL,除非将来允许覆盖)。
+//   - custom:据 baseURL 推导 GitLab/Gitea 风格端点(authorize/token/user)。
+//     custom 缺 baseURL → ErrBaseURLRequired。
+func resolveProvider(name, baseURL string) (Provider, error) {
+	n, err := normalizeProvider(name)
+	if err != nil {
+		return Provider{}, err
+	}
+	if n == ProviderCustom {
+		return customProvider(baseURL)
+	}
+	return presets[n], nil
+}
+
+// customProvider 据自建实例 baseURL 推导 GitLab/Gitea 风格 OAuth 端点。
+// 约定(GitLab 与 Gitea 端点路径一致):
+//
+//	authorize: {base}/oauth/authorize
+//	token    : {base}/oauth/token
+//	user     : {base}/api/v4/user   (GitLab;Gitea 为 /api/v1/user,登录名字段均含 username/login)
+//
+// 用户解析器同时认 username/login 字段,兼容 GitLab(username)与 Gitea(login)。
+func customProvider(baseURL string) (Provider, error) {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if base == "" {
+		return Provider{}, ErrBaseURLRequired
+	}
+	if _, err := url.Parse(base); err != nil {
+		return Provider{}, ErrBaseURLRequired
+	}
+	return Provider{
+		Name:          ProviderCustom,
+		AuthorizeURL:  base + "/oauth/authorize",
+		TokenURL:      base + "/oauth/token",
+		UserURL:       base + "/api/v4/user",
+		DefaultScopes: []string{"read_repository", "read_user"},
+		parseLogin:    parseLoginField("username"),
+	}, nil
+}

--- a/internal/oauth/state.go
+++ b/internal/oauth/state.go
@@ -1,0 +1,86 @@
+package oauth
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"sync"
+	"time"
+)
+
+// stateTTL 是 OAuth state 的有效期。授权来回(用户在 git 平台点同意)通常秒级~分钟级,
+// 10 分钟足够且不让陈旧 state 长期可用(限制 CSRF 重放窗口)。
+const stateTTL = 10 * time.Minute
+
+// stateEntry 是一条待校验的 state 记录:绑定发起授权的会话 + 过期时刻。
+type stateEntry struct {
+	sessionID string
+	expiresAt time.Time
+}
+
+// stateStore 是 OAuth state 的短期内存存储(CSRF 防护)。
+//
+// 发起 authorize 时生成高熵随机 state、绑定当前会话 ID 存入;callback 校验 state 存在、
+// 未过期、且绑定的会话 ID 与当前请求会话一致 —— 三者皆满足才放行 Exchange。这样攻击者
+// 即便诱导受害者点开伪造的 callback,其授权码也因 state 不匹配(或不绑该会话)被拒,
+// 防止 CSRF 注入伪造授权码把攻击者账号的 token 写进受害者保险库。
+//
+// 单进程内存即可(平台为单二进制);消费即删(一次性);惰性清理过期项。
+type stateStore struct {
+	mu      sync.Mutex
+	entries map[string]stateEntry
+	now     func() time.Time
+}
+
+// newStateStore 构造内存 state 存储。
+func newStateStore() *stateStore {
+	return &stateStore{
+		entries: make(map[string]stateEntry),
+		now:     time.Now,
+	}
+}
+
+// issue 生成并登记一个绑定 sessionID 的随机 state,返回供放进 authorize URL。
+func (s *stateStore) issue(sessionID string) (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	state := base64.RawURLEncoding.EncodeToString(buf)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.gcLocked()
+	s.entries[state] = stateEntry{sessionID: sessionID, expiresAt: s.now().Add(stateTTL)}
+	return state, nil
+}
+
+// consume 校验并一次性消费 state:存在 + 未过期 + 绑定会话匹配 → true(并删除);否则 false。
+// 用常量时间比较 sessionID(防时序侧信道)。
+func (s *stateStore) consume(state, sessionID string) bool {
+	if state == "" {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.entries[state]
+	if !ok {
+		return false
+	}
+	// 无论结果如何都消费掉这条 state(一次性,防重放)。
+	delete(s.entries, state)
+	if s.now().After(e.expiresAt) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(e.sessionID), []byte(sessionID)) == 1
+}
+
+// gcLocked 惰性清理过期项(调用方须持锁)。
+func (s *stateStore) gcLocked() {
+	now := s.now()
+	for k, e := range s.entries {
+		if now.After(e.expiresAt) {
+			delete(s.entries, k)
+		}
+	}
+}

--- a/internal/store/migrations/0022_oauth_apps.sql
+++ b/internal/store/migrations/0022_oauth_apps.sql
@@ -1,0 +1,25 @@
+-- 0022 oauth_apps:多 provider OAuth 应用配置(运营者一次性配,接 git 平台 OAuth)。
+-- 每行一个 provider(gitee|github|gitlab|custom),记录 OAuth 应用的 client_id +
+-- client_secret(加密)+ base_url(自建用)+ enabled 开关。
+--
+-- AC-SEC:client_secret 经 vault secretbox(master key)加密后仅以**密文 BLOB**
+-- (client_secret_ciphertext)入库;DB dump 绝无明文 secret。对外(REST)只暴露掩码 +
+-- configured 标志;明文绝不常驻/回显/日志。OAuth 拿到的 access_token 经 vault.Create
+-- 存成 git_token 凭据(credentials 表),不落本表。
+--   provider                : OAuth provider 主键(gitee|github|gitlab|custom)
+--   client_id               : OAuth 应用 client id(非敏感,明文)
+--   client_secret_ciphertext: vault secretbox 密文 BLOB(空=未设 secret)
+--   base_url                : 自建实例基址(custom 必填;gitee/github/gitlab 留空走预设端点)
+--   enabled                 : 启用开关(未启用 → authorize 拒绝发起)
+--   created_at              : 创建时间(RFC3339)
+--   updated_at              : 更新时间(RFC3339)
+
+CREATE TABLE IF NOT EXISTS oauth_apps (
+    provider                 TEXT PRIMARY KEY,
+    client_id                TEXT NOT NULL DEFAULT '',
+    client_secret_ciphertext BLOB,
+    base_url                 TEXT NOT NULL DEFAULT '',
+    enabled                  INTEGER NOT NULL DEFAULT 0,
+    created_at               TEXT NOT NULL,
+    updated_at               TEXT NOT NULL
+);

--- a/web/src/api/oauth.test.ts
+++ b/web/src/api/oauth.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { getOAuthApps, saveOAuthApp, authorizeUrl } from './oauth'
+
+function jsonResponse(status: number, body: unknown, ok = status < 400): Response {
+  return {
+    status,
+    ok,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response
+}
+
+describe('oauth api client', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    document.cookie.split(';').forEach((c) => {
+      const name = c.split('=')[0].trim()
+      if (name) document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('GET /api/oauth/apps returns the app list', async () => {
+    const apps = [
+      {
+        provider: 'github',
+        clientId: 'abc',
+        baseUrl: '',
+        enabled: true,
+        maskedSecret: '••••a91f',
+        configured: true,
+        updatedAt: '2026-05-30T00:00:00Z',
+      },
+    ]
+    fetchMock.mockResolvedValue(jsonResponse(200, apps))
+    const result = await getOAuthApps()
+    expect(result).toEqual(apps)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/oauth/apps')
+    expect(init.method).toBe('GET')
+  })
+
+  it('PUT /api/oauth/apps/{provider} hits the per-provider URL with the body', async () => {
+    document.cookie = 'pipewright_csrf=tok123'
+    fetchMock.mockResolvedValue(jsonResponse(200, { provider: 'gitee' }))
+    await saveOAuthApp('gitee', {
+      clientId: 'cid',
+      clientSecret: 'sec',
+      enabled: true,
+    })
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/oauth/apps/gitee')
+    expect(init.method).toBe('PUT')
+    expect(init.body).toBe(JSON.stringify({ clientId: 'cid', clientSecret: 'sec', enabled: true }))
+    // write methods carry the CSRF token
+    expect((init.headers as Headers).get('X-CSRF-Token')).toBe('tok123')
+  })
+
+  it('saveOAuthApp omits clientSecret when not provided (keep-existing semantics)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await saveOAuthApp('github', { clientId: 'cid', enabled: false })
+    const init = fetchMock.mock.calls[0][1]
+    const body = JSON.parse(init.body)
+    expect(body).not.toHaveProperty('clientSecret')
+    expect(body).toEqual({ clientId: 'cid', enabled: false })
+  })
+
+  it('authorizeUrl builds the per-provider full-page authorize entrypoint', () => {
+    expect(authorizeUrl('gitee')).toBe('/api/oauth/gitee/authorize')
+    expect(authorizeUrl('github')).toBe('/api/oauth/github/authorize')
+    expect(authorizeUrl('gitlab')).toBe('/api/oauth/gitlab/authorize')
+    expect(authorizeUrl('custom')).toBe('/api/oauth/custom/authorize')
+  })
+})

--- a/web/src/api/oauth.ts
+++ b/web/src/api/oauth.ts
@@ -1,0 +1,66 @@
+/**
+ * OAuth Apps API — aligns to the frozen OAuth contract.
+ *
+ * GET /api/oauth/apps               → OAuthApp[]
+ * PUT /api/oauth/apps/{provider}    → OAuthApp  (needs CSRF)
+ * GET /api/oauth/{provider}/authorize → backend 302 to the git platform.
+ *      This is NOT fetched — the browser must do a full-page navigation so
+ *      the 302 redirect chain runs. Use `authorizeUrl(provider)` with
+ *      `window.location.href = …`, never `http.get`.
+ *
+ * clientSecret is WRITE-ONLY: the server never returns plaintext.
+ * GET/PUT responses only include maskedSecret (e.g. "••••a91f").
+ * Leaving clientSecret empty on PUT keeps the existing secret unchanged.
+ */
+
+import { http } from './http'
+
+export type OAuthProvider = 'gitee' | 'github' | 'gitlab' | 'custom'
+
+/** GET /api/oauth/apps element — never contains plaintext clientSecret. */
+export interface OAuthApp {
+  provider: OAuthProvider
+  clientId: string
+  baseUrl: string
+  enabled: boolean
+  /** Server-computed mask, e.g. "••••a91f" — never plaintext. */
+  maskedSecret: string
+  configured: boolean
+  updatedAt: string | null
+}
+
+/** PUT /api/oauth/apps/{provider} request body. */
+export interface SaveOAuthAppInput {
+  clientId: string
+  /**
+   * Write-only: omit or leave empty to keep the existing secret unchanged.
+   * Non-empty rotates to the new secret.
+   */
+  clientSecret?: string
+  /** Only meaningful for the self-hosted (`custom`) provider. */
+  baseUrl?: string
+  enabled: boolean
+}
+
+export async function getOAuthApps(): Promise<OAuthApp[]> {
+  return http.get<OAuthApp[]>('/api/oauth/apps')
+}
+
+export async function saveOAuthApp(
+  provider: OAuthProvider,
+  input: SaveOAuthAppInput,
+): Promise<OAuthApp> {
+  return http.put<OAuthApp>(`/api/oauth/apps/${provider}`, input)
+}
+
+/**
+ * Build the authorize entrypoint URL for a provider.
+ *
+ * The caller must perform a full-page navigation:
+ *   window.location.href = authorizeUrl(provider)
+ * The backend responds with a 302 to the git platform's consent screen.
+ * Do NOT fetch this — fetch would follow the redirect without leaving the SPA.
+ */
+export function authorizeUrl(provider: OAuthProvider): string {
+  return `/api/oauth/${provider}/authorize`
+}

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -17,6 +17,8 @@ const AnomalyDetection = () => import('../views/AnomalyDetection.vue')
 const Notifications = () => import('../views/Notifications.vue')
 const Settings    = () => import('../views/Settings.vue')
 const SettingsAI  = () => import('../views/settings/SettingsAI.vue')
+// OAuth app config: per-provider Client ID/Secret for one-click "连接" in the vault
+const SettingsOAuth = () => import('../views/settings/SettingsOAuth.vue')
 const SettingsVault = () => import('../views/settings/SettingsVault.vue')
 const SettingsAccount = () => import('../views/settings/SettingsAccount.vue')
 const SettingsSystem = () => import('../views/settings/SettingsSystem.vue')
@@ -84,6 +86,7 @@ const router = createRouter({
           children: [
             { path: '', redirect: { name: 'settings-ai' } },
             { path: 'ai', name: 'settings-ai', component: SettingsAI },
+            { path: 'oauth', name: 'settings-oauth', component: SettingsOAuth },
             { path: 'notifications', name: 'settings-notifications', component: SettingsNotifications },
             { path: 'vault', name: 'settings-vault', component: SettingsVault },
             { path: 'account', name: 'settings-account', component: SettingsAccount },

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -12,6 +12,7 @@
     <!-- Secondary nav -->
     <nav class="settings-nav" aria-label="设置二级导航">
       <router-link to="/settings/ai" class="settings-nav-item">AI 提供商</router-link>
+      <router-link to="/settings/oauth" class="settings-nav-item">OAuth 应用</router-link>
       <router-link to="/settings/notifications" class="settings-nav-item">通知</router-link>
       <router-link to="/settings/vault" class="settings-nav-item">凭据保险库</router-link>
       <router-link to="/settings/account" class="settings-nav-item">账户</router-link>

--- a/web/src/views/settings/SettingsOAuth.test.ts
+++ b/web/src/views/settings/SettingsOAuth.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import SettingsOAuth from './SettingsOAuth.vue'
+
+// ─── module mocks ──────────────────────────────────────────────────────────
+
+const getOAuthApps = vi.fn()
+const saveOAuthApp = vi.fn()
+vi.mock('../../api/oauth', async () => {
+  const actual = await vi.importActual<typeof import('../../api/oauth')>('../../api/oauth')
+  return {
+    ...actual,
+    getOAuthApps: (...args: unknown[]) => getOAuthApps(...args),
+    saveOAuthApp: (...args: unknown[]) => saveOAuthApp(...args),
+  }
+})
+
+const toastSuccess = vi.fn()
+const toastError = vi.fn()
+vi.mock('../../composables/useToast', () => ({
+  useToast: () => ({ success: toastSuccess, error: toastError }),
+}))
+
+function makeApp(over: Partial<import('../../api/oauth').OAuthApp> = {}) {
+  return {
+    provider: 'github' as const,
+    clientId: 'existing-id',
+    baseUrl: '',
+    enabled: true,
+    maskedSecret: '••••a91f',
+    configured: true,
+    updatedAt: '2026-05-30T00:00:00Z',
+    ...over,
+  }
+}
+
+describe('SettingsOAuth', () => {
+  beforeEach(() => {
+    getOAuthApps.mockReset()
+    saveOAuthApp.mockReset()
+    toastSuccess.mockReset()
+    toastError.mockReset()
+  })
+
+  it('renders a card per provider and hydrates saved values', async () => {
+    getOAuthApps.mockResolvedValue([makeApp()])
+    const wrapper = mount(SettingsOAuth)
+    await flushPromises()
+
+    // four provider cards (gitee/github/gitlab/custom)
+    expect(wrapper.findAll('[data-provider]')).toHaveLength(4)
+
+    // github clientId hydrated from server
+    const githubInput = wrapper.get('#oauth-clientid-github')
+      .element as HTMLInputElement
+    expect(githubInput.value).toBe('existing-id')
+  })
+
+  it('never echoes the plaintext secret; shows masked hint + keep-existing placeholder', async () => {
+    getOAuthApps.mockResolvedValue([makeApp()])
+    const wrapper = mount(SettingsOAuth)
+    await flushPromises()
+
+    const secret = wrapper.get('#oauth-secret-github').element as HTMLInputElement
+    expect(secret.type).toBe('password')
+    expect(secret.value).toBe('') // never pre-filled
+    expect(secret.placeholder).toContain('留空保留已存')
+    // masked echo is shown, plaintext is not
+    expect(wrapper.text()).toContain('••••a91f')
+  })
+
+  it('only the self-hosted (custom) card exposes a Base URL field', async () => {
+    getOAuthApps.mockResolvedValue([])
+    const wrapper = mount(SettingsOAuth)
+    await flushPromises()
+
+    expect(wrapper.find('#oauth-baseurl-custom').exists()).toBe(true)
+    expect(wrapper.find('#oauth-baseurl-github').exists()).toBe(false)
+  })
+
+  it('blocks save when enabling a provider with no Client ID', async () => {
+    getOAuthApps.mockResolvedValue([
+      makeApp({ provider: 'gitee', clientId: '', enabled: false, configured: false, maskedSecret: '' }),
+    ])
+    const wrapper = mount(SettingsOAuth)
+    await flushPromises()
+
+    const card = wrapper.get('[data-provider="gitee"]')
+    // turn the enable toggle on
+    await card.get('[role="switch"]').trigger('click')
+    await card.get('form').trigger('submit')
+    await flushPromises()
+
+    expect(saveOAuthApp).not.toHaveBeenCalled()
+    expect(card.text()).toContain('启用时 Client ID 必填')
+  })
+
+  it('omits clientSecret on save when left blank (keep existing) and toasts success', async () => {
+    getOAuthApps.mockResolvedValue([makeApp()])
+    saveOAuthApp.mockResolvedValue(makeApp())
+    const wrapper = mount(SettingsOAuth)
+    await flushPromises()
+
+    await wrapper.get('[data-provider="github"] form').trigger('submit')
+    await flushPromises()
+
+    expect(saveOAuthApp).toHaveBeenCalledTimes(1)
+    const [provider, payload] = saveOAuthApp.mock.calls[0]
+    expect(provider).toBe('github')
+    expect(payload).not.toHaveProperty('clientSecret')
+    expect(payload).toMatchObject({ clientId: 'existing-id', enabled: true })
+    expect(toastSuccess).toHaveBeenCalledWith('OAuth 应用已保存', { detail: 'GitHub' })
+  })
+
+  it('sends clientSecret when the user enters a new one (rotation)', async () => {
+    getOAuthApps.mockResolvedValue([makeApp()])
+    saveOAuthApp.mockResolvedValue(makeApp())
+    const wrapper = mount(SettingsOAuth)
+    await flushPromises()
+
+    await wrapper.get('#oauth-secret-github').setValue('new-secret')
+    await wrapper.get('[data-provider="github"] form').trigger('submit')
+    await flushPromises()
+
+    const payload = saveOAuthApp.mock.calls[0][1]
+    expect(payload.clientSecret).toBe('new-secret')
+  })
+})

--- a/web/src/views/settings/SettingsOAuth.vue
+++ b/web/src/views/settings/SettingsOAuth.vue
@@ -1,0 +1,782 @@
+<script setup lang="ts">
+/**
+ * SettingsOAuth — OAuth application configuration for git providers.
+ *
+ * One config card per provider (Gitee / GitHub / GitLab / 自建):
+ *   - clientId text input
+ *   - clientSecret password input — WRITE-ONLY, never echoed; placeholder
+ *     hints "留空保留已存" when a secret is already configured
+ *   - baseUrl (only the self-hosted `custom` provider)
+ *   - enabled toggle
+ *   - Save (PUT) → toast "OAuth 应用已保存" + masked secret echo (mirrors SettingsAI)
+ *
+ * Once a provider is enabled, users connect a git account from the vault page
+ * (SettingsVault) where the "连接" buttons live and the callback is handled.
+ *
+ * Reuses: AppButton tokens + vault/AI patterns. No new UI libraries.
+ * Animation: transform/opacity + prefers-reduced-motion.
+ */
+import { reactive, ref, onMounted } from 'vue'
+import AppButton from '../../components/ui/AppButton.vue'
+import { useToast } from '../../composables/useToast'
+import { HttpError } from '../../api/http'
+import {
+  getOAuthApps,
+  saveOAuthApp,
+  type OAuthApp,
+  type OAuthProvider,
+  type SaveOAuthAppInput,
+} from '../../api/oauth'
+
+// ─── types ───────────────────────────────────────────────────────────────────
+
+type LoadState = 'loading' | 'ready' | 'error'
+
+interface ProviderMeta {
+  id: OAuthProvider
+  label: string
+  desc: string
+  logoText: string
+  logoStyle: string
+  /** Self-hosted provider exposes a base URL field. */
+  hasBaseUrl: boolean
+}
+
+/** Per-provider editable form + saved snapshot. */
+interface CardState {
+  meta: ProviderMeta
+  saved: OAuthApp | null
+  clientId: string
+  clientSecret: string // write-only: blank = keep existing
+  baseUrl: string
+  enabled: boolean
+  errors: { clientId: string; baseUrl: string }
+  saving: boolean
+}
+
+// ─── provider metadata ───────────────────────────────────────────────────────
+
+const PROVIDERS: ProviderMeta[] = [
+  {
+    id: 'gitee',
+    label: 'Gitee',
+    desc: '码云',
+    logoText: 'G',
+    logoStyle: 'background:#c71d23;color:#fff',
+    hasBaseUrl: false,
+  },
+  {
+    id: 'github',
+    label: 'GitHub',
+    desc: 'github.com',
+    logoText: '',
+    logoStyle: 'background:#1f2328;color:#fff',
+    hasBaseUrl: false,
+  },
+  {
+    id: 'gitlab',
+    label: 'GitLab',
+    desc: 'gitlab.com',
+    logoText: '',
+    logoStyle: 'background:#fc6d26;color:#fff',
+    hasBaseUrl: false,
+  },
+  {
+    id: 'custom',
+    label: '自建',
+    desc: '自托管 GitLab / Gitea 等',
+    logoText: '⚙',
+    logoStyle: 'background:var(--color-inset);color:var(--color-dim)',
+    hasBaseUrl: true,
+  },
+]
+
+// ─── toast ────────────────────────────────────────────────────────────────────
+
+const toast = useToast()
+
+// ─── load state ───────────────────────────────────────────────────────────────
+
+const loadState = ref<LoadState>('loading')
+const loadError = ref('')
+
+// ─── per-provider card state ──────────────────────────────────────────────────
+
+const cards = reactive<Record<OAuthProvider, CardState>>(
+  Object.fromEntries(
+    PROVIDERS.map((meta) => [
+      meta.id,
+      {
+        meta,
+        saved: null,
+        clientId: '',
+        clientSecret: '',
+        baseUrl: '',
+        enabled: false,
+        errors: { clientId: '', baseUrl: '' },
+        saving: false,
+      } satisfies CardState,
+    ]),
+  ) as Record<OAuthProvider, CardState>,
+)
+
+const cardList = PROVIDERS.map((m) => m.id)
+
+// ─── load ─────────────────────────────────────────────────────────────────────
+
+async function loadApps(): Promise<void> {
+  loadState.value = 'loading'
+  loadError.value = ''
+  try {
+    const apps = await getOAuthApps()
+    for (const app of apps) {
+      const card = cards[app.provider]
+      if (card) applyApp(card, app)
+    }
+    loadState.value = 'ready'
+  } catch (err) {
+    if (err instanceof HttpError) {
+      if (err.status === 0) {
+        loadError.value = '无法连接到服务器,请检查后端是否运行后重试'
+      } else if (err.apiError?.code === 'vault_unconfigured') {
+        loadError.value = '保险库未配置 master key,请设置 PIPEWRIGHT_MASTER_KEY 环境变量'
+      } else {
+        loadError.value = err.apiError?.message ?? `加载失败(${err.status})`
+      }
+    } else {
+      loadError.value = '加载 OAuth 应用失败,请稍后重试'
+    }
+    loadState.value = 'error'
+  }
+}
+
+function applyApp(card: CardState, app: OAuthApp): void {
+  card.saved = app
+  card.clientId = app.clientId
+  card.clientSecret = '' // never pre-fill the secret
+  card.baseUrl = app.baseUrl
+  card.enabled = app.enabled
+  card.errors = { clientId: '', baseUrl: '' }
+}
+
+onMounted(loadApps)
+
+// ─── save ─────────────────────────────────────────────────────────────────────
+
+async function handleSave(provider: OAuthProvider): Promise<void> {
+  const card = cards[provider]
+  card.errors = { clientId: '', baseUrl: '' }
+
+  // Client-side validation: an enabled provider must have a clientId, and a
+  // secret must exist (either already configured or freshly entered).
+  const clientId = card.clientId.trim()
+  const baseUrl = card.baseUrl.trim()
+  const hasExistingSecret = !!card.saved?.maskedSecret
+
+  if (card.enabled && !clientId) {
+    card.errors.clientId = '启用时 Client ID 必填'
+    return
+  }
+  if (card.enabled && !card.clientSecret && !hasExistingSecret) {
+    card.errors.clientId = card.errors.clientId || ''
+    toast.error('保存失败', { detail: '启用时需提供 Client Secret' })
+    return
+  }
+  if (card.meta.hasBaseUrl && card.enabled && !baseUrl) {
+    card.errors.baseUrl = '自建实例需填写 Base URL'
+    return
+  }
+
+  card.saving = true
+  try {
+    const payload: SaveOAuthAppInput = {
+      clientId,
+      ...(card.clientSecret ? { clientSecret: card.clientSecret } : {}),
+      ...(card.meta.hasBaseUrl ? { baseUrl } : {}),
+      enabled: card.enabled,
+    }
+    const updated = await saveOAuthApp(provider, payload)
+    applyApp(card, updated)
+    toast.success('OAuth 应用已保存', { detail: card.meta.label })
+  } catch (err) {
+    if (err instanceof HttpError) {
+      if (err.status === 422 && err.apiError) {
+        const code = err.apiError.code
+        if (code === 'client_id_required') {
+          card.errors.clientId = '请填写 Client ID'
+        } else if (code === 'base_url_required') {
+          card.errors.baseUrl = '请填写 Base URL'
+        } else {
+          toast.error('保存失败', { detail: err.apiError.message })
+        }
+        return
+      }
+      if (err.status === 0) {
+        toast.error('保存失败', { detail: '无法连接到服务器' })
+      } else {
+        toast.error('保存失败', { detail: err.apiError?.message ?? `HTTP ${err.status}` })
+      }
+    } else {
+      toast.error('保存失败', { detail: err instanceof Error ? err.message : '未知错误' })
+    }
+  } finally {
+    card.saving = false
+  }
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function relativeTime(iso: string | null): string {
+  if (!iso) return ''
+  const diff = Date.now() - new Date(iso).getTime()
+  const s = Math.floor(diff / 1000)
+  if (s < 60) return '刚刚'
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m} 分钟前`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h} 小时前`
+  return `${Math.floor(h / 24)} 天前`
+}
+</script>
+
+<template>
+  <div class="oauth-root">
+    <!-- ─── section header ──────────────────────────────────────────────────── -->
+    <div class="section-head">
+      <div class="section-head-text">
+        <h2 class="section-title">OAuth 应用</h2>
+        <p class="section-desc">
+          为每个 git 平台登记 OAuth 应用(Client ID / Secret),用户即可在凭据保险库一键「连接」账号自动换取令牌,无需手动粘贴 PAT。Secret 落库即掩码,写入后不可读出。
+        </p>
+      </div>
+    </div>
+
+    <!-- ─── load error ──────────────────────────────────────────────────────── -->
+    <div v-if="loadState === 'error'" class="banner banner--error" role="alert">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+        <circle cx="12" cy="12" r="9" /><path d="M12 8v4M12 16h.01" />
+      </svg>
+      <span>{{ loadError }}</span>
+      <button class="banner-retry" @click="loadApps">↻ 重试</button>
+    </div>
+
+    <!-- ─── loading skeleton ────────────────────────────────────────────────── -->
+    <template v-if="loadState === 'loading'">
+      <div v-for="i in 4" :key="i" class="panel panel--anim">
+        <div class="panel-head">
+          <span class="skel skel--text" style="width:120px" aria-hidden="true" />
+        </div>
+        <div class="panel-body">
+          <div class="skel skel--field" style="height:38px" aria-hidden="true" />
+          <div class="skel skel--field" style="height:38px;margin-top:14px" aria-hidden="true" />
+        </div>
+      </div>
+    </template>
+
+    <!-- ─── provider cards ──────────────────────────────────────────────────── -->
+    <template v-else-if="loadState === 'ready'">
+      <div
+        v-for="pid in cardList"
+        :key="pid"
+        class="panel panel--anim"
+        :data-provider="pid"
+      >
+        <div class="panel-head">
+          <div class="ph-logo" :style="cards[pid].meta.logoStyle" aria-hidden="true">
+            {{ cards[pid].meta.logoText }}
+          </div>
+          <span class="ph-label">{{ cards[pid].meta.label }}</span>
+          <span class="ph-desc">{{ cards[pid].meta.desc }}</span>
+
+          <span
+            v-if="cards[pid].saved?.configured"
+            class="status-chip"
+            :class="cards[pid].enabled ? 'status-chip--ok' : 'status-chip--idle'"
+          >
+            <span
+              class="status-dot"
+              :class="{ 'status-dot--ok': cards[pid].enabled }"
+              aria-hidden="true"
+            />
+            {{ cards[pid].enabled ? '已启用' : '已配置·未启用' }}
+          </span>
+          <span v-else class="status-chip status-chip--idle">
+            <span class="status-dot" aria-hidden="true" />
+            未配置
+          </span>
+        </div>
+
+        <div class="panel-body">
+          <form class="config-form" novalidate @submit.prevent="handleSave(pid)">
+            <!-- Client ID -->
+            <div class="field">
+              <label class="field-label" :for="`oauth-clientid-${pid}`">Client ID</label>
+              <input
+                :id="`oauth-clientid-${pid}`"
+                v-model="cards[pid].clientId"
+                type="text"
+                class="field-input field-input--mono"
+                :class="{ 'field-input--error': cards[pid].errors.clientId }"
+                placeholder="在 git 平台 OAuth 应用页获取"
+                autocomplete="off"
+                :aria-invalid="!!cards[pid].errors.clientId || undefined"
+                :disabled="cards[pid].saving"
+                @input="cards[pid].errors.clientId = ''"
+              />
+              <span v-if="cards[pid].errors.clientId" class="field-error" role="alert">
+                {{ cards[pid].errors.clientId }}
+              </span>
+            </div>
+
+            <!-- Client Secret — write-only -->
+            <div class="field">
+              <label class="field-label" :for="`oauth-secret-${pid}`">
+                Client Secret
+                <span class="field-optional">（写入后仅显示掩码）</span>
+              </label>
+              <input
+                :id="`oauth-secret-${pid}`"
+                v-model="cards[pid].clientSecret"
+                type="password"
+                class="field-input field-input--mono"
+                :placeholder="cards[pid].saved?.maskedSecret
+                  ? '留空保留已存 Secret'
+                  : '粘贴 Client Secret…'"
+                autocomplete="new-password"
+                :disabled="cards[pid].saving"
+              />
+              <span
+                v-if="cards[pid].saved?.maskedSecret && !cards[pid].clientSecret"
+                class="field-hint mono"
+              >已存:{{ cards[pid].saved?.maskedSecret }}</span>
+            </div>
+
+            <!-- Base URL — self-hosted only -->
+            <div v-if="cards[pid].meta.hasBaseUrl" class="field">
+              <label class="field-label" :for="`oauth-baseurl-${pid}`">Base URL</label>
+              <input
+                :id="`oauth-baseurl-${pid}`"
+                v-model="cards[pid].baseUrl"
+                type="url"
+                class="field-input field-input--mono"
+                :class="{ 'field-input--error': cards[pid].errors.baseUrl }"
+                placeholder="https://git.example.com"
+                autocomplete="off"
+                :aria-invalid="!!cards[pid].errors.baseUrl || undefined"
+                :disabled="cards[pid].saving"
+                @input="cards[pid].errors.baseUrl = ''"
+              />
+              <span v-if="cards[pid].errors.baseUrl" class="field-error" role="alert">
+                {{ cards[pid].errors.baseUrl }}
+              </span>
+            </div>
+
+            <!-- Enabled toggle + save -->
+            <div class="card-footer">
+              <div class="toggle-row">
+                <button
+                  type="button"
+                  class="toggle-track"
+                  :class="{ 'toggle-track--on': cards[pid].enabled }"
+                  role="switch"
+                  :aria-checked="cards[pid].enabled"
+                  :aria-label="`启用 ${cards[pid].meta.label} OAuth`"
+                  :disabled="cards[pid].saving"
+                  @click="cards[pid].enabled = !cards[pid].enabled"
+                >
+                  <span class="toggle-thumb" />
+                </button>
+                <div class="toggle-label">
+                  <strong>启用连接</strong>
+                  <span>启用后此平台的「连接」按钮出现在凭据保险库</span>
+                </div>
+              </div>
+
+              <div class="card-actions">
+                <span v-if="cards[pid].saved?.updatedAt" class="updated-note">
+                  上次保存 {{ relativeTime(cards[pid].saved?.updatedAt ?? null) }}
+                </span>
+                <AppButton
+                  variant="primary"
+                  type="submit"
+                  :loading="cards[pid].saving"
+                >
+                  保存
+                </AppButton>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+/* ─── layout ──────────────────────────────────────────────────────────────── */
+.oauth-root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--card-gap);
+}
+
+/* ─── section header ──────────────────────────────────────────────────────── */
+.section-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.section-head-text {
+  flex: 1;
+}
+
+.section-title {
+  font-size: 1.12rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--color-text);
+}
+
+.section-desc {
+  font-size: 0.82rem;
+  color: var(--color-faint);
+  margin-top: 4px;
+  max-width: 70ch;
+  line-height: 1.55;
+}
+
+/* ─── status chip ─────────────────────────────────────────────────────────── */
+.status-chip {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: var(--rounded-full);
+  font-size: 0.72rem;
+  font-weight: 600;
+  border: 1px solid;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.status-chip--ok {
+  background: var(--color-green-soft);
+  color: var(--color-green);
+  border-color: var(--color-green-line);
+}
+
+.status-chip--idle {
+  background: var(--color-inset);
+  color: var(--color-faint);
+  border-color: var(--color-border);
+}
+
+.status-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: var(--rounded-full);
+  background: var(--color-faint);
+  flex-shrink: 0;
+}
+
+.status-dot--ok {
+  background: var(--color-green);
+}
+
+/* ─── banner ──────────────────────────────────────────────────────────────── */
+.banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  padding: 11px 14px;
+  border-radius: var(--rounded);
+  font-size: 0.83rem;
+  line-height: 1.5;
+}
+
+.banner--error {
+  background: var(--color-red-soft);
+  border: 1px solid var(--color-red-line);
+  color: var(--color-red);
+}
+
+.banner-retry {
+  margin-left: auto;
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--color-red);
+  font-size: 0.83rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.banner-retry:hover { opacity: 0.8; }
+
+/* ─── panel ───────────────────────────────────────────────────────────────── */
+.panel {
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-card);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.panel--anim {
+  animation: panel-in 0.45s var(--ease-out-expo) both;
+}
+
+@keyframes panel-in {
+  from { opacity: 0; transform: translateY(13px); }
+  to   { opacity: 1; transform: none; }
+}
+
+.panel-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 13px 18px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.ph-logo {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--rounded-md);
+  display: grid;
+  place-items: center;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 0.86rem;
+  flex-shrink: 0;
+}
+
+.ph-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.ph-desc {
+  font-size: 0.74rem;
+  color: var(--color-faint);
+}
+
+.panel-body {
+  padding: 18px;
+}
+
+/* ─── skeleton ────────────────────────────────────────────────────────────── */
+.skel {
+  display: block;
+  background: linear-gradient(
+    90deg,
+    var(--color-inset) 0%,
+    oklch(100% 0 0 / 0.06) 50%,
+    var(--color-inset) 100%
+  );
+  background-size: 200% 100%;
+  border-radius: var(--rounded-md);
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+
+.skel--text { height: 14px; }
+.skel--field { width: 100%; }
+
+@keyframes shimmer {
+  0%   { background-position: 200% center; }
+  100% { background-position: -200% center; }
+}
+
+/* ─── config form ─────────────────────────────────────────────────────────── */
+.config-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field-label {
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--color-dim);
+}
+
+.field-optional {
+  font-weight: 400;
+  color: var(--color-faint);
+}
+
+.field-input {
+  width: 100%;
+  height: 38px;
+  background: var(--color-inset);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded);
+  padding: 0 12px;
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: 0.86rem;
+  transition:
+    border-color var(--duration-fast),
+    box-shadow var(--duration-fast);
+}
+
+.field-input--mono {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+}
+
+.field-input::placeholder {
+  color: var(--color-faint);
+}
+
+.field-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-soft);
+}
+
+.field-input--error {
+  border-color: var(--color-red) !important;
+}
+
+.field-input--error:focus {
+  box-shadow: 0 0 0 3px var(--color-red-soft) !important;
+}
+
+.field-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.field-error {
+  font-size: 0.76rem;
+  color: var(--color-red);
+  line-height: 1.4;
+}
+
+.field-hint {
+  font-size: 0.74rem;
+  color: var(--color-faint);
+  line-height: 1.4;
+}
+
+.mono {
+  font-family: var(--font-mono);
+  letter-spacing: 0.04em;
+  user-select: none;
+}
+
+/* ─── card footer ─────────────────────────────────────────────────────────── */
+.card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  border-top: 1px solid var(--color-border);
+  padding-top: 16px;
+}
+
+.card-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.updated-note {
+  font-size: 0.72rem;
+  color: var(--color-faint);
+}
+
+/* ─── toggle ──────────────────────────────────────────────────────────────── */
+.toggle-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+}
+
+.toggle-track {
+  position: relative;
+  width: 40px;
+  height: 22px;
+  border-radius: var(--rounded-full);
+  background: var(--color-border-strong);
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+  margin-top: 1px;
+  transition: background-color var(--duration-normal);
+}
+
+.toggle-track:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.toggle-track:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.toggle-track--on {
+  background: var(--color-primary);
+}
+
+.toggle-thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: var(--rounded-full);
+  background: #fff;
+  transition: transform var(--duration-normal) var(--ease-out-expo);
+  pointer-events: none;
+}
+
+.toggle-track--on .toggle-thumb {
+  transform: translateX(18px);
+}
+
+.toggle-label {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.toggle-label strong {
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.toggle-label span {
+  font-size: 0.74rem;
+  color: var(--color-faint);
+  line-height: 1.45;
+}
+
+/* ─── reduced motion ──────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+</style>

--- a/web/src/views/settings/SettingsVault.oauth.test.ts
+++ b/web/src/views/settings/SettingsVault.oauth.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import SettingsVault from './SettingsVault.vue'
+
+// ─── stub the OAuth-callback collaborators ───────────────────────────────────
+
+const listCredentials = vi.fn()
+vi.mock('../../api/credentials', () => ({
+  listCredentials: (...a: unknown[]) => listCredentials(...a),
+  createCredential: vi.fn(),
+  updateCredential: vi.fn(),
+  deleteCredential: vi.fn(),
+}))
+
+const getOAuthApps = vi.fn()
+vi.mock('../../api/oauth', async () => {
+  const actual = await vi.importActual<typeof import('../../api/oauth')>('../../api/oauth')
+  return { ...actual, getOAuthApps: (...a: unknown[]) => getOAuthApps(...a) }
+})
+
+const toastSuccess = vi.fn()
+const toastError = vi.fn()
+vi.mock('../../composables/useToast', () => ({
+  useToast: () => ({ success: toastSuccess, error: toastError }),
+}))
+
+// AuditTimeline pulls its own data — stub it out of this unit.
+vi.mock('../../components/AuditTimeline.vue', () => ({
+  default: { name: 'AuditTimeline', render: () => null },
+}))
+
+// vue-router: drive route.query and capture replace() calls.
+const routeQuery: { value: Record<string, string> } = { value: {} }
+const replace = vi.fn()
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ get query() { return routeQuery.value } }),
+  useRouter: () => ({ replace }),
+}))
+
+function mountVault() {
+  return mount(SettingsVault, {
+    global: { stubs: { Teleport: true, 'router-link': true } },
+  })
+}
+
+describe('SettingsVault — OAuth callback query handling', () => {
+  beforeEach(() => {
+    listCredentials.mockReset().mockResolvedValue([])
+    getOAuthApps.mockReset().mockResolvedValue([])
+    toastSuccess.mockReset()
+    toastError.mockReset()
+    replace.mockReset()
+    routeQuery.value = {}
+  })
+
+  it('shows a success toast and refreshes credentials on ?connected=&account=', async () => {
+    routeQuery.value = { connected: 'github', account: 'octocat' }
+    mountVault()
+    await flushPromises()
+
+    expect(toastSuccess).toHaveBeenCalledWith(
+      '已连接 GitHub(octocat)',
+      expect.objectContaining({ detail: expect.any(String) }),
+    )
+    // credentials loaded once on mount + once on callback refresh
+    expect(listCredentials).toHaveBeenCalledTimes(2)
+    // query is stripped so a refresh doesn't re-fire
+    expect(replace).toHaveBeenCalledWith({ query: {} })
+  })
+
+  it('falls back to provider-only message when account is absent', async () => {
+    routeQuery.value = { connected: 'gitee' }
+    mountVault()
+    await flushPromises()
+
+    expect(toastSuccess).toHaveBeenCalledWith(
+      '已连接 Gitee',
+      expect.any(Object),
+    )
+  })
+
+  it('shows an error toast on ?oauth_error= and clears the query', async () => {
+    routeQuery.value = { oauth_error: 'access_denied' }
+    mountVault()
+    await flushPromises()
+
+    expect(toastError).toHaveBeenCalledWith('连接失败', { detail: 'access_denied' })
+    expect(toastSuccess).not.toHaveBeenCalled()
+    expect(replace).toHaveBeenCalledWith({ query: {} })
+  })
+
+  it('does nothing (no toast) on a clean URL', async () => {
+    mountVault()
+    await flushPromises()
+
+    expect(toastSuccess).not.toHaveBeenCalled()
+    expect(toastError).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
+  })
+
+  it('preserves unrelated query params when clearing OAuth keys', async () => {
+    routeQuery.value = { connected: 'gitlab', account: 'me', tab: 'x' }
+    mountVault()
+    await flushPromises()
+
+    expect(replace).toHaveBeenCalledWith({ query: { tab: 'x' } })
+  })
+
+  it('renders connect buttons only for enabled & configured providers', async () => {
+    getOAuthApps.mockResolvedValue([
+      { provider: 'github', clientId: 'a', baseUrl: '', enabled: true, maskedSecret: 'm', configured: true, updatedAt: null },
+      { provider: 'gitee', clientId: 'b', baseUrl: '', enabled: false, maskedSecret: 'm', configured: true, updatedAt: null },
+      { provider: 'gitlab', clientId: '', baseUrl: '', enabled: true, maskedSecret: '', configured: false, updatedAt: null },
+    ])
+    const wrapper = mountVault()
+    await flushPromises()
+
+    const buttons = wrapper.findAll('.connect-btn')
+    expect(buttons).toHaveLength(1)
+    expect(buttons[0].text()).toContain('连接 GitHub')
+  })
+})

--- a/web/src/views/settings/SettingsVault.vue
+++ b/web/src/views/settings/SettingsVault.vue
@@ -9,6 +9,14 @@ import {
 import type { Credential, CredentialType, CreateCredentialInput, UpdateCredentialInput } from '../../api/credentials'
 import { HttpError } from '../../api/http'
 import AuditTimeline from '../../components/AuditTimeline.vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useToast } from '../../composables/useToast'
+import {
+  getOAuthApps,
+  authorizeUrl,
+  type OAuthApp,
+  type OAuthProvider,
+} from '../../api/oauth'
 
 // ─── state ──────────────────────────────────────────────────────────────────
 
@@ -51,6 +59,80 @@ const deleteBanner = ref('')
 // ─── copy feedback ──────────────────────────────────────────────────────────
 
 const copiedId = ref<string | null>(null)
+
+// ─── OAuth connect (enabled providers only) ──────────────────────────────────
+
+const toast = useToast()
+const route = useRoute()
+const router = useRouter()
+
+const oauthApps = ref<OAuthApp[]>([])
+
+const PROVIDER_LABELS: Record<OAuthProvider, string> = {
+  gitee: 'Gitee',
+  github: 'GitHub',
+  gitlab: 'GitLab',
+  custom: '自建',
+}
+
+const PROVIDER_LOGO: Record<OAuthProvider, { text: string; style: string }> = {
+  gitee: { text: 'G', style: 'background:#c71d23;color:#fff' },
+  github: { text: '', style: 'background:#1f2328;color:#fff' },
+  gitlab: { text: '', style: 'background:#fc6d26;color:#fff' },
+  custom: { text: '⚙', style: 'background:var(--color-inset);color:var(--color-dim)' },
+}
+
+const connectableProviders = computed(() =>
+  oauthApps.value.filter((a) => a.enabled && a.configured),
+)
+
+async function loadOAuthApps(): Promise<void> {
+  try {
+    oauthApps.value = await getOAuthApps()
+  } catch {
+    // Non-fatal: the connect section just stays empty if OAuth apps can't load.
+    oauthApps.value = []
+  }
+}
+
+/** Kick off the OAuth dance via a FULL-PAGE navigation (not fetch). */
+function connectProvider(provider: OAuthProvider): void {
+  window.location.href = authorizeUrl(provider)
+}
+
+/**
+ * Read OAuth callback result from the URL query:
+ *   ?connected={provider}&account={login}  → success toast + refresh
+ *   ?oauth_error={reason}                   → error toast
+ * The query is then stripped so a refresh doesn't re-fire the toast.
+ */
+function handleOAuthCallback(): void {
+  const connected = route.query.connected
+  const oauthError = route.query.oauth_error
+
+  if (typeof connected === 'string' && connected) {
+    const account = typeof route.query.account === 'string' ? route.query.account : ''
+    const label = PROVIDER_LABELS[connected as OAuthProvider] ?? connected
+    toast.success(
+      account ? `已连接 ${label}(${account})` : `已连接 ${label}`,
+      { detail: '凭据已自动写入保险库' },
+    )
+    void loadCredentials()
+    clearOAuthQuery()
+  } else if (typeof oauthError === 'string' && oauthError) {
+    toast.error('连接失败', { detail: oauthError })
+    clearOAuthQuery()
+  }
+}
+
+/** Remove OAuth-related query params, preserving any others. */
+function clearOAuthQuery(): void {
+  const query = { ...route.query }
+  delete query.connected
+  delete query.account
+  delete query.oauth_error
+  void router.replace({ query })
+}
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -109,7 +191,11 @@ async function loadCredentials(): Promise<void> {
   }
 }
 
-onMounted(loadCredentials)
+onMounted(() => {
+  void loadCredentials()
+  void loadOAuthApps()
+  handleOAuthCallback()
+})
 
 // ─── modal open / close ─────────────────────────────────────────────────────
 
@@ -289,6 +375,32 @@ async function copyReference(c: Credential): Promise<void> {
         </svg>
         添加凭据
       </button>
+    </div>
+
+    <!-- ─── OAuth connect (only for enabled & configured providers) ────────── -->
+    <div v-if="connectableProviders.length > 0" class="connect-panel">
+      <div class="connect-head">
+        <div class="connect-head-text">
+          <strong>连接 git 账号</strong>
+          <span>一键授权,自动写入凭据 —— 无需手动粘贴 PAT。</span>
+        </div>
+        <router-link to="/settings/oauth" class="connect-config-link">管理 OAuth 应用 →</router-link>
+      </div>
+      <div class="connect-grid">
+        <button
+          v-for="app in connectableProviders"
+          :key="app.provider"
+          type="button"
+          class="connect-btn"
+          :aria-label="`连接 ${PROVIDER_LABELS[app.provider]}`"
+          @click="connectProvider(app.provider)"
+        >
+          <span class="connect-logo" :style="PROVIDER_LOGO[app.provider].style" aria-hidden="true">
+            {{ PROVIDER_LOGO[app.provider].text }}
+          </span>
+          连接 {{ PROVIDER_LABELS[app.provider] }}
+        </button>
+      </div>
     </div>
 
     <!-- ─── load error banner ─────────────────────────────────────────────── -->
@@ -735,6 +847,105 @@ async function copyReference(c: Credential): Promise<void> {
   margin-top: 4px;
   max-width: 68ch;
   line-height: 1.55;
+}
+
+/* ─── OAuth connect panel ─────────────────────────────────────────────────── */
+.connect-panel {
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-card);
+  box-shadow: var(--shadow);
+  padding: 16px 18px;
+  animation: panel-in 0.45s var(--ease-out-expo) both;
+}
+
+.connect-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 13px;
+}
+
+.connect-head-text {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.connect-head-text strong {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.connect-head-text span {
+  font-size: 0.78rem;
+  color: var(--color-faint);
+  line-height: 1.5;
+}
+
+.connect-config-link {
+  flex-shrink: 0;
+  font-size: 0.76rem;
+  font-weight: 500;
+  color: var(--color-primary);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.connect-config-link:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.connect-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.connect-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 38px;
+  padding: 0 16px 0 8px;
+  background: var(--color-inset);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: 0.84rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast),
+    transform var(--duration-fast),
+    box-shadow var(--duration-fast);
+}
+
+.connect-btn:hover {
+  border-color: var(--color-faint);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow);
+}
+
+.connect-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.connect-logo {
+  width: 26px;
+  height: 26px;
+  border-radius: var(--rounded-md);
+  display: grid;
+  place-items: center;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 0.8rem;
+  flex-shrink: 0;
 }
 
 /* ─── panel ───────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
多 provider OAuth 凭据接入:页面点「连接」→ 跳授权 → 自动拿 token 存进 vault,不再手贴 PAT。后端 internal/oauth(provider 注册表 + 授权/换token/state CSRF + OAuth应用配置 vault加密)+ 端点;前端 设置→OAuth应用 配置 + 凭据库连接按钮 + callback 处理。后端 build/vet/test 绿,前端 typecheck/95测 绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)