### PR TITLE
feat(prstatus): 8-9 PR 状态回写 — 回写 GitHub/Gitee 提交状态

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/oauth"
 	"github.com/huangchengsir/pipewright/internal/pipeline"
 	"github.com/huangchengsir/pipewright/internal/project"
+	"github.com/huangchengsir/pipewright/internal/prstatus"
 	"github.com/huangchengsir/pipewright/internal/run"
 	"github.com/huangchengsir/pipewright/internal/store"
 	"github.com/huangchengsir/pipewright/internal/target"
@@ -159,14 +160,32 @@ func main() {
 	// 经同一 run.StepSink 喂出,复用既有持久化/SSE/脱敏(下方 WithLogMaskerFunc 对真实日志同样生效)。
 	runnerOpts := buildRunnerOption(projectSvc, pipelineSettingsSvc, credVault)
 
+	// 终态钩子:通知(Story 5.2);PIPEWRIGHT_PR_STATUS=1 时再叠加「PR 状态回写」(Story 8-9 / FR-8-9):
+	// run 终态 → 据项目仓库识别 GitHub/Gitee → 经项目凭据回写该 commit 的提交状态(PR 检查)。
+	// **默认关闭**(避免意外往用户真实仓库回写);开启时 best-effort,失败仅记日志不阻断 run 终态。
+	terminalHook := httpapi.NewNotifyHook(runSvc, notifySvc, secretSrc)
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("PIPEWRIGHT_PR_STATUS")), "1") {
+		// API base 可经 env 覆盖(GitHub/Gitee 企业版自托管;空则用公有云默认)。
+		reporter := prstatus.NewReporter(&http.Client{Timeout: 10 * time.Second}).WithBaseURLs(
+			strings.TrimSpace(os.Getenv("PIPEWRIGHT_PR_STATUS_GITHUB_BASE")),
+			strings.TrimSpace(os.Getenv("PIPEWRIGHT_PR_STATUS_GITEE_BASE")))
+		prHook := httpapi.NewPRStatusHook(runSvc, projectSvc, credVault, reporter,
+			strings.TrimSpace(os.Getenv("PIPEWRIGHT_PUBLIC_URL")))
+		notify := terminalHook
+		terminalHook = func(ctx context.Context, runID, finalStatus string) {
+			notify(ctx, runID, finalStatus)
+			prHook(ctx, runID, finalStatus)
+		}
+		log.Printf("[prstatus] PR 状态回写已启用(PIPEWRIGHT_PR_STATUS=1;GitHub/Gitee,经项目凭据,best-effort)")
+	}
+
 	pool := run.NewWorkerPool(runSvc,
 		append(runnerOpts,
 			run.WithDiagnoseHook(httpapi.NewDiagnoseHook(runSvc, aiSvc, secretSrc)),
 			// per-run 日志脱敏:每个 run 构建登记了该 run 真实凭据的 Masker(红线修)。
 			run.WithLogMaskerFunc(secretSrc.MaskerForRun),
-			// best-effort 通知钩子(Story 5.2;FR-20):run 终态 → event → 构 Payload → Router.RouteEvent。
-			// 未配路由的事件不发送;单渠道失败续发;绝不阻断 run 终态。run 包不 import notify(钩子解耦)。
-			run.WithNotifyHook(httpapi.NewNotifyHook(runSvc, notifySvc, secretSrc)),
+			// best-effort 终态钩子(通知 + 可选 PR 状态回写)。未配路由的事件不发送;绝不阻断 run 终态。
+			run.WithNotifyHook(terminalHook),
 		)...,
 	)
 	pool.Start()

