### PR TITLE
feat(pipeline): 8-1 阶段 needs DAG 持久化 + 接进 run 引擎

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/auth"
 	"github.com/huangchengsir/pipewright/internal/build"
 	"github.com/huangchengsir/pipewright/internal/config"
+	"github.com/huangchengsir/pipewright/internal/dagrun"
 	"github.com/huangchengsir/pipewright/internal/deploy"
 	"github.com/huangchengsir/pipewright/internal/httpapi"
 	"github.com/huangchengsir/pipewright/internal/mask"
@@ -157,7 +158,18 @@ func main() {
 	//   - 缺省 auto:探测到 docker/nerdctl/podman 用 real,否则回退桩(优雅降级,NFR-10)。
 	// 真实 Builder 经构造函数注入 projectSvc/pipelineSettingsSvc/credVault;真实日志/产物/失败日志
 	// 经同一 run.StepSink 喂出,复用既有持久化/SSE/脱敏(下方 WithLogMaskerFunc 对真实日志同样生效)。
-	runnerOpts := buildRunnerOption(projectSvc, pipelineSettingsSvc, credVault)
+	// PIPEWRIGHT_RUNNER=dag 时启用 DAG 调度执行器(Epic 8 · 8-1↔8-3):按阶段 needs 构 DAG 调度
+	// (无依赖阶段并行、失败阻断下游),阶段编排经既有 StepSink 持久化。**默认关闭**(不破存量):
+	// 缺省/其它值仍走 PIPEWRIGHT_BUILDER 选出的真实 Builder / 桩 runner。
+	// ⚠ 当前阶段执行体为占位 stub(仅打日志即成功);真实「阶段内并行 job → job 内有序 step
+	// 在隔离容器构建/部署」= Story 8-2 尚未接入,故 dag 模式现仅用于验证编排,不做真实构建。
+	var runnerOpts []run.PoolOption
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("PIPEWRIGHT_RUNNER")), "dag") {
+		log.Printf("[run] PIPEWRIGHT_RUNNER=dag:DAG 调度执行器已启用(阶段按 needs 编排;⚠ 阶段执行体=占位 stub,真实构建/部署=Story 8-2 未接入)")
+		runnerOpts = []run.PoolOption{run.WithRunner(dagrun.New(pipelineSvc))}
+	} else {
+		runnerOpts = buildRunnerOption(projectSvc, pipelineSettingsSvc, credVault)
+	}
 
 	pool := run.NewWorkerPool(runSvc,
 		append(runnerOpts,

--- a/internal/dagrun/dagrun.go
+++ b/internal/dagrun/dagrun.go
@@ -1,0 +1,219 @@
+// Package dagrun 把 DAG 调度内核(internal/dag)接进 run 引擎(Epic 8 · Story 8-1↔8-3 桥接)。
+//
+// Runner 实现 run.Runner 契约,可直接作为 WorkerPool 的执行器:它加载项目的流水线 spec
+// (阶段 + 依赖 needs),用 dag 把阶段构成 DAG 调度执行——无依赖阶段并行、按拓扑序推进、
+// 任一阶段失败按策略阻断下游(下游阶段记 skipped),并把每个阶段的运行/终态/日志经既有
+// StepSink 持久化(复用 run_steps + SSE + 脱敏管道)。
+//
+// 关注点分离:**单个阶段「怎么执行」**(跑 stage 内并行 job → job 内有序 step、在隔离容器里
+// 真实构建/部署)由注入的 StageExecutor 决定——那是 Story 8-2 的活;本包只负责「**按 DAG
+// 把阶段编排起来并如实上报**」。未注入真实执行器时用 StubStageExecutor(仅打日志即成功),
+// 便于纯单测覆盖编排逻辑、且不冒充真实执行。
+//
+// 向后兼容:当整个 spec 无任何阶段声明 needs 时,BuildGraph 退化为「按声明序线性」(存量
+// 直线流水线行为不变);一旦有阶段声明 needs,严格按声明的 DAG 调度。
+package dagrun
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/huangchengsir/pipewright/internal/dag"
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// SpecLoader 加载某项目的流水线配置(pipeline.Service 即满足此接口)。
+type SpecLoader interface {
+	Get(ctx context.Context, projectID string) (*pipeline.Config, error)
+}
+
+// StageReporter 给 StageExecutor 上报「本阶段」的日志/产物(自动关联到该阶段的 run_steps 序号)。
+type StageReporter interface {
+	// Log 报告本阶段一行日志(stream ∈ stdout|stderr)。落库前由 StepSink 脱敏。
+	Log(ctx context.Context, stream, line string) error
+	// EmitArtifact 报告本阶段产出的一条构建产物。
+	EmitArtifact(ctx context.Context, a run.Artifact) error
+}
+
+// StageExecutor 执行单个阶段(跑其 job/step);返回非 nil 表示该阶段失败。须响应 ctx 取消。
+// 真实实现(Story 8-2)在隔离容器内跑 stage 内并行 job 的有序 step;本包默认用 StubStageExecutor。
+type StageExecutor func(ctx context.Context, r *run.Run, stage pipeline.Stage, rep StageReporter) error
+
+// StubStageExecutor 是默认占位执行器:为每个 job 打一行日志后即判该阶段成功。
+// 不做任何真实构建/部署(诚实占位,真实执行 = Story 8-2)。
+func StubStageExecutor(ctx context.Context, _ *run.Run, stage pipeline.Stage, rep StageReporter) error {
+	if len(stage.Jobs) == 0 {
+		_ = rep.Log(ctx, "stdout", fmt.Sprintf("阶段「%s」无 job,跳过执行体", stage.Name))
+		return nil
+	}
+	for _, jb := range stage.Jobs {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		_ = rep.Log(ctx, "stdout", fmt.Sprintf("· %s(%s)", jb.Name, jb.Type))
+	}
+	return nil
+}
+
+// Runner 是 DAG 感知的 run.Runner 实现。
+type Runner struct {
+	loader      SpecLoader
+	exec        StageExecutor
+	concurrency int
+}
+
+// Option 配置 Runner。
+type Option func(*Runner)
+
+// WithConcurrency 设阶段并行上限(<=0 用阶段总数,即「能并行的全并行」)。
+func WithConcurrency(n int) Option {
+	return func(r *Runner) { r.concurrency = n }
+}
+
+// WithStageExecutor 注入真实阶段执行器(Story 8-2)。nil 忽略(保留 Stub)。
+func WithStageExecutor(e StageExecutor) Option {
+	return func(r *Runner) {
+		if e != nil {
+			r.exec = e
+		}
+	}
+}
+
+// New 构造 DAG Runner。loader 加载 spec;未注入执行器时用 StubStageExecutor。
+func New(loader SpecLoader, opts ...Option) *Runner {
+	r := &Runner{loader: loader, exec: StubStageExecutor}
+	for _, o := range opts {
+		o(r)
+	}
+	return r
+}
+
+// Run 实现 run.Runner:加载 spec → 构 DAG → 按拓扑/并行调度阶段 → 经 StepSink 上报。
+//
+// StepSink 非并发安全约定:本 Runner 用单一 mutex 串行化所有 sink 调用,即便阶段并行执行,
+// 对 sink 的 Plan/StepRunning/StepDone/Log/EmitArtifact 也互斥,安全复用既有持久化管道。
+func (r *Runner) Run(ctx context.Context, rn *run.Run, sink run.StepSink) error {
+	cfg, err := r.loader.Get(ctx, rn.ProjectID)
+	if err != nil {
+		return fmt.Errorf("dagrun: load pipeline spec: %w", err)
+	}
+	stages := cfg.Spec.Stages
+	if len(stages) == 0 {
+		// 无阶段:声明零步,直接成功(与既有空流水线语义一致)。
+		_ = sink.Plan(ctx, nil)
+		return nil
+	}
+
+	graph, err := BuildGraph(stages)
+	if err != nil {
+		return fmt.Errorf("dagrun: build graph: %w", err)
+	}
+
+	// 拓扑序决定 run_steps 的展示序与序号;每个阶段 = 一个 step。
+	order := graph.TopoOrder()
+	ordinalOf := make(map[string]int, len(order))
+	names := make([]string, 0, len(order))
+	stageByID := make(map[string]pipeline.Stage, len(stages))
+	for _, st := range stages {
+		stageByID[st.ID] = st
+	}
+	for i, id := range order {
+		ordinalOf[id] = i
+		names = append(names, stageByID[id].Name)
+	}
+
+	var mu sync.Mutex // 串行化对 sink 的全部调用(阶段可能并行)
+	lockedSink := func(fn func() error) error {
+		mu.Lock()
+		defer mu.Unlock()
+		return fn()
+	}
+
+	if err := lockedSink(func() error { return sink.Plan(ctx, names) }); err != nil {
+		return fmt.Errorf("dagrun: plan: %w", err)
+	}
+
+	maxc := r.concurrency
+	if maxc <= 0 {
+		maxc = len(order)
+	}
+
+	result := graph.Schedule(ctx, func(ctx context.Context, stageID string) error {
+		ord := ordinalOf[stageID]
+		stage := stageByID[stageID]
+		if err := lockedSink(func() error { return sink.StepRunning(ctx, ord) }); err != nil {
+			return err
+		}
+		rep := &stageReporter{sink: sink, mu: &mu, ordinal: ord}
+		execErr := r.exec(ctx, rn, stage, rep)
+		status := run.StepSuccess
+		if execErr != nil {
+			status = run.StepFailed
+		}
+		_ = lockedSink(func() error { return sink.StepDone(ctx, ord, status) })
+		return execErr
+	}, dag.Options{MaxConcurrency: maxc})
+
+	// 被跳过/取消(从未执行)的阶段:其 step 终态记为 skipped(与 dag 判定一致),避免悬挂 pending。
+	for id, nr := range result {
+		if nr.Status == dag.StatusSkipped || nr.Status == dag.StatusCanceled {
+			ord := ordinalOf[id]
+			_ = lockedSink(func() error { return sink.StepDone(ctx, ord, run.StepSkipped) })
+		}
+	}
+
+	if !result.Succeeded() {
+		return fmt.Errorf("dagrun: pipeline failed (%v)", summarize(result))
+	}
+	return nil
+}
+
+// stageReporter 把阶段级日志/产物绑定到该阶段的 step 序号,并经 mutex 串行化对 sink 的调用。
+type stageReporter struct {
+	sink    run.StepSink
+	mu      *sync.Mutex
+	ordinal int
+}
+
+func (s *stageReporter) Log(ctx context.Context, stream, line string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sink.Log(ctx, stream, s.ordinal, line)
+}
+
+func (s *stageReporter) EmitArtifact(ctx context.Context, a run.Artifact) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sink.EmitArtifact(ctx, a)
+}
+
+// summarize 汇总各终态计数(用于失败错误信息,不含敏感内容)。
+func summarize(res dag.Result) map[dag.Status]int { return res.Counts() }
+
+// BuildGraph 把流水线阶段构成 dag.Graph。
+//
+//   - 若**任一**阶段声明了 needs:严格按声明的依赖建图。
+//   - 若**所有**阶段都无 needs:退化为「按声明序线性」(stage[i] 依赖 stage[i-1]),
+//     保持存量直线流水线的执行顺序不变(向后兼容)。
+//
+// 返回的图已通过 dag.New 的构造校验(存在性 / 自指 / 环);spec 保存时也已校验过,此处兜底。
+func BuildGraph(stages []pipeline.Stage) (*dag.Graph, error) {
+	anyNeeds := false
+	for _, st := range stages {
+		if len(st.Needs) > 0 {
+			anyNeeds = true
+			break
+		}
+	}
+	nodes := make([]dag.Node, 0, len(stages))
+	for i, st := range stages {
+		needs := st.Needs
+		if !anyNeeds && i > 0 {
+			needs = []string{stages[i-1].ID} // 线性退化
+		}
+		nodes = append(nodes, dag.Node{ID: st.ID, Needs: needs, AllowFailure: st.AllowFailure})
+	}
+	return dag.New(nodes)
+}

--- a/internal/dagrun/dagrun_test.go
+++ b/internal/dagrun/dagrun_test.go
@@ -1,0 +1,258 @@
+package dagrun
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// ─── 测试替身 ──────────────────────────────────────────────────────────────────
+
+type fakeLoader struct{ cfg *pipeline.Config }
+
+func (f fakeLoader) Get(_ context.Context, _ string) (*pipeline.Config, error) {
+	return f.cfg, nil
+}
+
+// fakeSink 记录 StepSink 调用(dagrun 已串行化调用,这里再加锁防御)。
+type fakeSink struct {
+	mu      sync.Mutex
+	planned []string
+	running []int
+	done    map[int]string
+	logs    []string
+}
+
+func newFakeSink() *fakeSink { return &fakeSink{done: map[int]string{}} }
+
+func (s *fakeSink) Plan(_ context.Context, names []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.planned = append([]string{}, names...)
+	return nil
+}
+func (s *fakeSink) StepRunning(_ context.Context, ord int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.running = append(s.running, ord)
+	return nil
+}
+func (s *fakeSink) StepDone(_ context.Context, ord int, status string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.done[ord] = status
+	return nil
+}
+func (s *fakeSink) SetFailureLog(_ context.Context, _ string) error { return nil }
+func (s *fakeSink) Log(_ context.Context, _ string, _ int, line string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.logs = append(s.logs, line)
+	return nil
+}
+func (s *fakeSink) EmitArtifact(_ context.Context, _ run.Artifact) error { return nil }
+
+func cfgWith(stages ...pipeline.Stage) *pipeline.Config {
+	return &pipeline.Config{Spec: pipeline.Spec{Stages: stages}}
+}
+
+// ─── BuildGraph ────────────────────────────────────────────────────────────────
+
+func TestBuildGraphLinearFallback(t *testing.T) {
+	// 无 needs → 线性:a → b → c。
+	stages := []pipeline.Stage{
+		{ID: "a", Name: "A"}, {ID: "b", Name: "B"}, {ID: "c", Name: "C"},
+	}
+	g, err := BuildGraph(stages)
+	if err != nil {
+		t.Fatalf("BuildGraph: %v", err)
+	}
+	if got := g.TopoOrder(); !equal(got, []string{"a", "b", "c"}) {
+		t.Errorf("topo = %v, want linear [a b c]", got)
+	}
+}
+
+func TestBuildGraphExplicitNeeds(t *testing.T) {
+	// a → {b,c} → d(钻石)。
+	stages := []pipeline.Stage{
+		{ID: "a", Name: "A"},
+		{ID: "b", Name: "B", Needs: []string{"a"}},
+		{ID: "c", Name: "C", Needs: []string{"a"}},
+		{ID: "d", Name: "D", Needs: []string{"b", "c"}},
+	}
+	g, err := BuildGraph(stages)
+	if err != nil {
+		t.Fatalf("BuildGraph: %v", err)
+	}
+	order := g.TopoOrder()
+	pos := map[string]int{}
+	for i, id := range order {
+		pos[id] = i
+	}
+	if pos["a"] > pos["b"] || pos["b"] > pos["d"] || pos["c"] > pos["d"] {
+		t.Errorf("diamond order violated: %v", order)
+	}
+}
+
+// ─── Runner.Run ────────────────────────────────────────────────────────────────
+
+func TestRunnerLinearSuccess(t *testing.T) {
+	cfg := cfgWith(
+		pipeline.Stage{ID: "src", Name: "源", Jobs: []pipeline.Job{{Name: "clone", Type: "git_source"}}},
+		pipeline.Stage{ID: "build", Name: "构建"},
+		pipeline.Stage{ID: "deploy", Name: "部署"},
+	)
+	sink := newFakeSink()
+	r := New(fakeLoader{cfg})
+	err := r.Run(context.Background(), &run.Run{ProjectID: "p"}, sink)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !equal(sink.planned, []string{"源", "构建", "部署"}) {
+		t.Errorf("planned = %v", sink.planned)
+	}
+	for ord := 0; ord < 3; ord++ {
+		if sink.done[ord] != run.StepSuccess {
+			t.Errorf("step %d = %q, want success", ord, sink.done[ord])
+		}
+	}
+}
+
+func TestRunnerFailBlocksDownstreamAsSkipped(t *testing.T) {
+	// src → build → deploy ;build 失败 ⇒ deploy 记 skipped,Run 返回错误。
+	cfg := cfgWith(
+		pipeline.Stage{ID: "src", Name: "源"},
+		pipeline.Stage{ID: "build", Name: "构建"},
+		pipeline.Stage{ID: "deploy", Name: "部署"},
+	)
+	sink := newFakeSink()
+	r := New(fakeLoader{cfg}, WithStageExecutor(
+		func(_ context.Context, _ *run.Run, st pipeline.Stage, _ StageReporter) error {
+			if st.ID == "build" {
+				return errors.New("build boom")
+			}
+			return nil
+		}))
+	err := r.Run(context.Background(), &run.Run{ProjectID: "p"}, sink)
+	if err == nil {
+		t.Fatal("expected Run to fail")
+	}
+	// ordinals: src=0, build=1, deploy=2
+	if sink.done[0] != run.StepSuccess {
+		t.Errorf("src = %q, want success", sink.done[0])
+	}
+	if sink.done[1] != run.StepFailed {
+		t.Errorf("build = %q, want failed", sink.done[1])
+	}
+	if sink.done[2] != run.StepSkipped {
+		t.Errorf("deploy = %q, want skipped", sink.done[2])
+	}
+	// deploy 不应被置 running(从未执行)。
+	for _, ord := range sink.running {
+		if ord == 2 {
+			t.Error("deploy must not have been marked running")
+		}
+	}
+}
+
+func TestRunnerParallelSiblingsContinueOnFailure(t *testing.T) {
+	// src → {a,b} ; a 失败,b 应照常成功(互不依赖)。
+	cfg := cfgWith(
+		pipeline.Stage{ID: "src", Name: "源"},
+		pipeline.Stage{ID: "a", Name: "A", Needs: []string{"src"}},
+		pipeline.Stage{ID: "b", Name: "B", Needs: []string{"src"}},
+	)
+	var ranB atomic.Bool
+	sink := newFakeSink()
+	r := New(fakeLoader{cfg}, WithStageExecutor(
+		func(_ context.Context, _ *run.Run, st pipeline.Stage, _ StageReporter) error {
+			if st.ID == "a" {
+				return errors.New("a boom")
+			}
+			if st.ID == "b" {
+				ranB.Store(true)
+			}
+			return nil
+		}))
+	_ = r.Run(context.Background(), &run.Run{ProjectID: "p"}, sink)
+	if !ranB.Load() {
+		t.Error("sibling b should run despite a's failure")
+	}
+	// find ordinals by planned name
+	ord := func(name string) int {
+		for i, n := range sink.planned {
+			if n == name {
+				return i
+			}
+		}
+		return -1
+	}
+	if sink.done[ord("A")] != run.StepFailed {
+		t.Errorf("A = %q, want failed", sink.done[ord("A")])
+	}
+	if sink.done[ord("B")] != run.StepSuccess {
+		t.Errorf("B = %q, want success", sink.done[ord("B")])
+	}
+}
+
+func TestRunnerExecutesIndependentStagesInParallel(t *testing.T) {
+	// src → {a,b,c} 三个独立分支;若串行会超时(每个等所有都开始)。
+	cfg := cfgWith(
+		pipeline.Stage{ID: "src", Name: "源"},
+		pipeline.Stage{ID: "a", Name: "A", Needs: []string{"src"}},
+		pipeline.Stage{ID: "b", Name: "B", Needs: []string{"src"}},
+		pipeline.Stage{ID: "c", Name: "C", Needs: []string{"src"}},
+	)
+	var started, maxInFlight, inFlight int32
+	allStarted := make(chan struct{})
+	var once sync.Once
+	const par = 3
+	sink := newFakeSink()
+	r := New(fakeLoader{cfg}, WithStageExecutor(
+		func(_ context.Context, _ *run.Run, st pipeline.Stage, _ StageReporter) error {
+			if st.ID == "src" {
+				return nil
+			}
+			cur := atomic.AddInt32(&inFlight, 1)
+			for {
+				m := atomic.LoadInt32(&maxInFlight)
+				if cur <= m || atomic.CompareAndSwapInt32(&maxInFlight, m, cur) {
+					break
+				}
+			}
+			if atomic.AddInt32(&started, 1) == par {
+				once.Do(func() { close(allStarted) })
+			}
+			select {
+			case <-allStarted:
+			case <-time.After(2 * time.Second):
+			}
+			atomic.AddInt32(&inFlight, -1)
+			return nil
+		}))
+	if err := r.Run(context.Background(), &run.Run{ProjectID: "p"}, sink); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if maxInFlight < par {
+		t.Errorf("max parallel stages = %d, want %d", maxInFlight, par)
+	}
+}
+
+// equal 比较两个字符串切片。
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/httpapi/pipelines.go
+++ b/internal/httpapi/pipelines.go
@@ -20,10 +20,12 @@ type pipelineDTO struct {
 }
 
 type stageDTO struct {
-	ID   string   `json:"id"`
-	Name string   `json:"name"`
-	Kind string   `json:"kind"`
-	Jobs []jobDTO `json:"jobs"`
+	ID           string   `json:"id"`
+	Name         string   `json:"name"`
+	Kind         string   `json:"kind"`
+	Needs        []string `json:"needs"`
+	AllowFailure bool     `json:"allowFailure"`
+	Jobs         []jobDTO `json:"jobs"`
 }
 
 type jobDTO struct {
@@ -52,7 +54,11 @@ func toPipelineDTO(c *pipeline.Config) pipelineDTO {
 				Config:  cfg,
 			})
 		}
