### PR TITLE
feat(canvas): 8-7 画布编辑阶段依赖(needs)+ 按 DAG 渲染连线

### DIFF
--- a/web/src/api/pipeline.ts
+++ b/web/src/api/pipeline.ts
@@ -30,6 +30,10 @@ export interface PipelineStage {
   id: string
   name: string
   kind: StageKind
+  /** Upstream stage IDs this stage depends on (Epic 8 DAG). Empty = no explicit deps. */
+  needs?: string[]
+  /** When true, this stage's failure does not block downstream stages. */
+  allowFailure?: boolean
   jobs: PipelineJob[]
 }
 
@@ -49,6 +53,8 @@ export interface SavePipelineInput {
     id?: string
     name: string
     kind: StageKind
+    needs?: string[]
+    allowFailure?: boolean
     jobs: Array<{
       id?: string
       name: string

--- a/web/src/components/pipeline/PipelineCanvas.vue
+++ b/web/src/components/pipeline/PipelineCanvas.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
 import type { PipelineStage, PipelineJob, StageKind } from '../../api/pipeline'
 import type { Credential } from '../../api/credentials'
 import type { Server } from '../../api/servers'
@@ -7,6 +7,7 @@ import StageColumn from './StageColumn.vue'
 import JobDrawer from './JobDrawer.vue'
 import JobTypePicker from './JobTypePicker.vue'
 import { jobTypeLabel } from './jobConfigSchema'
+import { hasAnyNeeds } from './stageDeps'
 import './pipeline.css'
 
 // ─── Props / emits ────────────────────────────────────────────────────────────
@@ -64,6 +65,11 @@ function updateJob(stageId: string, jobId: string, patch: Partial<PipelineJob>):
       jobs: s.jobs.map((j) => (j.id === jobId ? { ...j, ...patch } : j)),
     }
   })
+  emit('update', next)
+}
+
+function updateStage(stageId: string, patch: Partial<PipelineStage>): void {
+  const next = props.stages.map((s) => (s.id === stageId ? { ...s, ...patch } : s))
   emit('update', next)
 }
 
