### PR TITLE
feat(cron): 8-6 定时(cron)触发 — 调度器 + 项目配置 + API

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/auth"
 	"github.com/huangchengsir/pipewright/internal/build"
 	"github.com/huangchengsir/pipewright/internal/config"
+	"github.com/huangchengsir/pipewright/internal/cron"
 	"github.com/huangchengsir/pipewright/internal/deploy"
 	"github.com/huangchengsir/pipewright/internal/httpapi"
 	"github.com/huangchengsir/pipewright/internal/mask"
@@ -96,6 +97,10 @@ func main() {
 	// 装配构建/部署配置服务(Story 2.4):独立于 2-2 spec;经 vault 校验 secret 引用存在性 +
 	// 回算掩码。master key 未配置时,涉及 secret 引用的保存降级为明确错误(不 panic)。
 	pipelineSettingsSvc := pipeline.NewSettingsService(st.DB, credVault)
+
+	// 装配定时(cron)触发配置服务(Story 8-6):每项目一份 cron 表达式 + 分支 + 启用开关。
+	// 调度器(下方,pool 后)按启用配置分钟粒度扫描、到点经 run.Service 创建「定时」触发的运行。
+	cronSvc := cron.NewService(st.DB)
 
 	// 装配运行服务(Story 3.1):本期桩 runner 跑占位步骤打通状态机;真实构建/部署=3-3/4-x。
 	// worker pool 在 aiSvc 装配后创建(以便注入 best-effort 自动诊断钩子,Story 7.2)。
@@ -172,6 +177,13 @@ func main() {
 	pool.Start()
 	log.Printf("[run] worker pool started")
 
+	// 装配并启动定时(cron)调度器(Story 8-6):分钟粒度扫描启用的项目 cron,到点经 run.Service
+	// 创建「定时」触发的运行(入 pool 调度)。同一项目同一分钟去重;表达式非法的项目跳过。
+	// 无启用配置时空转无副作用。优雅停机随 worker pool 停。
+	cronScheduler := cron.NewScheduler(cronSvc, httpapi.NewScheduledRunCreator(runSvc))
+	cronScheduler.Start(context.Background())
+	log.Printf("[cron] 定时调度器已启动")
+
 	// 装配只读源码读取器(Story 3.6;FR-4 预埋):go-git 浅克隆读 tree/blob;严格 SSRF 收口;
 	// 克隆失败优雅降级(不致命)。无 init 副作用/不驻留。
 	sourceReader := httpapi.NewSourceReader()
@@ -203,7 +215,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithServers(targetSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc)),
+		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithServers(targetSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc)),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		// WriteTimeout 置 0:SSE 长连接(/api/runs/{id}/events)不可被写超时切断;
@@ -232,6 +244,7 @@ func main() {
 		log.Printf("graceful shutdown failed: %v", err)
 	}
 	// HTTP 停机后停 worker pool:取消在途运行执行,等 worker 退出(随 shutdownCtx 超时)。
+	cronScheduler.Stop()
 	pool.Stop(shutdownCtx)
 	log.Printf("[run] worker pool stopped")
 }

