### PR TITLE
fix(git): Gitee HTTPS 克隆用真实账号名作 BasicAuth 用户名

### DIFF
--- a/internal/ai/analyze.go
+++ b/internal/ai/analyze.go
@@ -26,8 +26,9 @@ import (
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/memfs"
 	gogit "github.com/go-git/go-git/v5"
-	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+
 	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/huangchengsir/pipewright/internal/gitauth"
 )
 
 // cloneTimeout 是单次浅克隆的硬超时(防黑洞 IP / 慢 DNS 把 goroutine 挂死)。
@@ -106,7 +107,7 @@ func (a goGitAnalyzer) Analyze(ctx context.Context, repoURL, token string) RepoA
 	fs := memfs.New()
 	storer := memory.NewStorage()
 
-	auth := &githttp.BasicAuth{Username: "git", Password: token}
+	auth := gitauth.BasicAuth(repoURL, token)
 
 	cctx, cancel := context.WithTimeout(ctx, cloneTimeout)
 	defer cancel()

--- a/internal/ai/diff.go
+++ b/internal/ai/diff.go
@@ -28,8 +28,9 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	fdiff "github.com/go-git/go-git/v5/plumbing/format/diff"
 	"github.com/go-git/go-git/v5/plumbing/object"
-	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+
 	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/huangchengsir/pipewright/internal/gitauth"
 )
 
 // diffCloneTimeout 是单次克隆的硬超时(防黑洞 IP / 慢 DNS 把 goroutine 挂死)。