--- a/internal/httpapi/prstatus.go
+++ b/internal/httpapi/prstatus.go
@@ -1,0 +1,90 @@
+package httpapi
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/huangchengsir/pipewright/internal/project"
+	"github.com/huangchengsir/pipewright/internal/prstatus"
+	"github.com/huangchengsir/pipewright/internal/run"
+	"github.com/huangchengsir/pipewright/internal/vault"
+)
+
+// prstatus.go 装配「运行结果回写代码平台提交状态」的终态钩子(Story 8-9 / FR-8-9)。
+//
+// 钩子由 main 在 run 终态时调用(复用通知钩子的终态时机,组合执行):取本次运行的 commit +
+// 项目仓库/凭据 → 识别平台(GitHub/Gitee)→ 经项目凭据回写提交状态(success/failure)+ 详情链接。
+// best-effort:无 commit / 不支持平台 / 无凭据 / 回写失败 一律静默跳过或仅记日志,绝不影响运行终态。
+
+// NewPRStatusHook 构造 PR 状态回写终态钩子。publicBaseURL 为平台对外访问地址(用于 target_url;
+// 空则不带链接)。token 经 vault 即取即用,绝不进 URL/日志。
+func NewPRStatusHook(
+	runs run.Service,
+	projects project.Service,
+	v vault.Vault,
+	reporter *prstatus.Reporter,
+	publicBaseURL string,
+) func(ctx context.Context, runID, finalStatus string) {
+	publicBaseURL = strings.TrimRight(strings.TrimSpace(publicBaseURL), "/")
+	return func(ctx context.Context, runID, finalStatus string) {
+		r, err := runs.Get(ctx, runID)
+		if err != nil {
+			return
+		}
+		commit := strings.TrimSpace(r.Trigger.Commit)
+		if commit == "" {
+			return // 无 commit(如手动触发未指定):无处可回写
+		}
+		proj, err := projects.Get(ctx, r.ProjectID)
+		if err != nil {
+			return
+		}
+		target, ok := prstatus.Detect(proj.RepoURL)
+		if !ok {
+			return // 不支持的代码平台
+		}
+		token := revealPRToken(v, proj.CredentialID)
+		if token == "" {
+			return // 无可用凭据
+		}
+
+		state := prstatus.StateForRunStatus(finalStatus)
+		desc := prDescription(finalStatus)
+		targetURL := ""
+		if publicBaseURL != "" {
+			targetURL = publicBaseURL + "/runs/" + runID
+		}
+		if err := reporter.Report(ctx, target, commit, state, desc, targetURL, token); err != nil {
+			log.Printf("[prstatus] 回写 %s/%s 失败(run %s):%v", target.Owner, target.Repo, runID, err)
+			return
+		}
+		log.Printf("[prstatus] 已回写 %s %s/%s @ %s = %s", target.Platform, target.Owner, target.Repo, shortSHA(commit), state)
+	}
+}
+
+// revealPRToken 取项目凭据明文(失败/未配 → 空,best-effort)。
+func revealPRToken(v vault.Vault, credID string) string {
+	if v == nil || strings.TrimSpace(credID) == "" {
+		return ""
+	}
+	tok, err := v.Reveal(credID)
+	if err != nil {
+		return ""
+	}
+	return tok
+}
+
+func prDescription(finalStatus string) string {
+	if finalStatus == run.StatusSuccess {
+		return "Pipewright 流水线成功"
+	}
+	return "Pipewright 流水线失败"
+}
+
+func shortSHA(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
+}