--- a/internal/cron/parser.go
+++ b/internal/cron/parser.go
@@ -1,0 +1,204 @@
+// Package cron 是定时触发的最小实现(Epic 8 · Story 8-6):一个 5 字段 cron 解析器 +
+// 分钟粒度调度器,无第三方依赖(项目刻意保持依赖精简)。
+//
+// 字段(标准 Vixie cron):分 时 日 月 周。
+//
+//	┌───────── 分钟 minute (0-59)
+//	│ ┌─────── 小时 hour   (0-23)
+//	│ │ ┌───── 日   dom    (1-31)
+//	│ │ │ ┌─── 月   month  (1-12)
+//	│ │ │ │ ┌─ 周   dow    (0-6;0=周日,7 亦为周日)
+//	* * * * *
+//
+// 每字段支持:`*`、单值 `n`、范围 `a-b`、步进 `*/n` 或 `a-b/n`、逗号列表 `a,b,c`。
+// 日(dom)与周(dow)同时被限定(均非 `*`)时按「或」匹配(Vixie 经典语义)。
+package cron
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// field 是一个解析后的 cron 字段:allowed 为命中值集合;restricted 表示该字段非 `*`。
+type field struct {
+	allowed    map[int]bool
+	restricted bool
+}
+
+func (f field) match(v int) bool { return f.allowed[v] }
+
+// Schedule 是解析后的 cron 计划(5 字段)。
+type Schedule struct {
+	minute field
+	hour   field
+	dom    field
+	month  field
+	dow    field
+}
+
+const (
+	minMinute, maxMinute = 0, 59
+	minHour, maxHour     = 0, 23
+	minDom, maxDom       = 1, 31
+	minMonth, maxMonth   = 1, 12
+	minDow, maxDow       = 0, 6
+)
+
+// Parse 解析一个 5 字段 cron 表达式。多余空白容忍;字段数不为 5 → 错误。
+func Parse(expr string) (*Schedule, error) {
+	parts := strings.Fields(strings.TrimSpace(expr))
+	if len(parts) != 5 {
+		return nil, fmt.Errorf("cron: 表达式须为 5 个字段(分 时 日 月 周),实际 %d 个", len(parts))
+	}
+	minute, err := parseField(parts[0], minMinute, maxMinute, "minute")
+	if err != nil {
+		return nil, err
+	}
+	hour, err := parseField(parts[1], minHour, maxHour, "hour")
+	if err != nil {
+		return nil, err
+	}
+	dom, err := parseField(parts[2], minDom, maxDom, "day-of-month")
+	if err != nil {
+		return nil, err
+	}
+	month, err := parseField(parts[3], minMonth, maxMonth, "month")
+	if err != nil {
+		return nil, err
+	}
+	dow, err := parseDow(parts[4])
+	if err != nil {
+		return nil, err
+	}
+	return &Schedule{minute: minute, hour: hour, dom: dom, month: month, dow: dow}, nil
+}
+
+// Valid 是「仅校验」便捷封装。
+func Valid(expr string) error {
+	_, err := Parse(expr)
+	return err
+}
+
+// parseField 解析单字段为 [min,max] 内的命中集合(支持 *、n、a-b、*/n、a-b/n、逗号列表)。
+func parseField(spec string, min, max int, name string) (field, error) {
+	f := field{allowed: make(map[int]bool)}
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return f, fmt.Errorf("cron: %s 字段为空", name)
+	}
+	if spec == "*" {
+		for v := min; v <= max; v++ {
+			f.allowed[v] = true
+		}
+		return f, nil // restricted=false
+	}
+	f.restricted = true
+	for _, term := range strings.Split(spec, ",") {
+		if err := parseTerm(term, min, max, name, f.allowed); err != nil {
+			return field{}, err
+		}
+	}
+	return f, nil
+}
+
+// parseTerm 解析单个项(`*`、`n`、`a-b`、`*/n`、`a-b/n`),写入 allowed。
+func parseTerm(term string, min, max int, name string, allowed map[int]bool) error {
+	term = strings.TrimSpace(term)
+	if term == "" {
+		return fmt.Errorf("cron: %s 字段含空项", name)
+	}
+
+	rangePart := term
+	step := 1
+	if slash := strings.IndexByte(term, '/'); slash >= 0 {
+		rangePart = term[:slash]
+		s, err := strconv.Atoi(strings.TrimSpace(term[slash+1:]))
+		if err != nil || s <= 0 {
+			return fmt.Errorf("cron: %s 字段步进非法 %q", name, term)
+		}
+		step = s
+	}
+
+	lo, hi := min, max
+	switch {
+	case rangePart == "*":
+		// 全域 + 步进
+	case strings.ContainsRune(rangePart, '-'):
+		bounds := strings.SplitN(rangePart, "-", 2)
+		a, err1 := strconv.Atoi(strings.TrimSpace(bounds[0]))
+		b, err2 := strconv.Atoi(strings.TrimSpace(bounds[1]))
+		if err1 != nil || err2 != nil {
+			return fmt.Errorf("cron: %s 字段范围非法 %q", name, term)
+		}
+		lo, hi = a, b
+	default:
+		v, err := strconv.Atoi(rangePart)
+		if err != nil {
+			return fmt.Errorf("cron: %s 字段值非法 %q", name, term)
+		}
+		lo, hi = v, v
+	}
+
+	if lo < min || hi > max || lo > hi {
+		return fmt.Errorf("cron: %s 字段越界 %q(允许 %d-%d)", name, term, min, max)
+	}
+	for v := lo; v <= hi; v += step {
+		allowed[v] = true
+	}
+	return nil
+}
+
+// parseDow 解析周字段:7 归一为 0(周日)。
+func parseDow(spec string) (field, error) {
+	spec = strings.TrimSpace(spec)
+	// 允许 0-7 输入,内部 7→0;先按 0-7 解析再归一。
+	raw, err := parseField(spec, 0, 7, "day-of-week")
+	if err != nil {
+		return field{}, err
+	}
+	out := field{allowed: make(map[int]bool), restricted: raw.restricted}
+	for v := range raw.allowed {
+		if v == 7 {
+			v = 0
+		}
+		out.allowed[v] = true
+	}
+	return out, nil
+}
+
+// Matches 报告时刻 t(取分钟精度)是否命中本计划。
+// 日/周同时被限定时按「或」匹配(Vixie 经典语义);否则用被限定者(或全放行)。
+func (s *Schedule) Matches(t time.Time) bool {
+	if !s.minute.match(t.Minute()) || !s.hour.match(t.Hour()) || !s.month.match(int(t.Month())) {
+		return false
+	}
+	domHit := s.dom.match(t.Day())
+	dowHit := s.dow.match(int(t.Weekday())) // time.Weekday: 0=Sunday
+	switch {
+	case s.dom.restricted && s.dow.restricted:
+		return domHit || dowHit
+	case s.dom.restricted:
+		return domHit
+	case s.dow.restricted:
+		return dowHit
+	default:
+		return true // 日、周皆 *
+	}
+}
+
+// Next 返回严格晚于 after 的下一个命中时刻(分钟精度;同一时区)。
+// 一年内无命中(如不存在的日期组合)→ 返回零值 time.Time。
+func (s *Schedule) Next(after time.Time) time.Time {
+	// 进位到下一整分钟。
+	t := after.Truncate(time.Minute).Add(time.Minute)
+	limit := t.Add(366 * 24 * time.Hour)
+	for t.Before(limit) {
+		if s.Matches(t) {
+			return t
+		}
+		t = t.Add(time.Minute)
+	}
+	return time.Time{}
+}