@@ -125,7 +126,7 @@ func (d goGitDiffer) Diff(ctx context.Context, repoURL, token, baselineCommit, c
 	// 克隆到内存(不设 Depth:浅克隆 HEAD 取不到任意历史 commit;此处需两个具体 commit 的 tree,
 	// 故取全量历史。内存 storer 限驻留,用完即随 GC 释放)。
 	storer := memory.NewStorage()
-	auth := &githttp.BasicAuth{Username: "git", Password: token}
+	auth := gitauth.BasicAuth(repoURL, token)
 	repo, err := gogit.CloneContext(cctx, storer, memfs.New(), &gogit.CloneOptions{
 		URL:  repoURL,
 		Auth: auth,

--- a/internal/build/cloner.go
+++ b/internal/build/cloner.go
@@ -11,7 +11,8 @@ import (
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
-	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+
+	"github.com/huangchengsir/pipewright/internal/gitauth"
 )
 
 // cloneTimeout 是单次克隆的硬超时(防黑洞 IP / 慢 DNS 把构建 goroutine 挂死)。
@@ -62,7 +63,7 @@ func (c *Cloner) Clone(ctx context.Context, repoURL, token, branch, commit, dest
 	cctx, cancel := context.WithTimeout(ctx, cloneTimeout)
 	defer cancel()
 
-	auth := &githttp.BasicAuth{Username: "git", Password: token}
+	auth := gitauth.BasicAuth(repoURL, token)
 	commit = strings.TrimSpace(commit)
 	branch = strings.TrimSpace(branch)
 

--- a/internal/gitauth/gitauth.go
+++ b/internal/gitauth/gitauth.go
@@ -1,0 +1,67 @@
+// Package gitauth centralizes how an HTTPS git token is turned into BasicAuth
+// credentials for clone / ls-remote across the codebase (source reader, project
+// prober, build cloner, AI diff/analyze).
+//
+// 背景:不同平台对「token 经 HTTPS BasicAuth」的用户名要求不同:
+//   - GitHub / GitLab / 自建 Gitea 等:用户名任意非空,密码=token(历史上本项目
+//     一律写死 Username="git",对这些平台没问题)。
+//   - **Gitee**:个人访问令牌走 HTTPS 时,用户名必须是「真实账号用户名」,密码=token;
+//     用 "git" 当用户名会被拒(表现为「凭据错误 / 认证失败」)。这正是用户真实
+//     Gitee 令牌克隆失败的根因。
+//
+// 因此本包按仓库 URL 的 host 决定用户名:仅对 gitee.com(及其子域)取 URL 路径里的
+// owner 段当用户名(个人仓库场景 owner==账号名,正确);其余 host 一律保持 "git"
+// (与历史行为完全一致,绝不回归 GitHub/GitLab)。
+//
+// 安全:token 仅作为 BasicAuth.Password,绝不拼进 URL / 日志 / 错误。
+package gitauth
+
+import (
+	"net/url"
+	"strings"
+
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+)
+
+// defaultUsername 是非 Gitee 平台沿用的 BasicAuth 用户名(任意非空即可)。
+const defaultUsername = "git"
+
+// BasicAuth 依据 repoURL 选择合适的 BasicAuth 用户名,密码恒为 token。
+// token 为空时仍返回非 nil（go-git 对匿名公开仓亦可,鉴权失败再由调用方映射干净错误)。
+func BasicAuth(repoURL, token string) *githttp.BasicAuth {
+	return &githttp.BasicAuth{Username: Username(repoURL), Password: token}
+}
+
+// Username 返回该 repoURL 应使用的 BasicAuth 用户名。
+//   - gitee.com / *.gitee.com:取 URL 路径第一段(owner)作用户名;取不到则回退 "git"。
+//   - 其余 host:恒为 "git"(历史行为,不回归)。
+//
+// 解析失败 / 无 host 时回退 "git",绝不 panic。
+func Username(repoURL string) string {
+	u, err := url.Parse(strings.TrimSpace(repoURL))
+	if err != nil {
+		return defaultUsername
+	}
+	host := strings.ToLower(u.Hostname()) // Hostname() 自动剥离端口与用户信息
+	if host == "" {
+		return defaultUsername
+	}
+	if host == "gitee.com" || strings.HasSuffix(host, ".gitee.com") {
+		if owner := firstPathSegment(u.Path); owner != "" {
+			return owner
+		}
+	}
+	return defaultUsername
+}
+
+// firstPathSegment 取 URL path 的第一段(owner)。"/cool-jiawei/aireboot.git" → "cool-jiawei"。
+func firstPathSegment(p string) string {
+	p = strings.TrimLeft(p, "/")
+	if p == "" {
+		return ""
+	}
+	if i := strings.IndexByte(p, '/'); i >= 0 {
+		p = p[:i]
+	}
+	return strings.TrimSpace(p)
+}

--- a/internal/gitauth/gitauth_test.go
+++ b/internal/gitauth/gitauth_test.go
@@ -1,0 +1,44 @@
+package gitauth
+
+import "testing"
+
+func TestUsername(t *testing.T) {
+	cases := []struct {
+		name    string
+		repoURL string
+		want    string
+	}{
+		// Gitee:取 owner 段当用户名(用户的真实仓库场景)
+		{"gitee personal repo", "https://gitee.com/cool-jiawei/aireboot.git", "cool-jiawei"},
+		{"gitee no .git suffix", "https://gitee.com/cool-jiawei/aireboot", "cool-jiawei"},
+		{"gitee with port", "https://gitee.com:443/octo/app.git", "octo"},
+		{"gitee subdomain", "https://api.gitee.com/octo/app.git", "octo"},
+		{"gitee with creds in url", "https://u:p@gitee.com/octo/app.git", "octo"},
+		// 非 Gitee:沿用 "git"(不回归)
+		{"github", "https://github.com/octo/app.git", "git"},
+		{"gitlab", "https://gitlab.com/octo/app.git", "git"},
+		{"self-hosted", "https://git.example.com/octo/app.git", "git"},
+		// 退化:仍回退 "git",不 panic
+		{"empty", "", "git"},
+		{"garbage", "::::not a url", "git"},
+		{"gitee no path", "https://gitee.com", "git"},
+		{"gitee root slash", "https://gitee.com/", "git"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Username(c.repoURL); got != c.want {
+				t.Errorf("Username(%q) = %q, want %q", c.repoURL, got, c.want)
+			}
+		})
+	}
+}
+
+func TestBasicAuthCarriesToken(t *testing.T) {
+	auth := BasicAuth("https://gitee.com/cool-jiawei/aireboot.git", "tok123")
+	if auth.Username != "cool-jiawei" {
+		t.Errorf("username = %q, want cool-jiawei", auth.Username)
+	}
+	if auth.Password != "tok123" {
+		t.Errorf("password not carried through")
+	}
+}

--- a/internal/httpapi/source.go
+++ b/internal/httpapi/source.go
@@ -18,8 +18,9 @@ import (
 	"github.com/go-git/go-billy/v5/memfs"
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
-	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+
 	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/huangchengsir/pipewright/internal/gitauth"
 	"github.com/huangchengsir/pipewright/internal/project"
 	"github.com/huangchengsir/pipewright/internal/vault"
 )
@@ -105,7 +106,7 @@ func (g goGitSourceReader) cloneWorktree(ctx context.Context, repoURL, token, re
 
 	fs := memfs.New()
 	storer := memory.NewStorage()
-	auth := &githttp.BasicAuth{Username: "git", Password: token}
+	auth := gitauth.BasicAuth(repoURL, token)
 
 	cctx, cancel := context.WithTimeout(ctx, sourceCloneTimeout)
 	defer cancel()

--- a/internal/project/prober.go
+++ b/internal/project/prober.go
@@ -10,8 +10,9 @@ import (
 
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport"
-	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+
 	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/huangchengsir/pipewright/internal/gitauth"
 
 	gogit "github.com/go-git/go-git/v5"
 	gogitconfig "github.com/go-git/go-git/v5/config"
@@ -54,8 +55,8 @@ func (p goGitProber) Probe(ctx context.Context, repoURL, token string) (string, 
 		URLs: []string{repoURL},
 	})
 
-	// Gitee/GitHub 等 HTTPS token 鉴权:用户名任意非空,密码=token。
-	auth := &githttp.BasicAuth{Username: "git", Password: token}
+	// HTTPS token 鉴权:用户名按平台选取(Gitee 须真实账号名,其余 "git"),密码=token。见 gitauth 包。
+	auth := gitauth.BasicAuth(repoURL, token)
 
 	// 硬超时:防黑洞 IP/慢 DNS 把请求 goroutine 挂死。
 	cctx, cancel := context.WithTimeout(ctx, probeTimeout)


### PR DESCRIPTION
修复 Gitee 真实令牌克隆「凭据错误」:5 处克隆点写死用户名 "git",Gitee 要真实账号名。新增 internal/gitauth 按 host 推导(gitee 取 owner 段,其余仍 git,不回归 GitHub/GitLab)。**真令牌实测**:git→FAIL「The token username invalid」/cool-jiawei→OK main(HEAD)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)