-		stages = append(stages, stageDTO{ID: st.ID, Name: st.Name, Kind: st.Kind, Jobs: jobs})
+		needs := st.Needs
+		if needs == nil {
+			needs = []string{}
+		}
+		stages = append(stages, stageDTO{ID: st.ID, Name: st.Name, Kind: st.Kind, Needs: needs, AllowFailure: st.AllowFailure, Jobs: jobs})
 	}
 	return pipelineDTO{
 		Stages:    stages,
@@ -109,10 +115,12 @@ func makeSavePipelineHandler(svc pipeline.Service) http.HandlerFunc {
 		r.Body = http.MaxBytesReader(w, r.Body, 1<<18) // 256KB
 		var req struct {
 			Stages []struct {
-				ID   string `json:"id"`
-				Name string `json:"name"`
-				Kind string `json:"kind"`
-				Jobs []struct {
+				ID           string   `json:"id"`
+				Name         string   `json:"name"`
+				Kind         string   `json:"kind"`
+				Needs        []string `json:"needs"`
+				AllowFailure bool     `json:"allowFailure"`
+				Jobs         []struct {
 					ID      string         `json:"id"`
 					Name    string         `json:"name"`
 					Type    string         `json:"type"`
@@ -139,10 +147,12 @@ func makeSavePipelineHandler(svc pipeline.Service) http.HandlerFunc {
 				})
 			}
 			stages = append(stages, pipeline.Stage{
-				ID:   st.ID,
-				Name: st.Name,
-				Kind: st.Kind,
-				Jobs: jobs,
+				ID:           st.ID,
+				Name:         st.Name,
+				Kind:         st.Kind,
+				Needs:        st.Needs,
+				AllowFailure: st.AllowFailure,
+				Jobs:         jobs,
 			})
 		}
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/huangchengsir/pipewright/internal/dag"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -66,11 +67,18 @@ type Job struct {
 }
 
 // Stage 是一个阶段(阶段列),含若干 Job。Kind 为 kind 枚举之一。
+//
+// Needs 是该阶段依赖的上游阶段 ID 列表(Epic 8 · Story 8-1,构成 DAG):为空表示「无显式依赖」。
+// 当**整个流水线**无任何阶段声明 needs 时,执行层按声明序退化为线性(向后兼容存量「直线」流水线);
+// 一旦有阶段声明 needs,则严格按声明的 DAG 调度(见 dagrun 适配)。AllowFailure 为 true 时,
+// 该阶段失败仍放行下游(自身仍记 failed)。Needs 在保存时校验:引用必须存在、不可自指、不可成环。
 type Stage struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	Kind string `json:"kind"`
-	Jobs []Job  `json:"jobs"`
+	ID           string   `json:"id"`
+	Name         string   `json:"name"`
+	Kind         string   `json:"kind"`
+	Needs        []string `json:"needs,omitempty"`
+	AllowFailure bool     `json:"allowFailure,omitempty"`
+	Jobs         []Job    `json:"jobs"`
 }
 
 // Spec 是流水线编排声明式配置(阶段集合)。
@@ -331,7 +339,10 @@ func normalizeSpec(in Spec) (Spec, error) {
 			})
 		}
 
