### PR TITLE
feat(pipeline): 画布节点按任务类型给专属配置表单 + 弹出式选择器

### DIFF
--- a/web/src/components/pipeline/JobCard.vue
+++ b/web/src/components/pipeline/JobCard.vue
@@ -1,36 +1,24 @@
 <script setup lang="ts">
 import type { PipelineJob, StageKind } from '../../api/pipeline'
+import { jobTypeLabel } from './jobConfigSchema'
+import JobTypeIcon from './JobTypeIcon.vue'
 
-const props = defineProps<{
+defineProps<{
   job: PipelineJob
   stageKind: StageKind
   selected: boolean
+  dragging?: boolean
+  dragOver?: boolean
 }>()
 
 const emit = defineEmits<{
   (e: 'select'): void
   (e: 'delete'): void
+  (e: 'dragstart'): void
+  (e: 'dragend'): void
+  (e: 'dragenter'): void
+  (e: 'drop'): void
 }>()
-
-function iconClass(): string {
-  switch (props.stageKind) {
-    case 'source': return 'job-icon--source'
-    case 'build':  return 'job-icon--build'
-    case 'deploy': return 'job-icon--deploy'
-    case 'notify': return 'job-icon--notify'
-    default:       return 'job-icon--custom'
-  }
-}
-
-function iconGlyph(): string {
-  switch (props.stageKind) {
-    case 'source': return '⎇'
-    case 'build':  return '▢'
-    case 'deploy': return '⬆'
-    case 'notify': return '✉'
-    default:       return '◈'
-  }
-}
 
 function handleDelete(e: MouseEvent): void {
   e.stopPropagation()
@@ -41,17 +29,27 @@ function handleDelete(e: MouseEvent): void {
 <template>
   <div
     class="job-card"
-    :class="{ 'job-card--selected': selected }"
+    :class="{
+      'job-card--selected': selected,
+      'job-card--dragging': dragging,
+      'job-card--dragover': dragOver,
+    }"
     role="button"
     tabindex="0"
+    draggable="true"
     :aria-pressed="selected"
-    :aria-label="`任务: ${job.name}`"
+    :aria-label="`任务: ${job.name}(${jobTypeLabel(job.type)})`"
     @click="emit('select')"
     @keydown.enter="emit('select')"
     @keydown.space.prevent="emit('select')"
+    @dragstart="emit('dragstart')"
+    @dragend="emit('dragend')"
+    @dragenter.prevent="emit('dragenter')"
+    @dragover.prevent
+    @drop.prevent="emit('drop')"
   >
     <div class="job-card-top">
-      <span class="job-icon" :class="iconClass()" aria-hidden="true">{{ iconGlyph() }}</span>
+      <JobTypeIcon :type="job.type" :size="24" />
       <span class="job-name">{{ job.name }}</span>
       <button
         class="job-card-del"
@@ -64,6 +62,7 @@ function handleDelete(e: MouseEvent): void {
         </svg>
       </button>
     </div>
+    <div class="job-card-type">{{ jobTypeLabel(job.type) }}</div>
     <div v-if="job.summary" class="job-summary">{{ job.summary }}</div>
   </div>
 </template>
@@ -75,5 +74,23 @@ function handleDelete(e: MouseEvent): void {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.job-card-type {
+  margin-top: 4px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--color-faint);
+}
+
+.job-card--dragging {
+  opacity: 0.45;
+}
+
+.job-card--dragover {
+  border-color: var(--color-primary);
+  box-shadow: 0 -2px 0 0 var(--color-primary);
 }
 </style>

--- a/web/src/components/pipeline/JobDrawer.vue
+++ b/web/src/components/pipeline/JobDrawer.vue
@@ -6,9 +6,10 @@ import type { Server } from '../../api/servers'
 import {
   getJobTypeSpec,
   splitConfig,
-  JOB_TYPE_OPTIONS,
+  jobTypeLabel,
   type JobField,
 } from './jobConfigSchema'
+import JobTypeIcon from './JobTypeIcon.vue'
 
 const props = defineProps<{
   job: PipelineJob
@@ -20,6 +21,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'close'): void
   (e: 'update', patch: Partial<PipelineJob>): void
+  (e: 'change-type'): void
 }>()
 
 // ─── Local editable copy ──────────────────────────────────────────────────────
@@ -122,16 +124,6 @@ function extrasToObject(rows: KVRow[]): Record<string, string> {
   return out
 }
 
-// ─── Type change ───────────────────────────────────────────────────────────────
-
-function onTypeChange(type: string): void {
-  // Preserve all current values, just re-split owned vs. extra for the new type.
-  const merged = { ...extrasToObject(extraRows.value), ...typedConfig.value }
-  localType.value = type
-  splitOnType(type, merged)
-  flush()
-}
-
 // ─── Flush ─────────────────────────────────────────────────────────────────────
 
 function flush(): void {
@@ -189,24 +181,19 @@ function flush(): void {
 
       <div class="drawer-field">
         <div class="drawer-field-label">任务类型</div>
-        <select
-          :value="localType"
-          class="drawer-select"
-          aria-label="任务类型"
-          @change="onTypeChange(($event.target as HTMLSelectElement).value)"
+        <button
+          type="button"
+          class="type-trigger"
+          aria-label="更换任务类型"
+          @click="emit('change-type')"
         >
-          <option
-            v-for="opt in JOB_TYPE_OPTIONS"
-            :key="opt.value"
-            :value="opt.value"
-          >{{ opt.label }}</option>
-          <!-- Allow custom types not in the list -->
-          <option
-            v-if="!JOB_TYPE_OPTIONS.some(o => o.value === localType) && localType"
-            :value="localType"
-          >{{ localType }}</option>
-        </select>
-        <p v-if="spec" class="field-desc">{{ spec.description }}</p>
+          <JobTypeIcon :type="localType" :size="32" />
+          <span class="type-trigger-body">
+            <span class="type-trigger-name">{{ jobTypeLabel(localType) }}</span>
+            <span class="type-trigger-desc">{{ spec ? spec.description : localType }}</span>
+          </span>
+          <span class="type-trigger-action">更换</span>
+        </button>
       </div>
 
       <div class="drawer-field">
@@ -389,6 +376,59 @@ function flush(): void {
   margin: 6px 0 0;
   font-size: 0.74rem;
   color: var(--color-faint);
+}
+
+.type-trigger {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--color-inset);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color var(--duration-fast), box-shadow var(--duration-fast);
+}
+
+.type-trigger:hover {
+  border-color: var(--color-primary);
+}
+
+.type-trigger:focus-visible {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-soft);
+}
+
+.type-trigger-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  flex: 1;
+}
+
+.type-trigger-name {
+  font-size: 0.86rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.type-trigger-desc {
+  font-size: 0.73rem;
+  color: var(--color-faint);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.type-trigger-action {
+  flex-shrink: 0;
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: var(--color-primary);
 }
 
 .field-hint {

--- a/web/src/components/pipeline/JobDrawer.vue
+++ b/web/src/components/pipeline/JobDrawer.vue
@@ -1,10 +1,20 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
-import type { PipelineJob, PipelineStage, StageKind } from '../../api/pipeline'
+import { ref, computed, watch } from 'vue'
+import type { PipelineJob, PipelineStage } from '../../api/pipeline'
+import type { Credential } from '../../api/credentials'
+import type { Server } from '../../api/servers'
+import {
+  getJobTypeSpec,
+  splitConfig,
+  JOB_TYPE_OPTIONS,
+  type JobField,
+} from './jobConfigSchema'
 
 const props = defineProps<{
   job: PipelineJob
   stage: PipelineStage
+  credentials?: Credential[]
+  servers?: Server[]
 }>()
 
 const emit = defineEmits<{
@@ -25,60 +35,115 @@ let _kvSeq = 0
 const localName    = ref(props.job.name)
 const localType    = ref(props.job.type)
 const localSummary = ref(props.job.summary)
-const localKV      = ref<KVRow[]>(objectToKV(props.job.config))
+/** Schema-owned keys for the current type (the typed form binds here) */
+const typedConfig  = ref<Record<string, string>>({})
+/** Keys NOT covered by the type schema — editable in the advanced section */
+const extraRows    = ref<KVRow[]>([])
 
-// Sync when the selected job changes
-watch(
-  () => props.job,
-  (next) => {
-    localName.value    = next.name
-    localType.value    = next.type
-    localSummary.value = next.summary
-    localKV.value      = objectToKV(next.config)
-  },
-)
+const showAdvanced = ref(false)
 
-function objectToKV(obj: Record<string, string> | null | undefined): KVRow[] {
-  return Object.entries(obj ?? {}).map(([k, v]) => ({ _key: ++_kvSeq, k, v }))
+function hydrate(job: PipelineJob): void {
+  localName.value    = job.name
+  localType.value    = job.type
+  localSummary.value = job.summary
+  splitOnType(job.type, job.config ?? {})
 }
 
-function kvToObject(rows: KVRow[]): Record<string, string> {
-  const result: Record<string, string> = {}
+/** Recompute typed config + raw extras for a given type, preserving all values. */
+function splitOnType(type: string, config: Record<string, string>): void {
+  const { extras } = splitConfig(type, config)
+  const typed: Record<string, string> = {}
+  for (const [k, v] of Object.entries(config)) {
+    if (!extras.some(([ek]) => ek === k)) typed[k] = v
+  }
+  typedConfig.value = typed
+  extraRows.value = extras.map(([k, v]) => ({ _key: ++_kvSeq, k, v }))
+  showAdvanced.value = extras.length > 0
+}
+
+// Resync when the selected job changes
+watch(() => props.job, (next) => hydrate(next))
+hydrate(props.job)
+
+// ─── Field schema for the current type ────────────────────────────────────────
+
+const spec = computed(() => getJobTypeSpec(localType.value))
+
+const visibleFields = computed<JobField[]>(() => {
+  if (!spec.value) return []
+  return spec.value.fields.filter((f) => !f.when || f.when(typedConfig.value))
+})
+
+function credentialOptions(field: JobField): Credential[] {
+  const all = props.credentials ?? []
+  if (!field.credentialType) return all
+  return all.filter((c) => c.type === field.credentialType)
+}
+
+// ─── Value get/set ────────────────────────────────────────────────────────────
+
+function fieldValue(key: string): string {
+  return typedConfig.value[key] ?? ''
+}
+
+/** Default-display value for selects so the first option shows before any edit. */
+function selectValue(field: JobField): string {
+  const v = typedConfig.value[field.key]
+  if (v) return v
+  return field.options?.[0]?.value ?? ''
+}
+
+function updateLocal(key: string, value: string): void {
+  typedConfig.value = { ...typedConfig.value, [key]: value }
+}
+
+function setField(key: string, value: string): void {
+  updateLocal(key, value)
+  flush()
+}
+
+// ─── Raw extras (advanced) ─────────────────────────────────────────────────────
+
+function addExtra(): void {
+  extraRows.value.push({ _key: ++_kvSeq, k: '', v: '' })
+}
+
+function removeExtra(key: number): void {
+  extraRows.value = extraRows.value.filter((r) => r._key !== key)
+  flush()
+}
+
+function extrasToObject(rows: KVRow[]): Record<string, string> {
+  const out: Record<string, string> = {}
   for (const row of rows) {
     const key = row.k.trim()
-    if (key) result[key] = row.v
+    if (key) out[key] = row.v
   }
-  return result
+  return out
 }
 
-function addKV(): void {
-  localKV.value.push({ _key: ++_kvSeq, k: '', v: '' })
+// ─── Type change ───────────────────────────────────────────────────────────────
+
+function onTypeChange(type: string): void {
+  // Preserve all current values, just re-split owned vs. extra for the new type.
+  const merged = { ...extrasToObject(extraRows.value), ...typedConfig.value }
+  localType.value = type
+  splitOnType(type, merged)
+  flush()
 }
 
-function removeKV(key: number): void {
-  localKV.value = localKV.value.filter((r) => r._key !== key)
-}
+// ─── Flush ─────────────────────────────────────────────────────────────────────
 
 function flush(): void {
+  // typed wins over extras on key conflict (they should never overlap).
+  const config = { ...extrasToObject(extraRows.value), ...typedConfig.value }
   emit('update', {
     name:    localName.value.trim() || props.job.name,
     type:    localType.value.trim() || props.job.type,
     summary: localSummary.value,
-    config:  kvToObject(localKV.value),
+    config,
   })
 }
-
-// ─── YAML preview ─────────────────────────────────────────────────────────────
-
-const KIND_TYPE_OPTIONS: Array<{ value: string; label: string }> = [
-  { value: 'git_source',   label: 'git_source' },
-  { value: 'build_image',  label: 'build_image' },
-  { value: 'push_image',   label: 'push_image' },
-  { value: 'deploy_ssh',   label: 'deploy_ssh' },
-  { value: 'health_check', label: 'health_check' },
-  { value: 'notify',       label: 'notify' },
-  { value: 'custom',       label: 'custom' },
-]
 </script>
 
 <template>
@@ -124,25 +189,24 @@ const KIND_TYPE_OPTIONS: Array<{ value: string; label: string }> = [
 
       <div class="drawer-field">
         <div class="drawer-field-label">任务类型</div>
-        <div style="position:relative">
-          <select
-            v-model="localType"
-            class="drawer-select"
-            aria-label="任务类型"
-            @change="flush"
-          >
-            <option
-              v-for="opt in KIND_TYPE_OPTIONS"
-              :key="opt.value"
-              :value="opt.value"
-            >{{ opt.label }}</option>
-            <!-- Allow custom types not in the list -->
-            <option
-              v-if="!KIND_TYPE_OPTIONS.some(o => o.value === localType) && localType"
-              :value="localType"
-            >{{ localType }}</option>
-          </select>
-        </div>
+        <select
+          :value="localType"
+          class="drawer-select"
+          aria-label="任务类型"
+          @change="onTypeChange(($event.target as HTMLSelectElement).value)"
+        >
+          <option
+            v-for="opt in JOB_TYPE_OPTIONS"
+            :key="opt.value"
+            :value="opt.value"
+          >{{ opt.label }}</option>
+          <!-- Allow custom types not in the list -->
+          <option
+            v-if="!JOB_TYPE_OPTIONS.some(o => o.value === localType) && localType"
+            :value="localType"
+          >{{ localType }}</option>
+        </select>
+        <p v-if="spec" class="field-desc">{{ spec.description }}</p>
       </div>
 
       <div class="drawer-field">
@@ -158,52 +222,157 @@ const KIND_TYPE_OPTIONS: Array<{ value: string; label: string }> = [
       </div>
     </div>
 
-    <!-- Config KV section -->
-    <div class="drawer-section">
-      <div class="drawer-section-label">配置参数</div>
-
-      <div v-if="localKV.length === 0" class="kv-empty">
-        暂无配置项
-      </div>
+    <!-- Typed config section (per-type form) -->
+    <div v-if="spec" class="drawer-section">
+      <div class="drawer-section-label">{{ spec.label }}配置</div>
 
       <div
-        v-for="row in localKV"
-        :key="row._key"
-        class="kv-row"
+        v-for="field in visibleFields"
+        :key="field.key"
+        class="drawer-field"
       >
-        <input
-          v-model="row.k"
-          class="kv-input"
-          type="text"
-          placeholder="key"
-          :aria-label="`配置键 ${row._key}`"
+        <div class="drawer-field-label">{{ field.label }}</div>
+
+        <!-- textarea -->
+        <textarea
+          v-if="field.kind === 'textarea'"
+          :value="fieldValue(field.key)"
+          class="drawer-input drawer-textarea"
+          :class="{ 'is-mono': field.monospace }"
+          rows="4"
+          :placeholder="field.placeholder"
+          :aria-label="field.label"
+          @input="updateLocal(field.key, ($event.target as HTMLTextAreaElement).value)"
           @blur="flush"
-        />
-        <input
-          v-model="row.v"
-          class="kv-input"
-          type="text"
-          placeholder="value"
-          :aria-label="`配置值 ${row._key}`"
-          @blur="flush"
-        />
-        <button
-          class="kv-del"
-          :aria-label="`删除配置项 ${row.k || row._key}`"
-          @click="removeKV(row._key); flush()"
+        ></textarea>
+
+        <!-- select -->
+        <select
+          v-else-if="field.kind === 'select'"
+          :value="selectValue(field)"
+          class="drawer-select"
+          :aria-label="field.label"
+          @change="setField(field.key, ($event.target as HTMLSelectElement).value)"
         >
-          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-            <path d="M18 6 6 18M6 6l12 12"/>
+          <option v-for="opt in field.options" :key="opt.value" :value="opt.value">
+            {{ opt.label }}
+          </option>
+        </select>
+
+        <!-- credential picker -->
+        <select
+          v-else-if="field.kind === 'credential'"
+          :value="fieldValue(field.key)"
+          class="drawer-select"
+          :aria-label="field.label"
+          @change="setField(field.key, ($event.target as HTMLSelectElement).value)"
+        >
+          <option value="">— 未选择 —</option>
+          <option v-for="c in credentialOptions(field)" :key="c.id" :value="c.id">
+            {{ c.name }} ({{ c.maskedValue }})
+          </option>
+        </select>
+
+        <!-- server picker -->
+        <select
+          v-else-if="field.kind === 'server'"
+          :value="fieldValue(field.key)"
+          class="drawer-select"
+          :aria-label="field.label"
+          @change="setField(field.key, ($event.target as HTMLSelectElement).value)"
+        >
+          <option value="">— 未选择 —</option>
+          <option v-for="srv in (servers ?? [])" :key="srv.id" :value="srv.id">
+            {{ srv.name }} · {{ srv.host }}
+          </option>
+        </select>
+
+        <!-- toggle -->
+        <label v-else-if="field.kind === 'toggle'" class="drawer-toggle">
+          <input
+            type="checkbox"
+            :checked="fieldValue(field.key) === 'true'"
+            :aria-label="field.label"
+            @change="setField(field.key, ($event.target as HTMLInputElement).checked ? 'true' : 'false')"
+          />
+          <span>{{ field.hint || '启用' }}</span>
+        </label>
+
+        <!-- number / text -->
+        <input
+          v-else
+          :value="fieldValue(field.key)"
+          class="drawer-input"
+          :class="{ 'is-mono': field.monospace }"
+          :type="field.kind === 'number' ? 'number' : 'text'"
+          :placeholder="field.placeholder"
+          :aria-label="field.label"
+          @input="updateLocal(field.key, ($event.target as HTMLInputElement).value)"
+          @blur="flush"
+        />
+
+        <p v-if="field.hint && field.kind !== 'toggle'" class="field-hint">{{ field.hint }}</p>
+      </div>
+    </div>
+
+    <!-- Advanced raw KV (extras not covered by the schema) -->
+    <div class="drawer-section">
+      <button
+        class="advanced-toggle"
+        :class="{ 'advanced-toggle--open': showAdvanced }"
+        :aria-expanded="showAdvanced"
+        @click="showAdvanced = !showAdvanced"
+      >
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true">
+          <path d="M9 18l6-6-6-6"/>
+        </svg>
+        高级 · 原始参数<span v-if="extraRows.length" class="advanced-count">{{ extraRows.length }}</span>
+      </button>
+
+      <div v-if="showAdvanced" class="advanced-body">
+        <div v-if="extraRows.length === 0" class="kv-empty">
+          {{ spec ? '该类型的参数已在上方表单;此处可加自定义键值' : '为该类型添加自定义键值参数' }}
+        </div>
+
+        <div
+          v-for="row in extraRows"
+          :key="row._key"
+          class="kv-row"
+        >
+          <input
+            v-model="row.k"
+            class="kv-input"
+            type="text"
+            placeholder="key"
+            :aria-label="`配置键 ${row._key}`"
+            @blur="flush"
+          />
+          <input
+            v-model="row.v"
+            class="kv-input"
+            type="text"
+            placeholder="value"
+            :aria-label="`配置值 ${row._key}`"
+            @blur="flush"
+          />
+          <button
+            class="kv-del"
+            :aria-label="`删除配置项 ${row.k || row._key}`"
+            @click="removeExtra(row._key)"
+          >
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="M18 6 6 18M6 6l12 12"/>
+            </svg>
+          </button>
+        </div>
+
+        <button class="kv-add-btn" @click="addExtra">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
+            <path d="M12 5v14M5 12h14"/>
           </svg>
+          添加参数
         </button>
       </div>
-
-      <button class="kv-add-btn" @click="addKV">
-        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
-          <path d="M12 5v14M5 12h14"/>
-        </svg>
-        添加配置项
-      </button>
     </div>
   </aside>
 </template>
@@ -214,5 +383,92 @@ const KIND_TYPE_OPTIONS: Array<{ value: string; label: string }> = [
   color: var(--color-faint);
   font-style: italic;
   margin-bottom: 8px;
+}
+
+.field-desc {
+  margin: 6px 0 0;
+  font-size: 0.74rem;
+  color: var(--color-faint);
+}
+
+.field-hint {
+  margin: 5px 0 0;
+  font-size: 0.72rem;
+  color: var(--color-faint);
+  line-height: 1.4;
+}
+
+.drawer-textarea {
+  height: auto;
+  min-height: 84px;
+  padding: 9px 11px;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.is-mono {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+}
+
+.drawer-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.8rem;
+  color: var(--color-dim);
+  cursor: pointer;
+}
+
+.drawer-toggle input {
+  width: 15px;
+  height: 15px;
+  accent-color: var(--color-primary);
+  cursor: pointer;
+}
+
+.advanced-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--color-dim);
+  font: inherit;
+  font-size: 0.76rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.advanced-toggle svg {
+  transition: transform var(--duration-fast);
+}
+
+.advanced-toggle--open svg {
+  transform: rotate(90deg);
+}
+
+.advanced-toggle:hover {
+  color: var(--color-text);
+}
+
+.advanced-count {
+  display: inline-grid;
+  place-items: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  font-size: 0.66rem;
+  font-weight: 700;
+}
+
+.advanced-body {
+  margin-top: 11px;
 }
 </style>

--- a/web/src/components/pipeline/JobTypeIcon.vue
+++ b/web/src/components/pipeline/JobTypeIcon.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { jobTypeAccent } from './jobConfigSchema'
+
+const props = withDefaults(
+  defineProps<{
+    type: string
+    /** Swatch edge length in px */
+    size?: number
+  }>(),
+  { size: 30 },
+)
+
+const accent = computed(() => jobTypeAccent(props.type))
+
+/** Inline SVG path(s) per type. Stroke icons, 24×24 viewBox, consistent weight. */
+const ICONS: Record<string, string> = {
+  git_source:
+    '<circle cx="6" cy="6" r="2.4"/><circle cx="6" cy="18" r="2.4"/><circle cx="18" cy="9" r="2.4"/><path d="M6 8.4v7.2M18 11.4c0 3-2.4 4.2-5 4.2"/>',
+  build_image:
+    '<path d="M21 7.5 12 3 3 7.5 12 12l9-4.5Z"/><path d="M3 7.5v9l9 4.5 9-4.5v-9"/><path d="M12 12v9"/>',
+  push_image:
+    '<path d="M12 15V4"/><path d="m8 8 4-4 4 4"/><path d="M5 15v3a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3"/>',
+  deploy_ssh:
+    '<rect x="3" y="4" width="18" height="6" rx="1.6"/><rect x="3" y="14" width="18" height="6" rx="1.6"/><path d="M7 7h.01M7 17h.01"/>',
+  health_check: '<path d="M3 12h4l2-6 4 12 2-6h6"/>',
+  notify:
+    '<path d="M18 8.5a6 6 0 0 0-12 0c0 6.5-2.5 8.5-2.5 8.5h17S18 15 18 8.5"/><path d="M13.6 21a2 2 0 0 1-3.2 0"/>',
+  script:
+    '<rect x="3" y="4.5" width="18" height="15" rx="1.8"/><path d="m7 10 3 2.5-3 2.5M13 15.5h4"/>',
+  custom:
+    '<rect x="3" y="4.5" width="18" height="15" rx="1.8"/><path d="m7 10 3 2.5-3 2.5M13 15.5h4"/>',
+}
+
+const path = computed(() => ICONS[props.type] ?? '<circle cx="12" cy="12" r="7"/><path d="M12 9v3M12 15h.01"/>')
+const inner = computed(() => props.size * 0.5)
+</script>
+
+<template>
+  <span
+    class="type-icon"
+    :class="`type-icon--${accent}`"
+    :style="{ width: `${size}px`, height: `${size}px` }"
+    aria-hidden="true"
+  >
+    <svg
+      :width="inner"
+      :height="inner"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.9"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      v-html="path"
+    />
+  </span>
+</template>
+
+<style scoped>
+.type-icon {
+  display: inline-grid;
+  place-items: center;
+  border-radius: var(--rounded-md);
+  flex-shrink: 0;
+}
+.type-icon--cyan    { background: var(--color-cyan-soft);    color: var(--color-cyan); }
+.type-icon--primary { background: var(--color-primary-soft); color: var(--color-primary); }
+.type-icon--green   { background: var(--color-green-soft);   color: var(--color-green); }
+.type-icon--amber   { background: var(--color-amber-soft);   color: var(--color-amber); }
+.type-icon--red     { background: var(--color-red-soft);     color: var(--color-red); }
+.type-icon--neutral { background: var(--color-inset);        color: var(--color-faint); }
+</style>

--- a/web/src/components/pipeline/JobTypePicker.vue
+++ b/web/src/components/pipeline/JobTypePicker.vue
@@ -1,0 +1,271 @@
+<script setup lang="ts">
+/**
+ * JobTypePicker — Jenkins/云效-style task-type gallery (modal).
+ *
+ * Replaces the crude type dropdown: presents each task type as a card with its
+ * own icon, name, and description, grouped by category. Used both when adding a
+ * new node and when changing an existing node's type.
+ *
+ * Controlled by the parent via `open`; emits `select(type)` and `close`.
+ */
+import { ref, watch, nextTick } from 'vue'
+import { groupedJobTypes } from './jobConfigSchema'
+import JobTypeIcon from './JobTypeIcon.vue'
+
+const props = defineProps<{
+  open: boolean
+  /** Currently selected type (highlighted), if changing an existing node */
+  current?: string
+  /** Heading — "添加任务" vs "更换任务类型" */
+  title?: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'select', type: string): void
+  (e: 'close'): void
+}>()
+
+const groups = groupedJobTypes()
+const dialogRef = ref<HTMLElement | null>(null)
+let focusedBeforeOpen: HTMLElement | null = null
+
+function choose(type: string): void {
+  emit('select', type)
+}
+
+function onKeydown(e: KeyboardEvent): void {
+  if (!props.open) return
+  if (e.key === 'Escape') {
+    e.preventDefault()
+    emit('close')
+  }
+}
+
+watch(
+  () => props.open,
+  async (isOpen) => {
+    if (isOpen) {
+      focusedBeforeOpen = document.activeElement as HTMLElement | null
+      await nextTick()
+      dialogRef.value?.querySelector<HTMLElement>('.type-card')?.focus()
+    } else {
+      focusedBeforeOpen?.focus?.()
+    }
+  },
+)
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="jtp-overlay">
+      <div
+        v-if="open"
+        class="jtp-overlay"
+        @click.self="emit('close')"
+        @keydown="onKeydown"
+      >
+        <div
+          ref="dialogRef"
+          class="jtp-dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="jtp-title"
+        >
+          <header class="jtp-head">
+            <h2 id="jtp-title" class="jtp-title">{{ title || '选择任务类型' }}</h2>
+            <p class="jtp-sub">挑选一个任务类型,每类有自己的配置参数</p>
+            <button class="jtp-close" aria-label="关闭" @click="emit('close')">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <path d="M18 6 6 18M6 6l12 12"/>
+              </svg>
+            </button>
+          </header>
+
+          <div class="jtp-body">
+            <section v-for="group in groups" :key="group.id" class="jtp-group">
+              <h3 class="jtp-group-label">{{ group.label }}</h3>
+              <div class="jtp-grid">
+                <button
+                  v-for="spec in group.specs"
+                  :key="spec.type"
+                  class="type-card"
+                  :class="{ 'type-card--current': spec.type === current }"
+                  @click="choose(spec.type)"
+                >
+                  <JobTypeIcon :type="spec.type" :size="38" />
+                  <span class="type-card-body">
+                    <span class="type-card-name">
+                      {{ spec.label }}
+                      <span v-if="spec.type === current" class="type-card-badge">当前</span>
+                    </span>
+                    <span class="type-card-desc">{{ spec.description }}</span>
+                    <code class="type-card-token">{{ spec.type }}</code>
+                  </span>
+                </button>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.jtp-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 8200;
+  background: rgba(8, 10, 18, 0.5);
+  backdrop-filter: blur(3px);
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.jtp-dialog {
+  width: min(840px, 100%);
+  max-height: min(82vh, 760px);
+  display: flex;
+  flex-direction: column;
+  background: var(--color-card);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded-lg, 14px);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.32);
+  overflow: hidden;
+}
+
+.jtp-head {
+  position: relative;
+  padding: 18px 22px 14px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.jtp-title {
+  margin: 0;
+  font-size: 1.04rem;
+  font-weight: 650;
+  color: var(--color-text);
+}
+
+.jtp-sub {
+  margin: 3px 0 0;
+  font-size: 0.8rem;
+  color: var(--color-faint);
+}
+
+.jtp-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  background: none;
+  border: none;
+  border-radius: var(--rounded-md);
+  color: var(--color-faint);
+  cursor: pointer;
+  transition: color var(--duration-fast), background-color var(--duration-fast);
+}
+.jtp-close:hover { color: var(--color-text); background: var(--color-inset); }
+.jtp-close:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
+
+.jtp-body {
+  padding: 18px 22px 22px;
+  overflow-y: auto;
+}
+
+.jtp-group + .jtp-group { margin-top: 18px; }
+
+.jtp-group-label {
+  margin: 0 0 9px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-faint);
+}
+
+.jtp-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(232px, 1fr));
+  gap: 10px;
+}
+
+.type-card {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  text-align: left;
+  padding: 13px 14px;
+  background: var(--color-inset);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded);
+  cursor: pointer;
+  transition: border-color var(--duration-fast), background-color var(--duration-fast),
+    transform var(--duration-fast), box-shadow var(--duration-fast);
+}
+
+.type-card:hover {
+  border-color: var(--color-primary);
+  background: var(--color-card);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+}
+
+.type-card:focus-visible {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-soft);
+}
+
+.type-card--current {
+  border-color: var(--color-primary);
+  background: var(--color-primary-soft);
+}
+
+.type-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.type-card-name {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.type-card-badge {
+  font-size: 0.64rem;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 7px;
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.type-card-desc {
+  font-size: 0.76rem;
+  line-height: 1.4;
+  color: var(--color-dim);
+}
+
+.type-card-token {
+  margin-top: 2px;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--color-faint);
+}
+
+.jtp-overlay-enter-active,
+.jtp-overlay-leave-active { transition: opacity var(--duration-normal); }
+.jtp-overlay-enter-from,
+.jtp-overlay-leave-to { opacity: 0; }
+</style>

--- a/web/src/components/pipeline/PipelineCanvas.vue
+++ b/web/src/components/pipeline/PipelineCanvas.vue
@@ -5,6 +5,8 @@ import type { Credential } from '../../api/credentials'
 import type { Server } from '../../api/servers'
 import StageColumn from './StageColumn.vue'
 import JobDrawer from './JobDrawer.vue'
+import JobTypePicker from './JobTypePicker.vue'
+import { jobTypeLabel } from './jobConfigSchema'
 import './pipeline.css'
 
 // ─── Props / emits ────────────────────────────────────────────────────────────
@@ -74,23 +76,72 @@ function deleteJob(stageId: string, jobId: string): void {
   emit('update', next)
 }
 
-function addJob(stageId: string): void {
-  const stage = props.stages.find((s) => s.id === stageId)
-  if (!stage) return
-  const newJob: PipelineJob = {
-    id:      `job_${uid()}`,
-    name:    '新任务',
-    type:    'custom',
-    summary: '',
-    config:  {},
+// ─── Type picker (add new job / change existing job's type) ───────────────────
+
+interface PickerState {
+  open: boolean
+  mode: 'add' | 'change'
+  stageId: string
+  jobId: string
+  current: string
+}
+
+const picker = ref<PickerState>({ open: false, mode: 'add', stageId: '', jobId: '', current: '' })
+
+/** Open the type picker to add a new job to a stage. */
+function requestAddJob(stageId: string): void {
+  picker.value = { open: true, mode: 'add', stageId, jobId: '', current: '' }
+}
+
+/** Open the type picker to change the selected job's type (from the drawer). */
+function requestChangeType(): void {
+  if (!selectedJob.value || !selectedStage.value) return
+  picker.value = {
+    open: true,
+    mode: 'change',
+    stageId: selectedStage.value.id,
+    jobId: selectedJob.value.id,
+    current: selectedJob.value.type,
   }
+}
+
+function closePicker(): void {
+  picker.value = { ...picker.value, open: false }
+}
+
+function onPickerSelect(type: string): void {
+  const p = picker.value
+  if (p.mode === 'add') {
+    const stage = props.stages.find((s) => s.id === p.stageId)
+    if (!stage) return closePicker()
+    const newJob: PipelineJob = {
+      id:      `job_${uid()}`,
+      name:    jobTypeLabel(type),
+      type,
+      summary: '',
+      config:  {},
+    }
+    const next = props.stages.map((s) =>
+      s.id === p.stageId ? { ...s, jobs: [...s.jobs, newJob] } : s,
+    )
+    emit('update', next)
+    selectedJobId.value = newJob.id
+  } else {
+    updateJob(p.stageId, p.jobId, { type })
+  }
+  closePicker()
+}
+
+function reorderJob(stageId: string, from: number, to: number): void {
   const next = props.stages.map((s) => {
     if (s.id !== stageId) return s
-    return { ...s, jobs: [...s.jobs, newJob] }
+    const jobs = [...s.jobs]
+    if (from < 0 || from >= jobs.length || to < 0 || to >= jobs.length) return s
+    const [moved] = jobs.splice(from, 1)
+    jobs.splice(to, 0, moved)
+    return { ...s, jobs }
   })
   emit('update', next)
-  // Auto-select the new job
-  selectedJobId.value = newJob.id
 }
 
 function deleteStage(stageId: string): void {
@@ -143,8 +194,9 @@ function handleDrawerUpdate(patch: Partial<PipelineJob>): void {
             role="listitem"
             @select-job="selectJob"
             @delete-job="(jobId) => deleteJob(stage.id, jobId)"
-            @add-job="addJob(stage.id)"
+            @add-job="requestAddJob(stage.id)"
             @delete-stage="deleteStage(stage.id)"
+            @reorder-job="(p) => reorderJob(stage.id, p.from, p.to)"
           />
 
           <!-- SVG curved connector between stages -->
@@ -199,6 +251,16 @@ function handleDrawerUpdate(patch: Partial<PipelineJob>): void {
       :servers="props.servers"
       @close="closeDrawer"
       @update="handleDrawerUpdate"
+      @change-type="requestChangeType"
+    />
+
+    <!-- Type picker modal (add new job / change type) -->
+    <JobTypePicker
+      :open="picker.open"
+      :current="picker.mode === 'change' ? picker.current : ''"
+      :title="picker.mode === 'change' ? '更换任务类型' : '添加任务'"
+      @select="onPickerSelect"
+      @close="closePicker"
     />
   </div>
 </template>

--- a/web/src/components/pipeline/PipelineCanvas.vue
+++ b/web/src/components/pipeline/PipelineCanvas.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import type { PipelineStage, PipelineJob, StageKind } from '../../api/pipeline'
+import type { Credential } from '../../api/credentials'
+import type { Server } from '../../api/servers'
 import StageColumn from './StageColumn.vue'
 import JobDrawer from './JobDrawer.vue'
 import './pipeline.css'
@@ -10,6 +12,8 @@ import './pipeline.css'
 const props = defineProps<{
   stages: PipelineStage[]
   yaml: string
+  credentials?: Credential[]
+  servers?: Server[]
 }>()
 
 const emit = defineEmits<{
@@ -191,6 +195,8 @@ function handleDrawerUpdate(patch: Partial<PipelineJob>): void {
       v-if="selectedJob && selectedStage"
       :job="selectedJob"
       :stage="selectedStage"
+      :credentials="props.credentials"
+      :servers="props.servers"
       @close="closeDrawer"
       @update="handleDrawerUpdate"
     />

--- a/web/src/components/pipeline/StageColumn.vue
+++ b/web/src/components/pipeline/StageColumn.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import type { PipelineJob, PipelineStage } from '../../api/pipeline'
+import { ref } from 'vue'
+import type { PipelineStage } from '../../api/pipeline'
 import JobCard from './JobCard.vue'
 
 const props = defineProps<{
@@ -13,11 +14,36 @@ const emit = defineEmits<{
   (e: 'delete-job', jobId: string): void
   (e: 'add-job'): void
   (e: 'delete-stage'): void
+  (e: 'reorder-job', payload: { from: number; to: number }): void
 }>()
 
 function stageLabel(index: number): string {
   if (props.stage.kind === 'source') return '源'
   return String(index)
+}
+
+// ─── Drag-to-reorder (within this stage) ──────────────────────────────────────
+
+const dragFrom = ref<number | null>(null)
+const dragOver = ref<number | null>(null)
+
+function onDragStart(i: number): void {
+  dragFrom.value = i
+}
+
+function onDragEnter(i: number): void {
+  if (dragFrom.value !== null) dragOver.value = i
+}
+
+function onDrop(i: number): void {
+  const from = dragFrom.value
+  if (from !== null && from !== i) emit('reorder-job', { from, to: i })
+  resetDrag()
+}
+
+function resetDrag(): void {
+  dragFrom.value = null
+  dragOver.value = null
 }
 </script>
 
@@ -49,13 +75,19 @@ function stageLabel(index: number): string {
 
     <!-- Job cards -->
     <JobCard
-      v-for="job in stage.jobs"
+      v-for="(job, i) in stage.jobs"
       :key="job.id"
       :job="job"
       :stage-kind="stage.kind"
       :selected="job.id === selectedJobId"
+      :dragging="dragFrom === i"
+      :drag-over="dragOver === i && dragFrom !== i"
       @select="emit('select-job', job.id)"
       @delete="emit('delete-job', job.id)"
+      @dragstart="onDragStart(i)"
+      @dragend="resetDrag"
+      @dragenter="onDragEnter(i)"
+      @drop="onDrop(i)"
     />
 
     <!-- Add job trigger (source stage has no add-job since it's preset) -->

--- a/web/src/components/pipeline/jobConfigSchema.test.ts
+++ b/web/src/components/pipeline/jobConfigSchema.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import {
+  JOB_TYPE_SPECS,
+  JOB_TYPE_OPTIONS,
+  getJobTypeSpec,
+  jobTypeLabel,
+  schemaKeys,
+  splitConfig,
+} from './jobConfigSchema'
+
+describe('jobConfigSchema', () => {
+  it('exposes a typed spec for every dropdown option', () => {
+    for (const opt of JOB_TYPE_OPTIONS) {
+      const spec = getJobTypeSpec(opt.value)
+      expect(spec, `spec for ${opt.value}`).not.toBeNull()
+      expect(spec!.fields.length).toBeGreaterThan(0)
+      expect(opt.label).toContain(spec!.label)
+    }
+  })
+
+  it('returns null for an unknown type and falls back to the raw token label', () => {
+    expect(getJobTypeSpec('totally_unknown')).toBeNull()
+    expect(jobTypeLabel('totally_unknown')).toBe('totally_unknown')
+    expect(jobTypeLabel('build_image')).toBe('构建')
+  })
+
+  it('every field key is unique within a type', () => {
+    for (const spec of Object.values(JOB_TYPE_SPECS)) {
+      const keys = spec.fields.map((f) => f.key)
+      expect(new Set(keys).size, `duplicate key in ${spec.type}`).toBe(keys.length)
+    }
+  })
+
+  it('select/credential fields are well-formed', () => {
+    for (const spec of Object.values(JOB_TYPE_SPECS)) {
+      for (const f of spec.fields) {
+        if (f.kind === 'select') {
+          expect(f.options && f.options.length > 0, `${spec.type}.${f.key} needs options`).toBe(
+            true,
+          )
+        }
+        if (f.kind === 'credential') {
+          expect(typeof f.credentialType === 'string' || f.credentialType === undefined).toBe(true)
+        }
+      }
+    }
+  })
+
+  describe('build_image conditional fields', () => {
+    const fields = JOB_TYPE_SPECS.build_image.fields
+
+    function visible(config: Record<string, string>): string[] {
+      return fields.filter((f) => !f.when || f.when(config)).map((f) => f.key)
+    }
+
+    it('shows Dockerfile fields by default (no model set)', () => {
+      const keys = visible({})
+      expect(keys).toContain('dockerfilePath')
+      expect(keys).toContain('context')
+      expect(keys).not.toContain('toolchainLanguage')
+    })
+
+    it('shows toolchain fields when model = toolchain', () => {
+      const keys = visible({ buildModel: 'toolchain' })
+      expect(keys).toContain('toolchainLanguage')
+      expect(keys).toContain('buildCommand')
+      expect(keys).not.toContain('dockerfilePath')
+    })
+  })
+
+  describe('schemaKeys / splitConfig', () => {
+    it('owns its declared keys', () => {
+      const keys = schemaKeys('push_image')
+      expect(keys.has('registry')).toBe(true)
+      expect(keys.has('tag')).toBe(true)
+      expect(keys.has('nonexistent')).toBe(false)
+    })
+
+    it('returns an empty key set for unknown types', () => {
+      expect(schemaKeys('unknown').size).toBe(0)
+    })
+
+    it('splits owned keys out and keeps unknown keys as extras', () => {
+      const config = { registry: 'r', tag: 'v1', myCustomFlag: 'x', another: 'y' }
+      const { extras } = splitConfig('push_image', config)
+      const extraKeys = extras.map(([k]) => k)
+      expect(extraKeys).toEqual(['myCustomFlag', 'another'])
+    })
+
+    it('treats every key as an extra for an unknown type', () => {
+      const config = { a: '1', b: '2' }
+      const { extras } = splitConfig('unknown', config)
+      expect(extras.map(([k]) => k)).toEqual(['a', 'b'])
+    })
+  })
+})

--- a/web/src/components/pipeline/jobConfigSchema.test.ts
+++ b/web/src/components/pipeline/jobConfigSchema.test.ts
@@ -2,8 +2,11 @@ import { describe, it, expect } from 'vitest'
 import {
   JOB_TYPE_SPECS,
   JOB_TYPE_OPTIONS,
+  PICKABLE_TYPES,
   getJobTypeSpec,
   jobTypeLabel,
+  jobTypeAccent,
+  groupedJobTypes,
   schemaKeys,
   splitConfig,
 } from './jobConfigSchema'
@@ -22,6 +25,40 @@ describe('jobConfigSchema', () => {
     expect(getJobTypeSpec('totally_unknown')).toBeNull()
     expect(jobTypeLabel('totally_unknown')).toBe('totally_unknown')
     expect(jobTypeLabel('build_image')).toBe('构建')
+  })
+
+  it('every spec has a valid accent and category', () => {
+    const accents = ['cyan', 'primary', 'green', 'amber', 'red', 'neutral']
+    for (const spec of Object.values(JOB_TYPE_SPECS)) {
+      expect(accents, `${spec.type} accent`).toContain(spec.accent)
+      expect(typeof spec.category).toBe('string')
+    }
+  })
+
+  describe('groupedJobTypes', () => {
+    it('covers every pickable type exactly once across groups', () => {
+      const grouped = groupedJobTypes()
+      const flat = grouped.flatMap((g) => g.specs.map((s) => s.type))
+      expect(flat.slice().sort()).toEqual([...PICKABLE_TYPES].sort())
+      expect(new Set(flat).size).toBe(PICKABLE_TYPES.length)
+    })
+
+    it('omits empty groups and keeps display order', () => {
+      const grouped = groupedJobTypes()
+      for (const g of grouped) expect(g.specs.length).toBeGreaterThan(0)
+      // source group comes before custom group
+      const ids = grouped.map((g) => g.id)
+      expect(ids.indexOf('source')).toBeLessThan(ids.indexOf('custom'))
+    })
+
+    it('never lists the custom alias as a pickable type', () => {
+      expect(PICKABLE_TYPES).not.toContain('custom')
+    })
+  })
+
+  it('jobTypeAccent falls back to neutral for unknown types', () => {
+    expect(jobTypeAccent('build_image')).toBe('primary')
+    expect(jobTypeAccent('totally_unknown')).toBe('neutral')
   })
 
   it('every field key is unique within a type', () => {

--- a/web/src/components/pipeline/jobConfigSchema.ts
+++ b/web/src/components/pipeline/jobConfigSchema.ts
@@ -51,12 +51,22 @@ export interface JobField {
   when?: (config: Record<string, string>) => boolean
 }
 
+/** Accent palette keys — map to --color-{accent} / --color-{accent}-soft tokens. */
+export type AccentName = 'cyan' | 'primary' | 'green' | 'amber' | 'red' | 'neutral'
+
+/** Picker category id for grouping task types (Jenkins/云效-style gallery). */
+export type CategoryId = 'source' | 'build' | 'deploy' | 'quality' | 'notify' | 'custom'
+
 export interface JobTypeSpec {
   type: string
-  /** Friendly zh label shown in the type dropdown and drawer */
+  /** Friendly zh label shown in the picker, drawer, and node card */
   label: string
-  /** One-line description of what this node does */
+  /** One-line description of what this node does (shown in the picker card) */
   description: string
+  /** Accent colour for the type icon */
+  accent: AccentName
+  /** Category the type belongs to (picker grouping) */
+  category: CategoryId
   fields: JobField[]
 }
 
@@ -132,6 +142,8 @@ export const JOB_TYPE_SPECS: Record<string, JobTypeSpec> = {
     type: 'git_source',
     label: '拉取源码',
     description: '克隆 Git 仓库到构建工作区',
+    accent: 'cyan',
+    category: 'source',
     fields: [
       {
         key: 'repoUrl',
@@ -170,6 +182,8 @@ export const JOB_TYPE_SPECS: Record<string, JobTypeSpec> = {
     type: 'build_image',
     label: '构建',
     description: '构建产物(镜像 / JAR / 静态资源)',
+    accent: 'primary',
+    category: 'build',
     fields: [
       { key: 'artifactType', label: '产物类型', kind: 'select', options: ARTIFACT_OPTIONS },
       {
@@ -227,6 +241,8 @@ export const JOB_TYPE_SPECS: Record<string, JobTypeSpec> = {
     type: 'push_image',
     label: '推送镜像',
     description: '推送镜像到容器仓库',
+    accent: 'amber',
+    category: 'build',
     fields: [
       {
         key: 'registry',
@@ -264,6 +280,8 @@ export const JOB_TYPE_SPECS: Record<string, JobTypeSpec> = {
     type: 'deploy_ssh',
     label: 'SSH 部署',
     description: '通过 SSH 把产物部署到目标服务器',
+    accent: 'green',
+    category: 'deploy',
     fields: [
       {
         key: 'serverId',
@@ -299,6 +317,8 @@ export const JOB_TYPE_SPECS: Record<string, JobTypeSpec> = {
     type: 'health_check',
     label: '健康门控',
     description: '部署后探测健康,失败则回滚',
+    accent: 'green',
+    category: 'quality',
     fields: [
       { key: 'probeMode', label: '探测方式', kind: 'select', options: PROBE_MODE_OPTIONS },
       {
@@ -333,6 +353,8 @@ export const JOB_TYPE_SPECS: Record<string, JobTypeSpec> = {
     type: 'notify',
     label: '通知',
     description: '运行结束时发送通知',
+    accent: 'cyan',
+    category: 'notify',
     fields: [
       {
         key: 'channel',
@@ -356,6 +378,8 @@ export const JOB_TYPE_SPECS: Record<string, JobTypeSpec> = {
     type: 'script',
     label: '自定义脚本',
     description: '在隔离容器内执行任意命令',
+    accent: 'primary',
+    category: 'custom',
     fields: SCRIPT_FIELDS,
   },
 
@@ -363,14 +387,16 @@ export const JOB_TYPE_SPECS: Record<string, JobTypeSpec> = {
     type: 'custom',
     label: '自定义脚本',
     description: '在隔离容器内执行任意命令',
+    accent: 'primary',
+    category: 'custom',
     fields: SCRIPT_FIELDS,
   },
 }
 
 // ─── Lookups ──────────────────────────────────────────────────────────────────
 
-/** Dropdown options for the job type selector (friendly label + token). */
-export const JOB_TYPE_OPTIONS: SelectOption[] = [
+/** Canonical, ordered list of pickable types (excludes the `custom` alias of `script`). */
+export const PICKABLE_TYPES: readonly string[] = [
   'git_source',
   'build_image',
   'push_image',
@@ -378,7 +404,37 @@ export const JOB_TYPE_OPTIONS: SelectOption[] = [
   'health_check',
   'notify',
   'script',
-].map((type) => ({ value: type, label: `${JOB_TYPE_SPECS[type].label} · ${type}` }))
+]
+
+/** Dropdown options for the job type selector (friendly label + token). */
+export const JOB_TYPE_OPTIONS: SelectOption[] = PICKABLE_TYPES.map((type) => ({
+  value: type,
+  label: `${JOB_TYPE_SPECS[type].label} · ${type}`,
+}))
+
+/** Picker categories in display order. */
+export const JOB_CATEGORIES: ReadonlyArray<{ id: CategoryId; label: string }> = [
+  { id: 'source', label: '源' },
+  { id: 'build', label: '构建与制品' },
+  { id: 'deploy', label: '部署' },
+  { id: 'quality', label: '质量门禁' },
+  { id: 'notify', label: '通知' },
+  { id: 'custom', label: '自定义' },
+]
+
+/** Pickable specs grouped by category, in display order; empty groups omitted. */
+export function groupedJobTypes(): Array<{ id: CategoryId; label: string; specs: JobTypeSpec[] }> {
+  return JOB_CATEGORIES.map((cat) => ({
+    id: cat.id,
+    label: cat.label,
+    specs: PICKABLE_TYPES.map((t) => JOB_TYPE_SPECS[t]).filter((s) => s.category === cat.id),
+  })).filter((g) => g.specs.length > 0)
+}
+
+/** Accent colour for a type, falling back to neutral for unknown types. */
+export function jobTypeAccent(type: string): AccentName {
+  return JOB_TYPE_SPECS[type]?.accent ?? 'neutral'
+}
 
 /** Spec for a job type, or null when the type has no typed schema. */
 export function getJobTypeSpec(type: string): JobTypeSpec | null {

--- a/web/src/components/pipeline/jobConfigSchema.ts
+++ b/web/src/components/pipeline/jobConfigSchema.ts
@@ -1,0 +1,410 @@
+/**
+ * jobConfigSchema — declarative, per-type parameter forms for pipeline canvas nodes.
+ *
+ * The 2-2 pipeline contract freezes the node shape as `config: Record<string,string>`
+ * (a flat string map). Rather than widen that contract, every known job *type* declares
+ * a typed field schema here; JobDrawer renders those fields and reads/writes specific
+ * keys in the same flat map. Anything not covered by a type's schema stays editable via
+ * the drawer's "raw parameters" fallback, so custom/unknown types and power users lose
+ * nothing. This is the Jenkins/云效-style "each step type has its own form" behaviour,
+ * implemented without a backend DTO change.
+ *
+ * All values are strings (config is Record<string,string>). number/toggle fields are
+ * serialized to/from strings at the field layer; multiline commands are stored as a
+ * single newline-joined string.
+ */
+
+import type { CredentialType } from '../../api/credentials'
+
+// ─── Field model ──────────────────────────────────────────────────────────────
+
+export type FieldKind =
+  | 'text'
+  | 'textarea'
+  | 'select'
+  | 'number'
+  | 'toggle'
+  | 'credential'
+  | 'server'
+
+export interface SelectOption {
+  value: string
+  label: string
+}
+
+export interface JobField {
+  /** Key written into job.config */
+  key: string
+  /** Human label (zh) */
+  label: string
+  kind: FieldKind
+  placeholder?: string
+  /** Helper text shown under the control */
+  hint?: string
+  /** Options for `select` */
+  options?: SelectOption[]
+  /** Restrict the credential picker to one credential type */
+  credentialType?: CredentialType
+  /** Render with monospace font (paths, commands, image refs) */
+  monospace?: boolean
+  /** Conditional visibility based on the current config values */
+  when?: (config: Record<string, string>) => boolean
+}
+
+export interface JobTypeSpec {
+  type: string
+  /** Friendly zh label shown in the type dropdown and drawer */
+  label: string
+  /** One-line description of what this node does */
+  description: string
+  fields: JobField[]
+}
+
+// ─── Shared option sets ─────────────────────────────────────────────────────────
+
+const ARTIFACT_OPTIONS: SelectOption[] = [
+  { value: 'image', label: '容器镜像 (image)' },
+  { value: 'jar', label: 'JAR 包 (jar)' },
+  { value: 'dist', label: '静态资源 (dist)' },
+]
+
+const BUILD_MODEL_OPTIONS: SelectOption[] = [
+  { value: 'dockerfile', label: '自带 Dockerfile' },
+  { value: 'toolchain', label: '平台工具链' },
+]
+
+const TOOLCHAIN_OPTIONS: SelectOption[] = [
+  { value: 'node', label: 'Node.js' },
+  { value: 'java', label: 'Java / Maven' },
+  { value: 'go', label: 'Go' },
+  { value: 'python', label: 'Python' },
+  { value: 'custom', label: '自定义' },
+]
+
+const DEPLOY_STRATEGY_OPTIONS: SelectOption[] = [
+  { value: 'rolling', label: '滚动更新(零停机)' },
+  { value: 'recreate', label: '先停后起 (recreate)' },
+  { value: 'blue-green', label: '蓝绿部署' },
+]
+
+const PROBE_MODE_OPTIONS: SelectOption[] = [
+  { value: 'http', label: 'HTTP 探测' },
+  { value: 'command', label: '命令探测' },
+]
+
+// `when` helpers
+const modelIs = (v: string) => (c: Record<string, string>) =>
+  (c.buildModel || 'dockerfile') === v
+const probeIs = (v: string) => (c: Record<string, string>) =>
+  (c.probeMode || 'http') === v
+
+// ─── Per-type specs ──────────────────────────────────────────────────────────────
+
+const SCRIPT_FIELDS: JobField[] = [
+  {
+    key: 'image',
+    label: '运行镜像',
+    kind: 'text',
+    monospace: true,
+    placeholder: 'node:20',
+    hint: '在该隔离容器内执行命令(对标 Jenkins agent / 云效构建镜像)',
+  },
+  {
+    key: 'commands',
+    label: '执行命令',
+    kind: 'textarea',
+    monospace: true,
+    placeholder: 'npm ci\nnpm run build',
+    hint: '每行一条命令,按顺序执行',
+  },
+  {
+    key: 'workDir',
+    label: '工作目录',
+    kind: 'text',
+    monospace: true,
+    placeholder: '.',
+    hint: '相对克隆工作区根;留空为工作区根',
+  },
+]
+
+export const JOB_TYPE_SPECS: Record<string, JobTypeSpec> = {
+  git_source: {
+    type: 'git_source',
+    label: '拉取源码',
+    description: '克隆 Git 仓库到构建工作区',
+    fields: [
+      {
+        key: 'repoUrl',
+        label: '仓库地址',
+        kind: 'text',
+        monospace: true,
+        placeholder: 'https://gitee.com/org/repo.git',
+        hint: '留空则使用项目绑定的默认仓库',
+      },
+      {
+        key: 'branch',
+        label: '分支 / Ref',
+        kind: 'text',
+        monospace: true,
+        placeholder: 'main',
+        hint: '留空则使用触发时的分支或项目默认分支',
+      },
+      {
+        key: 'credentialId',
+        label: '访问凭据',
+        kind: 'credential',
+        credentialType: 'git_token',
+        hint: '私有仓库需引用 Git 令牌凭据',
+      },
+      {
+        key: 'depth',
+        label: '克隆深度',
+        kind: 'number',
+        placeholder: '1',
+        hint: '浅克隆深度;留空为完整历史',
+      },
+    ],
+  },
+
+  build_image: {
+    type: 'build_image',
+    label: '构建',
+    description: '构建产物(镜像 / JAR / 静态资源)',
+    fields: [
+      { key: 'artifactType', label: '产物类型', kind: 'select', options: ARTIFACT_OPTIONS },
+      {
+        key: 'buildModel',
+        label: '构建方式',
+        kind: 'select',
+        options: BUILD_MODEL_OPTIONS,
+        hint: '自带 Dockerfile,或由平台按工具链构建',
+      },
+      {
+        key: 'dockerfilePath',
+        label: 'Dockerfile 路径',
+        kind: 'text',
+        monospace: true,
+        placeholder: 'Dockerfile',
+        when: modelIs('dockerfile'),
+      },
+      {
+        key: 'context',
+        label: '构建上下文',
+        kind: 'text',
+        monospace: true,
+        placeholder: '.',
+        hint: '相对仓库根的构建上下文目录',
+        when: modelIs('dockerfile'),
+      },
+      {
+        key: 'toolchainLanguage',
+        label: '工具链语言',
+        kind: 'select',
+        options: TOOLCHAIN_OPTIONS,
+        when: modelIs('toolchain'),
+      },
+      {
+        key: 'toolchainVersion',
+        label: '工具链版本',
+        kind: 'text',
+        monospace: true,
+        placeholder: '20',
+        when: modelIs('toolchain'),
+      },
+      {
+        key: 'buildCommand',
+        label: '构建命令',
+        kind: 'text',
+        monospace: true,
+        placeholder: 'npm run build',
+        hint: '工具链方式下的构建入口命令',
+        when: modelIs('toolchain'),
+      },
+    ],
+  },
+
+  push_image: {
+    type: 'push_image',
+    label: '推送镜像',
+    description: '推送镜像到容器仓库',
+    fields: [
+      {
+        key: 'registry',
+        label: '镜像仓库地址',
+        kind: 'text',
+        monospace: true,
+        placeholder: 'registry.cn-hangzhou.aliyuncs.com',
+      },
+      {
+        key: 'imageName',
+        label: '镜像名',
+        kind: 'text',
+        monospace: true,
+        placeholder: 'org/app',
+      },
+      {
+        key: 'tag',
+        label: '标签',
+        kind: 'text',
+        monospace: true,
+        placeholder: '${COMMIT_SHA}',
+        hint: '可用变量:${COMMIT_SHA} ${BRANCH} ${BUILD_NUMBER}',
+      },
+      {
+        key: 'credentialId',
+        label: '仓库凭据',
+        kind: 'credential',
+        credentialType: 'registry',
+        hint: '引用镜像仓库登录凭据',
+      },
+    ],
+  },
+
+  deploy_ssh: {
+    type: 'deploy_ssh',
+    label: 'SSH 部署',
+    description: '通过 SSH 把产物部署到目标服务器',
+    fields: [
+      {
+        key: 'serverId',
+        label: '目标服务器',
+        kind: 'server',
+        hint: '选择已登记的服务器(凭据按引用绑定)',
+      },
+      {
+        key: 'deployPath',
+        label: '部署路径',
+        kind: 'text',
+        monospace: true,
+        placeholder: '/opt/app',
+      },
+      {
+        key: 'strategy',
+        label: '部署策略',
+        kind: 'select',
+        options: DEPLOY_STRATEGY_OPTIONS,
+      },
+      {
+        key: 'restartCommand',
+        label: '重启 / 切换命令',
+        kind: 'text',
+        monospace: true,
+        placeholder: 'systemctl restart app',
+        hint: '部署后在目标机执行,用于重启或原子切换',
+      },
+    ],
+  },
+
+  health_check: {
+    type: 'health_check',
+    label: '健康门控',
+    description: '部署后探测健康,失败则回滚',
+    fields: [
+      { key: 'probeMode', label: '探测方式', kind: 'select', options: PROBE_MODE_OPTIONS },
+      {
+        key: 'url',
+        label: '探测 URL',
+        kind: 'text',
+        monospace: true,
+        placeholder: 'http://localhost:8080/healthz',
+        when: probeIs('http'),
+      },
+      {
+        key: 'expectStatus',
+        label: '期望状态码',
+        kind: 'number',
+        placeholder: '200',
+        when: probeIs('http'),
+      },
+      {
+        key: 'command',
+        label: '探测命令',
+        kind: 'text',
+        monospace: true,
+        placeholder: 'curl -fsS localhost:8080/healthz',
+        when: probeIs('command'),
+      },
+      { key: 'retries', label: '重试次数', kind: 'number', placeholder: '3' },
+      { key: 'intervalSeconds', label: '重试间隔(秒)', kind: 'number', placeholder: '5' },
+    ],
+  },
+
+  notify: {
+    type: 'notify',
+    label: '通知',
+    description: '运行结束时发送通知',
+    fields: [
+      {
+        key: 'channel',
+        label: '通知渠道',
+        kind: 'text',
+        placeholder: '渠道 ID 或名称',
+        hint: '引用「通知」设置里已配置的渠道',
+      },
+      {
+        key: 'events',
+        label: '触发事件',
+        kind: 'text',
+        monospace: true,
+        placeholder: 'success,failed',
+        hint: '逗号分隔;留空为全部终态',
+      },
+    ],
+  },
+
+  script: {
+    type: 'script',
+    label: '自定义脚本',
+    description: '在隔离容器内执行任意命令',
+    fields: SCRIPT_FIELDS,
+  },
+
+  custom: {
+    type: 'custom',
+    label: '自定义脚本',
+    description: '在隔离容器内执行任意命令',
+    fields: SCRIPT_FIELDS,
+  },
+}
+
+// ─── Lookups ──────────────────────────────────────────────────────────────────
+
+/** Dropdown options for the job type selector (friendly label + token). */
+export const JOB_TYPE_OPTIONS: SelectOption[] = [
+  'git_source',
+  'build_image',
+  'push_image',
+  'deploy_ssh',
+  'health_check',
+  'notify',
+  'script',
+].map((type) => ({ value: type, label: `${JOB_TYPE_SPECS[type].label} · ${type}` }))
+
+/** Spec for a job type, or null when the type has no typed schema. */
+export function getJobTypeSpec(type: string): JobTypeSpec | null {
+  return JOB_TYPE_SPECS[type] ?? null
+}
+
+/** Friendly zh label for a type, falling back to the raw token. */
+export function jobTypeLabel(type: string): string {
+  return JOB_TYPE_SPECS[type]?.label ?? type
+}
+
+/** The set of config keys owned by a type's schema (used to split out raw extras). */
+export function schemaKeys(type: string): Set<string> {
+  const spec = JOB_TYPE_SPECS[type]
+  return new Set(spec ? spec.fields.map((f) => f.key) : [])
+}
+
+/**
+ * Split a config map into the keys owned by the type's schema vs. the rest
+ * (rendered in the "raw parameters" advanced section). Order of extras preserved.
+ */
+export function splitConfig(
+  type: string,
+  config: Record<string, string>,
+): { extras: Array<[string, string]> } {
+  const owned = schemaKeys(type)
+  const extras = Object.entries(config).filter(([k]) => !owned.has(k))
+  return { extras }
+}

--- a/web/src/views/ProjectPipeline.vue
+++ b/web/src/views/ProjectPipeline.vue
@@ -16,6 +16,7 @@ import {
   type SaveSettingsInput,
 } from '../api/pipelineSettings'
 import { listCredentials, type Credential } from '../api/credentials'
+import { listServers, type Server } from '../api/servers'
 import { getValidation, type ValidationDTO, type IssueScope } from '../api/pipelineValidation'
 import { HttpError } from '../api/http'
 import PipelineCanvas from '../components/pipeline/PipelineCanvas.vue'
@@ -101,6 +102,7 @@ const settings    = ref<SettingsDTO | null>(null)
 const editBuild    = ref<BuildConfig | null>(null)
 const editEnvs     = ref<Environment[]>([])
 const credentials  = ref<Credential[]>([])
+const servers      = ref<Server[]>([])
 
 function applySettings(dto: SettingsDTO): void {
   settings.value = dto
@@ -110,12 +112,14 @@ function applySettings(dto: SettingsDTO): void {
 
 async function loadSettings(): Promise<void> {
   try {
-    const [dto, creds] = await Promise.all([
+    const [dto, creds, srvs] = await Promise.all([
       getSettings(projectId.value),
       listCredentials().catch(() => [] as Credential[]),
+      listServers().catch(() => [] as Server[]),
     ])
     applySettings(dto)
     credentials.value = creds
+    servers.value = srvs
   } catch {
     // Settings load failure is non-fatal for the canvas; the vars/envs tabs show
     // their own empty state until a successful save. Surfaced on save attempts.
@@ -451,6 +455,8 @@ const projectName = computed(() => String(route.params.id))
             v-else-if="loadState === 'idle' && pipeline"
             :stages="editStages"
             :yaml="pipeline.yaml"
+            :credentials="credentials"
+            :servers="servers"
             @update="handleCanvasUpdate"
           />
         </div>


### PR DESCRIPTION
画布节点选类型后不再「暂无配置项」:每类型一套参数表单(构建/推送/部署/脚本…),凭据/服务器下拉引真实数据;类型选择改云效/Jenkins 式弹出画廊 + 节点类型图标 + 阶段内拖拽。不动 2-2 冻结契约(纯前端)。截图核验 + 往返持久化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)