--- a/internal/prstatus/reporter.go
+++ b/internal/prstatus/reporter.go
@@ -1,0 +1,172 @@
+// Package prstatus 把流水线运行结果回写为代码平台的「提交状态/检查」(Epic 8 · Story 8-9 / FR-8-9)。
+//
+// GitHub/Gitee 的 PR 检查本质是「给某个 commit SHA 打一条状态」(success/failure/pending),
+// 平台在 PR 页把该 commit 的状态聚合展示。本包据项目仓库地址识别平台,经项目凭据(PAT/OAuth token)
+// 调对应 commit-status API 回写本次运行结果,附跳回运行详情的 target_url。
+//
+// 安全:token 仅作鉴权头/参数,绝不进 URL/日志/错误;owner/repo/sha 经 url.PathEscape 进路径(防注入)。
+// best-effort:失败仅由调用方记日志,绝不影响运行终态(NFR-10)。
+package prstatus
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Platform 是受支持的代码平台。
+type Platform string
+
+const (
+	GitHub Platform = "github"
+	Gitee  Platform = "gitee"
+)
+
+// statusContext 是回写状态的「检查名」(平台 PR 页展示)。
+const statusContext = "pipewright"
+
+// Target 是解析出的回写目标(平台 + owner/repo)。
+type Target struct {
+	Platform Platform
+	Owner    string
+	Repo     string
+}
+
+// Detect 从仓库地址解析回写目标。不支持的 host / 无法解析 owner/repo → ok=false。
+func Detect(repoURL string) (Target, bool) {
+	u, err := url.Parse(strings.TrimSpace(repoURL))
+	if err != nil {
+		return Target{}, false
+	}
+	host := strings.ToLower(u.Hostname())
+	var plat Platform
+	switch {
+	case host == "github.com" || strings.HasSuffix(host, ".github.com"):
+		plat = GitHub
+	case host == "gitee.com" || strings.HasSuffix(host, ".gitee.com"):
+		plat = Gitee
+	default:
+		return Target{}, false
+	}
+	owner, repo, ok := ownerRepo(u.Path)
+	if !ok {
+		return Target{}, false
+	}
+	return Target{Platform: plat, Owner: owner, Repo: repo}, true
+}
+
+// ownerRepo 从 URL path 取 owner/repo(去 .git 后缀)。
+func ownerRepo(p string) (string, string, bool) {
+	p = strings.Trim(p, "/")
+	parts := strings.Split(p, "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	repo := strings.TrimSuffix(parts[1], ".git")
+	if repo == "" {
+		return "", "", false
+	}
+	return parts[0], repo, true
+}
+
+// State 是回写的提交状态值(两平台共用枚举的交集)。
+const (
+	StateSuccess = "success"
+	StateFailure = "failure"
+	StatePending = "pending"
+)
+
+// Reporter 经 HTTP 回写提交状态。
+type Reporter struct {
+	client        *http.Client
+	githubAPIBase string
+	giteeAPIBase  string
+}
+
+// NewReporter 构造 Reporter。client 为 nil 用默认;API base 缺省指向真实平台,测试可经 With* 覆盖。
+func NewReporter(client *http.Client) *Reporter {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &Reporter{
+		client:        client,
+		githubAPIBase: "https://api.github.com",
+		giteeAPIBase:  "https://gitee.com/api/v5",
+	}
+}
+
+// WithBaseURLs 覆盖平台 API base(测试注入 stub server)。
+func (r *Reporter) WithBaseURLs(github, gitee string) *Reporter {
+	if github != "" {
+		r.githubAPIBase = strings.TrimRight(github, "/")
+	}
+	if gitee != "" {
+		r.giteeAPIBase = strings.TrimRight(gitee, "/")
+	}
+	return r
+}
+
+// Report 给 target 的 commit sha 回写一条状态。state ∈ success|failure|pending。
+// token 为平台访问令牌(绝不进 URL/日志)。非 2xx → 错误(含状态码,不含 token)。
+func (r *Reporter) Report(ctx context.Context, t Target, sha, state, description, targetURL, token string) error {
+	sha = strings.TrimSpace(sha)
+	if sha == "" {
+		return fmt.Errorf("prstatus: empty commit sha")
+	}
+	path := fmt.Sprintf("/repos/%s/%s/statuses/%s",
+		url.PathEscape(t.Owner), url.PathEscape(t.Repo), url.PathEscape(sha))
+
+	var (
+		endpoint string
+		body     map[string]any
+		req      *http.Request
+		err      error
+	)
+	switch t.Platform {
+	case GitHub:
+		endpoint = r.githubAPIBase + path
+		body = map[string]any{"state": state, "context": statusContext, "description": description, "target_url": targetURL}
+	case Gitee:
+		endpoint = r.giteeAPIBase + path
+		// Gitee v5 提交状态:access_token 作 body 参数 + Authorization 头双保险。
+		body = map[string]any{"access_token": token, "state": state, "context": statusContext, "description": description, "target_url": targetURL}
+	default:
+		return fmt.Errorf("prstatus: unsupported platform %q", t.Platform)
+	}
+
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("prstatus: marshal: %w", err)
+	}
+	req, err = http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(buf))
+	if err != nil {
+		return fmt.Errorf("prstatus: new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "token "+token)
+	if t.Platform == GitHub {
+		req.Header.Set("Accept", "application/vnd.github+json")
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("prstatus: post status: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("prstatus: %s status post got HTTP %d", t.Platform, resp.StatusCode)
+	}
+	return nil
+}
+
+// StateForRunStatus 把运行终态映射为提交状态(success→success,其余终态→failure)。
+func StateForRunStatus(runStatus string) string {
+	if runStatus == "success" {
+		return StateSuccess
+	}
+	return StateFailure
+}

--- a/internal/prstatus/reporter_test.go
+++ b/internal/prstatus/reporter_test.go
@@ -1,0 +1,137 @@
+package prstatus
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDetect(t *testing.T) {
+	cases := []struct {
+		url      string
+		wantPlat Platform
+		wantOwn  string
+		wantRepo string
+		ok       bool
+	}{
+		{"https://github.com/octo/app.git", GitHub, "octo", "app", true},
+		{"https://github.com/octo/app", GitHub, "octo", "app", true},
+		{"https://gitee.com/cool-jiawei/aireboot.git", Gitee, "cool-jiawei", "aireboot", true},
+		{"https://gitlab.com/x/y.git", "", "", "", false},   // 不支持
+		{"https://github.com/onlyowner", "", "", "", false}, // 缺 repo
+		{"not a url at all ::::", "", "", "", false},
+	}
+	for _, c := range cases {
+		got, ok := Detect(c.url)
+		if ok != c.ok {
+			t.Errorf("Detect(%q) ok=%v want %v", c.url, ok, c.ok)
+			continue
+		}
+		if ok && (got.Platform != c.wantPlat || got.Owner != c.wantOwn || got.Repo != c.wantRepo) {
+			t.Errorf("Detect(%q) = %+v, want %s %s/%s", c.url, got, c.wantPlat, c.wantOwn, c.wantRepo)
+		}
+	}
+}
+
+func TestStateForRunStatus(t *testing.T) {
+	if StateForRunStatus("success") != StateSuccess {
+		t.Error("success → success")
+	}
+	for _, s := range []string{"failed", "partial_failed", "rolled_back"} {
+		if StateForRunStatus(s) != StateFailure {
+			t.Errorf("%s → failure", s)
+		}
+	}
+}
+
+// 用 stub server 校验真实请求形状(诚实机制验证;真 PR 回写需用户 token+repo)。
+func TestReportGitHubRequestShape(t *testing.T) {
+	var (
+		gotPath, gotMethod, gotAuth, gotAccept string
+		gotBody                                map[string]any
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		gotAuth, gotAccept = r.Header.Get("Authorization"), r.Header.Get("Accept")
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	rep := NewReporter(srv.Client()).WithBaseURLs(srv.URL, "")
+	target := Target{Platform: GitHub, Owner: "octo", Repo: "app"}
+	err := rep.Report(context.Background(), target, "abc123", StateSuccess, "构建成功", "http://pw/runs/r1", "ghp_secret")
+	if err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %s", gotMethod)
+	}
+	if gotPath != "/repos/octo/app/statuses/abc123" {
+		t.Errorf("path = %s", gotPath)
+	}
+	if gotAuth != "token ghp_secret" {
+		t.Errorf("auth header = %q", gotAuth)
+	}
+	if !strings.Contains(gotAccept, "github") {
+		t.Errorf("accept = %q", gotAccept)
+	}
+	if gotBody["state"] != "success" || gotBody["context"] != "pipewright" || gotBody["target_url"] != "http://pw/runs/r1" {
+		t.Errorf("body = %+v", gotBody)
+	}
+	// GitHub body 不应含 access_token(token 只在头)。
+	if _, ok := gotBody["access_token"]; ok {
+		t.Error("GitHub body 不应含 access_token")
+	}
+}
+
+func TestReportGiteeIncludesAccessToken(t *testing.T) {
+	var gotBody map[string]any
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rep := NewReporter(srv.Client()).WithBaseURLs("", srv.URL)
+	target := Target{Platform: Gitee, Owner: "cool-jiawei", Repo: "aireboot"}
+	if err := rep.Report(context.Background(), target, "deadbeef", StateFailure, "失败", "http://pw/runs/r2", "gitee_tok"); err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	if gotPath != "/repos/cool-jiawei/aireboot/statuses/deadbeef" {
+		t.Errorf("path = %s", gotPath)
+	}
+	if gotBody["access_token"] != "gitee_tok" || gotBody["state"] != "failure" {
+		t.Errorf("gitee body = %+v", gotBody)
+	}
+}
+
+func TestReportNon2xxErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	rep := NewReporter(srv.Client()).WithBaseURLs(srv.URL, "")
+	err := rep.Report(context.Background(), Target{Platform: GitHub, Owner: "o", Repo: "r"}, "sha", StateSuccess, "", "", "bad")
+	if err == nil {
+		t.Error("非 2xx 应返回错误")
+	}
+	if strings.Contains(err.Error(), "bad") {
+		t.Error("错误信息不应含 token")
+	}
+}
+
+func TestReportEmptyShaErrors(t *testing.T) {
+	rep := NewReporter(nil)
+	if err := rep.Report(context.Background(), Target{Platform: GitHub, Owner: "o", Repo: "r"}, "  ", StateSuccess, "", "", "t"); err == nil {
+		t.Error("空 sha 应报错(不发请求)")
+	}
+}


### PR DESCRIPTION
run 终态回写代码平台提交状态(PR 检查),默认关闭(PIPEWRIGHT_PR_STATUS=1)。internal/prstatus Detect+Report(token 不进 URL/日志)。真二进制铁证:stub 收到 POST /repos/octo/app/statuses/abc1234(token=项目凭据/state=success/带 target_url)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)