-		out.Stages = append(out.Stages, Stage{ID: stageID, Name: name, Kind: kind, Jobs: jobs})
+		// Needs 规范化:trim、去空、去重、剔除自指(自指交由 dag 校验报错以给明确信息)。
+		needs := normalizeNeeds(st.Needs)
+
+		out.Stages = append(out.Stages, Stage{ID: stageID, Name: name, Kind: kind, Needs: needs, AllowFailure: st.AllowFailure, Jobs: jobs})
 	}
 
 	// 源阶段不变式:流水线必须恰有一个 source 阶段(引用项目仓库)。前端不渲染删源阶段的入口,
@@ -346,7 +357,59 @@ func normalizeSpec(in Spec) (Spec, error) {
 		return Spec{}, fmt.Errorf("%w: pipeline must have exactly one source stage", ErrInvalidStage)
 	}
 
+	// 阶段依赖(needs)校验:引用必须存在、不可自指、不可成环(Epic 8 · 8-1)。
+	// 复用 dag 的构造期校验(Kahn 环检测),把其错误归一为 ErrInvalidStage(不外泄内部细节)。
+	if err := validateStageDAG(out.Stages); err != nil {
+		return Spec{}, err
+	}
+
 	return out, nil
+}
+
+// normalizeNeeds 规范化阶段依赖列表:trim、剔空、去重(保留首次出现序)。
+func normalizeNeeds(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, d := range in {
+		d = strings.TrimSpace(d)
+		if d == "" {
+			continue
+		}
+		if _, ok := seen[d]; ok {
+			continue
+		}
+		seen[d] = struct{}{}
+		out = append(out, d)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// validateStageDAG 用 dag 包做阶段依赖的构造期校验(存在性 + 自指 + 环)。
+// 任一问题归一为 ErrInvalidStage(附简短原因,不外泄底层细节)。
+func validateStageDAG(stages []Stage) error {
+	nodes := make([]dag.Node, 0, len(stages))
+	for _, st := range stages {
+		nodes = append(nodes, dag.Node{ID: st.ID, Needs: st.Needs, AllowFailure: st.AllowFailure})
+	}
+	if _, err := dag.New(nodes); err != nil {
+		switch {
+		case errors.Is(err, dag.ErrUnknownDep):
+			return fmt.Errorf("%w: stage needs reference an unknown stage", ErrInvalidStage)
+		case errors.Is(err, dag.ErrSelfDep):
+			return fmt.Errorf("%w: stage must not depend on itself", ErrInvalidStage)
+		case errors.Is(err, dag.ErrCycle):
+			return fmt.Errorf("%w: stage dependencies form a cycle", ErrInvalidStage)
+		default:
+			return fmt.Errorf("%w: invalid stage dependencies", ErrInvalidStage)
+		}
+	}
+	return nil
 }
 
 // normalizeSpecShape 保证从库回读的 spec 切片/map 非 nil(JSON 输出为 [] / {} 而非 null)。

--- a/internal/pipeline/stage_dag_test.go
+++ b/internal/pipeline/stage_dag_test.go
@@ -1,0 +1,94 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// specWithNeeds 构造一个含源阶段 + 两个带依赖阶段的 spec(满足源阶段不变式)。
+func specWithNeeds(buildNeeds, deployNeeds []string) Spec {
+	return Spec{Stages: []Stage{
+		{ID: "stg_src", Name: "源", Kind: KindSource, Jobs: []Job{{ID: "j_src", Name: "src", Type: "git_source"}}},
+		{ID: "stg_build", Name: "构建", Kind: KindBuild, Needs: buildNeeds, Jobs: []Job{}},
+		{ID: "stg_deploy", Name: "部署", Kind: KindDeploy, Needs: deployNeeds, Jobs: []Job{}},
+	}}
+}
+
+func TestSaveValidStageNeedsRoundTrips(t *testing.T) {
+	svc, _, projID := newSvc(t)
+	ctx := context.Background()
+
+	spec := specWithNeeds([]string{"stg_src"}, []string{"stg_build"})
+	saved, err := svc.Save(ctx, projID, spec)
+	if err != nil {
+		t.Fatalf("Save valid needs: %v", err)
+	}
+
+	// 回读并核验 needs 持久化往返。
+	got, err := svc.Get(ctx, projID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	_ = saved
+	byID := map[string]Stage{}
+	for _, st := range got.Spec.Stages {
+		byID[st.ID] = st
+	}
+	if len(byID["stg_build"].Needs) != 1 || byID["stg_build"].Needs[0] != "stg_src" {
+		t.Errorf("build.Needs = %v, want [stg_src]", byID["stg_build"].Needs)
+	}
+	if len(byID["stg_deploy"].Needs) != 1 || byID["stg_deploy"].Needs[0] != "stg_build" {
+		t.Errorf("deploy.Needs = %v, want [stg_build]", byID["stg_deploy"].Needs)
+	}
+}
+
+func TestSaveRejectsUnknownNeed(t *testing.T) {
+	svc, _, projID := newSvc(t)
+	spec := specWithNeeds([]string{"does_not_exist"}, nil)
+	if _, err := svc.Save(context.Background(), projID, spec); !errors.Is(err, ErrInvalidStage) {
+		t.Fatalf("err = %v, want ErrInvalidStage", err)
+	}
+}
+
+func TestSaveRejectsSelfNeed(t *testing.T) {
+	svc, _, projID := newSvc(t)
+	spec := specWithNeeds([]string{"stg_build"}, nil) // build 依赖自身
+	if _, err := svc.Save(context.Background(), projID, spec); !errors.Is(err, ErrInvalidStage) {
+		t.Fatalf("err = %v, want ErrInvalidStage", err)
+	}
+}
+
+func TestSaveRejectsCycle(t *testing.T) {
+	svc, _, projID := newSvc(t)
+	// build ↔ deploy 互相依赖成环。
+	spec := specWithNeeds([]string{"stg_deploy"}, []string{"stg_build"})
+	if _, err := svc.Save(context.Background(), projID, spec); !errors.Is(err, ErrInvalidStage) {
+		t.Fatalf("err = %v, want ErrInvalidStage", err)
+	}
+}
+
+func TestSaveDedupesNeeds(t *testing.T) {
+	svc, _, projID := newSvc(t)
+	ctx := context.Background()
+	spec := specWithNeeds([]string{"stg_src", "stg_src", " stg_src "}, nil)
+	if _, err := svc.Save(ctx, projID, spec); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, _ := svc.Get(ctx, projID)
+	for _, st := range got.Spec.Stages {
+		if st.ID == "stg_build" {
+			if len(st.Needs) != 1 || st.Needs[0] != "stg_src" {
+				t.Errorf("build.Needs = %v, want deduped [stg_src]", st.Needs)
+			}
+		}
+	}
+}
+
+func TestSaveNoNeedsStillValid(t *testing.T) {
+	// 向后兼容:存量「直线」流水线(无 needs)照常保存。
+	svc, _, projID := newSvc(t)
+	if _, err := svc.Save(context.Background(), projID, validSpec()); err != nil {
+		t.Fatalf("Save no-needs spec: %v", err)
+	}
+}

--- a/web/src/api/pipeline.ts
+++ b/web/src/api/pipeline.ts
@@ -30,6 +30,10 @@ export interface PipelineStage {
   id: string
   name: string
   kind: StageKind
+  /** Upstream stage IDs this stage depends on (Epic 8 DAG). Empty = no explicit deps. */
+  needs?: string[]
+  /** When true, this stage's failure does not block downstream stages. */
+  allowFailure?: boolean
   jobs: PipelineJob[]
 }
 
@@ -49,6 +53,8 @@ export interface SavePipelineInput {
     id?: string
     name: string
     kind: StageKind
+    needs?: string[]
+    allowFailure?: boolean
     jobs: Array<{
       id?: string
       name: string


### PR DESCRIPTION
(stacked on feat/dag-scheduler)Stage 加 needs/allowFailure(spec_json 无迁移)+ dag.New 校验。新增 internal/dagrun(实现 run.Runner,按 DAG 调度阶段经 StepSink 上报)。PIPEWRIGHT_RUNNER=dag 接入。真冒烟:乱序声明钻石 DAG 按拓扑序执行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)