--- a/internal/cron/parser_test.go
+++ b/internal/cron/parser_test.go
@@ -1,0 +1,120 @@
+package cron
+
+import (
+	"testing"
+	"time"
+)
+
+func mustParse(t *testing.T, expr string) *Schedule {
+	t.Helper()
+	s, err := Parse(expr)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", expr, err)
+	}
+	return s
+}
+
+// 固定时区(UTC)便于断言。
+func at(y int, mo time.Month, d, h, mi int) time.Time {
+	return time.Date(y, mo, d, h, mi, 0, 0, time.UTC)
+}
+
+func TestParseErrors(t *testing.T) {
+	bad := []string{
+		"",            // 空
+		"* * * *",     // 4 字段
+		"* * * * * *", // 6 字段
+		"60 * * * *",  // 分越界
+		"* 24 * * *",  // 时越界
+		"* * 0 * *",   // 日越界(下限 1)
+		"* * * 13 *",  // 月越界
+		"* * * * 8",   // 周越界(上限 7)
+		"a * * * *",   // 非数字
+		"5-2 * * * *", // 逆范围
+		"*/0 * * * *", // 步进 0
+	}
+	for _, expr := range bad {
+		if err := Valid(expr); err == nil {
+			t.Errorf("Valid(%q) = nil, 期望错误", expr)
+		}
+	}
+}
+
+func TestMatchesBasic(t *testing.T) {
+	// 每天 02:30
+	s := mustParse(t, "30 2 * * *")
+	if !s.Matches(at(2026, 5, 31, 2, 30)) {
+		t.Error("应命中 02:30")
+	}
+	if s.Matches(at(2026, 5, 31, 2, 31)) {
+		t.Error("不应命中 02:31")
+	}
+	if s.Matches(at(2026, 5, 31, 3, 30)) {
+		t.Error("不应命中 03:30")
+	}
+}
+
+func TestMatchesStepAndList(t *testing.T) {
+	// 每 15 分钟
+	s := mustParse(t, "*/15 * * * *")
+	for _, m := range []int{0, 15, 30, 45} {
+		if !s.Matches(at(2026, 5, 31, 10, m)) {
+			t.Errorf("*/15 应命中分钟 %d", m)
+		}
+	}
+	if s.Matches(at(2026, 5, 31, 10, 7)) {
+		t.Error("*/15 不应命中分钟 7")
+	}
+	// 列表
+	l := mustParse(t, "0,30 9-17 * * *")
+	if !l.Matches(at(2026, 5, 31, 9, 0)) || !l.Matches(at(2026, 5, 31, 17, 30)) {
+		t.Error("列表/范围应命中工作时间整点/半点")
+	}
+	if l.Matches(at(2026, 5, 31, 18, 0)) {
+		t.Error("不应命中 18:00")
+	}
+}
+
+func TestDowSunday7And0(t *testing.T) {
+	// 2026-05-31 是周日。
+	sun := at(2026, 5, 31, 0, 0)
+	if sun.Weekday() != time.Sunday {
+		t.Fatalf("测试前提错误:2026-05-31 应为周日,实际 %v", sun.Weekday())
+	}
+	for _, expr := range []string{"0 0 * * 0", "0 0 * * 7"} {
+		if !mustParse(t, expr).Matches(sun) {
+			t.Errorf("%q 应命中周日", expr)
+		}
+	}
+	if mustParse(t, "0 0 * * 1").Matches(sun) {
+		t.Error("周一表达式不应命中周日")
+	}
+}
+
+func TestDomDowOrSemantics(t *testing.T) {
+	// 日=1 或 周=一(均限定 → 或)。2026-06-01 是周一且是 1 号。
+	s := mustParse(t, "0 0 1 * 1")
+	if !s.Matches(at(2026, 6, 15, 0, 0)) { // 6-15 周一 → dow 命中
+		t.Error("周一应命中(或语义)")
+	}
+	if !s.Matches(at(2026, 7, 1, 0, 0)) { // 7-1 周三 → dom 命中
+		t.Error("1 号应命中(或语义)")
+	}
+	if s.Matches(at(2026, 6, 16, 0, 0)) { // 周二且非 1 号
+		t.Error("既非 1 号又非周一不应命中")
+	}
+}
+
+func TestNext(t *testing.T) {
+	s := mustParse(t, "0 3 * * *") // 每天 03:00
+	next := s.Next(at(2026, 5, 31, 4, 0))
+	want := at(2026, 6, 1, 3, 0)
+	if !next.Equal(want) {
+		t.Errorf("Next = %v, 期望 %v", next, want)
+	}
+	// 严格晚于:正好在命中分钟时,返回下一次。
+	n2 := s.Next(at(2026, 5, 31, 3, 0))
+	if !n2.Equal(at(2026, 6, 1, 3, 0)) {
+		t.Errorf("Next 应严格晚于 after,得 %v", n2)
+	}
+}