@@ -149,7 +155,13 @@ function deleteStage(stageId: string): void {
   if (idx < 0) return
   // Deselect if selected job was in this stage
   if (selectedStage.value?.id === stageId) selectedJobId.value = null
-  emit('update', props.stages.filter((s) => s.id !== stageId))
+  // Drop the deleted stage and strip any dangling needs referencing it (else save 422s).
+  const next = props.stages
+    .filter((s) => s.id !== stageId)
+    .map((s) =>
+      s.needs?.includes(stageId) ? { ...s, needs: s.needs.filter((n) => n !== stageId) } : s,
+    )
+  emit('update', next)
 }
 
 function addStage(): void {
@@ -169,6 +181,62 @@ function addStage(): void {
   emit('update', [...props.stages, newStage])
 }
 
+// ─── DAG edge overlay (Story 8-7) ─────────────────────────────────────────────
+// Draw connectors from each stage's declared needs (upstream → downstream). When no
+// stage declares needs, fall back to a linear chain (mirrors backend BuildGraph).
+
+const flowRef = ref<HTMLElement | null>(null)
+const overlay = ref({ w: 0, h: 0 })
+const edgePaths = ref<string[]>([])
+
+interface Edge { from: string; to: string }
+
+const edges = computed<Edge[]>(() => {
+  if (hasAnyNeeds(props.stages)) {
+    const out: Edge[] = []
+    for (const s of props.stages) for (const n of s.needs ?? []) out.push({ from: n, to: s.id })
+    return out
+  }
+  const out: Edge[] = []
+  for (let i = 1; i < props.stages.length; i++) {
+    out.push({ from: props.stages[i - 1].id, to: props.stages[i].id })
+  }
+  return out
+})
+
+const HEADER_Y = 13 // connect edges at stage-header vertical center
+
+function measureEdges(): void {
+  const flow = flowRef.value
+  if (!flow) return
+  const cols = Array.from(flow.querySelectorAll<HTMLElement>('.stage-col'))
+  const byId = new Map<string, HTMLElement>()
+  props.stages.forEach((s, i) => { if (cols[i]) byId.set(s.id, cols[i]) })
+  overlay.value = { w: flow.scrollWidth, h: flow.scrollHeight }
+  const paths: string[] = []
+  for (const e of edges.value) {
+    const a = byId.get(e.from)
+    const b = byId.get(e.to)
+    if (!a || !b) continue
+    const x1 = a.offsetLeft + a.offsetWidth
+    const y1 = a.offsetTop + HEADER_Y
+    const x2 = b.offsetLeft
+    const y2 = b.offsetTop + HEADER_Y
+    const dx = Math.max(26, Math.abs(x2 - x1) * 0.5)
+    paths.push(`M${x1},${y1} C${x1 + dx},${y1} ${x2 - dx},${y2} ${x2},${y2}`)
+  }
+  edgePaths.value = paths
+}
+
+let ro: ResizeObserver | null = null
+onMounted(() => {
+  measureEdges()
+  ro = new ResizeObserver(() => measureEdges())
+  if (flowRef.value) ro.observe(flowRef.value)
+})
+onBeforeUnmount(() => ro?.disconnect())
+watch(() => props.stages, () => nextTick(measureEdges), { deep: true })
+
 // ─── YAML preview toggle ──────────────────────────────────────────────────────
 
 const yamlOpen = ref(false)
@@ -183,7 +251,20 @@ function handleDrawerUpdate(patch: Partial<PipelineJob>): void {
   <div class="canvas-body">
     <!-- ─── Scrollable canvas ────────────────────────────────────────────── -->
     <div class="pipeline-canvas">
-      <div class="pipeline-flow" role="list" aria-label="流水线阶段">
+      <div ref="flowRef" class="pipeline-flow pipeline-flow--dag" role="list" aria-label="流水线阶段">
+
+        <!-- DAG edge overlay (drawn from declared needs; decorative) -->
+        <svg
+          v-if="edgePaths.length"
+          class="dag-overlay"
+          :width="overlay.w"
+          :height="overlay.h"
+          :viewBox="`0 0 ${overlay.w} ${overlay.h}`"
+          aria-hidden="true"
+        >
+          <path v-for="(d, i) in edgePaths" :key="i" class="dag-edge" :d="d" />
+          <path v-for="(d, i) in edgePaths" :key="`f${i}`" class="dag-edge-flow" :d="d" />
+        </svg>
 
         <template v-for="(stage, idx) in stages" :key="stage.id">
           <!-- Stage column -->
@@ -191,27 +272,16 @@ function handleDrawerUpdate(patch: Partial<PipelineJob>): void {
             :stage="stage"
             :stage-index="idx"
             :selected-job-id="selectedJobId"
+            :all-stages="stages"
             role="listitem"
             @select-job="selectJob"
             @delete-job="(jobId) => deleteJob(stage.id, jobId)"
             @add-job="requestAddJob(stage.id)"
             @delete-stage="deleteStage(stage.id)"
             @reorder-job="(p) => reorderJob(stage.id, p.from, p.to)"
+            @update-needs="(needs) => updateStage(stage.id, { needs })"
+            @update-allow-failure="(v) => updateStage(stage.id, { allowFailure: v })"
           />
-
-          <!-- SVG curved connector between stages -->
-          <div
-            v-if="idx < stages.length - 1"
-            class="stage-connector"
-            aria-hidden="true"
-          >
-            <svg viewBox="0 0 74 30">
-              <path class="conn-edge" d="M5,15 C28,3 46,27 69,15"/>
-              <path class="conn-flow" d="M5,15 C28,3 46,27 69,15"/>
-              <circle class="conn-port" cx="5"  cy="15" r="3.2"/>
-              <circle class="conn-port" cx="69" cy="15" r="3.2"/>
-            </svg>
-          </div>
         </template>
 
         <!-- Add stage button (dashed) -->
@@ -272,4 +342,48 @@ function handleDrawerUpdate(patch: Partial<PipelineJob>): void {
   min-height: 0;
   overflow: hidden;
 }
+
+/* DAG layout: position the flow so the overlay anchors to it; give columns a gap for edges. */
+.pipeline-flow--dag {
+  position: relative;
+  gap: 60px;
+}
+
+.dag-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  overflow: visible;
+}
+
+.dag-edge {
+  fill: none;
+  stroke: var(--color-border-strong);
+  stroke-width: 2;
+}
+
+/* animated flow pulse along the edge */
+.dag-edge-flow {
+  fill: none;
+  stroke: var(--color-primary);
+  stroke-width: 2;
+  stroke-dasharray: 5 12;
+  opacity: 0.75;
+  animation: dag-flow 1.4s linear infinite;
+}
+
+@keyframes dag-flow {
+  to {
+    stroke-dashoffset: -34;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dag-edge-flow {
+    animation: none;
+  }
+}
+/* The overlay (z-index 0, first child) paints below the stage columns (later siblings),
+   so edges show only in the gaps between columns. */
 </style>

--- a/web/src/components/pipeline/StageColumn.vue
+++ b/web/src/components/pipeline/StageColumn.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import type { PipelineStage } from '../../api/pipeline'
 import JobCard from './JobCard.vue'
+import { eligibleNeeds, toggleNeed } from './stageDeps'
 
 const props = defineProps<{
   stage: PipelineStage
   stageIndex: number
   selectedJobId: string | null
+  /** All stages — used to compute cycle-safe dependency options. */
+  allStages: PipelineStage[]
 }>()
 
 const emit = defineEmits<{
@@ -15,11 +18,33 @@ const emit = defineEmits<{
   (e: 'add-job'): void
   (e: 'delete-stage'): void
   (e: 'reorder-job', payload: { from: number; to: number }): void
+  (e: 'update-needs', needs: string[]): void
+  (e: 'update-allow-failure', value: boolean): void
 }>()
 
 function stageLabel(index: number): string {
   if (props.stage.kind === 'source') return '源'
   return String(index)
+}
+
+// ─── Stage dependencies (needs · DAG) ─────────────────────────────────────────
+
+const depsOpen = ref(false)
+
+const currentNeeds = computed<string[]>(() => props.stage.needs ?? [])
+
+/** Stages that can be an upstream dependency without creating a cycle. */
+const depChoices = computed(() => eligibleNeeds(props.allStages, props.stage.id))
+
+/** Display labels for the current needs (name of each upstream stage). */
+const needLabels = computed(() =>
+  currentNeeds.value
+    .map((id) => props.allStages.find((s) => s.id === id)?.name ?? id)
+    .filter(Boolean),
+)
+
+function toggleDep(needId: string): void {
+  emit('update-needs', toggleNeed(currentNeeds.value, needId))
 }
 
 // ─── Drag-to-reorder (within this stage) ──────────────────────────────────────
@@ -52,7 +77,22 @@ function resetDrag(): void {
     <!-- Stage header -->
     <div class="stage-header">
       <span class="stage-index" aria-hidden="true">{{ stageLabel(stageIndex) }}</span>
-      <span>{{ stage.name }}</span>
+      <span class="stage-name-text">{{ stage.name }}</span>
+      <button
+        v-if="stage.kind !== 'source'"
+        class="stage-deps-btn"
+        :class="{ 'stage-deps-btn--active': depsOpen || currentNeeds.length > 0 }"
+        :aria-label="`编辑阶段 ${stage.name} 的依赖`"
+        :aria-expanded="depsOpen"
+        title="编辑依赖(DAG)"
+        @click="depsOpen = !depsOpen"
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <circle cx="6" cy="6" r="2.4"/><circle cx="6" cy="18" r="2.4"/><circle cx="18" cy="12" r="2.4"/>
+          <path d="M8 6.6c5 0 3 5.4 8 5.4M8 17.4c5 0 3-5.4 8-5.4"/>
+        </svg>
+        依赖<span v-if="currentNeeds.length" class="stage-deps-count">{{ currentNeeds.length }}</span>
+      </button>
       <button
         v-if="stage.kind !== 'source'"
         class="stage-add-job"
@@ -71,6 +111,36 @@ function resetDrag(): void {
           <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2"/>
         </svg>
       </button>
+    </div>
+
+    <!-- Dependency chips (declared needs) -->
+    <div v-if="currentNeeds.length" class="stage-needs-chips" aria-label="上游依赖">
+      <span class="stage-needs-arrow" aria-hidden="true">⤳</span>
+      <span v-for="label in needLabels" :key="label" class="stage-need-chip">{{ label }}</span>
+    </div>
+
+    <!-- Dependency editor popover -->
+    <div v-if="depsOpen && stage.kind !== 'source'" class="deps-popover" role="group" aria-label="阶段依赖编辑">
+      <div class="deps-popover-title">依赖的上游阶段</div>
+      <p v-if="depChoices.length === 0" class="deps-empty">没有可选的上游阶段</p>
+      <label v-for="opt in depChoices" :key="opt.id" class="deps-option">
+        <input
+          type="checkbox"
+          :checked="currentNeeds.includes(opt.id)"
+          @change="toggleDep(opt.id)"
+        />
+        <span>{{ opt.name }}</span>
+      </label>
+      <div class="deps-divider"></div>
+      <label class="deps-option deps-option--toggle">
+        <input
+          type="checkbox"
+          :checked="stage.allowFailure === true"
+          @change="emit('update-allow-failure', ($event.target as HTMLInputElement).checked)"
+        />
+        <span>失败不阻断下游(allowFailure)</span>
+      </label>
+      <p class="deps-hint">留空 = 无显式依赖;全流水线无依赖时按从左到右线性执行</p>
     </div>
 
     <!-- Job cards -->
@@ -99,3 +169,102 @@ function resetDrag(): void {
     >+ 添加任务</button>
   </div>
 </template>
+
+<style scoped>
+.stage-col {
+  position: relative;
+}
+
+.stage-name-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stage-deps-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 22px;
+  padding: 0 7px;
+  background: none;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded-md);
+  color: var(--color-dim);
+  font: inherit;
+  font-size: 0.7rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color var(--duration-fast), color var(--duration-fast), background-color var(--duration-fast);
+}
+.stage-deps-btn:hover { border-color: var(--color-primary); color: var(--color-primary); }
+.stage-deps-btn--active { border-color: var(--color-primary); color: var(--color-primary); background: var(--color-primary-soft); }
+.stage-deps-btn:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 1px; }
+
+.stage-deps-count {
+  display: inline-grid;
+  place-items: center;
+  min-width: 14px;
+  height: 14px;
+  padding: 0 3px;
+  border-radius: 7px;
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 0.6rem;
+  font-weight: 700;
+}
+
+.stage-needs-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  margin: 2px 0 8px;
+}
+.stage-needs-arrow { color: var(--color-faint); font-size: 0.8rem; }
+.stage-need-chip {
+  font-size: 0.66rem;
+  font-weight: 600;
+  padding: 1px 7px;
+  border-radius: 8px;
+  background: var(--color-cyan-soft);
+  color: var(--color-cyan);
+}
+
+.deps-popover {
+  position: absolute;
+  top: 40px;
+  right: 6px;
+  z-index: 40;
+  width: 210px;
+  padding: 11px 12px;
+  background: var(--color-card);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.22);
+}
+.deps-popover-title {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--color-faint);
+  margin-bottom: 8px;
+}
+.deps-empty { font-size: 0.74rem; color: var(--color-faint); font-style: italic; margin: 0; }
+.deps-option {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 3px 0;
+  font-size: 0.78rem;
+  color: var(--color-text);
+  cursor: pointer;
+}
+.deps-option input { width: 14px; height: 14px; accent-color: var(--color-primary); cursor: pointer; }
+.deps-option--toggle { color: var(--color-dim); }
+.deps-divider { height: 1px; background: var(--color-border); margin: 8px 0; }
+.deps-hint { margin: 7px 0 0; font-size: 0.68rem; color: var(--color-faint); line-height: 1.4; }
+</style>

--- a/web/src/components/pipeline/stageDeps.test.ts
+++ b/web/src/components/pipeline/stageDeps.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import type { PipelineStage } from '../../api/pipeline'
+import { dependsOn, canAddNeed, eligibleNeeds, toggleNeed, hasAnyNeeds } from './stageDeps'
+
+function stage(id: string, needs: string[] = []): PipelineStage {
+  return { id, name: id.toUpperCase(), kind: 'custom', needs, jobs: [] }
+}
+
+describe('stageDeps', () => {
+  // src → build → deploy (deploy needs build, build needs src)
+  const chain: PipelineStage[] = [stage('src'), stage('build', ['src']), stage('deploy', ['build'])]
+
+  describe('dependsOn', () => {
+    it('finds direct and transitive deps', () => {
+      expect(dependsOn(chain, 'deploy', 'build')).toBe(true)
+      expect(dependsOn(chain, 'deploy', 'src')).toBe(true) // transitive
+      expect(dependsOn(chain, 'build', 'src')).toBe(true)
+    })
+    it('is directional', () => {
+      expect(dependsOn(chain, 'src', 'deploy')).toBe(false)
+      expect(dependsOn(chain, 'build', 'deploy')).toBe(false)
+    })
+    it('handles missing/empty', () => {
+      expect(dependsOn(chain, 'src', 'src')).toBe(false)
+      expect(dependsOn([], 'a', 'b')).toBe(false)
+    })
+  })
+
+  describe('canAddNeed', () => {
+    it('rejects self', () => {
+      expect(canAddNeed(chain, 'build', 'build')).toBe(false)
+    })
+    it('rejects cycle-closing edge', () => {
+      // deploy depends on build; making build need deploy would cycle.
+      expect(canAddNeed(chain, 'build', 'deploy')).toBe(false)
+      expect(canAddNeed(chain, 'src', 'deploy')).toBe(false)
+    })
+    it('allows safe edges', () => {
+      // build can additionally need... nothing new here; src can need build is unsafe(build needs src).
+      expect(canAddNeed(chain, 'deploy', 'src')).toBe(true) // already implied, still safe
+      const flat = [stage('a'), stage('b'), stage('c')]
+      expect(canAddNeed(flat, 'c', 'a')).toBe(true)
+      expect(canAddNeed(flat, 'c', 'b')).toBe(true)
+    })
+  })
+
+  describe('eligibleNeeds', () => {
+    it('excludes self and cycle-creating stages', () => {
+      // For 'build': self excluded; 'deploy' excluded (depends on build); 'src' eligible.
+      const ids = eligibleNeeds(chain, 'build').map((s) => s.id)
+      expect(ids).toEqual(['src'])
+    })
+    it('flat graph: all others eligible', () => {
+      const flat = [stage('a'), stage('b'), stage('c')]
+      expect(eligibleNeeds(flat, 'b').map((s) => s.id)).toEqual(['a', 'c'])
+    })
+  })
+
+  describe('toggleNeed', () => {
+    it('adds and removes immutably', () => {
+      expect(toggleNeed([], 'x')).toEqual(['x'])
+      expect(toggleNeed(['x', 'y'], 'x')).toEqual(['y'])
+      const orig = ['a']
+      toggleNeed(orig, 'b')
+      expect(orig).toEqual(['a']) // unchanged
+    })
+  })
+
+  describe('hasAnyNeeds', () => {
+    it('detects explicit needs vs linear', () => {
+      expect(hasAnyNeeds(chain)).toBe(true)
+      expect(hasAnyNeeds([stage('a'), stage('b')])).toBe(false)
+    })
+  })
+})

--- a/web/src/components/pipeline/stageDeps.ts
+++ b/web/src/components/pipeline/stageDeps.ts
@@ -1,0 +1,69 @@
+/**
+ * stageDeps — pure helpers for editing pipeline stage dependencies (Epic 8 · 8-7).
+ *
+ * A stage's `needs` lists upstream stage IDs it depends on. The canvas editor uses
+ * these helpers to offer only cycle-safe dependency choices; the backend re-validates
+ * (dag.New) on save, so this is UX guardrail, not the source of truth.
+ *
+ * Dependency edge direction: `S needs N` means N must finish before S (N is upstream).
+ */
+
+import type { PipelineStage } from '../../api/pipeline'
+
+/** Does `fromId` (transitively) depend on `targetId` via needs edges? */
+export function dependsOn(
+  stages: ReadonlyArray<PipelineStage>,
+  fromId: string,
+  targetId: string,
+): boolean {
+  const byId = new Map(stages.map((s) => [s.id, s]))
+  const seen = new Set<string>()
+  const stack: string[] = [...(byId.get(fromId)?.needs ?? [])]
+  while (stack.length) {
+    const id = stack.pop() as string
+    if (id === targetId) return true
+    if (seen.has(id)) continue
+    seen.add(id)
+    const node = byId.get(id)
+    if (node?.needs) stack.push(...node.needs)
+  }
+  return false
+}
+
+/**
+ * Is it safe to add `needId` to `stageId.needs`?
+ * Safe iff it's a different stage and `needId` does not already depend on `stageId`
+ * (which would close a cycle).
+ */
+export function canAddNeed(
+  stages: ReadonlyArray<PipelineStage>,
+  stageId: string,
+  needId: string,
+): boolean {
+  if (stageId === needId) return false
+  return !dependsOn(stages, needId, stageId)
+}
+
+/**
+ * Stages eligible to be an upstream dependency of `stageId`:
+ * every other stage that wouldn't create a cycle. Already-selected needs remain eligible
+ * (shown checked). Order preserved as given.
+ */
+export function eligibleNeeds(
+  stages: ReadonlyArray<PipelineStage>,
+  stageId: string,
+): PipelineStage[] {
+  return stages.filter((s) => s.id !== stageId && !dependsOn(stages, s.id, stageId))
+}
+
+/** Toggle `needId` in a needs list, returning a new array (immutable). */
+export function toggleNeed(needs: ReadonlyArray<string>, needId: string): string[] {
+  return needs.includes(needId)
+    ? needs.filter((n) => n !== needId)
+    : [...needs, needId]
+}
+
+/** Does the whole stage set declare any explicit needs? (false ⇒ linear fallback) */
+export function hasAnyNeeds(stages: ReadonlyArray<PipelineStage>): boolean {
+  return stages.some((s) => (s.needs?.length ?? 0) > 0)
+}


### PR DESCRIPTION
(stacked on feat/pipeline-node-config-forms)阶段头「依赖」按钮多选上游(防自指/防环,后端再校验)+ 依赖 chip + 按 needs 画 DAG 边。stageDeps 纯逻辑 10 单测 + 截图核验分支连线。

🤖 Generated with [Claude Code](https://claude.com/claude-code)