--- a/internal/cron/scheduler.go
+++ b/internal/cron/scheduler.go
@@ -1,0 +1,144 @@
+package cron
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+)
+
+// Clock 抽象当前时间(便于注入测试)。
+type Clock interface{ Now() time.Time }
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+// Entry 是一条启用的项目定时配置。
+type Entry struct {
+	ProjectID  string
+	Expression string
+	Branch     string
+}
+
+// Store 列出当前启用的定时配置(由持久层实现)。
+type Store interface {
+	ListEnabled(ctx context.Context) ([]Entry, error)
+}
+
+// Runner 为某项目创建一次「定时触发」的运行,返回 runID。
+// 由 run.Service 在 main 装配时适配(cron 包不 import run,避免耦合)。
+type Runner interface {
+	CreateScheduledRun(ctx context.Context, projectID, branch string) (runID string, err error)
+}
+
+// Scheduler 是分钟粒度的定时调度器:每分钟取启用配置,匹配当前分钟的逐个创建运行。
+// 同一分钟内对同一项目只触发一次(去重),避免重复运行(防滥用:最小粒度=1 分钟)。
+type Scheduler struct {
+	store  Store
+	runner Runner
+	clock  Clock
+
+	mu        sync.Mutex
+	lastFired map[string]string // projectID → 已触发的分钟键 "2006-01-02T15:04"
+
+	stop chan struct{}
+	wg   sync.WaitGroup
+}
+
+// Option 配置 Scheduler。
+type Option func(*Scheduler)
+
+// WithClock 注入时钟(测试用;缺省真实时钟)。
+func WithClock(c Clock) Option {
+	return func(s *Scheduler) {
+		if c != nil {
+			s.clock = c
+		}
+	}
+}
+
+// NewScheduler 构造调度器(未 Start 时不起任何 goroutine,不驻留)。
+func NewScheduler(store Store, runner Runner, opts ...Option) *Scheduler {
+	s := &Scheduler{
+		store:     store,
+		runner:    runner,
+		clock:     realClock{},
+		lastFired: make(map[string]string),
+		stop:      make(chan struct{}),
+	}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
+}
+
+// Tick 评估一个分钟时刻:对所有启用且命中的配置创建运行(每项目每分钟至多一次)。
+// 表达式非法的配置跳过(记日志,不阻断其它)。本方法与真实定时解耦,便于注入时钟单测。
+func (s *Scheduler) Tick(ctx context.Context, now time.Time) {
+	entries, err := s.store.ListEnabled(ctx)
+	if err != nil {
+		log.Printf("[cron] 列举启用配置失败:%v", err)
+		return
+	}
+	minuteKey := now.Format("2006-01-02T15:04")
+	for _, e := range entries {
+		sched, perr := Parse(e.Expression)
+		if perr != nil {
+			log.Printf("[cron] 项目 %s 表达式非法,跳过:%v", e.ProjectID, perr)
+			continue
+		}
+		if !sched.Matches(now) {
+			continue
+		}
+		// 去重:同一项目同一分钟只触发一次。
+		s.mu.Lock()
+		dup := s.lastFired[e.ProjectID] == minuteKey
+		if !dup {
+			s.lastFired[e.ProjectID] = minuteKey
+		}
+		s.mu.Unlock()
+		if dup {
+			continue
+		}
+		if _, rerr := s.runner.CreateScheduledRun(ctx, e.ProjectID, e.Branch); rerr != nil {
+			log.Printf("[cron] 项目 %s 定时触发创建运行失败:%v", e.ProjectID, rerr)
+		} else {
+			log.Printf("[cron] 项目 %s 定时触发(%s @ %s)", e.ProjectID, e.Expression, minuteKey)
+		}
+	}
+}
+
+// Start 启动后台调度 goroutine:对齐到每个整分钟边界后 Tick 一次。Stop / ctx 取消时退出。
+func (s *Scheduler) Start(ctx context.Context) {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		for {
+			now := s.clock.Now()
+			next := now.Truncate(time.Minute).Add(time.Minute)
+			timer := time.NewTimer(next.Sub(now))
+			select {
+			case <-s.stop:
+				timer.Stop()
+				return
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+				s.Tick(ctx, s.clock.Now())
+			}
+		}
+	}()
+}
+
+// Stop 停止调度 goroutine(幂等)并等待退出。
+func (s *Scheduler) Stop() {
+	select {
+	case <-s.stop:
+		// 已关闭
+	default:
+		close(s.stop)
+	}
+	s.wg.Wait()
+}

--- a/internal/cron/scheduler_test.go
+++ b/internal/cron/scheduler_test.go
@@ -1,0 +1,104 @@
+package cron
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeStore struct {
+	entries []Entry
+	err     error
+}
+
+func (f fakeStore) ListEnabled(context.Context) ([]Entry, error) { return f.entries, f.err }
+
+type fakeRunner struct {
+	mu    sync.Mutex
+	calls []Entry // 记录 (projectID, branch)
+	err   error
+}
+
+func (r *fakeRunner) CreateScheduledRun(_ context.Context, projectID, branch string) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, Entry{ProjectID: projectID, Branch: branch})
+	return "run-" + projectID, r.err
+}
+
+func (r *fakeRunner) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.calls)
+}
+
+func TestTickFiresOnMatch(t *testing.T) {
+	store := fakeStore{entries: []Entry{
+		{ProjectID: "p1", Expression: "30 2 * * *", Branch: "main"},
+		{ProjectID: "p2", Expression: "0 9 * * *", Branch: "release"}, // 不命中 02:30
+	}}
+	runner := &fakeRunner{}
+	s := NewScheduler(store, runner)
+
+	now := time.Date(2026, 5, 31, 2, 30, 0, 0, time.UTC)
+	s.Tick(context.Background(), now)
+
+	if runner.count() != 1 {
+		t.Fatalf("应仅 p1 触发,实际 %d 次", runner.count())
+	}
+	if runner.calls[0].ProjectID != "p1" || runner.calls[0].Branch != "main" {
+		t.Errorf("触发参数不符:%+v", runner.calls[0])
+	}
+}
+
+func TestTickDedupSameMinute(t *testing.T) {
+	store := fakeStore{entries: []Entry{{ProjectID: "p1", Expression: "*/1 * * * *", Branch: "main"}}}
+	runner := &fakeRunner{}
+	s := NewScheduler(store, runner)
+
+	now := time.Date(2026, 5, 31, 2, 30, 0, 0, time.UTC)
+	s.Tick(context.Background(), now)
+	s.Tick(context.Background(), now) // 同一分钟再次 → 去重
+	if runner.count() != 1 {
+		t.Fatalf("同一分钟应只触发一次,实际 %d", runner.count())
+	}
+	// 下一分钟应再次触发。
+	s.Tick(context.Background(), now.Add(time.Minute))
+	if runner.count() != 2 {
+		t.Fatalf("下一分钟应再触发,实际 %d", runner.count())
+	}
+}
+
+func TestTickSkipsInvalidExpression(t *testing.T) {
+	store := fakeStore{entries: []Entry{
+		{ProjectID: "bad", Expression: "not a cron", Branch: "main"},
+		{ProjectID: "ok", Expression: "*/1 * * * *", Branch: "main"},
+	}}
+	runner := &fakeRunner{}
+	s := NewScheduler(store, runner)
+	s.Tick(context.Background(), time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC))
+	if runner.count() != 1 || runner.calls[0].ProjectID != "ok" {
+		t.Errorf("非法表达式应跳过、合法的照常触发;calls=%+v", runner.calls)
+	}
+}
+
+func TestTickRunnerErrorDoesNotPanic(t *testing.T) {
+	store := fakeStore{entries: []Entry{{ProjectID: "p1", Expression: "*/1 * * * *"}}}
+	runner := &fakeRunner{err: errors.New("boom")}
+	s := NewScheduler(store, runner)
+	// 不应 panic;错误仅记日志。
+	s.Tick(context.Background(), time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC))
+	if runner.count() != 1 {
+		t.Errorf("应尝试创建一次")
+	}
+}
+
+func TestStartStopClean(t *testing.T) {
+	store := fakeStore{}
+	s := NewScheduler(store, &fakeRunner{})
+	s.Start(context.Background())
+	s.Stop() // 应干净退出
+	s.Stop() // 幂等
+}

--- a/internal/cron/store.go
+++ b/internal/cron/store.go
@@ -1,0 +1,136 @@
+package cron
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// 领域错误。
+var (
+	// ErrProjectNotFound 表示引用的项目不存在。
+	ErrProjectNotFound = errors.New("cron: project not found")
+	// ErrInvalidExpression 表示 cron 表达式非法。
+	ErrInvalidExpression = errors.New("cron: invalid expression")
+	// ErrEnabledNeedsExpression 表示启用了定时但未填表达式。
+	ErrEnabledNeedsExpression = errors.New("cron: enabled cron requires an expression")
+)
+
+// Config 是项目定时配置领域模型。
+type Config struct {
+	Expression string
+	Branch     string
+	Enabled    bool
+	UpdatedAt  time.Time
+}
+
+// SaveInput 是保存入参。
+type SaveInput struct {
+	Expression string
+	Branch     string
+	Enabled    bool
+}
+
+// Service 定义定时配置领域接口(同时实现调度器所需的 Store)。
+type Service interface {
+	Store
+	// Get 返回项目定时配置;无配置 → 返回禁用态空配置(非错误)。项目不存在不区分(交由上层 Get 校验)。
+	Get(ctx context.Context, projectID string) (*Config, error)
+	// Save 校验(启用须有合法表达式;表达式非空则必合法)→ 持久化(upsert)→ 回读。
+	// 项目不存在 → ErrProjectNotFound。
+	Save(ctx context.Context, projectID string, in SaveInput) (*Config, error)
+}
+
+type service struct {
+	db *sql.DB
+}
+
+// NewService 构造定时配置 Service(经参数化 SQL 触库;无 init 副作用、不驻留)。
+func NewService(db *sql.DB) Service { return &service{db: db} }
+
+func (s *service) Get(ctx context.Context, projectID string) (*Config, error) {
+	var (
+		expr, branch, updated string
+		enabled               int
+	)
+	err := s.db.QueryRowContext(ctx,
+		`SELECT expression, branch, enabled, updated_at FROM project_crons WHERE project_id = ?`,
+		projectID,
+	).Scan(&expr, &branch, &enabled, &updated)
+	if errors.Is(err, sql.ErrNoRows) {
+		return &Config{}, nil // 未配置 → 禁用态空配置
+	}
+	if err != nil {
+		return nil, fmt.Errorf("cron: load config: %w", err)
+	}
+	t, _ := time.Parse(time.RFC3339, updated)
+	return &Config{Expression: expr, Branch: branch, Enabled: enabled != 0, UpdatedAt: t}, nil
+}
+
+func (s *service) Save(ctx context.Context, projectID string, in SaveInput) (*Config, error) {
+	expr := strings.TrimSpace(in.Expression)
+	branch := strings.TrimSpace(in.Branch)
+
+	if in.Enabled && expr == "" {
+		return nil, ErrEnabledNeedsExpression
+	}
+	if expr != "" {
+		if err := Valid(expr); err != nil {
+			return nil, fmt.Errorf("%w: %s", ErrInvalidExpression, err.Error())
+		}
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	enabled := 0
+	if in.Enabled {
+		enabled = 1
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO project_crons (project_id, expression, branch, enabled, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(project_id) DO UPDATE SET
+		   expression = excluded.expression,
+		   branch     = excluded.branch,
+		   enabled    = excluded.enabled,
+		   updated_at = excluded.updated_at`,
+		projectID, expr, branch, enabled, now, now,
+	)
+	if err != nil {
+		if isForeignKeyErr(err) {
+			return nil, ErrProjectNotFound
+		}
+		return nil, fmt.Errorf("cron: upsert config: %w", err)
+	}
+	return s.Get(ctx, projectID)
+}
+
+// ListEnabled 实现 Store:返回所有启用且表达式非空的定时配置(供调度器扫描)。
+func (s *service) ListEnabled(ctx context.Context) ([]Entry, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT project_id, expression, branch FROM project_crons WHERE enabled = 1 AND expression <> ''`)
+	if err != nil {
+		return nil, fmt.Errorf("cron: list enabled: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []Entry
+	for rows.Next() {
+		var e Entry
+		if err := rows.Scan(&e.ProjectID, &e.Expression, &e.Branch); err != nil {
+			return nil, fmt.Errorf("cron: scan: %w", err)
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// isForeignKeyErr 判定是否为外键约束失败(项目不存在)。
+func isForeignKeyErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToUpper(err.Error()), "FOREIGN KEY")
+}

--- a/internal/cron/store_test.go
+++ b/internal/cron/store_test.go
@@ -1,0 +1,115 @@
+package cron
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/huangchengsir/pipewright/internal/store"
+)
+
+func testDB(t *testing.T) *sql.DB {
+	t.Helper()
+	st, err := store.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st.DB
+}
+
+func seedProject(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	cred := uuid.NewString()
+	if _, err := db.Exec(
+		`INSERT INTO credentials (id, name, type, scope, ciphertext, masked_value, created_at, updated_at)
+		 VALUES (?, 'c', 'git_token', '', X'00', 'm', ?, ?)`, cred, now, now); err != nil {
+		t.Fatalf("seed cred: %v", err)
+	}
+	pid := uuid.NewString()
+	if _, err := db.Exec(
+		`INSERT INTO projects (id, name, repo_url, default_branch, credential_id, created_at, updated_at)
+		 VALUES (?, 'p', 'https://gitee.com/a/b.git', 'main', ?, ?, ?)`, pid, cred, now, now); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	return pid
+}
+
+func TestServiceSaveGetRoundTrip(t *testing.T) {
+	db := testDB(t)
+	svc := NewService(db)
+	pid := seedProject(t, db)
+	ctx := context.Background()
+
+	// 默认无配置 → 禁用空。
+	got, err := svc.Get(ctx, pid)
+	if err != nil || got.Enabled || got.Expression != "" {
+		t.Fatalf("默认应为禁用空配置;got=%+v err=%v", got, err)
+	}
+
+	saved, err := svc.Save(ctx, pid, SaveInput{Expression: "30 2 * * *", Branch: "main", Enabled: true})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if saved.Expression != "30 2 * * *" || saved.Branch != "main" || !saved.Enabled {
+		t.Errorf("回读不符:%+v", saved)
+	}
+
+	// upsert 覆盖。
+	if _, err := svc.Save(ctx, pid, SaveInput{Expression: "0 9 * * 1", Branch: "release", Enabled: false}); err != nil {
+		t.Fatalf("Save2: %v", err)
+	}
+	g2, _ := svc.Get(ctx, pid)
+	if g2.Expression != "0 9 * * 1" || g2.Enabled {
+		t.Errorf("upsert 未覆盖:%+v", g2)
+	}
+}
+
+func TestServiceSaveValidation(t *testing.T) {
+	db := testDB(t)
+	svc := NewService(db)
+	pid := seedProject(t, db)
+	ctx := context.Background()
+
+	if _, err := svc.Save(ctx, pid, SaveInput{Expression: "bogus", Enabled: true}); !errors.Is(err, ErrInvalidExpression) {
+		t.Errorf("非法表达式应 ErrInvalidExpression,得 %v", err)
+	}
+	if _, err := svc.Save(ctx, pid, SaveInput{Expression: "", Enabled: true}); !errors.Is(err, ErrEnabledNeedsExpression) {
+		t.Errorf("启用空表达式应 ErrEnabledNeedsExpression,得 %v", err)
+	}
+	// 禁用 + 空表达式 → 允许(清空)。
+	if _, err := svc.Save(ctx, pid, SaveInput{Enabled: false}); err != nil {
+		t.Errorf("禁用空配置应允许:%v", err)
+	}
+}
+
+func TestServiceSaveProjectNotFound(t *testing.T) {
+	svc := NewService(testDB(t))
+	if _, err := svc.Save(context.Background(), "nope", SaveInput{Expression: "* * * * *", Enabled: true}); !errors.Is(err, ErrProjectNotFound) {
+		t.Errorf("项目不存在应 ErrProjectNotFound,得 %v", err)
+	}
+}
+
+func TestListEnabled(t *testing.T) {
+	db := testDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+	p1 := seedProject(t, db)
+	p2 := seedProject(t, db)
+
+	_, _ = svc.Save(ctx, p1, SaveInput{Expression: "*/5 * * * *", Branch: "main", Enabled: true})
+	_, _ = svc.Save(ctx, p2, SaveInput{Expression: "0 0 * * *", Branch: "", Enabled: false}) // 禁用
+
+	entries, err := svc.ListEnabled(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabled: %v", err)
+	}
+	if len(entries) != 1 || entries[0].ProjectID != p1 {
+		t.Errorf("仅启用的 p1 应被列出,得 %+v", entries)
+	}
+}

--- a/internal/httpapi/cron.go
+++ b/internal/httpapi/cron.go
@@ -1,0 +1,120 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/cron"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// cron.go 暴露项目定时(cron)触发配置端点(Epic 8 · Story 8-6)。
+//
+// GET /api/projects/{id}/cron  → { expression, branch, enabled, nextRun }
+// PUT /api/projects/{id}/cron  → 同上(需 CSRF)。校验在 cron.Service。
+//
+// nextRun 是据当前表达式算出的下一次触发时刻(启用且表达式合法时;否则空)。
+
+type cronDTO struct {
+	Expression string `json:"expression"`
+	Branch     string `json:"branch"`
+	Enabled    bool   `json:"enabled"`
+	// NextRun 是下一次触发时刻(RFC3339;未启用/非法/无下次 → 空串)。
+	NextRun string `json:"nextRun"`
+}
+
+func toCronDTO(c *cron.Config) cronDTO {
+	dto := cronDTO{Expression: c.Expression, Branch: c.Branch, Enabled: c.Enabled}
+	if c.Enabled && c.Expression != "" {
+		if sched, err := cron.Parse(c.Expression); err == nil {
+			if next := sched.Next(time.Now().UTC()); !next.IsZero() {
+				dto.NextRun = next.Format(time.RFC3339)
+			}
+		}
+	}
+	return dto
+}
+
+func writeCronError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, cron.ErrProjectNotFound):
+		writeError(w, http.StatusNotFound, "project_not_found", "项目不存在")
+	case errors.Is(err, cron.ErrInvalidExpression):
+		writeError(w, http.StatusUnprocessableEntity, "invalid_cron", "cron 表达式非法(须为 5 字段:分 时 日 月 周)")
+	case errors.Is(err, cron.ErrEnabledNeedsExpression):
+		writeError(w, http.StatusUnprocessableEntity, "cron_needs_expression", "启用定时触发须填写 cron 表达式")
+	default:
+		writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+	}
+}
+
+func makeGetCronHandler(svc cron.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "定时触发服务未初始化")
+			return
+		}
+		cfg, err := svc.Get(r.Context(), chi.URLParam(r, "id"))
+		if err != nil {
+			writeCronError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, toCronDTO(cfg))
+	}
+}
+
+func makeSaveCronHandler(svc cron.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "定时触发服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<14)
+		var req struct {
+			Expression string `json:"expression"`
+			Branch     string `json:"branch"`
+			Enabled    bool   `json:"enabled"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		cfg, err := svc.Save(r.Context(), id, cron.SaveInput{
+			Expression: req.Expression,
+			Branch:     req.Branch,
+			Enabled:    req.Enabled,
+		})
+		if err != nil {
+			writeCronError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, toCronDTO(cfg))
+	}
+}
+
+// NewScheduledRunCreator 把 run.Service 适配为 cron.Runner(供 main 装配调度器)。
+func NewScheduledRunCreator(svc run.Service) cron.Runner {
+	return scheduledRunAdapter{svc: svc}
+}
+
+type scheduledRunAdapter struct {
+	svc run.Service
+}
+
+// CreateScheduledRun 实现 cron.Runner:以「定时」触发类型创建运行(branch 空 → run.Create 解析默认分支)。
+func (a scheduledRunAdapter) CreateScheduledRun(ctx context.Context, projectID, branch string) (string, error) {
+	r, err := a.svc.Create(ctx, projectID, run.Trigger{
+		Type:   run.TriggerSchedule,
+		Branch: branch,
+		Actor:  "cron",
+	})
+	if err != nil {
+		return "", err
+	}
+	return r.ID, nil
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -20,6 +20,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/anomaly"
 	"github.com/huangchengsir/pipewright/internal/audit"
 	"github.com/huangchengsir/pipewright/internal/auth"
+	"github.com/huangchengsir/pipewright/internal/cron"
 	"github.com/huangchengsir/pipewright/internal/deploy"
 	"github.com/huangchengsir/pipewright/internal/notify"
 	"github.com/huangchengsir/pipewright/internal/oauth"
@@ -49,6 +50,7 @@ type options struct {
 	vault            vault.Vault
 	projects         project.Service
 	triggers         trigger.Service
+	cron             cron.Service
 	pipelines        pipeline.Service
 	pipelineSettings pipeline.SettingsService
 	runs             run.Service
@@ -79,6 +81,11 @@ func WithVault(v vault.Vault) Option {
 // 不传则项目相关端点返回 503(服务未初始化)。
 func WithProjects(s project.Service) Option {
 	return func(o *options) { o.projects = s }
+}
+
+// WithCron 注入定时触发配置服务,挂载 /api/projects/{id}/cron 路由(Story 8-6)。
+func WithCron(s cron.Service) Option {
+	return func(o *options) { o.cron = s }
 }
 
 // WithTriggers 注入触发配置服务,挂载 /api/projects/{id}/trigger* 路由。
@@ -281,6 +288,10 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		ar.Get("/projects/{id}/trigger", makeGetTriggerHandler(t))
 		ar.Put("/projects/{id}/trigger", makeSaveTriggerHandler(t))
 		ar.Post("/projects/{id}/trigger/secret/reset", makeResetTriggerSecretHandler(t, aud))
+
+		// 定时(cron)触发配置(Story 8-6)。o.cron 为 nil 时 handler 返回 503。GET 过 auth;PUT 过 auth + CSRF。
+		ar.Get("/projects/{id}/cron", makeGetCronHandler(o.cron))
+		ar.Put("/projects/{id}/cron", makeSaveCronHandler(o.cron))
 
 		// 流水线编排配置(Story 2.2)。pl 为 nil 时 handler 返回 503。
 		// 与 /projects/{id}/trigger 同在 {id} 路由组内并存(不会被 /projects/{id} 吞)。

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -60,6 +60,8 @@ const (
 	TriggerWebhook = "webhook"
 	// TriggerManual 表示手动触发。
 	TriggerManual = "manual"
+	// TriggerSchedule 表示定时(cron)触发(Story 8-6)。
+	TriggerSchedule = "schedule"
 )
 
 // 领域错误。错误体不含敏感数据。

--- a/internal/run/service.go
+++ b/internal/run/service.go
@@ -142,7 +142,7 @@ func (s *service) Create(ctx context.Context, projectID string, trigger Trigger)
 	}
 
 	tt := trigger.Type
-	if tt != TriggerWebhook && tt != TriggerManual {
+	if tt != TriggerWebhook && tt != TriggerManual && tt != TriggerSchedule {
 		tt = TriggerManual
 	}
 

--- a/internal/store/migrations/0024_project_crons.sql
+++ b/internal/store/migrations/0024_project_crons.sql
@@ -1,0 +1,21 @@
+-- 0024 project_crons:项目级定时(cron)触发配置(Epic 8 · Story 8-6 / FR-8-4)。
+-- 每项目至多一行(project_id 既是主键也是外键)。expression 为 5 字段 cron(分 时 日 月 周);
+-- branch 为定时触发要构建的分支(空 = 项目默认分支,由 run.Create 解析);enabled 控制是否参与调度。
+-- 不存敏感信息;删项目级联删定时配置。
+--   project_id : FK → projects.id;PK;ON DELETE CASCADE
+--   expression : 5 字段 cron 表达式(应用层 cron.Parse 校验)
+--   branch     : 触发构建的分支(可空)
+--   enabled    : 0/1 是否启用调度
+
+CREATE TABLE IF NOT EXISTS project_crons (
+    project_id TEXT PRIMARY KEY,
+    expression TEXT NOT NULL DEFAULT '',
+    branch     TEXT NOT NULL DEFAULT '',
+    enabled    INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);
+
+-- 调度器按 enabled 过滤扫描;建索引避免全表扫。
+CREATE INDEX IF NOT EXISTS idx_project_crons_enabled ON project_crons (enabled);


### PR DESCRIPTION
零依赖 5 字段 cron 解析 + 分钟粒度调度器(注入时钟、去重)+ DB 配置 + GET/PUT /api/projects/{id}/cron。run 加 schedule 触发类型。真二进制铁证:`* * * * *` 到整分钟边界真创建 schedule 运行只一次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)