### PR TITLE
feat(run): 8-11 参数化手动运行 — 参数注入 script 步骤容器

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -18,6 +18,7 @@ import (
 	root "github.com/huangchengsir/pipewright"
 	"github.com/huangchengsir/pipewright/internal/ai"
 	"github.com/huangchengsir/pipewright/internal/anomaly"
+	"github.com/huangchengsir/pipewright/internal/approval"
 	"github.com/huangchengsir/pipewright/internal/audit"
 	"github.com/huangchengsir/pipewright/internal/auth"
 	"github.com/huangchengsir/pipewright/internal/build"
@@ -102,6 +103,17 @@ func main() {
 	// worker pool 在 aiSvc 装配后创建(以便注入 best-effort 自动诊断钩子,Story 7.2)。
 	runSvc := run.New(st.DB)
 
+	// 装配人工审批门协调器 + 持久层(Story 8-4):DAG 调度到 Gate 阶段时阻塞等待批准/拒绝。
+	// 协调器为进程内(零持久状态);记录落 run_approvals 供 UI/审计/重启清理。
+	approvalCoord := approval.New()
+	approvalStore := approval.NewStore(st.DB)
+	// 重启清理:进程重启会丢失内存等待者,把残留 waiting_approval 运行清为 failed(孤儿不可恢复)。
+	if n, err := runSvc.FailOrphanedRuns(context.Background()); err != nil {
+		log.Printf("[run] 警告:清理孤儿运行失败:%v", err)
+	} else if n > 0 {
+		log.Printf("[run] 启动清理孤儿运行(waiting_approval/running):%d 条 → failed", n)
+	}
+
 	// 装配诊断反馈服务(Story 7.5;FR-26):诊断 👍/👎(👎 可附正确根因)持久化 + 准确率统计(知识库种子)。
 	// 复用同一 *sql.DB(参数化 SQL);correctRootCause 脱敏在 httpapi 层(过 mask)+ 领域层长度上限兜底。
 	// upsert by run_id(同 run 改判覆盖)。无 init 副作用、不抬高空载内存。
@@ -168,6 +180,8 @@ func main() {
 		// 阶段执行体(Story 8-2):探测到容器 CLI → 注入真实阶段执行器(script 类型 job 在隔离
 		// 容器内真实跑命令,复用 Builder 的 cloner+driver);否则回退 stub(优雅降级,NFR-10)。
 		var dagOpts []dagrun.Option
+		// 审批门 hook(Story 8-4):Gate 阶段阻塞等待人工批准/拒绝。
+		dagOpts = append(dagOpts, dagrun.WithGate(httpapi.NewApprovalGate(runSvc, approvalCoord, approvalStore)))
 		if b, berr := build.NewBuilder(projectSvc, pipelineSettingsSvc, credVault); berr == nil {
 			dagOpts = append(dagOpts, dagrun.WithStageExecutor(build.NewStageExecutor(b)))
 			log.Printf("[run] PIPEWRIGHT_RUNNER=dag:DAG 调度执行器已启用(阶段按 needs 编排;script 类型 job 在隔离容器真实执行,CLI=%s;build_image/push_image/deploy_ssh 真实化=后续)", b.DriverBinary())
@@ -223,7 +237,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithServers(targetSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc)),
+		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithServers(targetSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithApprovals(approvalCoord, approvalStore)),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		// WriteTimeout 置 0:SSE 长连接(/api/runs/{id}/events)不可被写超时切断;

--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/auth"
 	"github.com/huangchengsir/pipewright/internal/build"
 	"github.com/huangchengsir/pipewright/internal/config"
+	"github.com/huangchengsir/pipewright/internal/dagrun"
 	"github.com/huangchengsir/pipewright/internal/deploy"
 	"github.com/huangchengsir/pipewright/internal/httpapi"
 	"github.com/huangchengsir/pipewright/internal/mask"
@@ -157,7 +158,18 @@ func main() {
 	//   - 缺省 auto:探测到 docker/nerdctl/podman 用 real,否则回退桩(优雅降级,NFR-10)。
 	// 真实 Builder 经构造函数注入 projectSvc/pipelineSettingsSvc/credVault;真实日志/产物/失败日志
 	// 经同一 run.StepSink 喂出,复用既有持久化/SSE/脱敏(下方 WithLogMaskerFunc 对真实日志同样生效)。
-	runnerOpts := buildRunnerOption(projectSvc, pipelineSettingsSvc, credVault)
+	// PIPEWRIGHT_RUNNER=dag 时启用 DAG 调度执行器(Epic 8 · 8-1↔8-3):按阶段 needs 构 DAG 调度
+	// (无依赖阶段并行、失败阻断下游),阶段编排经既有 StepSink 持久化。**默认关闭**(不破存量):
+	// 缺省/其它值仍走 PIPEWRIGHT_BUILDER 选出的真实 Builder / 桩 runner。
+	// ⚠ 当前阶段执行体为占位 stub(仅打日志即成功);真实「阶段内并行 job → job 内有序 step
+	// 在隔离容器构建/部署」= Story 8-2 尚未接入,故 dag 模式现仅用于验证编排,不做真实构建。
+	var runnerOpts []run.PoolOption
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("PIPEWRIGHT_RUNNER")), "dag") {
+		log.Printf("[run] PIPEWRIGHT_RUNNER=dag:DAG 调度执行器已启用(阶段按 needs 编排;⚠ 阶段执行体=占位 stub,真实构建/部署=Story 8-2 未接入)")
+		runnerOpts = []run.PoolOption{run.WithRunner(dagrun.New(pipelineSvc))}
+	} else {
+		runnerOpts = buildRunnerOption(projectSvc, pipelineSettingsSvc, credVault)
+	}
 
 	pool := run.NewWorkerPool(runSvc,
 		append(runnerOpts,

--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -165,8 +165,16 @@ func main() {
 	// 在隔离容器构建/部署」= Story 8-2 尚未接入,故 dag 模式现仅用于验证编排,不做真实构建。
 	var runnerOpts []run.PoolOption
 	if strings.EqualFold(strings.TrimSpace(os.Getenv("PIPEWRIGHT_RUNNER")), "dag") {
-		log.Printf("[run] PIPEWRIGHT_RUNNER=dag:DAG 调度执行器已启用(阶段按 needs 编排;⚠ 阶段执行体=占位 stub,真实构建/部署=Story 8-2 未接入)")
-		runnerOpts = []run.PoolOption{run.WithRunner(dagrun.New(pipelineSvc))}
+		// 阶段执行体(Story 8-2):探测到容器 CLI → 注入真实阶段执行器(script 类型 job 在隔离
+		// 容器内真实跑命令,复用 Builder 的 cloner+driver);否则回退 stub(优雅降级,NFR-10)。
+		var dagOpts []dagrun.Option
+		if b, berr := build.NewBuilder(projectSvc, pipelineSettingsSvc, credVault); berr == nil {
+			dagOpts = append(dagOpts, dagrun.WithStageExecutor(build.NewStageExecutor(b)))
+			log.Printf("[run] PIPEWRIGHT_RUNNER=dag:DAG 调度执行器已启用(阶段按 needs 编排;script 类型 job 在隔离容器真实执行,CLI=%s;build_image/push_image/deploy_ssh 真实化=后续)", b.DriverBinary())
+		} else {
+			log.Printf("[run] PIPEWRIGHT_RUNNER=dag:DAG 调度执行器已启用(阶段按 needs 编排;⚠ 未探测到容器 CLI,阶段执行体回退 stub:%v)", berr)
+		}
+		runnerOpts = []run.PoolOption{run.WithRunner(dagrun.New(pipelineSvc, dagOpts...))}
 	} else {
 		runnerOpts = buildRunnerOption(projectSvc, pipelineSettingsSvc, credVault)
 	}

--- a/internal/approval/coordinator.go
+++ b/internal/approval/coordinator.go
@@ -1,0 +1,84 @@
+// Package approval 是人工审批门(Epic 8 · Story 8-4)的进程内协调器 + 持久化。
+//
+// 模型:阶段声明 Gate=true 时,执行该阶段前运行阻塞、状态置 waiting_approval;阻塞在门内的
+// worker 经 Coordinator.Wait 注册等待,审批端点经 Coordinator.Resolve 投递「批准/拒绝」决定。
+// 决定 + 待批记录持久化到 run_approvals(供 UI 展示 / 审计 / 重启清理)。
+//
+// 边界(诚实):审批期间 worker 仍持有该 run(在门内阻塞),不释放回池——故 worker 上限即「同时
+// 可挂起的待批运行数」;设审批超时兜底(默认),超时自动拒绝以释放 worker。进程重启会丢失内存
+// 等待者:重启时把残留 waiting_approval/running 运行清理为 failed(孤儿,无法恢复)。
+package approval
+
+import "sync"
+
+// Decision 是一次审批结果。
+type Decision struct {
+	Approved bool
+	Actor    string // 审批人(展示/审计;绝无敏感数据)
+}
+
+// Coordinator 是进程内审批门协调器(零持久状态;持久化在 Store)。
+type Coordinator struct {
+	mu      sync.Mutex
+	waiters map[string]chan Decision
+}
+
+// New 构造协调器。
+func New() *Coordinator {
+	return &Coordinator{waiters: make(map[string]chan Decision)}
+}
+
+// Key 由 runID + stageID 组成审批门唯一键。
+func Key(runID, stageID string) string { return runID + "|" + stageID }
+
+// Wait 为 key 注册一个等待,返回接收决定的只读 channel(缓冲 1,Resolve 不阻塞)。
+// 同 key 重复 Wait 覆盖旧等待者(旧 channel 永不收到决定;调用方应在 defer 里 Cancel 清理)。
+func (c *Coordinator) Wait(key string) <-chan Decision {
+	ch := make(chan Decision, 1)
+	c.mu.Lock()
+	c.waiters[key] = ch
+	c.mu.Unlock()
+	return ch
+}
+
+// Resolve 把决定投递给等待 key 的 worker。无等待者(未到门 / 已超时 / 已决) → false。
+// 投递后移除等待者(同一门只决一次)。
+func (c *Coordinator) Resolve(key string, d Decision) bool {
+	c.mu.Lock()
+	ch, ok := c.waiters[key]
+	if ok {
+		delete(c.waiters, key)
+	}
+	c.mu.Unlock()
+	if !ok {
+		return false
+	}
+	ch <- d // 缓冲 1,不阻塞
+	return true
+}
+
+// Cancel 移除 key 的等待者(worker 退出 / 取消 / 超时时清理)。幂等。
+func (c *Coordinator) Cancel(key string) {
+	c.mu.Lock()
+	delete(c.waiters, key)
+	c.mu.Unlock()
+}
+
+// IsWaiting 报告 key 是否有等待者(端点据此区分 404「未在审批」)。
+func (c *Coordinator) IsWaiting(key string) bool {
+	c.mu.Lock()
+	_, ok := c.waiters[key]
+	c.mu.Unlock()
+	return ok
+}
+
+// PendingKeys 返回当前所有等待中的 key(调试/列举)。
+func (c *Coordinator) PendingKeys() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, 0, len(c.waiters))
+	for k := range c.waiters {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/approval/coordinator_test.go
+++ b/internal/approval/coordinator_test.go
@@ -1,0 +1,82 @@
+package approval
+
+import (
+	"testing"
+	"time"
+)
+
+func TestKeyComposition(t *testing.T) {
+	if Key("r1", "s1") != "r1|s1" {
+		t.Errorf("Key = %q", Key("r1", "s1"))
+	}
+}
+
+func TestResolveDelivers(t *testing.T) {
+	c := New()
+	key := Key("r1", "s1")
+	ch := c.Wait(key)
+	if !c.IsWaiting(key) {
+		t.Fatal("应在等待")
+	}
+	go func() {
+		// 给主协程时间进入接收。
+		time.Sleep(5 * time.Millisecond)
+		if !c.Resolve(key, Decision{Approved: true, Actor: "admin"}) {
+			t.Errorf("Resolve 应成功")
+		}
+	}()
+	select {
+	case d := <-ch:
+		if !d.Approved || d.Actor != "admin" {
+			t.Errorf("决定不符:%+v", d)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("超时未收到决定")
+	}
+	if c.IsWaiting(key) {
+		t.Error("决定后应移除等待者")
+	}
+}
+
+func TestResolveNoWaiter(t *testing.T) {
+	c := New()
+	if c.Resolve(Key("x", "y"), Decision{Approved: true}) {
+		t.Error("无等待者时 Resolve 应返回 false")
+	}
+}
+
+func TestResolveTwiceSecondFails(t *testing.T) {
+	c := New()
+	key := Key("r", "s")
+	ch := c.Wait(key)
+	if !c.Resolve(key, Decision{Approved: true, Actor: "a"}) {
+		t.Fatal("首次 Resolve 应成功")
+	}
+	<-ch
+	if c.Resolve(key, Decision{Approved: false, Actor: "b"}) {
+		t.Error("二次 Resolve 应失败(同门只决一次)")
+	}
+}
+
+func TestCancelRemovesWaiter(t *testing.T) {
+	c := New()
+	key := Key("r", "s")
+	c.Wait(key)
+	c.Cancel(key)
+	if c.IsWaiting(key) {
+		t.Error("Cancel 后不应仍在等待")
+	}
+	if c.Resolve(key, Decision{}) {
+		t.Error("Cancel 后 Resolve 应失败")
+	}
+	c.Cancel(key) // 幂等
+}
+
+func TestPendingKeys(t *testing.T) {
+	c := New()
+	c.Wait(Key("r1", "s1"))
+	c.Wait(Key("r2", "s2"))
+	if len(c.PendingKeys()) != 2 {
+		t.Errorf("PendingKeys = %v", c.PendingKeys())
+	}
+}

--- a/internal/approval/store.go
+++ b/internal/approval/store.go
@@ -1,0 +1,85 @@
+package approval
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// 审批状态枚举。
+const (
+	StatusPending  = "pending"
+	StatusApproved = "approved"
+	StatusRejected = "rejected"
+)
+
+// Record 是一条审批门记录(供 UI 展示 / 审计)。
+type Record struct {
+	StageID   string `json:"stageId"`
+	StageName string `json:"stageName"`
+	Status    string `json:"status"`
+	DecidedBy string `json:"decidedBy"`
+	DecidedAt string `json:"decidedAt"`
+	CreatedAt string `json:"createdAt"`
+}
+
+// Store 持久化审批门记录(参数化 SQL)。
+type Store struct {
+	db *sql.DB
+}
+
+// NewStore 构造审批记录持久层。
+func NewStore(db *sql.DB) *Store { return &Store{db: db} }
+
+// CreatePending 登记一条待批记录(同 run+stage upsert,重入时复位为 pending)。
+func (s *Store) CreatePending(ctx context.Context, runID, stageID, stageName string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO run_approvals (id, run_id, stage_id, stage_name, status, decided_by, decided_at, created_at)
+		 VALUES (?, ?, ?, ?, 'pending', '', '', ?)
+		 ON CONFLICT(run_id, stage_id) DO UPDATE SET
+		   status = 'pending', decided_by = '', decided_at = '', stage_name = excluded.stage_name`,
+		uuid.NewString(), runID, stageID, stageName, now,
+	)
+	if err != nil {
+		return fmt.Errorf("approval: create pending: %w", err)
+	}
+	return nil
+}
+
+// Decide 记录一次决定(approved/rejected/其它如 timeout|canceled 走 status=rejected + decidedBy 标注)。
+func (s *Store) Decide(ctx context.Context, runID, stageID, status, decidedBy string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE run_approvals SET status = ?, decided_by = ?, decided_at = ?
+		 WHERE run_id = ? AND stage_id = ?`,
+		status, decidedBy, now, runID, stageID,
+	)
+	if err != nil {
+		return fmt.Errorf("approval: decide: %w", err)
+	}
+	return nil
+}
+
+// ListForRun 返回某运行的全部审批记录(按 created_at 升序)。
+func (s *Store) ListForRun(ctx context.Context, runID string) ([]Record, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT stage_id, stage_name, status, decided_by, decided_at, created_at
+		 FROM run_approvals WHERE run_id = ? ORDER BY created_at ASC`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("approval: list: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []Record
+	for rows.Next() {
+		var r Record
+		if err := rows.Scan(&r.StageID, &r.StageName, &r.Status, &r.DecidedBy, &r.DecidedAt, &r.CreatedAt); err != nil {
+			return nil, fmt.Errorf("approval: scan: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}

--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -1,0 +1,169 @@
+package build
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/huangchengsir/pipewright/internal/dagrun"
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// dag_stage_exec.go 是 DAG 调度器(dagrun)的**真实阶段执行器**(Epic 8 · Story 8-2)。
+//
+// dagrun.Runner 按阶段 DAG 编排;本文件提供「单个阶段怎么执行」的真实实现:复用 Builder 的
+// 容器基建(cloner + driver.RunToolchain)在隔离容器内真实跑 script 类型 job 的命令,而非 stub。
+//
+// 执行模型(自包含、并行安全):每个含 script job 的阶段**独立克隆一份临时工作区**(即用即销),
+// 在其中按 job 声明序逐个执行 script job 的命令(多行 → set -e 单脚本 → 容器内 sh -c)。
+// 不同阶段并行执行时各持各的工作区,互不干扰;宿主零落地(RunToolchain = docker run --rm)。
+//
+// job.Config 取值(对齐前端节点表单的 script 类型字段):image(必填)、commands(多行,必填)、
+// workDir(可选,相对工作区根)。非 script/custom 类型的 job 本期不做真实执行(build_image/
+// push_image/deploy_ssh 的真实化是后续 increment),仅打一行诚实占位日志后放行——**不冒充**
+// 真实构建/部署。
+//
+// 安全边界(复用 runScriptStep 的铁律):脚本只在隔离容器跑、绝不在宿主执行;命令注入防护
+// (宿主侧 array,用户命令仅容器内 sh 解释);ctx 取消即 kill;secret 注入但出网/落库脱敏。
+//
+// 工作区共享(跨阶段复用同一 clone)是性能优化项,留后续;本期每阶段独立 clone 以求简单与并行安全。
+
+// scriptJobTypes 是会触发真实容器执行的 job 类型。
+func isScriptJob(jobType string) bool {
+	t := strings.TrimSpace(jobType)
+	return t == pipeline.StepTypeScript || t == "custom"
+}
+
+// NewStageExecutor 返回一个复用 Builder 容器基建的真实 dagrun.StageExecutor。
+// 仅对 script/custom 类型 job 做真实容器执行;其余类型打占位日志放行。
+func NewStageExecutor(b *Builder) dagrun.StageExecutor {
+	return func(ctx context.Context, r *run.Run, stage pipeline.Stage, rep dagrun.StageReporter) error {
+		scriptJobs := make([]pipeline.Job, 0, len(stage.Jobs))
+		for _, jb := range stage.Jobs {
+			if isScriptJob(jb.Type) {
+				scriptJobs = append(scriptJobs, jb)
+			}
+		}
+
+		// 无 script job:对每个 job 打诚实占位日志(非 script 类型真实执行 = 后续 increment),放行。
+		if len(scriptJobs) == 0 {
+			for _, jb := range stage.Jobs {
+				_ = rep.Log(ctx, streamStdout, fmt.Sprintf("· %s(%s)— 真实执行未接入(仅 script 类型);本阶段放行", jb.Name, jb.Type))
+			}
+			if len(stage.Jobs) == 0 {
+				_ = rep.Log(ctx, streamStdout, fmt.Sprintf("阶段「%s」无 job", stage.Name))
+			}
+			return nil
+		}
+
+		// 有 script job:克隆一份临时工作区(即用即销)。
+		proj, _, perr := b.resolve(ctx, r)
+		if perr != nil {
+			_ = rep.Log(ctx, streamStderr, "无法加载项目构建配置:"+perr.Error())
+			return ErrBuildFailed
+		}
+		workspace, mkErr := mkTempWorkspace()
+		if mkErr != nil {
+			_ = rep.Log(ctx, streamStderr, "创建临时工作区失败:"+mkErr.Error())
+			return ErrBuildFailed
+		}
+		defer func() { _ = os.RemoveAll(workspace) }() // 宿主零污染
+
+		token := b.revealToken(proj.CredentialID)
+		_, cerr := b.cloner.Clone(ctx, proj.RepoURL, token, r.Trigger.Branch, r.Trigger.Commit, workspace)
+		token = "" // 明文用完即弃
+		_ = token
+		if cerr != nil {
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return run.ErrCanceled
+			}
+			_ = rep.Log(ctx, streamStderr, "源码克隆失败(鉴权/网络/ref 不存在或被 SSRF 拒绝)")
+			return ErrBuildFailed
+		}
+
+		sink := &reporterSink{rep: rep}
+		for _, jb := range scriptJobs {
+			if canceled(ctx) {
+				return run.ErrCanceled
+			}
+			step, verr := scriptStepFromJob(jb)
+			if verr != nil {
+				_ = rep.Log(ctx, streamStderr, fmt.Sprintf("script job「%s」配置无效:%v", jb.Name, verr))
+				return ErrBuildFailed
+			}
+			// runScriptStep 用 lineSink(sink, ordinal) 喂日志;reporterSink 忽略 ordinal、转 rep(已绑定本阶段序号)。
+			if err := b.runScriptStep(ctx, sink, 0, step, workspace); err != nil {
+				return err // ErrBuildFailed / run.ErrCanceled
+			}
+		}
+		return nil
+	}
+}
+
+// scriptStepFromJob 从画布 job.Config 构造一条 script 步骤(image + 多行 commands + 可选 workDir)。
+// image 缺失或 commands 全空 → 错误(诚实失败,不静默跳过)。
+func scriptStepFromJob(jb pipeline.Job) (pipeline.PipelineStep, error) {
+	image := cfgString(jb.Config, "image")
+	if image == "" {
+		return pipeline.PipelineStep{}, errors.New("缺少运行镜像(image)")
+	}
+	cmds := splitCommands(cfgString(jb.Config, "commands"))
+	if len(cmds) == 0 {
+		return pipeline.PipelineStep{}, errors.New("缺少执行命令(commands)")
+	}
+	return pipeline.PipelineStep{
+		ID:       jb.ID,
+		Name:     jb.Name,
+		Type:     pipeline.StepTypeScript,
+		Image:    image,
+		Commands: cmds,
+		WorkDir:  cfgString(jb.Config, "workDir"),
+	}, nil
+}
+
+// cfgString 从自由 KV config 取字符串值(非字符串/缺失 → "")。
+func cfgString(cfg map[string]any, key string) string {
+	if cfg == nil {
+		return ""
+	}
+	if v, ok := cfg[key].(string); ok {
+		return strings.TrimSpace(v)
+	}
+	return ""
+}
+
+// splitCommands 把多行命令字符串拆成逐行命令(trim 尾随 CR、剔空行)。
+func splitCommands(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	out := make([]string, 0, 4)
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// reporterSink 把 runScriptStep 期望的 run.StepSink 适配到 dagrun.StageReporter:
+// Log/EmitArtifact 转发到已绑定本阶段序号的 reporter,其余步骤生命周期方法为 no-op
+// (阶段的 StepRunning/StepDone 由 dagrun.Runner 负责)。
+type reporterSink struct {
+	rep dagrun.StageReporter
+}
+
+func (s *reporterSink) Plan(context.Context, []string) error        { return nil }
+func (s *reporterSink) StepRunning(context.Context, int) error      { return nil }
+func (s *reporterSink) StepDone(context.Context, int, string) error { return nil }
+func (s *reporterSink) SetFailureLog(context.Context, string) error { return nil }
+func (s *reporterSink) Log(ctx context.Context, stream string, _ int, line string) error {
+	return s.rep.Log(ctx, stream, line)
+}
+func (s *reporterSink) EmitArtifact(ctx context.Context, a run.Artifact) error {
+	return s.rep.EmitArtifact(ctx, a)
+}

--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -94,6 +94,9 @@ func NewStageExecutor(b *Builder) dagrun.StageExecutor {
 				_ = rep.Log(ctx, streamStderr, fmt.Sprintf("script job「%s」配置无效:%v", jb.Name, verr))
 				return ErrBuildFailed
 			}
+			// 参数化运行(Story 8-11):把本次运行参数作明文环境变量注入容器(置于 step env 前,
+			// step 自身 env 同名可覆盖)。明文 K=V,经 buildArgs 进容器。
+			step.Env = append(runParamsAsEnv(r.Trigger.Params), step.Env...)
 			// runScriptStep 用 lineSink(sink, ordinal) 喂日志;reporterSink 忽略 ordinal、转 rep(已绑定本阶段序号)。
 			if err := b.runScriptStep(ctx, sink, 0, step, workspace); err != nil {
 				return err // ErrBuildFailed / run.ErrCanceled
@@ -122,6 +125,19 @@ func scriptStepFromJob(jb pipeline.Job) (pipeline.PipelineStep, error) {
 		Commands: cmds,
 		WorkDir:  cfgString(jb.Config, "workDir"),
 	}, nil
+}
+
+// runParamsAsEnv 把运行参数(明文 K=V)转为非 secret BuildVar(注入容器环境)。键序确定性不保证(map),
+// 但同名键不会重复(map 天然去重)。
+func runParamsAsEnv(params map[string]string) []pipeline.BuildVar {
+	if len(params) == 0 {
+		return nil
+	}
+	out := make([]pipeline.BuildVar, 0, len(params))
+	for k, v := range params {
+		out = append(out, pipeline.BuildVar{Key: k, Value: v, Secret: false})
+	}
+	return out
 }
 
 // cfgString 从自由 KV config 取字符串值(非字符串/缺失 → "")。

--- a/internal/build/dag_stage_exec_test.go
+++ b/internal/build/dag_stage_exec_test.go
@@ -1,0 +1,224 @@
+package build
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/project"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// ─── 测试替身 ──────────────────────────────────────────────────────────────────
+
+// fakeReporter 记录 dagrun.StageReporter 调用。
+type fakeReporter struct {
+	logs []string
+	arts []run.Artifact
+}
+
+func (r *fakeReporter) Log(_ context.Context, _ string, line string) error {
+	r.logs = append(r.logs, line)
+	return nil
+}
+func (r *fakeReporter) EmitArtifact(_ context.Context, a run.Artifact) error {
+	r.arts = append(r.arts, a)
+	return nil
+}
+
+// recordingDriver 记录 RunToolchain 调用并按配置回退码/日志(其余 Driver 方法不应被调到)。
+type recordingDriver struct {
+	code      int
+	emit      []string
+	gotImage  string
+	gotCmd    []string
+	gotWork   string
+	callCount int
+}
+
+func (d *recordingDriver) Binary() string { return "fake" }
+func (d *recordingDriver) RunToolchain(_ context.Context, image, _, workdir string, _ []string, cmd []string, onLine func(stream, line string)) (int, error) {
+	d.callCount++
+	d.gotImage = image
+	d.gotCmd = cmd
+	d.gotWork = workdir
+	for _, l := range d.emit {
+		onLine("stdout", l)
+	}
+	return d.code, nil
+}
+func (d *recordingDriver) Build(context.Context, string, string, string, []string, []string, func(string, string)) (int, error) {
+	panic("Build not expected")
+}
+func (d *recordingDriver) Tag(context.Context, string, string, func(string, string)) (int, error) {
+	panic("Tag not expected")
+}
+func (d *recordingDriver) Login(context.Context, string, string, string, func(string, string)) (int, error) {
+	panic("Login not expected")
+}
+func (d *recordingDriver) Push(context.Context, string, func(string, string)) (int, error) {
+	panic("Push not expected")
+}
+func (d *recordingDriver) InspectImage(context.Context, string) (string, int64, error) {
+	panic("InspectImage not expected")
+}
+
+// markerCloner 把一个标记文件写进工作区(替代真触网克隆)。
+type markerCloner struct {
+	file    string
+	content string
+}
+
+func (c *markerCloner) Clone(_ context.Context, _, _, _, _, destDir string) (*CloneResolved, error) {
+	if c.file != "" {
+		_ = os.WriteFile(filepath.Join(destDir, c.file), []byte(c.content), 0o644)
+	}
+	return &CloneResolved{CommitShort: "abc1234"}, nil
+}
+
+func newDAGTestBuilder(drv Driver, cl repoCloner) *Builder {
+	return &Builder{
+		projects: fakeProjects{proj: &project.Project{ID: "p1", RepoURL: "https://example.com/r.git"}},
+		settings: fakeSettings{settings: &pipeline.Settings{}},
+		vault:    fakeVault{secrets: map[string]string{}},
+		driver:   drv,
+		cloner:   cl,
+	}
+}
+
+func scriptStage(jobs ...pipeline.Job) pipeline.Stage {
+	return pipeline.Stage{ID: "s1", Name: "构建", Kind: pipeline.KindBuild, Jobs: jobs}
+}
+
+func scriptJob(name, image, commands string) pipeline.Job {
+	return pipeline.Job{Name: name, Type: pipeline.StepTypeScript, Config: map[string]any{"image": image, "commands": commands}}
+}
+
+// ─── scriptStepFromJob / splitCommands ──────────────────────────────────────────
+
+func TestScriptStepFromJob(t *testing.T) {
+	jb := pipeline.Job{
+		ID: "j1", Name: "test", Type: "script",
+		Config: map[string]any{"image": " node:20 ", "commands": "npm ci\n\nnpm test\n", "workDir": "app"},
+	}
+	step, err := scriptStepFromJob(jb)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if step.Image != "node:20" {
+		t.Errorf("image = %q", step.Image)
+	}
+	if len(step.Commands) != 2 || step.Commands[0] != "npm ci" || step.Commands[1] != "npm test" {
+		t.Errorf("commands = %v", step.Commands)
+	}
+	if step.WorkDir != "app" {
+		t.Errorf("workDir = %q", step.WorkDir)
+	}
+}
+
+func TestScriptStepFromJobMissing(t *testing.T) {
+	if _, err := scriptStepFromJob(pipeline.Job{Config: map[string]any{"commands": "x"}}); err == nil {
+		t.Error("expected error for missing image")
+	}
+	if _, err := scriptStepFromJob(pipeline.Job{Config: map[string]any{"image": "x"}}); err == nil {
+		t.Error("expected error for missing commands")
+	}
+}
+
+// ─── NewStageExecutor(fake driver,无 Docker)───────────────────────────────────
+
+func TestStageExecutorRunsScriptJobInContainer(t *testing.T) {
+	drv := &recordingDriver{code: 0, emit: []string{"hello from container"}}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b)
+	rep := &fakeReporter{}
+
+	err := exec(context.Background(), &run.Run{ProjectID: "p1"},
+		scriptStage(scriptJob("unit", "busybox", "echo hello")), rep)
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if drv.callCount != 1 {
+		t.Fatalf("RunToolchain called %d times, want 1", drv.callCount)
+	}
+	if drv.gotImage != "busybox" {
+		t.Errorf("image = %q", drv.gotImage)
+	}
+	// 多行命令合成 sh -c set -e 脚本。
+	if len(drv.gotCmd) != 3 || drv.gotCmd[0] != "sh" || drv.gotCmd[1] != "-c" || !strings.Contains(drv.gotCmd[2], "echo hello") {
+		t.Errorf("cmd = %v", drv.gotCmd)
+	}
+	if !strings.Contains(strings.Join(rep.logs, "\n"), "hello from container") {
+		t.Errorf("container log not forwarded to reporter: %v", rep.logs)
+	}
+}
+
+func TestStageExecutorNonScriptPlaceholder(t *testing.T) {
+	drv := &recordingDriver{}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b)
+	rep := &fakeReporter{}
+
+	stage := pipeline.Stage{ID: "s", Name: "构建", Kind: pipeline.KindBuild,
+		Jobs: []pipeline.Job{{Name: "img", Type: "build_image", Config: map[string]any{}}}}
+	if err := exec(context.Background(), &run.Run{ProjectID: "p1"}, stage, rep); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if drv.callCount != 0 {
+		t.Error("non-script job must not invoke RunToolchain")
+	}
+	if !strings.Contains(strings.Join(rep.logs, "\n"), "真实执行未接入") {
+		t.Errorf("expected honest placeholder log, got %v", rep.logs)
+	}
+}
+
+func TestStageExecutorScriptFailureNonZero(t *testing.T) {
+	drv := &recordingDriver{code: 1} // 容器非零退出
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b)
+	if err := exec(context.Background(), &run.Run{ProjectID: "p1"},
+		scriptStage(scriptJob("unit", "busybox", "false")), &fakeReporter{}); err == nil {
+		t.Error("expected ErrBuildFailed on nonzero container exit")
+	}
+}
+
+func TestStageExecutorInvalidScriptConfig(t *testing.T) {
+	drv := &recordingDriver{}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b)
+	// script job 缺 image。
+	bad := pipeline.Job{Name: "x", Type: "script", Config: map[string]any{"commands": "echo hi"}}
+	if err := exec(context.Background(), &run.Run{ProjectID: "p1"}, scriptStage(bad), &fakeReporter{}); err == nil {
+		t.Error("expected error for invalid script config")
+	}
+}
+
+// ─── 真 Docker e2e(gated)─────────────────────────────────────────────────────
+
+func TestE2EDockerStageExecutorReal(t *testing.T) {
+	drv := dockerReadyOrSkip(t)
+	b := newDAGTestBuilder(drv, &markerCloner{file: "marker.txt", content: "PIPEWRIGHT_DAG_OK"})
+	exec := NewStageExecutor(b)
+	rep := &fakeReporter{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	// 真容器:busybox 读回工作区里的标记文件 + echo 命令输出。
+	job := scriptJob("verify", "busybox", "cat marker.txt\necho RAN-IN-CONTAINER")
+	if err := exec(ctx, &run.Run{ProjectID: "p1", Trigger: run.Trigger{Branch: "main"}},
+		scriptStage(job), rep); err != nil {
+		t.Fatalf("真 Docker 阶段执行失败: %v\n日志:\n%s", err, strings.Join(rep.logs, "\n"))
+	}
+	logs := strings.Join(rep.logs, "\n")
+	if !strings.Contains(logs, "PIPEWRIGHT_DAG_OK") {
+		t.Errorf("容器未读到挂载的工作区文件;日志:\n%s", logs)
+	}
+	if !strings.Contains(logs, "RAN-IN-CONTAINER") {
+		t.Errorf("容器命令未真实执行;日志:\n%s", logs)
+	}
+}

--- a/internal/build/dag_stage_exec_test.go
+++ b/internal/build/dag_stage_exec_test.go
@@ -37,15 +37,17 @@ type recordingDriver struct {
 	gotImage  string
 	gotCmd    []string
 	gotWork   string
+	gotEnv    []string
 	callCount int
 }
 
 func (d *recordingDriver) Binary() string { return "fake" }
-func (d *recordingDriver) RunToolchain(_ context.Context, image, _, workdir string, _ []string, cmd []string, onLine func(stream, line string)) (int, error) {
+func (d *recordingDriver) RunToolchain(_ context.Context, image, _, workdir string, env []string, cmd []string, onLine func(stream, line string)) (int, error) {
 	d.callCount++
 	d.gotImage = image
 	d.gotCmd = cmd
 	d.gotWork = workdir
+	d.gotEnv = env
 	for _, l := range d.emit {
 		onLine("stdout", l)
 	}
@@ -157,6 +159,20 @@ func TestStageExecutorRunsScriptJobInContainer(t *testing.T) {
 	}
 }
 
+func TestStageExecutorInjectsRunParams(t *testing.T) {
+	drv := &recordingDriver{code: 0}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b)
+	r := &run.Run{ProjectID: "p1", Trigger: run.Trigger{Params: map[string]string{"DEPLOY_ENV": "staging", "VER": "1.2"}}}
+	if err := exec(context.Background(), r, scriptStage(scriptJob("unit", "busybox", "echo hi")), &fakeReporter{}); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	env := strings.Join(drv.gotEnv, " ")
+	if !strings.Contains(env, "DEPLOY_ENV=staging") || !strings.Contains(env, "VER=1.2") {
+		t.Errorf("run params not injected into container env: %v", drv.gotEnv)
+	}
+}
+
 func TestStageExecutorNonScriptPlaceholder(t *testing.T) {
 	drv := &recordingDriver{}
 	b := newDAGTestBuilder(drv, &markerCloner{})
@@ -198,6 +214,25 @@ func TestStageExecutorInvalidScriptConfig(t *testing.T) {
 }
 
 // ─── 真 Docker e2e(gated)─────────────────────────────────────────────────────
+
+func TestE2EDockerStageExecutorParamsReal(t *testing.T) {
+	drv := dockerReadyOrSkip(t)
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b)
+	rep := &fakeReporter{}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	// 参数化运行:容器内 echo 注入的参数,断言真值被注入并执行。
+	r := &run.Run{ProjectID: "p1", Trigger: run.Trigger{Branch: "main", Params: map[string]string{"PW_PARAM": "HELLO_FROM_PARAM"}}}
+	job := scriptJob("verify", "busybox", `echo "p=$PW_PARAM"`)
+	if err := exec(ctx, r, scriptStage(job), rep); err != nil {
+		t.Fatalf("真 Docker 参数化执行失败: %v\n日志:\n%s", err, strings.Join(rep.logs, "\n"))
+	}
+	if !strings.Contains(strings.Join(rep.logs, "\n"), "p=HELLO_FROM_PARAM") {
+		t.Errorf("容器未读到注入的运行参数;日志:\n%s", strings.Join(rep.logs, "\n"))
+	}
+}
 
 func TestE2EDockerStageExecutorReal(t *testing.T) {
 	drv := dockerReadyOrSkip(t)

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -101,6 +101,11 @@ var (
 	ErrCycle = errors.New("dag: cycle detected")
 )
 
+// ErrSkip 是 RunFunc 可返回的哨兵:表示「按条件跳过本节点」(非失败)。
+// 节点据此记 StatusSkipped(而非 StatusFailed),其下游照「上游未成功」逻辑被跳过;
+// 但它**不算失败**——调用方据 Counts()[StatusFailed] 判定整体是否失败,条件跳过不令整体失败。
+var ErrSkip = errors.New("dag: node skipped by condition")
+
 // Graph 是一张已校验的 DAG。
 type Graph struct {
 	nodes      map[string]Node
@@ -263,7 +268,10 @@ func (g *Graph) Schedule(ctx context.Context, run RunFunc, opts Options) Result 
 			}
 			err := run(ctx, id)
 			st := StatusSuccess
-			if err != nil {
+			switch {
+			case errors.Is(err, ErrSkip):
+				st = StatusSkipped // 条件跳过:非失败,但下游照「未成功」跳过
+			case err != nil:
 				st = StatusFailed
 			}
 			finCh <- fin{id, st, err}

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -1,0 +1,346 @@
+// Package dag 是流水线 DAG 调度引擎核心(Epic 8 · Story 8-3)。
+//
+// 它是一个**纯粹、确定、可并发**的调度内核:给定一组带依赖(needs)的节点(= 流水线阶段)
+// 与一个「执行单节点」的回调,按 DAG 拓扑序调度执行 —— 无依赖关系的节点并行跑(受
+// 最大并发上限约束),节点在其全部上游成功后才就绪,任一上游失败则该节点(及其下游)
+// 被跳过(skipped),除非该上游声明了 AllowFailure。构造期做环检测(防环)。
+//
+// 本内核刻意**不触库、不发事件、不感知容器/SSH** —— 执行副作用全在调用方传入的 RunFunc 里。
+// 这样它能被纯单测彻底覆盖,后续由 run 引擎(8-2 脚本执行器 + StepSink 流式日志)把每个
+// 节点的真实执行(stage 内并行 job → job 内有序 step)接进 RunFunc,复用现有持久化/SSE 管道。
+//
+// 失败语义(对标 Jenkins/云效):
+//   - 节点成功 ⇒ 下游解锁。
+//   - 节点失败且未声明 AllowFailure ⇒ 下游(直接与间接)全部 skipped;**互不依赖的并行分支照常继续**。
+//   - 节点失败但声明 AllowFailure ⇒ 视为「有效成功」解锁下游,但自身仍记为 failed(整体 run 计失败可由调用方据 Result 判定)。
+//   - context 取消 ⇒ 已在跑的节点收到取消(由 RunFunc 自行响应);未跑的节点记为 canceled 并向下游传播为跳过。
+package dag
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// Status 是一个节点调度后的终态。
+type Status string
+
+const (
+	// StatusSuccess 表示节点执行成功。
+	StatusSuccess Status = "success"
+	// StatusFailed 表示节点执行失败(RunFunc 返回非 nil)。
+	StatusFailed Status = "failed"
+	// StatusSkipped 表示节点因上游失败/跳过而未执行。
+	StatusSkipped Status = "skipped"
+	// StatusCanceled 表示节点因 context 取消而未(完整)执行。
+	StatusCanceled Status = "canceled"
+)
+
+// Node 是一个可调度单元(对应流水线一个 stage)。
+type Node struct {
+	// ID 是节点唯一标识(同图内不可重复、非空)。
+	ID string
+	// Needs 是该节点依赖的上游节点 ID 列表(必须都在图内;不可自指;整体不可成环)。
+	Needs []string
+	// AllowFailure 为 true 时,该节点失败仍视为「有效成功」放行下游(自身仍记 failed)。
+	AllowFailure bool
+}
+
+// NodeResult 是单个节点的调度结果。
+type NodeResult struct {
+	Status Status
+	// Err 是 RunFunc 返回的错误(仅 failed 时非 nil)。
+	Err error
+}
+
+// Result 是整图调度结果(节点 ID → 终态)。
+type Result map[string]NodeResult
+
+// Succeeded 报告是否所有节点都成功(无 failed/skipped/canceled)。
+// AllowFailure 节点失败时本方法仍返回 false(它确实失败了);若调用方希望宽容,
+// 可自行遍历 Result 按业务判定。
+func (r Result) Succeeded() bool {
+	for _, nr := range r {
+		if nr.Status != StatusSuccess {
+			return false
+		}
+	}
+	return true
+}
+
+// Counts 汇总各终态数量(便于摘要/断言)。
+func (r Result) Counts() map[Status]int {
+	out := map[Status]int{}
+	for _, nr := range r {
+		out[nr.Status]++
+	}
+	return out
+}
+
+// RunFunc 执行单个节点;返回非 nil 表示该节点失败。必须响应 ctx 取消。
+type RunFunc func(ctx context.Context, id string) error
+
+// Options 调度选项。
+type Options struct {
+	// MaxConcurrency 是同时执行的节点数上限;<=0 表示不限(取节点总数)。
+	MaxConcurrency int
+}
+
+// 构造期错误。
+var (
+	// ErrEmptyID 表示存在空 ID 节点。
+	ErrEmptyID = errors.New("dag: node id must not be empty")
+	// ErrDuplicateID 表示节点 ID 重复。
+	ErrDuplicateID = errors.New("dag: duplicate node id")
+	// ErrUnknownDep 表示某节点依赖了图中不存在的节点。
+	ErrUnknownDep = errors.New("dag: unknown dependency")
+	// ErrSelfDep 表示某节点依赖了自身。
+	ErrSelfDep = errors.New("dag: node depends on itself")
+	// ErrCycle 表示图中存在环(非 DAG)。
+	ErrCycle = errors.New("dag: cycle detected")
+)
+
+// Graph 是一张已校验的 DAG。
+type Graph struct {
+	nodes      map[string]Node
+	order      []string            // 稳定声明序(用于确定性遍历/种子)
+	dependents map[string][]string // id → 依赖它的下游(按声明序)
+}
+
+// New 校验节点集合并构造 DAG。
+// 校验:ID 非空且唯一;Needs 去重后必须都在图内、不可自指;整体不可成环(Kahn 拓扑校验)。
+func New(nodes []Node) (*Graph, error) {
+	g := &Graph{
+		nodes:      make(map[string]Node, len(nodes)),
+		order:      make([]string, 0, len(nodes)),
+		dependents: make(map[string][]string),
+	}
+	// 收集 + 唯一性
+	for _, n := range nodes {
+		if n.ID == "" {
+			return nil, ErrEmptyID
+		}
+		if _, dup := g.nodes[n.ID]; dup {
+			return nil, fmt.Errorf("%w: %s", ErrDuplicateID, n.ID)
+		}
+		// 去重 needs(保留首次出现序)
+		seen := make(map[string]struct{}, len(n.Needs))
+		deduped := make([]string, 0, len(n.Needs))
+		for _, d := range n.Needs {
+			if d == n.ID {
+				return nil, fmt.Errorf("%w: %s", ErrSelfDep, n.ID)
+			}
+			if _, ok := seen[d]; ok {
+				continue
+			}
+			seen[d] = struct{}{}
+			deduped = append(deduped, d)
+		}
+		nn := Node{ID: n.ID, Needs: deduped, AllowFailure: n.AllowFailure}
+		g.nodes[nn.ID] = nn
+		g.order = append(g.order, nn.ID)
+	}
+	// 依赖存在性 + 反向边
+	for _, id := range g.order {
+		for _, d := range g.nodes[id].Needs {
+			if _, ok := g.nodes[d]; !ok {
+				return nil, fmt.Errorf("%w: %s -> %s", ErrUnknownDep, id, d)
+			}
+			g.dependents[d] = append(g.dependents[d], id)
+		}
+	}
+	if err := g.checkAcyclic(); err != nil {
+		return nil, err
+	}
+	return g, nil
+}
+
+// checkAcyclic 用 Kahn 算法做拓扑校验:若无法把所有节点排完,则存在环。
+func (g *Graph) checkAcyclic() error {
+	indeg := make(map[string]int, len(g.nodes))
+	for _, id := range g.order {
+		indeg[id] = len(g.nodes[id].Needs)
+	}
+	queue := make([]string, 0, len(g.order))
+	for _, id := range g.order {
+		if indeg[id] == 0 {
+			queue = append(queue, id)
+		}
+	}
+	visited := 0
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		visited++
+		for _, dep := range g.dependents[id] {
+			indeg[dep]--
+			if indeg[dep] == 0 {
+				queue = append(queue, dep)
+			}
+		}
+	}
+	if visited != len(g.nodes) {
+		return ErrCycle
+	}
+	return nil
+}
+
+// TopoOrder 返回一个确定性的拓扑序(同层按声明序),便于串行执行或测试断言。
+func (g *Graph) TopoOrder() []string {
+	indeg := make(map[string]int, len(g.nodes))
+	for _, id := range g.order {
+		indeg[id] = len(g.nodes[id].Needs)
+	}
+	out := make([]string, 0, len(g.order))
+	// 反复取出当前 indeg==0 的节点(按声明序),保证确定性。
+	resolved := make(map[string]bool, len(g.order))
+	for len(out) < len(g.order) {
+		progressed := false
+		for _, id := range g.order {
+			if resolved[id] || indeg[id] != 0 {
+				continue
+			}
+			resolved[id] = true
+			out = append(out, id)
+			for _, dep := range g.dependents[id] {
+				indeg[dep]--
+			}
+			progressed = true
+		}
+		if !progressed {
+			break // 不应发生(已 checkAcyclic);防御性退出
+		}
+	}
+	return out
+}
+
+// Schedule 按 DAG 调度执行整图,返回每个节点的终态。
+//
+// 并发:互不依赖且就绪的节点并行执行(受 opts.MaxConcurrency 约束)。
+// 失败传播:见包注释。本方法阻塞至所有节点终态。
+func (g *Graph) Schedule(ctx context.Context, run RunFunc, opts Options) Result {
+	total := len(g.nodes)
+	results := make(Result, total)
+	if total == 0 {
+		return results
+	}
+
+	max := opts.MaxConcurrency
+	if max <= 0 || max > total {
+		max = total
+	}
+	sem := make(chan struct{}, max)
+
+	indeg := make(map[string]int, total)
+	for _, id := range g.order {
+		indeg[id] = len(g.nodes[id].Needs)
+	}
+	// upstreamFailed[id]:其某个上游「有效失败」(失败且未 AllowFailure,或被跳过/取消)。
+	upstreamFailed := make(map[string]bool, total)
+
+	type fin struct {
+		id     string
+		status Status
+		err    error
+	}
+	finCh := make(chan fin)
+	done := 0
+
+	launch := func(id string) {
+		go func() {
+			// 取并发令牌前先看取消,避免无谓占位。
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				finCh <- fin{id, StatusCanceled, ctx.Err()}
+				return
+			}
+			defer func() { <-sem }()
+			if ctx.Err() != nil {
+				finCh <- fin{id, StatusCanceled, ctx.Err()}
+				return
+			}
+			err := run(ctx, id)
+			st := StatusSuccess
+			if err != nil {
+				st = StatusFailed
+			}
+			finCh <- fin{id, st, err}
+		}()
+	}
+
+	// effectiveFail 报告某终态是否应让下游「跳过」。
+	// 失败但 AllowFailure 的节点不阻断下游;skipped/canceled 阻断;真失败阻断。
+	effectiveFail := func(id string, st Status) bool {
+		switch st {
+		case StatusSuccess:
+			return false
+		case StatusFailed:
+			return !g.nodes[id].AllowFailure
+		default: // skipped / canceled
+			return true
+		}
+	}
+
+	// resolve 处理一个已终态节点对其下游的影响:递减下游 indeg,标记上游失败传播;
+	// 下游 indeg 归零时,要么立即跳过(并递归传播为跳过),要么 launch 执行。
+	// 用显式栈处理跳过链(避免递归)。
+	var resolve func(id string, st Status)
+	resolve = func(id string, st Status) {
+		type pending struct {
+			id   string
+			fail bool
+		}
+		stack := make([]pending, 0)
+		for _, dep := range g.dependents[id] {
+			stack = append(stack, pending{dep, effectiveFail(id, st)})
+		}
+		for len(stack) > 0 {
+			p := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			indeg[p.id]--
+			if p.fail {
+				upstreamFailed[p.id] = true
+			}
+			if indeg[p.id] != 0 {
+				continue
+			}
+			if upstreamFailed[p.id] {
+				// 上游有效失败 → 跳过;跳过本身向其下游传播为失败。
+				results[p.id] = NodeResult{Status: StatusSkipped}
+				done++
+				for _, dd := range g.dependents[p.id] {
+					stack = append(stack, pending{dd, true})
+				}
+			} else {
+				launch(p.id)
+			}
+		}
+	}
+
+	// 种子:所有 indeg==0 节点按声明序启动。
+	for _, id := range g.order {
+		if indeg[id] == 0 {
+			launch(id)
+		}
+	}
+
+	for done < total {
+		f := <-finCh
+		results[f.id] = NodeResult{Status: f.status, Err: f.err}
+		done++
+		resolve(f.id, f.status)
+	}
+	return results
+}
+
+// SortedIDs 返回结果里所有节点 ID 的稳定排序(测试便利)。
+func (r Result) SortedIDs() []string {
+	ids := make([]string, 0, len(r))
+	for id := range r {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -313,6 +313,35 @@ func TestScheduleContextCanceled(t *testing.T) {
 
 // ─── 结果辅助 ──────────────────────────────────────────────────────────────────
 
+func TestScheduleErrSkipMarksSkippedNotFailed(t *testing.T) {
+	// a → b → c ;  a → d。 b 返回 ErrSkip(条件跳过):b=skipped、c=skipped(下游)、d=success。
+	// 关键:条件跳过不计入 StatusFailed(整体不因 when 跳过而失败)。
+	g, _ := New([]Node{
+		{ID: "a"},
+		{ID: "b", Needs: []string{"a"}},
+		{ID: "c", Needs: []string{"b"}},
+		{ID: "d", Needs: []string{"a"}},
+	})
+	res := g.Schedule(context.Background(), func(_ context.Context, id string) error {
+		if id == "b" {
+			return ErrSkip
+		}
+		return nil
+	}, Options{})
+	if res["b"].Status != StatusSkipped {
+		t.Errorf("b = %v, want skipped", res["b"].Status)
+	}
+	if res["c"].Status != StatusSkipped {
+		t.Errorf("c = %v, want skipped (downstream of skipped)", res["c"].Status)
+	}
+	if res["d"].Status != StatusSuccess {
+		t.Errorf("d = %v, want success (independent)", res["d"].Status)
+	}
+	if n := res.Counts()[StatusFailed]; n != 0 {
+		t.Errorf("条件跳过不应计为失败,StatusFailed=%d", n)
+	}
+}
+
 func TestResultCounts(t *testing.T) {
 	g, _ := New([]Node{
 		{ID: "a"},

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -1,0 +1,332 @@
+package dag
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// okRun 是恒成功的 RunFunc。
+func okRun(_ context.Context, _ string) error { return nil }
+
+// ─── 构造校验 ──────────────────────────────────────────────────────────────────
+
+func TestNewValidation(t *testing.T) {
+	cases := []struct {
+		name  string
+		nodes []Node
+		want  error
+	}{
+		{"empty id", []Node{{ID: ""}}, ErrEmptyID},
+		{"dup id", []Node{{ID: "a"}, {ID: "a"}}, ErrDuplicateID},
+		{"unknown dep", []Node{{ID: "a", Needs: []string{"x"}}}, ErrUnknownDep},
+		{"self dep", []Node{{ID: "a", Needs: []string{"a"}}}, ErrSelfDep},
+		{"2-cycle", []Node{{ID: "a", Needs: []string{"b"}}, {ID: "b", Needs: []string{"a"}}}, ErrCycle},
+		{"3-cycle", []Node{
+			{ID: "a", Needs: []string{"c"}},
+			{ID: "b", Needs: []string{"a"}},
+			{ID: "c", Needs: []string{"b"}},
+		}, ErrCycle},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := New(c.nodes)
+			if !errors.Is(err, c.want) {
+				t.Fatalf("New() err = %v, want %v", err, c.want)
+			}
+		})
+	}
+}
+
+func TestNewValidGraph(t *testing.T) {
+	g, err := New([]Node{
+		{ID: "build"},
+		{ID: "test", Needs: []string{"build"}},
+		{ID: "deploy", Needs: []string{"test", "test"}}, // 重复 need 应被去重
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(g.nodes["deploy"].Needs) != 1 {
+		t.Errorf("duplicate need not deduped: %v", g.nodes["deploy"].Needs)
+	}
+}
+
+// ─── TopoOrder ────────────────────────────────────────────────────────────────
+
+func TestTopoOrderLinear(t *testing.T) {
+	g, _ := New([]Node{
+		{ID: "c", Needs: []string{"b"}},
+		{ID: "b", Needs: []string{"a"}},
+		{ID: "a"},
+	})
+	got := g.TopoOrder()
+	want := []string{"a", "b", "c"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("TopoOrder = %v, want %v", got, want)
+	}
+}
+
+func TestTopoOrderRespectsDeps(t *testing.T) {
+	// 钻石:a → {b,c} → d
+	g, _ := New([]Node{
+		{ID: "a"},
+		{ID: "b", Needs: []string{"a"}},
+		{ID: "c", Needs: []string{"a"}},
+		{ID: "d", Needs: []string{"b", "c"}},
+	})
+	order := g.TopoOrder()
+	pos := map[string]int{}
+	for i, id := range order {
+		pos[id] = i
+	}
+	if pos["a"] > pos["b"] || pos["a"] > pos["c"] || pos["b"] > pos["d"] || pos["c"] > pos["d"] {
+		t.Errorf("topo order violates deps: %v", order)
+	}
+}
+
+// ─── Schedule: 成功路径 ─────────────────────────────────────────────────────────
+
+func TestScheduleLinearSuccess(t *testing.T) {
+	var mu sync.Mutex
+	var seq []string
+	g, _ := New([]Node{
+		{ID: "a"},
+		{ID: "b", Needs: []string{"a"}},
+		{ID: "c", Needs: []string{"b"}},
+	})
+	res := g.Schedule(context.Background(), func(_ context.Context, id string) error {
+		mu.Lock()
+		seq = append(seq, id)
+		mu.Unlock()
+		return nil
+	}, Options{})
+	if !res.Succeeded() {
+		t.Fatalf("expected success, got %v", res)
+	}
+	if fmt.Sprint(seq) != "[a b c]" {
+		t.Errorf("exec order = %v, want [a b c]", seq)
+	}
+}
+
+func TestScheduleEmptyGraph(t *testing.T) {
+	g, _ := New(nil)
+	res := g.Schedule(context.Background(), okRun, Options{})
+	if !res.Succeeded() || len(res) != 0 {
+		t.Errorf("empty graph: got %v", res)
+	}
+}
+
+// ─── Schedule: 失败阻断 ─────────────────────────────────────────────────────────
+
+func TestScheduleFailBlocksDownstreamButNotSiblings(t *testing.T) {
+	// a → b → c ;  a → d (独立分支)
+	// b 失败:c 应 skipped,d 应照常 success。
+	g, _ := New([]Node{
+		{ID: "a"},
+		{ID: "b", Needs: []string{"a"}},
+		{ID: "c", Needs: []string{"b"}},
+		{ID: "d", Needs: []string{"a"}},
+	})
+	var ranC atomic.Bool
+	res := g.Schedule(context.Background(), func(_ context.Context, id string) error {
+		if id == "b" {
+			return errors.New("boom")
+		}
+		if id == "c" {
+			ranC.Store(true)
+		}
+		return nil
+	}, Options{})
+
+	if res["a"].Status != StatusSuccess {
+		t.Errorf("a = %v, want success", res["a"].Status)
+	}
+	if res["b"].Status != StatusFailed {
+		t.Errorf("b = %v, want failed", res["b"].Status)
+	}
+	if res["c"].Status != StatusSkipped {
+		t.Errorf("c = %v, want skipped", res["c"].Status)
+	}
+	if res["d"].Status != StatusSuccess {
+		t.Errorf("d = %v, want success", res["d"].Status)
+	}
+	if ranC.Load() {
+		t.Error("c must not have executed (upstream failed)")
+	}
+	if res.Succeeded() {
+		t.Error("Succeeded() must be false when a node failed")
+	}
+}
+
+func TestScheduleSkipPropagatesTransitively(t *testing.T) {
+	// a → b → c → d ; b 失败 ⇒ c、d 都 skipped
+	g, _ := New([]Node{
+		{ID: "a"},
+		{ID: "b", Needs: []string{"a"}},
+		{ID: "c", Needs: []string{"b"}},
+		{ID: "d", Needs: []string{"c"}},
+	})
+	res := g.Schedule(context.Background(), func(_ context.Context, id string) error {
+		if id == "b" {
+			return errors.New("boom")
+		}
+		return nil
+	}, Options{})
+	for _, id := range []string{"c", "d"} {
+		if res[id].Status != StatusSkipped {
+			t.Errorf("%s = %v, want skipped", id, res[id].Status)
+		}
+	}
+}
+
+func TestScheduleAllowFailureUnblocksDownstream(t *testing.T) {
+	// b 失败但 AllowFailure ⇒ c 仍执行;b 自身仍记 failed。
+	g, _ := New([]Node{
+		{ID: "a"},
+		{ID: "b", Needs: []string{"a"}, AllowFailure: true},
+		{ID: "c", Needs: []string{"b"}},
+	})
+	var ranC atomic.Bool
+	res := g.Schedule(context.Background(), func(_ context.Context, id string) error {
+		if id == "b" {
+			return errors.New("boom")
+		}
+		if id == "c" {
+			ranC.Store(true)
+		}
+		return nil
+	}, Options{})
+	if res["b"].Status != StatusFailed {
+		t.Errorf("b = %v, want failed (recorded)", res["b"].Status)
+	}
+	if res["c"].Status != StatusSuccess || !ranC.Load() {
+		t.Errorf("c should run despite b's allowed failure; c=%v ran=%v", res["c"].Status, ranC.Load())
+	}
+}
+
+// ─── Schedule: 并发 ─────────────────────────────────────────────────────────────
+
+func TestScheduleParallelBarrier(t *testing.T) {
+	const n = 5
+	nodes := make([]Node, n)
+	for i := range nodes {
+		nodes[i] = Node{ID: fmt.Sprintf("n%d", i)}
+	}
+	g, _ := New(nodes)
+
+	var inFlight, maxInFlight int32
+	var startedCount int32
+	allStarted := make(chan struct{})
+	var once sync.Once
+
+	res := g.Schedule(context.Background(), func(_ context.Context, _ string) error {
+		cur := atomic.AddInt32(&inFlight, 1)
+		for {
+			m := atomic.LoadInt32(&maxInFlight)
+			if cur <= m || atomic.CompareAndSwapInt32(&maxInFlight, m, cur) {
+				break
+			}
+		}
+		if atomic.AddInt32(&startedCount, 1) == n {
+			once.Do(func() { close(allStarted) })
+		}
+		select {
+		case <-allStarted:
+		case <-time.After(2 * time.Second):
+		}
+		atomic.AddInt32(&inFlight, -1)
+		return nil
+	}, Options{MaxConcurrency: n})
+
+	if !res.Succeeded() {
+		t.Fatalf("got %v", res)
+	}
+	if maxInFlight < n {
+		t.Errorf("max in-flight = %d, want %d (insufficient parallelism)", maxInFlight, n)
+	}
+}
+
+func TestScheduleRespectsMaxConcurrency(t *testing.T) {
+	const n = 8
+	const limit = 3
+	nodes := make([]Node, n)
+	for i := range nodes {
+		nodes[i] = Node{ID: fmt.Sprintf("n%d", i)}
+	}
+	g, _ := New(nodes)
+
+	var inFlight, maxInFlight int32
+	res := g.Schedule(context.Background(), func(_ context.Context, _ string) error {
+		cur := atomic.AddInt32(&inFlight, 1)
+		for {
+			m := atomic.LoadInt32(&maxInFlight)
+			if cur <= m || atomic.CompareAndSwapInt32(&maxInFlight, m, cur) {
+				break
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+		atomic.AddInt32(&inFlight, -1)
+		return nil
+	}, Options{MaxConcurrency: limit})
+
+	if !res.Succeeded() {
+		t.Fatalf("got %v", res)
+	}
+	if maxInFlight > limit {
+		t.Errorf("max in-flight = %d, exceeds limit %d", maxInFlight, limit)
+	}
+}
+
+// ─── Schedule: 取消 ─────────────────────────────────────────────────────────────
+
+func TestScheduleContextCanceled(t *testing.T) {
+	g, _ := New([]Node{
+		{ID: "a"},
+		{ID: "b", Needs: []string{"a"}},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 调度前即取消
+
+	res := g.Schedule(ctx, func(ctx context.Context, _ string) error {
+		return ctx.Err()
+	}, Options{})
+
+	// a 取消;b 因上游未成功 → 跳过或取消(均非 success)。
+	if res["a"].Status == StatusSuccess {
+		t.Errorf("a should not succeed under canceled ctx, got %v", res["a"].Status)
+	}
+	if res["b"].Status == StatusSuccess {
+		t.Errorf("b should not succeed under canceled ctx, got %v", res["b"].Status)
+	}
+	if res.Succeeded() {
+		t.Error("Succeeded() must be false under cancellation")
+	}
+	if len(res) != 2 {
+		t.Errorf("all nodes must be terminal, got %d", len(res))
+	}
+}
+
+// ─── 结果辅助 ──────────────────────────────────────────────────────────────────
+
+func TestResultCounts(t *testing.T) {
+	g, _ := New([]Node{
+		{ID: "a"},
+		{ID: "b", Needs: []string{"a"}},
+		{ID: "c", Needs: []string{"b"}},
+	})
+	res := g.Schedule(context.Background(), func(_ context.Context, id string) error {
+		if id == "b" {
+			return errors.New("x")
+		}
+		return nil
+	}, Options{})
+	counts := res.Counts()
+	if counts[StatusSuccess] != 1 || counts[StatusFailed] != 1 || counts[StatusSkipped] != 1 {
+		t.Errorf("counts = %v", counts)
+	}
+}

--- a/internal/dagrun/dagrun.go
+++ b/internal/dagrun/dagrun.go
@@ -1,0 +1,219 @@
+// Package dagrun 把 DAG 调度内核(internal/dag)接进 run 引擎(Epic 8 · Story 8-1↔8-3 桥接)。
+//
+// Runner 实现 run.Runner 契约,可直接作为 WorkerPool 的执行器:它加载项目的流水线 spec
+// (阶段 + 依赖 needs),用 dag 把阶段构成 DAG 调度执行——无依赖阶段并行、按拓扑序推进、
+// 任一阶段失败按策略阻断下游(下游阶段记 skipped),并把每个阶段的运行/终态/日志经既有
+// StepSink 持久化(复用 run_steps + SSE + 脱敏管道)。
+//
+// 关注点分离:**单个阶段「怎么执行」**(跑 stage 内并行 job → job 内有序 step、在隔离容器里
+// 真实构建/部署)由注入的 StageExecutor 决定——那是 Story 8-2 的活;本包只负责「**按 DAG
+// 把阶段编排起来并如实上报**」。未注入真实执行器时用 StubStageExecutor(仅打日志即成功),
+// 便于纯单测覆盖编排逻辑、且不冒充真实执行。
+//
+// 向后兼容:当整个 spec 无任何阶段声明 needs 时,BuildGraph 退化为「按声明序线性」(存量
+// 直线流水线行为不变);一旦有阶段声明 needs,严格按声明的 DAG 调度。
+package dagrun
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/huangchengsir/pipewright/internal/dag"
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// SpecLoader 加载某项目的流水线配置(pipeline.Service 即满足此接口)。
+type SpecLoader interface {
+	Get(ctx context.Context, projectID string) (*pipeline.Config, error)
+}
+
+// StageReporter 给 StageExecutor 上报「本阶段」的日志/产物(自动关联到该阶段的 run_steps 序号)。
+type StageReporter interface {
+	// Log 报告本阶段一行日志(stream ∈ stdout|stderr)。落库前由 StepSink 脱敏。
+	Log(ctx context.Context, stream, line string) error
+	// EmitArtifact 报告本阶段产出的一条构建产物。
+	EmitArtifact(ctx context.Context, a run.Artifact) error
+}
+
+// StageExecutor 执行单个阶段(跑其 job/step);返回非 nil 表示该阶段失败。须响应 ctx 取消。
+// 真实实现(Story 8-2)在隔离容器内跑 stage 内并行 job 的有序 step;本包默认用 StubStageExecutor。
+type StageExecutor func(ctx context.Context, r *run.Run, stage pipeline.Stage, rep StageReporter) error
+
+// StubStageExecutor 是默认占位执行器:为每个 job 打一行日志后即判该阶段成功。
+// 不做任何真实构建/部署(诚实占位,真实执行 = Story 8-2)。
+func StubStageExecutor(ctx context.Context, _ *run.Run, stage pipeline.Stage, rep StageReporter) error {
+	if len(stage.Jobs) == 0 {
+		_ = rep.Log(ctx, "stdout", fmt.Sprintf("阶段「%s」无 job,跳过执行体", stage.Name))
+		return nil
+	}
+	for _, jb := range stage.Jobs {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		_ = rep.Log(ctx, "stdout", fmt.Sprintf("· %s(%s)", jb.Name, jb.Type))
+	}
+	return nil
+}
+
+// Runner 是 DAG 感知的 run.Runner 实现。
+type Runner struct {
+	loader      SpecLoader
+	exec        StageExecutor
+	concurrency int
+}
+
+// Option 配置 Runner。
+type Option func(*Runner)
+
+// WithConcurrency 设阶段并行上限(<=0 用阶段总数,即「能并行的全并行」)。
+func WithConcurrency(n int) Option {
+	return func(r *Runner) { r.concurrency = n }
+}
+
+// WithStageExecutor 注入真实阶段执行器(Story 8-2)。nil 忽略(保留 Stub)。
+func WithStageExecutor(e StageExecutor) Option {
+	return func(r *Runner) {
+		if e != nil {
+			r.exec = e
+		}
+	}
+}
+
+// New 构造 DAG Runner。loader 加载 spec;未注入执行器时用 StubStageExecutor。
+func New(loader SpecLoader, opts ...Option) *Runner {
+	r := &Runner{loader: loader, exec: StubStageExecutor}
+	for _, o := range opts {
+		o(r)
+	}
+	return r
+}
+
+// Run 实现 run.Runner:加载 spec → 构 DAG → 按拓扑/并行调度阶段 → 经 StepSink 上报。
+//
+// StepSink 非并发安全约定:本 Runner 用单一 mutex 串行化所有 sink 调用,即便阶段并行执行,
+// 对 sink 的 Plan/StepRunning/StepDone/Log/EmitArtifact 也互斥,安全复用既有持久化管道。
+func (r *Runner) Run(ctx context.Context, rn *run.Run, sink run.StepSink) error {
+	cfg, err := r.loader.Get(ctx, rn.ProjectID)
+	if err != nil {
+		return fmt.Errorf("dagrun: load pipeline spec: %w", err)
+	}
+	stages := cfg.Spec.Stages
+	if len(stages) == 0 {
+		// 无阶段:声明零步,直接成功(与既有空流水线语义一致)。
+		_ = sink.Plan(ctx, nil)
+		return nil
+	}
+
+	graph, err := BuildGraph(stages)
+	if err != nil {
+		return fmt.Errorf("dagrun: build graph: %w", err)
+	}
+
+	// 拓扑序决定 run_steps 的展示序与序号;每个阶段 = 一个 step。
+	order := graph.TopoOrder()
+	ordinalOf := make(map[string]int, len(order))
+	names := make([]string, 0, len(order))
+	stageByID := make(map[string]pipeline.Stage, len(stages))
+	for _, st := range stages {
+		stageByID[st.ID] = st
+	}
+	for i, id := range order {
+		ordinalOf[id] = i
+		names = append(names, stageByID[id].Name)
+	}
+
+	var mu sync.Mutex // 串行化对 sink 的全部调用(阶段可能并行)
+	lockedSink := func(fn func() error) error {
+		mu.Lock()
+		defer mu.Unlock()
+		return fn()
+	}
+
+	if err := lockedSink(func() error { return sink.Plan(ctx, names) }); err != nil {
+		return fmt.Errorf("dagrun: plan: %w", err)
+	}
+
+	maxc := r.concurrency
+	if maxc <= 0 {
+		maxc = len(order)
+	}
+
+	result := graph.Schedule(ctx, func(ctx context.Context, stageID string) error {
+		ord := ordinalOf[stageID]
+		stage := stageByID[stageID]
+		if err := lockedSink(func() error { return sink.StepRunning(ctx, ord) }); err != nil {
+			return err
+		}
+		rep := &stageReporter{sink: sink, mu: &mu, ordinal: ord}
+		execErr := r.exec(ctx, rn, stage, rep)
+		status := run.StepSuccess
+		if execErr != nil {
+			status = run.StepFailed
+		}
+		_ = lockedSink(func() error { return sink.StepDone(ctx, ord, status) })
+		return execErr
+	}, dag.Options{MaxConcurrency: maxc})
+
+	// 被跳过/取消(从未执行)的阶段:其 step 终态记为 skipped(与 dag 判定一致),避免悬挂 pending。
+	for id, nr := range result {
+		if nr.Status == dag.StatusSkipped || nr.Status == dag.StatusCanceled {
+			ord := ordinalOf[id]
+			_ = lockedSink(func() error { return sink.StepDone(ctx, ord, run.StepSkipped) })
+		}
+	}
+
+	if !result.Succeeded() {
+		return fmt.Errorf("dagrun: pipeline failed (%v)", summarize(result))
+	}
+	return nil
+}
+
+// stageReporter 把阶段级日志/产物绑定到该阶段的 step 序号,并经 mutex 串行化对 sink 的调用。
+type stageReporter struct {
+	sink    run.StepSink
+	mu      *sync.Mutex
+	ordinal int
+}
+
+func (s *stageReporter) Log(ctx context.Context, stream, line string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sink.Log(ctx, stream, s.ordinal, line)
+}
+
+func (s *stageReporter) EmitArtifact(ctx context.Context, a run.Artifact) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sink.EmitArtifact(ctx, a)
+}
+
+// summarize 汇总各终态计数(用于失败错误信息,不含敏感内容)。
+func summarize(res dag.Result) map[dag.Status]int { return res.Counts() }
+
+// BuildGraph 把流水线阶段构成 dag.Graph。
+//
+//   - 若**任一**阶段声明了 needs:严格按声明的依赖建图。
+//   - 若**所有**阶段都无 needs:退化为「按声明序线性」(stage[i] 依赖 stage[i-1]),
+//     保持存量直线流水线的执行顺序不变(向后兼容)。
+//
+// 返回的图已通过 dag.New 的构造校验(存在性 / 自指 / 环);spec 保存时也已校验过,此处兜底。
+func BuildGraph(stages []pipeline.Stage) (*dag.Graph, error) {
+	anyNeeds := false
+	for _, st := range stages {
+		if len(st.Needs) > 0 {
+			anyNeeds = true
+			break
+		}
+	}
+	nodes := make([]dag.Node, 0, len(stages))
+	for i, st := range stages {
+		needs := st.Needs
+		if !anyNeeds && i > 0 {
+			needs = []string{stages[i-1].ID} // 线性退化
+		}
+		nodes = append(nodes, dag.Node{ID: st.ID, Needs: needs, AllowFailure: st.AllowFailure})
+	}
+	return dag.New(nodes)
+}

--- a/internal/dagrun/dagrun.go
+++ b/internal/dagrun/dagrun.go
@@ -143,6 +143,14 @@ func (r *Runner) Run(ctx context.Context, rn *run.Run, sink run.StepSink) error 
 	result := graph.Schedule(ctx, func(ctx context.Context, stageID string) error {
 		ord := ordinalOf[stageID]
 		stage := stageByID[stageID]
+		// 条件执行(Story 8-5):when 不满足 → 跳过(非失败),其下游照「未成功」跳过。
+		if !stage.When.Matches(rn.Trigger.Branch, rn.Trigger.Type) {
+			_ = lockedSink(func() error {
+				return sink.Log(ctx, "stdout", ord, fmt.Sprintf(
+					"阶段「%s」条件不满足(分支=%q 触发=%q),跳过", stage.Name, rn.Trigger.Branch, rn.Trigger.Type))
+			})
+			return dag.ErrSkip
+		}
 		if err := lockedSink(func() error { return sink.StepRunning(ctx, ord) }); err != nil {
 			return err
 		}
@@ -156,7 +164,7 @@ func (r *Runner) Run(ctx context.Context, rn *run.Run, sink run.StepSink) error 
 		return execErr
 	}, dag.Options{MaxConcurrency: maxc})
 
-	// 被跳过/取消(从未执行)的阶段:其 step 终态记为 skipped(与 dag 判定一致),避免悬挂 pending。
+	// 被跳过/取消(从未执行)的阶段:其 step 终态记为 skipped(条件跳过 + 上游未成功皆然),避免悬挂 pending。
 	for id, nr := range result {
 		if nr.Status == dag.StatusSkipped || nr.Status == dag.StatusCanceled {
 			ord := ordinalOf[id]
@@ -164,7 +172,9 @@ func (r *Runner) Run(ctx context.Context, rn *run.Run, sink run.StepSink) error 
 		}
 	}
 
-	if !result.Succeeded() {
+	// 整体失败判定:仅当有阶段**真失败**(StatusFailed)。条件跳过 / 上游被跳过不令整体失败
+	// (上游若真失败,该失败阶段本身即计入 StatusFailed)。
+	if result.Counts()[dag.StatusFailed] > 0 {
 		return fmt.Errorf("dagrun: pipeline failed (%v)", summarize(result))
 	}
 	return nil

--- a/internal/dagrun/dagrun.go
+++ b/internal/dagrun/dagrun.go
@@ -16,6 +16,7 @@ package dagrun
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -57,15 +58,34 @@ func StubStageExecutor(ctx context.Context, _ *run.Run, stage pipeline.Stage, re
 	return nil
 }
 
+// GateFunc 在进入「审批门」阶段(Gate=true)前阻塞等待人工决定(Story 8-4)。
+// 返回 (true,nil)=批准继续;(false,nil)=拒绝(该阶段失败);(_,err)=取消/超时等(阶段失败)。
+// 实现(在 main/httpapi 装配)负责:登记待批 + 置 run 状态 waiting_approval + 阻塞协调器 +
+// 决定后置回 running。dagrun 经此 hook 解耦,不直接 import run.Service / approval。
+type GateFunc func(ctx context.Context, r *run.Run, stage pipeline.Stage) (approved bool, err error)
+
+// ErrGateRejected 表示审批门被人工拒绝(该阶段失败 → 运行终止)。
+var ErrGateRejected = errors.New("dagrun: approval gate rejected")
+
 // Runner 是 DAG 感知的 run.Runner 实现。
 type Runner struct {
 	loader      SpecLoader
 	exec        StageExecutor
+	gate        GateFunc
 	concurrency int
 }
 
 // Option 配置 Runner。
 type Option func(*Runner)
+
+// WithGate 注入审批门 hook(Story 8-4)。nil 忽略(无门:Gate 阶段直接执行)。
+func WithGate(g GateFunc) Option {
+	return func(r *Runner) {
+		if g != nil {
+			r.gate = g
+		}
+	}
+}
 
 // WithConcurrency 设阶段并行上限(<=0 用阶段总数,即「能并行的全并行」)。
 func WithConcurrency(n int) Option {
@@ -153,6 +173,26 @@ func (r *Runner) Run(ctx context.Context, rn *run.Run, sink run.StepSink) error 
 		}
 		if err := lockedSink(func() error { return sink.StepRunning(ctx, ord) }); err != nil {
 			return err
+		}
+		// 人工审批门(Story 8-4):进入该阶段前阻塞等待批准。run 状态由 gate 置 waiting_approval。
+		if stage.Gate && r.gate != nil {
+			_ = lockedSink(func() error {
+				return sink.Log(ctx, "stdout", ord, fmt.Sprintf("⏸ 阶段「%s」等待人工审批…", stage.Name))
+			})
+			approved, gerr := r.gate(ctx, rn, stage)
+			if gerr != nil {
+				_ = lockedSink(func() error {
+					return sink.Log(ctx, "stderr", ord, fmt.Sprintf("审批门中断:%v", gerr))
+				})
+				_ = lockedSink(func() error { return sink.StepDone(ctx, ord, run.StepFailed) })
+				return gerr
+			}
+			if !approved {
+				_ = lockedSink(func() error { return sink.Log(ctx, "stderr", ord, "⛔ 审批被拒绝,终止该阶段") })
+				_ = lockedSink(func() error { return sink.StepDone(ctx, ord, run.StepFailed) })
+				return ErrGateRejected
+			}
+			_ = lockedSink(func() error { return sink.Log(ctx, "stdout", ord, "✅ 审批通过,继续执行") })
 		}
 		rep := &stageReporter{sink: sink, mu: &mu, ordinal: ord}
 		execErr := r.exec(ctx, rn, stage, rep)

--- a/internal/dagrun/dagrun_test.go
+++ b/internal/dagrun/dagrun_test.go
@@ -107,6 +107,68 @@ func TestRunnerWhenSkipsStageAndDownstreamWithoutFailing(t *testing.T) {
 	}
 }
 
+func TestRunnerGateApprovedRunsStage(t *testing.T) {
+	cfg := cfgWith(
+		pipeline.Stage{ID: "src", Name: "源"},
+		pipeline.Stage{ID: "deploy", Name: "部署", Needs: []string{"src"}, Gate: true},
+	)
+	var ran bool
+	r := New(fakeLoader{cfg},
+		WithGate(func(_ context.Context, _ *run.Run, _ pipeline.Stage) (bool, error) {
+			return true, nil // 批准
+		}),
+		WithStageExecutor(func(_ context.Context, _ *run.Run, st pipeline.Stage, _ StageReporter) error {
+			if st.ID == "deploy" {
+				ran = true
+			}
+			return nil
+		}))
+	sink := newFakeSink()
+	if err := r.Run(context.Background(), &run.Run{ProjectID: "p"}, sink); err != nil {
+		t.Fatalf("批准后 Run 不应失败:%v", err)
+	}
+	if !ran {
+		t.Error("批准后 deploy 应执行")
+	}
+}
+
+func TestRunnerGateRejectedFailsStage(t *testing.T) {
+	cfg := cfgWith(
+		pipeline.Stage{ID: "src", Name: "源"},
+		pipeline.Stage{ID: "deploy", Name: "部署", Needs: []string{"src"}, Gate: true},
+	)
+	var ran bool
+	r := New(fakeLoader{cfg},
+		WithGate(func(_ context.Context, _ *run.Run, _ pipeline.Stage) (bool, error) {
+			return false, nil // 拒绝
+		}),
+		WithStageExecutor(func(_ context.Context, _ *run.Run, st pipeline.Stage, _ StageReporter) error {
+			if st.ID == "deploy" {
+				ran = true
+			}
+			return nil
+		}))
+	sink := newFakeSink()
+	err := r.Run(context.Background(), &run.Run{ProjectID: "p"}, sink)
+	if err == nil {
+		t.Fatal("拒绝应使 Run 失败")
+	}
+	if ran {
+		t.Error("拒绝后 deploy executor 不应被调用")
+	}
+	ord := func(name string) int {
+		for i, n := range sink.planned {
+			if n == name {
+				return i
+			}
+		}
+		return -1
+	}
+	if sink.done[ord("部署")] != run.StepFailed {
+		t.Errorf("部署 step = %q, want failed(被拒绝)", sink.done[ord("部署")])
+	}
+}
+
 func TestRunnerWhenMatchedRunsStage(t *testing.T) {
 	cfg := cfgWith(
 		pipeline.Stage{ID: "src", Name: "源"},

--- a/internal/dagrun/dagrun_test.go
+++ b/internal/dagrun/dagrun_test.go
@@ -62,6 +62,74 @@ func cfgWith(stages ...pipeline.Stage) *pipeline.Config {
 	return &pipeline.Config{Spec: pipeline.Spec{Stages: stages}}
 }
 
+func TestRunnerWhenSkipsStageAndDownstreamWithoutFailing(t *testing.T) {
+	// src → deploy(when branches=[main]) → notify。 触发分支=dev:
+	// deploy 条件不满足 → skipped;notify(下游)→ skipped;但整体 run **不失败**(无真失败阶段)。
+	cfg := cfgWith(
+		pipeline.Stage{ID: "src", Name: "源"},
+		pipeline.Stage{ID: "deploy", Name: "部署", Needs: []string{"src"},
+			When: pipeline.When{Branches: []string{"main"}}},
+		pipeline.Stage{ID: "notify", Name: "通知", Needs: []string{"deploy"}},
+	)
+	var ranDeploy bool
+	sink := newFakeSink()
+	r := New(fakeLoader{cfg}, WithStageExecutor(
+		func(_ context.Context, _ *run.Run, st pipeline.Stage, _ StageReporter) error {
+			if st.ID == "deploy" {
+				ranDeploy = true
+			}
+			return nil
+		}))
+	// 触发分支 dev(不匹配 when branches=[main])。
+	err := r.Run(context.Background(), &run.Run{ProjectID: "p", Trigger: run.Trigger{Type: "manual", Branch: "dev"}}, sink)
+	if err != nil {
+		t.Fatalf("条件跳过不应使 Run 失败,得 %v", err)
+	}
+	if ranDeploy {
+		t.Error("deploy 阶段条件不满足,executor 不应被调用")
+	}
+	ord := func(name string) int {
+		for i, n := range sink.planned {
+			if n == name {
+				return i
+			}
+		}
+		return -1
+	}
+	if sink.done[ord("源")] != run.StepSuccess {
+		t.Errorf("源 = %q, want success", sink.done[ord("源")])
+	}
+	if sink.done[ord("部署")] != run.StepSkipped {
+		t.Errorf("部署 = %q, want skipped(条件不满足)", sink.done[ord("部署")])
+	}
+	if sink.done[ord("通知")] != run.StepSkipped {
+		t.Errorf("通知 = %q, want skipped(上游被跳过)", sink.done[ord("通知")])
+	}
+}
+
+func TestRunnerWhenMatchedRunsStage(t *testing.T) {
+	cfg := cfgWith(
+		pipeline.Stage{ID: "src", Name: "源"},
+		pipeline.Stage{ID: "deploy", Name: "部署", Needs: []string{"src"},
+			When: pipeline.When{Branches: []string{"main"}, Events: []string{"manual"}}},
+	)
+	var ranDeploy bool
+	sink := newFakeSink()
+	r := New(fakeLoader{cfg}, WithStageExecutor(
+		func(_ context.Context, _ *run.Run, st pipeline.Stage, _ StageReporter) error {
+			if st.ID == "deploy" {
+				ranDeploy = true
+			}
+			return nil
+		}))
+	if err := r.Run(context.Background(), &run.Run{ProjectID: "p", Trigger: run.Trigger{Type: "manual", Branch: "main"}}, sink); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !ranDeploy {
+		t.Error("分支与触发类型均匹配,deploy 应执行")
+	}
+}
+
 // ─── BuildGraph ────────────────────────────────────────────────────────────────
 
 func TestBuildGraphLinearFallback(t *testing.T) {

--- a/internal/dagrun/dagrun_test.go
+++ b/internal/dagrun/dagrun_test.go
@@ -1,0 +1,258 @@
+package dagrun
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// ─── 测试替身 ──────────────────────────────────────────────────────────────────
+
+type fakeLoader struct{ cfg *pipeline.Config }
+
+func (f fakeLoader) Get(_ context.Context, _ string) (*pipeline.Config, error) {
+	return f.cfg, nil
+}
+
+// fakeSink 记录 StepSink 调用(dagrun 已串行化调用,这里再加锁防御)。
+type fakeSink struct {
+	mu      sync.Mutex
+	planned []string
+	running []int
+	done    map[int]string
+	logs    []string
+}
+
+func newFakeSink() *fakeSink { return &fakeSink{done: map[int]string{}} }
+
+func (s *fakeSink) Plan(_ context.Context, names []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.planned = append([]string{}, names...)
+	return nil
+}
+func (s *fakeSink) StepRunning(_ context.Context, ord int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.running = append(s.running, ord)
+	return nil
+}
+func (s *fakeSink) StepDone(_ context.Context, ord int, status string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.done[ord] = status
+	return nil
+}
+func (s *fakeSink) SetFailureLog(_ context.Context, _ string) error { return nil }
+func (s *fakeSink) Log(_ context.Context, _ string, _ int, line string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.logs = append(s.logs, line)
+	return nil
+}
+func (s *fakeSink) EmitArtifact(_ context.Context, _ run.Artifact) error { return nil }
+
+func cfgWith(stages ...pipeline.Stage) *pipeline.Config {
+	return &pipeline.Config{Spec: pipeline.Spec{Stages: stages}}
+}
+
+// ─── BuildGraph ────────────────────────────────────────────────────────────────
+
+func TestBuildGraphLinearFallback(t *testing.T) {
+	// 无 needs → 线性:a → b → c。
+	stages := []pipeline.Stage{
+		{ID: "a", Name: "A"}, {ID: "b", Name: "B"}, {ID: "c", Name: "C"},
+	}
+	g, err := BuildGraph(stages)
+	if err != nil {
+		t.Fatalf("BuildGraph: %v", err)
+	}
+	if got := g.TopoOrder(); !equal(got, []string{"a", "b", "c"}) {
+		t.Errorf("topo = %v, want linear [a b c]", got)
+	}
+}
+
+func TestBuildGraphExplicitNeeds(t *testing.T) {
+	// a → {b,c} → d(钻石)。
+	stages := []pipeline.Stage{
+		{ID: "a", Name: "A"},
+		{ID: "b", Name: "B", Needs: []string{"a"}},
+		{ID: "c", Name: "C", Needs: []string{"a"}},
+		{ID: "d", Name: "D", Needs: []string{"b", "c"}},
+	}
+	g, err := BuildGraph(stages)
+	if err != nil {
+		t.Fatalf("BuildGraph: %v", err)
+	}
+	order := g.TopoOrder()
+	pos := map[string]int{}
+	for i, id := range order {
+		pos[id] = i
+	}
+	if pos["a"] > pos["b"] || pos["b"] > pos["d"] || pos["c"] > pos["d"] {
+		t.Errorf("diamond order violated: %v", order)
+	}
+}
+
+// ─── Runner.Run ────────────────────────────────────────────────────────────────
+
+func TestRunnerLinearSuccess(t *testing.T) {
+	cfg := cfgWith(
+		pipeline.Stage{ID: "src", Name: "源", Jobs: []pipeline.Job{{Name: "clone", Type: "git_source"}}},
+		pipeline.Stage{ID: "build", Name: "构建"},
+		pipeline.Stage{ID: "deploy", Name: "部署"},
+	)
+	sink := newFakeSink()
+	r := New(fakeLoader{cfg})
+	err := r.Run(context.Background(), &run.Run{ProjectID: "p"}, sink)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !equal(sink.planned, []string{"源", "构建", "部署"}) {
+		t.Errorf("planned = %v", sink.planned)
+	}
+	for ord := 0; ord < 3; ord++ {
+		if sink.done[ord] != run.StepSuccess {
+			t.Errorf("step %d = %q, want success", ord, sink.done[ord])
+		}
+	}
+}
+
+func TestRunnerFailBlocksDownstreamAsSkipped(t *testing.T) {
+	// src → build → deploy ;build 失败 ⇒ deploy 记 skipped,Run 返回错误。
+	cfg := cfgWith(
+		pipeline.Stage{ID: "src", Name: "源"},
+		pipeline.Stage{ID: "build", Name: "构建"},
+		pipeline.Stage{ID: "deploy", Name: "部署"},
+	)
+	sink := newFakeSink()
+	r := New(fakeLoader{cfg}, WithStageExecutor(
+		func(_ context.Context, _ *run.Run, st pipeline.Stage, _ StageReporter) error {
+			if st.ID == "build" {
+				return errors.New("build boom")
+			}
+			return nil
+		}))
+	err := r.Run(context.Background(), &run.Run{ProjectID: "p"}, sink)
+	if err == nil {
+		t.Fatal("expected Run to fail")
+	}
+	// ordinals: src=0, build=1, deploy=2
+	if sink.done[0] != run.StepSuccess {
+		t.Errorf("src = %q, want success", sink.done[0])
+	}
+	if sink.done[1] != run.StepFailed {
+		t.Errorf("build = %q, want failed", sink.done[1])
+	}
+	if sink.done[2] != run.StepSkipped {
+		t.Errorf("deploy = %q, want skipped", sink.done[2])
+	}
+	// deploy 不应被置 running(从未执行)。
+	for _, ord := range sink.running {
+		if ord == 2 {
+			t.Error("deploy must not have been marked running")
+		}
+	}
+}
+
+func TestRunnerParallelSiblingsContinueOnFailure(t *testing.T) {
+	// src → {a,b} ; a 失败,b 应照常成功(互不依赖)。
+	cfg := cfgWith(
+		pipeline.Stage{ID: "src", Name: "源"},
+		pipeline.Stage{ID: "a", Name: "A", Needs: []string{"src"}},
+		pipeline.Stage{ID: "b", Name: "B", Needs: []string{"src"}},
+	)
+	var ranB atomic.Bool
+	sink := newFakeSink()
+	r := New(fakeLoader{cfg}, WithStageExecutor(
+		func(_ context.Context, _ *run.Run, st pipeline.Stage, _ StageReporter) error {
+			if st.ID == "a" {
+				return errors.New("a boom")
+			}
+			if st.ID == "b" {
+				ranB.Store(true)
+			}
+			return nil
+		}))
+	_ = r.Run(context.Background(), &run.Run{ProjectID: "p"}, sink)
+	if !ranB.Load() {
+		t.Error("sibling b should run despite a's failure")
+	}
+	// find ordinals by planned name
+	ord := func(name string) int {
+		for i, n := range sink.planned {
+			if n == name {
+				return i
+			}
+		}
+		return -1
+	}
+	if sink.done[ord("A")] != run.StepFailed {
+		t.Errorf("A = %q, want failed", sink.done[ord("A")])
+	}
+	if sink.done[ord("B")] != run.StepSuccess {
+		t.Errorf("B = %q, want success", sink.done[ord("B")])
+	}
+}
+
+func TestRunnerExecutesIndependentStagesInParallel(t *testing.T) {
+	// src → {a,b,c} 三个独立分支;若串行会超时(每个等所有都开始)。
+	cfg := cfgWith(
+		pipeline.Stage{ID: "src", Name: "源"},
+		pipeline.Stage{ID: "a", Name: "A", Needs: []string{"src"}},
+		pipeline.Stage{ID: "b", Name: "B", Needs: []string{"src"}},
+		pipeline.Stage{ID: "c", Name: "C", Needs: []string{"src"}},
+	)
+	var started, maxInFlight, inFlight int32
+	allStarted := make(chan struct{})
+	var once sync.Once
+	const par = 3
+	sink := newFakeSink()
+	r := New(fakeLoader{cfg}, WithStageExecutor(
+		func(_ context.Context, _ *run.Run, st pipeline.Stage, _ StageReporter) error {
+			if st.ID == "src" {
+				return nil
+			}
+			cur := atomic.AddInt32(&inFlight, 1)
+			for {
+				m := atomic.LoadInt32(&maxInFlight)
+				if cur <= m || atomic.CompareAndSwapInt32(&maxInFlight, m, cur) {
+					break
+				}
+			}
+			if atomic.AddInt32(&started, 1) == par {
+				once.Do(func() { close(allStarted) })
+			}
+			select {
+			case <-allStarted:
+			case <-time.After(2 * time.Second):
+			}
+			atomic.AddInt32(&inFlight, -1)
+			return nil
+		}))
+	if err := r.Run(context.Background(), &run.Run{ProjectID: "p"}, sink); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if maxInFlight < par {
+		t.Errorf("max parallel stages = %d, want %d", maxInFlight, par)
+	}
+}
+
+// equal 比较两个字符串切片。
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/httpapi/approvals.go
+++ b/internal/httpapi/approvals.go
@@ -1,0 +1,132 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/approval"
+	"github.com/huangchengsir/pipewright/internal/audit"
+	"github.com/huangchengsir/pipewright/internal/dagrun"
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// approvals.go 实现人工审批门(Epic 8 · Story 8-4)的 gate hook 与审批端点。
+//
+// gate hook(NewApprovalGate)注入 dagrun:进入 Gate 阶段前登记待批 + 置 run 状态 waiting_approval +
+// 阻塞协调器,直到端点投递批准/拒绝(或取消/超时)。端点(approve/reject)经协调器解析决定 + 审计。
+
+// defaultGateTimeout 是审批门兜底超时:超时自动拒绝以释放被该运行占用的 worker。
+// 审批人节奏可较慢,故取较长值;运行亦可经取消端点立即释放。
+const defaultGateTimeout = 24 * time.Hour
+
+// NewApprovalGate 构造注入 dagrun 的审批门 hook(供 main 装配)。
+func NewApprovalGate(runs run.Service, coord *approval.Coordinator, store *approval.Store) dagrun.GateFunc {
+	return func(ctx context.Context, r *run.Run, stage pipeline.Stage) (bool, error) {
+		key := approval.Key(r.ID, stage.ID)
+		_ = store.CreatePending(ctx, r.ID, stage.ID, stage.Name)
+		ch := coord.Wait(key)
+		defer coord.Cancel(key)
+
+		// 先注册等待者再置 waiting,确保端点在状态切换后总能解析到该门。
+		if err := runs.MarkWaitingApproval(ctx, r.ID); err != nil {
+			// 已终态/被取消:无法进入等待,退化失败让 worker 收尾。
+			return false, err
+		}
+
+		var (
+			approved bool
+			status   = approval.StatusRejected
+			by       string
+		)
+		select {
+		case d := <-ch:
+			approved = d.Approved
+			by = d.Actor
+			if approved {
+				status = approval.StatusApproved
+			}
+		case <-ctx.Done():
+			by = "canceled"
+			_ = store.Decide(context.Background(), r.ID, stage.ID, status, by)
+			_ = runs.ResumeFromApproval(context.Background(), r.ID)
+			return false, ctx.Err()
+		case <-time.After(defaultGateTimeout):
+			by = "timeout"
+			_ = store.Decide(context.Background(), r.ID, stage.ID, status, by)
+			_ = runs.ResumeFromApproval(context.Background(), r.ID)
+			return false, fmt.Errorf("approval gate timed out after %s", defaultGateTimeout)
+		}
+		_ = store.Decide(context.Background(), r.ID, stage.ID, status, by)
+		// 决定后置回 running,让 worker 在收尾时按 running→终态 落定。
+		_ = runs.ResumeFromApproval(context.Background(), r.ID)
+		return approved, nil
+	}
+}
+
+// makeApprovalDecisionHandler 返回 approve(approve=true)/reject(false)端点 handler。
+// body {stageId};经协调器投递决定。该阶段当前不在等待 → 409。
+func makeApprovalDecisionHandler(coord *approval.Coordinator, store *approval.Store, rec audit.Recorder, approve bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if coord == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "审批门服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<13)
+		var req struct {
+			StageID string `json:"stageId"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		stageID := strings.TrimSpace(req.StageID)
+		if stageID == "" {
+			writeError(w, http.StatusUnprocessableEntity, "missing_stage", "缺少 stageId")
+			return
+		}
+		key := approval.Key(id, stageID)
+		if !coord.Resolve(key, approval.Decision{Approved: approve, Actor: auditActor}) {
+			writeError(w, http.StatusConflict, "not_waiting", "该运行阶段当前不在等待审批")
+			return
+		}
+		action := "run.approve"
+		if !approve {
+			action = "run.reject"
+		}
+		recordAudit(r.Context(), rec, audit.Entry{
+			Actor:      auditActor,
+			Action:     action,
+			TargetType: "run",
+			TargetID:   id,
+			Detail:     map[string]any{"stageId": stageID},
+			IP:         clientIP(r),
+		})
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "approved": approve})
+	}
+}
+
+// makeListApprovalsHandler 返回 GET /api/runs/{id}/approvals(某运行的审批门记录列表)。
+func makeListApprovalsHandler(store *approval.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if store == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "审批门服务未初始化")
+			return
+		}
+		recs, err := store.ListForRun(r.Context(), chi.URLParam(r, "id"))
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+			return
+		}
+		if recs == nil {
+			recs = []approval.Record{}
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"items": recs})
+	}
+}

--- a/internal/httpapi/pipelines.go
+++ b/internal/httpapi/pipelines.go
@@ -26,6 +26,7 @@ type stageDTO struct {
 	Needs        []string `json:"needs"`
 	AllowFailure bool     `json:"allowFailure"`
 	When         whenDTO  `json:"when"`
+	Gate         bool     `json:"gate"`
 	Jobs         []jobDTO `json:"jobs"`
 }
 
@@ -75,7 +76,7 @@ func toPipelineDTO(c *pipeline.Config) pipelineDTO {
 		if needs == nil {
 			needs = []string{}
 		}
-		stages = append(stages, stageDTO{ID: st.ID, Name: st.Name, Kind: st.Kind, Needs: needs, AllowFailure: st.AllowFailure, When: toWhenDTO(st.When), Jobs: jobs})
+		stages = append(stages, stageDTO{ID: st.ID, Name: st.Name, Kind: st.Kind, Needs: needs, AllowFailure: st.AllowFailure, When: toWhenDTO(st.When), Gate: st.Gate, Jobs: jobs})
 	}
 	return pipelineDTO{
 		Stages:    stages,
@@ -141,6 +142,7 @@ func makeSavePipelineHandler(svc pipeline.Service) http.HandlerFunc {
 					Branches []string `json:"branches"`
 					Events   []string `json:"events"`
 				} `json:"when"`
+				Gate bool `json:"gate"`
 				Jobs []struct {
 					ID      string         `json:"id"`
 					Name    string         `json:"name"`
@@ -174,6 +176,7 @@ func makeSavePipelineHandler(svc pipeline.Service) http.HandlerFunc {
 				Needs:        st.Needs,
 				AllowFailure: st.AllowFailure,
 				When:         pipeline.When{Branches: st.When.Branches, Events: st.When.Events},
+				Gate:         st.Gate,
 				Jobs:         jobs,
 			})
 		}

--- a/internal/httpapi/pipelines.go
+++ b/internal/httpapi/pipelines.go
@@ -20,10 +20,12 @@ type pipelineDTO struct {
 }
 
 type stageDTO struct {
-	ID   string   `json:"id"`
-	Name string   `json:"name"`
-	Kind string   `json:"kind"`
-	Jobs []jobDTO `json:"jobs"`
+	ID           string   `json:"id"`
+	Name         string   `json:"name"`
+	Kind         string   `json:"kind"`
+	Needs        []string `json:"needs"`
+	AllowFailure bool     `json:"allowFailure"`
+	Jobs         []jobDTO `json:"jobs"`
 }
 
 type jobDTO struct {
@@ -52,7 +54,11 @@ func toPipelineDTO(c *pipeline.Config) pipelineDTO {
 				Config:  cfg,
 			})
 		}
-		stages = append(stages, stageDTO{ID: st.ID, Name: st.Name, Kind: st.Kind, Jobs: jobs})
+		needs := st.Needs
+		if needs == nil {
+			needs = []string{}
+		}
+		stages = append(stages, stageDTO{ID: st.ID, Name: st.Name, Kind: st.Kind, Needs: needs, AllowFailure: st.AllowFailure, Jobs: jobs})
 	}
 	return pipelineDTO{
 		Stages:    stages,
@@ -109,10 +115,12 @@ func makeSavePipelineHandler(svc pipeline.Service) http.HandlerFunc {
 		r.Body = http.MaxBytesReader(w, r.Body, 1<<18) // 256KB
 		var req struct {
 			Stages []struct {
-				ID   string `json:"id"`
-				Name string `json:"name"`
-				Kind string `json:"kind"`
-				Jobs []struct {
+				ID           string   `json:"id"`
+				Name         string   `json:"name"`
+				Kind         string   `json:"kind"`
+				Needs        []string `json:"needs"`
+				AllowFailure bool     `json:"allowFailure"`
+				Jobs         []struct {
 					ID      string         `json:"id"`
 					Name    string         `json:"name"`
 					Type    string         `json:"type"`
@@ -139,10 +147,12 @@ func makeSavePipelineHandler(svc pipeline.Service) http.HandlerFunc {
 				})
 			}
 			stages = append(stages, pipeline.Stage{
-				ID:   st.ID,
-				Name: st.Name,
-				Kind: st.Kind,
-				Jobs: jobs,
+				ID:           st.ID,
+				Name:         st.Name,
+				Kind:         st.Kind,
+				Needs:        st.Needs,
+				AllowFailure: st.AllowFailure,
+				Jobs:         jobs,
 			})
 		}
 

--- a/internal/httpapi/pipelines.go
+++ b/internal/httpapi/pipelines.go
@@ -25,7 +25,24 @@ type stageDTO struct {
 	Kind         string   `json:"kind"`
 	Needs        []string `json:"needs"`
 	AllowFailure bool     `json:"allowFailure"`
+	When         whenDTO  `json:"when"`
 	Jobs         []jobDTO `json:"jobs"`
+}
+
+type whenDTO struct {
+	Branches []string `json:"branches"`
+	Events   []string `json:"events"`
+}
+
+func toWhenDTO(w pipeline.When) whenDTO {
+	b, e := w.Branches, w.Events
+	if b == nil {
+		b = []string{}
+	}
+	if e == nil {
+		e = []string{}
+	}
+	return whenDTO{Branches: b, Events: e}
 }
 
 type jobDTO struct {
@@ -58,7 +75,7 @@ func toPipelineDTO(c *pipeline.Config) pipelineDTO {
 		if needs == nil {
 			needs = []string{}
 		}
-		stages = append(stages, stageDTO{ID: st.ID, Name: st.Name, Kind: st.Kind, Needs: needs, AllowFailure: st.AllowFailure, Jobs: jobs})
+		stages = append(stages, stageDTO{ID: st.ID, Name: st.Name, Kind: st.Kind, Needs: needs, AllowFailure: st.AllowFailure, When: toWhenDTO(st.When), Jobs: jobs})
 	}
 	return pipelineDTO{
 		Stages:    stages,
@@ -120,7 +137,11 @@ func makeSavePipelineHandler(svc pipeline.Service) http.HandlerFunc {
 				Kind         string   `json:"kind"`
 				Needs        []string `json:"needs"`
 				AllowFailure bool     `json:"allowFailure"`
-				Jobs         []struct {
+				When         struct {
+					Branches []string `json:"branches"`
+					Events   []string `json:"events"`
+				} `json:"when"`
+				Jobs []struct {
 					ID      string         `json:"id"`
 					Name    string         `json:"name"`
 					Type    string         `json:"type"`
@@ -152,6 +173,7 @@ func makeSavePipelineHandler(svc pipeline.Service) http.HandlerFunc {
 				Kind:         st.Kind,
 				Needs:        st.Needs,
 				AllowFailure: st.AllowFailure,
+				When:         pipeline.When{Branches: st.When.Branches, Events: st.When.Events},
 				Jobs:         jobs,
 			})
 		}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/huangchengsir/pipewright/internal/ai"
 	"github.com/huangchengsir/pipewright/internal/anomaly"
+	"github.com/huangchengsir/pipewright/internal/approval"
 	"github.com/huangchengsir/pipewright/internal/audit"
 	"github.com/huangchengsir/pipewright/internal/auth"
 	"github.com/huangchengsir/pipewright/internal/deploy"
@@ -67,6 +68,17 @@ type options struct {
 	deployer         deploy.Service
 	anomaly          anomaly.Service
 	oauth            oauth.Service
+	approvalCoord    *approval.Coordinator
+	approvalStore    *approval.Store
+}
+
+// WithApprovals 注入审批门协调器 + 持久层(Story 8-4),挂载 /api/runs/{id}/{approve,reject,approvals} 路由。
+// 不传则审批端点返回 503。
+func WithApprovals(coord *approval.Coordinator, store *approval.Store) Option {
+	return func(o *options) {
+		o.approvalCoord = coord
+		o.approvalStore = store
+	}
 }
 
 // WithVault 注入凭据保险库,挂载 /api/credentials* 路由。
@@ -313,6 +325,11 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		// 构建产物契约(Story 3.4 / FR-6):只读 + 认证;按 (type, reference) 供 Epic 4 消费。
 		ar.Get("/runs/{id}/artifacts", makeRunArtifactsHandler(rs))
 		ar.Post("/runs/{id}/cancel", makeCancelRunHandler(rs))
+		// 人工审批门(Story 8-4):批准/拒绝某运行的审批门阶段 + 列审批记录。
+		// approve/reject 为写方法,过 auth + CSRF;coord/store 为 nil → 503。
+		ar.Post("/runs/{id}/approve", makeApprovalDecisionHandler(o.approvalCoord, o.approvalStore, aud, true))
+		ar.Post("/runs/{id}/reject", makeApprovalDecisionHandler(o.approvalCoord, o.approvalStore, aud, false))
+		ar.Get("/runs/{id}/approvals", makeListApprovalsHandler(o.approvalStore))
 		// SSH 部署执行(Story 4.2 / FR-10):认证 + CSRF(写方法)。dep 为 nil → 503。
 		// 取 run + 产物 + 服务器 → deploy.Deploy(逐机经 SSH 执行部署命令,array 不拼 shell)
 		// → 据结果更新 run 终态 → 返回填好的 targets。部署执行失败不 500(每机 status=failed)。

--- a/internal/httpapi/webhooks.go
+++ b/internal/httpapi/webhooks.go
@@ -116,8 +116,9 @@ func makeManualRunHandler(svc run.Service, aud audit.Recorder) http.HandlerFunc 
 		id := chi.URLParam(r, "id")
 		r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
 		var req struct {
-			Branch string `json:"branch"`
-			Commit string `json:"commit"`
+			Branch string            `json:"branch"`
+			Commit string            `json:"commit"`
+			Params map[string]string `json:"params"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
@@ -126,11 +127,14 @@ func makeManualRunHandler(svc run.Service, aud audit.Recorder) http.HandlerFunc 
 		// 分支可选:留空时由 run.Service.Create 取项目默认分支(项目已知默认分支,系统自动解析)。
 		branch := strings.TrimSpace(req.Branch)
 		commit := strings.TrimSpace(req.Commit)
+		// 参数化运行(Story 8-11):trim key、剔空 key;明文构建参数(注入 script 步骤容器环境)。
+		params := normalizeRunParams(req.Params)
 		rn, err := svc.Create(r.Context(), id, run.Trigger{
 			Type:   run.TriggerManual,
 			Branch: branch,
 			Commit: commit,
 			Actor:  "admin",
+			Params: params,
 		})
 		if err != nil {
 			writeRunError(w, err)
@@ -141,10 +145,28 @@ func makeManualRunHandler(svc run.Service, aud audit.Recorder) http.HandlerFunc 
 			Action:     audit.ActionRunTriggerManual,
 			TargetType: audit.TargetRun,
 			TargetID:   rn.ID,
-			Detail:     map[string]any{"projectId": id, "branch": branch, "commit": commit},
+			Detail:     map[string]any{"projectId": id, "branch": branch, "commit": commit, "paramCount": len(params)},
 			IP:         clientIP(r),
 		})
 		// 刚创建(queued)的运行尚无产物/无部署;nil → []/null。产物在成功路径由 worker emit、部署经 deploy 端点。
 		writeJSON(w, http.StatusCreated, toRunDetailDTO(rn, nil, nil))
 	}
+}
+
+// normalizeRunParams 规范化运行参数:trim key、剔除空 key(value 原样保留)。nil/空 → nil。
+func normalizeRunParams(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		k = strings.TrimSpace(k)
+		if k != "" {
+			out[k] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -79,7 +79,10 @@ type Stage struct {
 	Needs        []string `json:"needs,omitempty"`
 	AllowFailure bool     `json:"allowFailure,omitempty"`
 	When         When     `json:"when,omitempty"`
-	Jobs         []Job    `json:"jobs"`
+	// Gate 为 true 时,进入该阶段前需人工审批(Story 8-4):运行阻塞、状态置 waiting_approval,
+	// 批准→继续,拒绝→该阶段失败(运行终止)。
+	Gate bool  `json:"gate,omitempty"`
+	Jobs []Job `json:"jobs"`
 }
 
 // Spec 是流水线编排声明式配置(阶段集合)。
@@ -343,7 +346,7 @@ func normalizeSpec(in Spec) (Spec, error) {
 		// Needs 规范化:trim、去空、去重、剔除自指(自指交由 dag 校验报错以给明确信息)。
 		needs := normalizeNeeds(st.Needs)
 
-		out.Stages = append(out.Stages, Stage{ID: stageID, Name: name, Kind: kind, Needs: needs, AllowFailure: st.AllowFailure, When: normalizeWhen(st.When), Jobs: jobs})
+		out.Stages = append(out.Stages, Stage{ID: stageID, Name: name, Kind: kind, Needs: needs, AllowFailure: st.AllowFailure, When: normalizeWhen(st.When), Gate: st.Gate, Jobs: jobs})
 	}
 
 	// 源阶段不变式:流水线必须恰有一个 source 阶段(引用项目仓库)。前端不渲染删源阶段的入口,

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -78,6 +78,7 @@ type Stage struct {
 	Kind         string   `json:"kind"`
 	Needs        []string `json:"needs,omitempty"`
 	AllowFailure bool     `json:"allowFailure,omitempty"`
+	When         When     `json:"when,omitempty"`
 	Jobs         []Job    `json:"jobs"`
 }
 
@@ -342,7 +343,7 @@ func normalizeSpec(in Spec) (Spec, error) {
 		// Needs 规范化:trim、去空、去重、剔除自指(自指交由 dag 校验报错以给明确信息)。
 		needs := normalizeNeeds(st.Needs)
 
-		out.Stages = append(out.Stages, Stage{ID: stageID, Name: name, Kind: kind, Needs: needs, AllowFailure: st.AllowFailure, Jobs: jobs})
+		out.Stages = append(out.Stages, Stage{ID: stageID, Name: name, Kind: kind, Needs: needs, AllowFailure: st.AllowFailure, When: normalizeWhen(st.When), Jobs: jobs})
 	}
 
 	// 源阶段不变式:流水线必须恰有一个 source 阶段(引用项目仓库)。前端不渲染删源阶段的入口,

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/huangchengsir/pipewright/internal/dag"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -66,11 +67,18 @@ type Job struct {
 }
 
 // Stage 是一个阶段(阶段列),含若干 Job。Kind 为 kind 枚举之一。
+//
+// Needs 是该阶段依赖的上游阶段 ID 列表(Epic 8 · Story 8-1,构成 DAG):为空表示「无显式依赖」。
+// 当**整个流水线**无任何阶段声明 needs 时,执行层按声明序退化为线性(向后兼容存量「直线」流水线);
+// 一旦有阶段声明 needs,则严格按声明的 DAG 调度(见 dagrun 适配)。AllowFailure 为 true 时,
+// 该阶段失败仍放行下游(自身仍记 failed)。Needs 在保存时校验:引用必须存在、不可自指、不可成环。
 type Stage struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	Kind string `json:"kind"`
-	Jobs []Job  `json:"jobs"`
+	ID           string   `json:"id"`
+	Name         string   `json:"name"`
+	Kind         string   `json:"kind"`
+	Needs        []string `json:"needs,omitempty"`
+	AllowFailure bool     `json:"allowFailure,omitempty"`
+	Jobs         []Job    `json:"jobs"`
 }
 
 // Spec 是流水线编排声明式配置(阶段集合)。
@@ -331,7 +339,10 @@ func normalizeSpec(in Spec) (Spec, error) {
 			})
 		}
 
-		out.Stages = append(out.Stages, Stage{ID: stageID, Name: name, Kind: kind, Jobs: jobs})
+		// Needs 规范化:trim、去空、去重、剔除自指(自指交由 dag 校验报错以给明确信息)。
+		needs := normalizeNeeds(st.Needs)
+
+		out.Stages = append(out.Stages, Stage{ID: stageID, Name: name, Kind: kind, Needs: needs, AllowFailure: st.AllowFailure, Jobs: jobs})
 	}
 
 	// 源阶段不变式:流水线必须恰有一个 source 阶段(引用项目仓库)。前端不渲染删源阶段的入口,
@@ -346,7 +357,59 @@ func normalizeSpec(in Spec) (Spec, error) {
 		return Spec{}, fmt.Errorf("%w: pipeline must have exactly one source stage", ErrInvalidStage)
 	}
 
+	// 阶段依赖(needs)校验:引用必须存在、不可自指、不可成环(Epic 8 · 8-1)。
+	// 复用 dag 的构造期校验(Kahn 环检测),把其错误归一为 ErrInvalidStage(不外泄内部细节)。
+	if err := validateStageDAG(out.Stages); err != nil {
+		return Spec{}, err
+	}
+
 	return out, nil
+}
+
+// normalizeNeeds 规范化阶段依赖列表:trim、剔空、去重(保留首次出现序)。
+func normalizeNeeds(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, d := range in {
+		d = strings.TrimSpace(d)
+		if d == "" {
+			continue
+		}
+		if _, ok := seen[d]; ok {
+			continue
+		}
+		seen[d] = struct{}{}
+		out = append(out, d)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// validateStageDAG 用 dag 包做阶段依赖的构造期校验(存在性 + 自指 + 环)。
+// 任一问题归一为 ErrInvalidStage(附简短原因,不外泄底层细节)。
+func validateStageDAG(stages []Stage) error {
+	nodes := make([]dag.Node, 0, len(stages))
+	for _, st := range stages {
+		nodes = append(nodes, dag.Node{ID: st.ID, Needs: st.Needs, AllowFailure: st.AllowFailure})
+	}
+	if _, err := dag.New(nodes); err != nil {
+		switch {
+		case errors.Is(err, dag.ErrUnknownDep):
+			return fmt.Errorf("%w: stage needs reference an unknown stage", ErrInvalidStage)
+		case errors.Is(err, dag.ErrSelfDep):
+			return fmt.Errorf("%w: stage must not depend on itself", ErrInvalidStage)
+		case errors.Is(err, dag.ErrCycle):
+			return fmt.Errorf("%w: stage dependencies form a cycle", ErrInvalidStage)
+		default:
+			return fmt.Errorf("%w: invalid stage dependencies", ErrInvalidStage)
+		}
+	}
+	return nil
 }
 
 // normalizeSpecShape 保证从库回读的 spec 切片/map 非 nil(JSON 输出为 [] / {} 而非 null)。

--- a/internal/pipeline/stage_dag_test.go
+++ b/internal/pipeline/stage_dag_test.go
@@ -1,0 +1,94 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// specWithNeeds 构造一个含源阶段 + 两个带依赖阶段的 spec(满足源阶段不变式)。
+func specWithNeeds(buildNeeds, deployNeeds []string) Spec {
+	return Spec{Stages: []Stage{
+		{ID: "stg_src", Name: "源", Kind: KindSource, Jobs: []Job{{ID: "j_src", Name: "src", Type: "git_source"}}},
+		{ID: "stg_build", Name: "构建", Kind: KindBuild, Needs: buildNeeds, Jobs: []Job{}},
+		{ID: "stg_deploy", Name: "部署", Kind: KindDeploy, Needs: deployNeeds, Jobs: []Job{}},
+	}}
+}
+
+func TestSaveValidStageNeedsRoundTrips(t *testing.T) {
+	svc, _, projID := newSvc(t)
+	ctx := context.Background()
+
+	spec := specWithNeeds([]string{"stg_src"}, []string{"stg_build"})
+	saved, err := svc.Save(ctx, projID, spec)
+	if err != nil {
+		t.Fatalf("Save valid needs: %v", err)
+	}
+
+	// 回读并核验 needs 持久化往返。
+	got, err := svc.Get(ctx, projID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	_ = saved
+	byID := map[string]Stage{}
+	for _, st := range got.Spec.Stages {
+		byID[st.ID] = st
+	}
+	if len(byID["stg_build"].Needs) != 1 || byID["stg_build"].Needs[0] != "stg_src" {
+		t.Errorf("build.Needs = %v, want [stg_src]", byID["stg_build"].Needs)
+	}
+	if len(byID["stg_deploy"].Needs) != 1 || byID["stg_deploy"].Needs[0] != "stg_build" {
+		t.Errorf("deploy.Needs = %v, want [stg_build]", byID["stg_deploy"].Needs)
+	}
+}
+
+func TestSaveRejectsUnknownNeed(t *testing.T) {
+	svc, _, projID := newSvc(t)
+	spec := specWithNeeds([]string{"does_not_exist"}, nil)
+	if _, err := svc.Save(context.Background(), projID, spec); !errors.Is(err, ErrInvalidStage) {
+		t.Fatalf("err = %v, want ErrInvalidStage", err)
+	}
+}
+
+func TestSaveRejectsSelfNeed(t *testing.T) {
+	svc, _, projID := newSvc(t)
+	spec := specWithNeeds([]string{"stg_build"}, nil) // build 依赖自身
+	if _, err := svc.Save(context.Background(), projID, spec); !errors.Is(err, ErrInvalidStage) {
+		t.Fatalf("err = %v, want ErrInvalidStage", err)
+	}
+}
+
+func TestSaveRejectsCycle(t *testing.T) {
+	svc, _, projID := newSvc(t)
+	// build ↔ deploy 互相依赖成环。
+	spec := specWithNeeds([]string{"stg_deploy"}, []string{"stg_build"})
+	if _, err := svc.Save(context.Background(), projID, spec); !errors.Is(err, ErrInvalidStage) {
+		t.Fatalf("err = %v, want ErrInvalidStage", err)
+	}
+}
+
+func TestSaveDedupesNeeds(t *testing.T) {
+	svc, _, projID := newSvc(t)
+	ctx := context.Background()
+	spec := specWithNeeds([]string{"stg_src", "stg_src", " stg_src "}, nil)
+	if _, err := svc.Save(ctx, projID, spec); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, _ := svc.Get(ctx, projID)
+	for _, st := range got.Spec.Stages {
+		if st.ID == "stg_build" {
+			if len(st.Needs) != 1 || st.Needs[0] != "stg_src" {
+				t.Errorf("build.Needs = %v, want deduped [stg_src]", st.Needs)
+			}
+		}
+	}
+}
+
+func TestSaveNoNeedsStillValid(t *testing.T) {
+	// 向后兼容:存量「直线」流水线(无 needs)照常保存。
+	svc, _, projID := newSvc(t)
+	if _, err := svc.Save(context.Background(), projID, validSpec()); err != nil {
+		t.Fatalf("Save no-needs spec: %v", err)
+	}
+}

--- a/internal/pipeline/stage_when.go
+++ b/internal/pipeline/stage_when.go
@@ -1,0 +1,109 @@
+package pipeline
+
+import "strings"
+
+// stage_when.go 是阶段条件执行(Epic 8 · Story 8-5)的领域逻辑:When 规则 + 匹配。
+//
+// When 决定一个阶段在某次运行里是否执行——不满足则该阶段(及其下游)被 skipped(非失败)。
+// 「上游成功」条件已由 DAG 依赖(needs)天然表达,故 When 只覆盖「分支匹配」与「触发类型」。
+
+// When 是阶段条件执行规则。空(无 Branches 且无 Events)= 无条件,总执行。
+//   - Branches:仅当触发分支匹配其一(glob `*`,跨 `/`)时执行;空 = 任意分支。
+//   - Events:仅当触发类型 ∈ 其中(manual/webhook/schedule)时执行;空 = 任意触发。
+//
+// 两组皆设时按「与」:分支命中 **且** 触发类型命中才执行;任一不满足 → skipped。
+type When struct {
+	Branches []string `json:"branches,omitempty"`
+	Events   []string `json:"events,omitempty"`
+}
+
+// IsEmpty 报告该 When 是否无任何条件(总执行)。
+func (w When) IsEmpty() bool { return len(w.Branches) == 0 && len(w.Events) == 0 }
+
+// Matches 报告给定触发分支/类型是否满足本条件(空条件恒真)。
+func (w When) Matches(branch, event string) bool {
+	if len(w.Branches) > 0 {
+		hit := false
+		for _, p := range w.Branches {
+			if globMatch(strings.TrimSpace(p), branch) {
+				hit = true
+				break
+			}
+		}
+		if !hit {
+			return false
+		}
+	}
+	if len(w.Events) > 0 {
+		hit := false
+		for _, e := range w.Events {
+			if strings.TrimSpace(e) == event {
+				hit = true
+				break
+			}
+		}
+		if !hit {
+			return false
+		}
+	}
+	return true
+}
+
+// normalizeWhen 规范化 When:trim、剔空、去重(保留序);返回的零值表示无条件。
+func normalizeWhen(in When) When {
+	return When{Branches: dedupTrim(in.Branches), Events: dedupTrim(in.Events)}
+}
+
+func dedupTrim(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// globMatch 是 `*`(匹配任意字符,含 `/`)的简易 glob;无 `*` 精确匹配;`*`/空 patten 匹配一切。
+// 仿 trigger.globMatch 语义(分支模式 release/* 命中 release/1.2)。
+func globMatch(pattern, s string) bool {
+	if pattern == "" || pattern == "*" {
+		return true
+	}
+	if !strings.Contains(pattern, "*") {
+		return pattern == s
+	}
+	parts := strings.Split(pattern, "*")
+	pos := 0
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		idx := strings.Index(s[pos:], part)
+		if idx < 0 {
+			return false
+		}
+		if i == 0 && idx != 0 {
+			return false // 非通配前缀须从头匹配
+		}
+		pos += idx + len(part)
+	}
+	// 末段非空且 pattern 不以 `*` 结尾时,须匹配到字符串结尾。
+	if last := parts[len(parts)-1]; last != "" && !strings.HasSuffix(s, last) {
+		return false
+	}
+	return true
+}

--- a/internal/pipeline/stage_when_test.go
+++ b/internal/pipeline/stage_when_test.go
@@ -1,0 +1,72 @@
+package pipeline
+
+import "testing"
+
+func TestWhenMatches(t *testing.T) {
+	cases := []struct {
+		name   string
+		when   When
+		branch string
+		event  string
+		want   bool
+	}{
+		{"empty always matches", When{}, "anything", "manual", true},
+		{"branch exact hit", When{Branches: []string{"main"}}, "main", "webhook", true},
+		{"branch exact miss", When{Branches: []string{"main"}}, "dev", "webhook", false},
+		{"branch glob crosses slash", When{Branches: []string{"release/*"}}, "release/1.2", "webhook", true},
+		{"branch glob miss", When{Branches: []string{"release/*"}}, "main", "webhook", false},
+		{"branch star matches all", When{Branches: []string{"*"}}, "whatever", "manual", true},
+		{"event hit", When{Events: []string{"schedule"}}, "main", "schedule", true},
+		{"event miss", When{Events: []string{"schedule"}}, "main", "manual", false},
+		{"both and-hit", When{Branches: []string{"main"}, Events: []string{"webhook"}}, "main", "webhook", true},
+		{"both branch-hit event-miss", When{Branches: []string{"main"}, Events: []string{"webhook"}}, "main", "manual", false},
+		{"both branch-miss event-hit", When{Branches: []string{"main"}, Events: []string{"webhook"}}, "dev", "webhook", false},
+		{"list any hit", When{Branches: []string{"main", "release/*"}}, "release/9", "manual", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.when.Matches(c.branch, c.event); got != c.want {
+				t.Errorf("Matches(%q,%q) = %v, want %v", c.branch, c.event, got, c.want)
+			}
+		})
+	}
+}
+
+func TestWhenIsEmptyAndNormalize(t *testing.T) {
+	if !(When{}).IsEmpty() {
+		t.Error("zero When should be empty")
+	}
+	if (When{Branches: []string{"x"}}).IsEmpty() {
+		t.Error("with branch not empty")
+	}
+	n := normalizeWhen(When{Branches: []string{" main ", "main", "", "dev"}, Events: []string{" manual ", "manual"}})
+	if len(n.Branches) != 2 || n.Branches[0] != "main" || n.Branches[1] != "dev" {
+		t.Errorf("branches not deduped/trimmed: %v", n.Branches)
+	}
+	if len(n.Events) != 1 || n.Events[0] != "manual" {
+		t.Errorf("events not deduped/trimmed: %v", n.Events)
+	}
+}
+
+func TestGlobMatch(t *testing.T) {
+	cases := []struct {
+		pattern, s string
+		want       bool
+	}{
+		{"*", "x", true},
+		{"", "x", true},
+		{"main", "main", true},
+		{"main", "dev", false},
+		{"release/*", "release/1.2", true},
+		{"release/*", "release", false},
+		{"feature/*", "feature/a/b", true},
+		{"*-rc", "v1-rc", true},
+		{"*-rc", "v1-final", false},
+		{"v*-rc", "v2-rc", true},
+	}
+	for _, c := range cases {
+		if got := globMatch(c.pattern, c.s); got != c.want {
+			t.Errorf("globMatch(%q,%q) = %v, want %v", c.pattern, c.s, got, c.want)
+		}
+	}
+}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -104,6 +104,10 @@ type Trigger struct {
 	ResolvedEnvironment string
 	// ResolvedTargetServerIDs 是解析出的目标服务器引用 id 列表(手动触发为空)。
 	ResolvedTargetServerIDs []string
+
+	// Params 是参数化手动运行的 key=value 参数(Story 8-11);执行时注入 script 步骤容器作环境变量。
+	// 非敏感明文(含密钥应走保险库引用);为空表示无参数。
+	Params map[string]string
 }
 
 // Step 是穿珠时间线节点(运行步骤)。

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -30,6 +30,9 @@ const (
 	StatusQueued = "queued"
 	// StatusRunning 表示 worker 正在执行。
 	StatusRunning = "running"
+	// StatusWaitingApproval 表示运行阻塞在人工审批门(Story 8-4),等待批准/拒绝(非终态)。
+	// worker 仍持有该 run(在审批门内阻塞);批准 → 回 running 继续,拒绝/超时 → failed。
+	StatusWaitingApproval = "waiting_approval"
 	// StatusSuccess 表示全部步骤成功(终态)。
 	StatusSuccess = "success"
 	// StatusFailed 表示执行失败或被取消(终态)。
@@ -52,6 +55,8 @@ const (
 	StepFailed = "failed"
 	// StepSkipped 表示步骤被跳过。
 	StepSkipped = "skipped"
+	// StepWaitingApproval 表示步骤(审批门阶段)正等待人工批准(Story 8-4;非终态步骤状态)。
+	StepWaitingApproval = "waiting_approval"
 )
 
 // 触发类型枚举。
@@ -191,10 +196,15 @@ var allowedTransitions = map[string]map[string]bool{
 		StatusFailed:  true, // 入队即取消 / 调度前失败
 	},
 	StatusRunning: {
-		StatusSuccess:       true,
-		StatusFailed:        true,
-		StatusPartialFailed: true,
-		StatusRolledBack:    true,
+		StatusSuccess:         true,
+		StatusFailed:          true,
+		StatusPartialFailed:   true,
+		StatusRolledBack:      true,
+		StatusWaitingApproval: true, // 进入审批门:running → waiting_approval(Story 8-4)
+	},
+	StatusWaitingApproval: {
+		StatusRunning: true, // 批准:waiting_approval → running 继续
+		StatusFailed:  true, // 拒绝/超时/取消:waiting_approval → failed
 	},
 }
 
@@ -214,7 +224,7 @@ func IsStepTerminal(status string) bool {
 // isValidStatus 报告状态是否为已知运行状态枚举。
 func isValidStatus(status string) bool {
 	switch status {
-	case StatusQueued, StatusRunning, StatusSuccess, StatusFailed, StatusPartialFailed, StatusRolledBack:
+	case StatusQueued, StatusRunning, StatusWaitingApproval, StatusSuccess, StatusFailed, StatusPartialFailed, StatusRolledBack:
 		return true
 	default:
 		return false

--- a/internal/run/service.go
+++ b/internal/run/service.go
@@ -33,6 +33,17 @@ type Service interface {
 	// Cancel 取消进行中(queued/running)运行:经 context 传播到 Runner;终态 → ErrNotCancelable。
 	Cancel(ctx context.Context, id string) (*Run, error)
 
+	// MarkWaitingApproval 把运行从 running 置为 waiting_approval(Story 8-4 审批门阻塞)。
+	// 非 running → ErrInvalidTransition。
+	MarkWaitingApproval(ctx context.Context, id string) error
+	// ResumeFromApproval 把运行从 waiting_approval 置回 running(批准/拒绝后让 worker 收尾)。
+	// 非 waiting_approval → ErrInvalidTransition。
+	ResumeFromApproval(ctx context.Context, id string) error
+
+	// FailOrphanedRuns 把启动时残留的非终态运行(queued/running/waiting_approval)清为 failed。
+	// 进程重启会丢失内存队列与审批等待者,这些运行无法恢复,应一次性清理(返回清理条数)。
+	FailOrphanedRuns(ctx context.Context) (int, error)
+
 	// LastSuccessfulRun 查 baseline:同 project + 同 trigger.Branch、created_at 早于 before、
 	// 最近一条 status=success 的运行(Story 7.3 / FR-25 成功/失败差异对比)。
 	// 用于「本次失败运行 → 上一次成功运行」对比的基线选取。无匹配 → ErrNotFound。
@@ -567,6 +578,31 @@ func (s *service) GetLogs(ctx context.Context, runID string, sinceSeq int) ([]Lo
 // transition 校验并持久化运行状态转移:CAS 式更新(WHERE status=from),
 // 顺带按 to 维护 started_at/finished_at;成功后经事件总线发布 status 事件。
 // requireFrom=true 时,当前状态非 from(竞态/非法)→ ErrInvalidTransition。
+// MarkWaitingApproval 实现 Service:running → waiting_approval(审批门进入)。
+func (s *service) MarkWaitingApproval(ctx context.Context, id string) error {
+	return s.transition(ctx, id, StatusRunning, StatusWaitingApproval, true)
+}
+
+// ResumeFromApproval 实现 Service:waiting_approval → running(决定后让 worker 收尾)。
+func (s *service) ResumeFromApproval(ctx context.Context, id string) error {
+	return s.transition(ctx, id, StatusWaitingApproval, StatusRunning, true)
+}
+
+// FailOrphanedRuns 实现 Service:启动时把残留非终态运行清为 failed(孤儿,不可恢复)。
+func (s *service) FailOrphanedRuns(ctx context.Context) (int, error) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE pipeline_runs SET status = ?, finished_at = ?
+		 WHERE status IN (?, ?, ?)`,
+		StatusFailed, now, StatusQueued, StatusRunning, StatusWaitingApproval,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("run: fail orphaned runs: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
 func (s *service) transition(ctx context.Context, id, from, to string, requireFrom bool) error {
 	if !canTransition(from, to) {
 		return ErrInvalidTransition

--- a/internal/run/service.go
+++ b/internal/run/service.go
@@ -168,15 +168,25 @@ func (s *service) Create(ctx context.Context, projectID string, trigger Trigger)
 		return nil, fmt.Errorf("run: marshal resolved target server ids: %w", err)
 	}
 
+	// 参数化运行参数(Story 8-11):空 → {}。
+	params := trigger.Params
+	if params == nil {
+		params = map[string]string{}
+	}
+	paramsJSON, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("run: marshal params: %w", err)
+	}
+
 	now := time.Now().UTC()
 	id := uuid.NewString()
 	_, err = s.db.ExecContext(ctx,
 		`INSERT INTO pipeline_runs
 		   (id, project_id, status, trigger_type, trigger_branch, trigger_commit, trigger_actor,
-		    resolved_environment, resolved_target_server_ids, created_at, started_at, finished_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)`,
+		    resolved_environment, resolved_target_server_ids, params_json, created_at, started_at, finished_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)`,
 		id, projectID, StatusQueued, tt, trigger.Branch, trigger.Commit, trigger.Actor,
-		trigger.ResolvedEnvironment, string(targetIDsJSON),
+		trigger.ResolvedEnvironment, string(targetIDsJSON), string(paramsJSON),
 		now.Format(time.RFC3339),
 	)
 	if err != nil {
@@ -212,20 +222,21 @@ func (s *service) Get(ctx context.Context, id string) (*Run, error) {
 		finishStr     sql.NullString
 		failureLog    string
 		diagnosisJSON string
+		paramsJSON    string
 	)
 	r.ID = id
 	err := s.db.QueryRowContext(ctx,
 		`SELECT pr.project_id, COALESCE(p.name, ''), pr.status,
 		        pr.trigger_type, pr.trigger_branch, pr.trigger_commit, pr.trigger_actor,
 		        pr.created_at, pr.started_at, pr.finished_at,
-		        pr.failure_log, pr.diagnosis_json
+		        pr.failure_log, pr.diagnosis_json, pr.params_json
 		 FROM pipeline_runs pr
 		 LEFT JOIN projects p ON p.id = pr.project_id
 		 WHERE pr.id = ?`, id,
 	).Scan(&r.ProjectID, &r.ProjectName, &r.Status,
 		&r.Trigger.Type, &r.Trigger.Branch, &r.Trigger.Commit, &r.Trigger.Actor,
 		&createdStr, &startedStr, &finishStr,
-		&failureLog, &diagnosisJSON)
+		&failureLog, &diagnosisJSON, &paramsJSON)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
@@ -236,6 +247,12 @@ func (s *service) Get(ctx context.Context, id string) (*Run, error) {
 	r.FailureLog = failureLog
 	if d, derr := decodeDiagnosis(diagnosisJSON); derr == nil {
 		r.Diagnosis = d
+	}
+	if strings.TrimSpace(paramsJSON) != "" {
+		var params map[string]string
+		if json.Unmarshal([]byte(paramsJSON), &params) == nil {
+			r.Trigger.Params = params
+		}
 	}
 
 	if r.CreatedAt, err = time.Parse(time.RFC3339, createdStr); err != nil {

--- a/internal/store/migrations/0025_run_approvals.sql
+++ b/internal/store/migrations/0025_run_approvals.sql
@@ -1,0 +1,26 @@
+-- 0025 run_approvals:人工审批门记录(Epic 8 · Story 8-4)。
+-- 每个「运行×审批门阶段」一行;记录待批/已批准/已拒绝 + 审批人 + 决定时刻,供 UI 展示 + 审计 + 重启清理。
+-- 不存敏感信息;删运行级联删审批记录。
+--   id          : uuid v4
+--   run_id      : FK → pipeline_runs.id;ON DELETE CASCADE
+--   stage_id    : 审批门阶段 id(spec 内)
+--   stage_name  : 阶段展示名(冗余,便于列表展示)
+--   status      : pending | approved | rejected
+--   decided_by  : 审批人(approved/rejected 时);timeout/canceled 亦记于此
+--   decided_at  : 决定时刻(RFC3339;pending 时空)
+--   created_at  : 待批创建时刻
+
+CREATE TABLE IF NOT EXISTS run_approvals (
+    id         TEXT PRIMARY KEY,
+    run_id     TEXT NOT NULL,
+    stage_id   TEXT NOT NULL,
+    stage_name TEXT NOT NULL DEFAULT '',
+    status     TEXT NOT NULL DEFAULT 'pending',
+    decided_by TEXT NOT NULL DEFAULT '',
+    decided_at TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    UNIQUE (run_id, stage_id),
+    FOREIGN KEY (run_id) REFERENCES pipeline_runs (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_run_approvals_run ON run_approvals (run_id);

--- a/internal/store/migrations/0026_run_params.sql
+++ b/internal/store/migrations/0026_run_params.sql
@@ -1,0 +1,4 @@
+-- 0026 run_params:参数化手动运行(Epic 8 · Story 8-11 / FR-8-11)。
+-- 手动触发可附一组 key=value 参数(如 DEPLOY_ENV=staging),执行时注入 script 步骤容器作环境变量。
+-- 以 JSON 存于 pipeline_runs 新列(非敏感;若含密钥应走保险库引用,本期为明文构建参数)。
+ALTER TABLE pipeline_runs ADD COLUMN params_json TEXT NOT NULL DEFAULT '{}';

--- a/web/src/api/pipeline.ts
+++ b/web/src/api/pipeline.ts
@@ -30,6 +30,10 @@ export interface PipelineStage {
   id: string
   name: string
   kind: StageKind
+  /** Upstream stage IDs this stage depends on (Epic 8 DAG). Empty = no explicit deps. */
+  needs?: string[]
+  /** When true, this stage's failure does not block downstream stages. */
+  allowFailure?: boolean
   jobs: PipelineJob[]
 }
 
@@ -49,6 +53,8 @@ export interface SavePipelineInput {
     id?: string
     name: string
     kind: StageKind
+    needs?: string[]
+    allowFailure?: boolean
     jobs: Array<{
       id?: string
       name: string

--- a/web/src/api/pipeline.ts
+++ b/web/src/api/pipeline.ts
@@ -44,6 +44,8 @@ export interface PipelineStage {
   allowFailure?: boolean
   /** Conditional execution; unmet → stage (and downstream) skipped. */
   when?: StageWhen
+  /** Require manual approval before entering this stage (Epic 8 · 8-4). */
+  gate?: boolean
   jobs: PipelineJob[]
 }
 
@@ -66,6 +68,7 @@ export interface SavePipelineInput {
     needs?: string[]
     allowFailure?: boolean
     when?: StageWhen
+    gate?: boolean
     jobs: Array<{
       id?: string
       name: string

--- a/web/src/api/pipeline.ts
+++ b/web/src/api/pipeline.ts
@@ -26,6 +26,14 @@ export interface PipelineJob {
   config: Record<string, string>
 }
 
+/** Conditional execution rule (Epic 8 · 8-5). Empty = always run. */
+export interface StageWhen {
+  /** Run only if the trigger branch matches one of these globs (empty = any). */
+  branches?: string[]
+  /** Run only on these trigger types: manual | webhook | schedule (empty = any). */
+  events?: string[]
+}
+
 export interface PipelineStage {
   id: string
   name: string
@@ -34,6 +42,8 @@ export interface PipelineStage {
   needs?: string[]
   /** When true, this stage's failure does not block downstream stages. */
   allowFailure?: boolean
+  /** Conditional execution; unmet → stage (and downstream) skipped. */
+  when?: StageWhen
   jobs: PipelineJob[]
 }
 
@@ -55,6 +65,7 @@ export interface SavePipelineInput {
     kind: StageKind
     needs?: string[]
     allowFailure?: boolean
+    when?: StageWhen
     jobs: Array<{
       id?: string
       name: string

--- a/web/src/api/runs.ts
+++ b/web/src/api/runs.ts
@@ -13,6 +13,7 @@ import { http } from './http'
 export type RunStatus =
   | 'queued'
   | 'running'
+  | 'waiting_approval'
   | 'success'
   | 'failed'
   | 'partial_failed'
@@ -20,7 +21,26 @@ export type RunStatus =
 
 // ─── Step ────────────────────────────────────────────────────────────────────
 
-export type StepStatus = 'pending' | 'running' | 'success' | 'failed' | 'skipped'
+export type StepStatus =
+  | 'pending'
+  | 'running'
+  | 'waiting_approval'
+  | 'success'
+  | 'failed'
+  | 'skipped'
+
+// ─── Approval gate (Epic 8 · 8-4) ──────────────────────────────────────────────
+
+export type ApprovalStatus = 'pending' | 'approved' | 'rejected'
+
+export interface ApprovalRecord {
+  stageId: string
+  stageName: string
+  status: ApprovalStatus
+  decidedBy: string
+  decidedAt: string
+  createdAt: string
+}
 
 export interface RunStep {
   id: string
@@ -177,6 +197,20 @@ export function getRun(id: string): Promise<RunDetail> {
 
 export function cancelRun(id: string): Promise<RunDetail> {
   return http.post<RunDetail>(`/api/runs/${id}/cancel`)
+}
+
+// ─── Approval gate (Epic 8 · 8-4) ──────────────────────────────────────────────
+
+export function listApprovals(runId: string): Promise<{ items: ApprovalRecord[] }> {
+  return http.get<{ items: ApprovalRecord[] }>(`/api/runs/${runId}/approvals`)
+}
+
+export function approveStage(runId: string, stageId: string): Promise<{ ok: boolean }> {
+  return http.post<{ ok: boolean }>(`/api/runs/${runId}/approve`, { stageId })
+}
+
+export function rejectStage(runId: string, stageId: string): Promise<{ ok: boolean }> {
+  return http.post<{ ok: boolean }>(`/api/runs/${runId}/reject`, { stageId })
 }
 
 // ─── (Re-)diagnose a failed run ───────────────────────────────────────────────

--- a/web/src/views/RunDetail.vue
+++ b/web/src/views/RunDetail.vue
@@ -22,12 +22,16 @@ import {
   diagnoseRun,
   deployRun,
   retryFailedDeploy,
+  listApprovals,
+  approveStage,
+  rejectStage,
   type RunDetail,
   type RunStatus,
   type StepStatus,
   type DiagnosisDTO,
   type HealthCheckType,
   type HealthCheckInput,
+  type ApprovalRecord,
 } from '../api/runs'
 import { listServers, type Server } from '../api/servers'
 import { HttpError } from '../api/http'
@@ -71,6 +75,44 @@ async function handleCancel(): Promise<void> {
     }
   } finally {
     cancelling.value = false
+  }
+}
+
+// ─── approval gate (Story 8-4) ──────────────────────────────────────────────────
+// 运行阻塞在审批门(status=waiting_approval)时,展示待批阶段 + 批准/拒绝按钮。
+
+const pendingApproval = ref<ApprovalRecord | null>(null)
+const approving = ref(false)
+const approvalError = ref('')
+
+async function loadApprovals(): Promise<void> {
+  try {
+    const { items } = await listApprovals(runId.value)
+    pendingApproval.value = items.find((a) => a.status === 'pending') ?? null
+  } catch {
+    pendingApproval.value = null
+  }
+}
+
+async function decideApproval(approve: boolean): Promise<void> {
+  const stage = pendingApproval.value
+  if (!stage || approving.value) return
+  approving.value = true
+  approvalError.value = ''
+  try {
+    if (approve) await approveStage(runId.value, stage.stageId)
+    else await rejectStage(runId.value, stage.stageId)
+    pendingApproval.value = null
+    // status flips via SSE (waiting_approval → running → terminal); refresh run + approvals.
+    run.value = await getRun(runId.value)
+    await loadApprovals()
+  } catch (err) {
+    approvalError.value =
+      err instanceof HttpError
+        ? (err.apiError?.message ?? `操作失败(${err.status})`)
+        : '审批请求失败,请稍后重试'
+  } finally {
+    approving.value = false
   }
 }
 
@@ -261,6 +303,7 @@ async function loadRun(): Promise<void> {
   try {
     run.value = await getRun(runId.value)
     loadState.value = 'idle'
+    if (run.value.status === 'waiting_approval') void loadApprovals()
   } catch (err) {
     if (err instanceof HttpError) {
       loadError.value = err.status === 404
@@ -285,6 +328,9 @@ function startSse(): void {
     onStatus({ status }) {
       if (!run.value) return
       run.value = { ...run.value, status }
+      // Approval gate (8-4): load pending stage when blocked; clear once resumed.
+      if (status === 'waiting_approval') void loadApprovals()
+      else pendingApproval.value = null
       // Stop SSE on terminal state
       if (isTerminal(status)) stopSse()
     },
@@ -313,7 +359,7 @@ watch(
   () => run.value?.status,
   (status) => {
     if (!status) return
-    if ((status === 'running' || status === 'queued') && !cleanupSse) {
+    if ((status === 'running' || status === 'queued' || status === 'waiting_approval') && !cleanupSse) {
       startSse()
     } else if (isTerminal(status)) {
       stopSse()
@@ -323,7 +369,8 @@ watch(
 
 onMounted(async () => {
   await loadRun()
-  if (run.value && (run.value.status === 'running' || run.value.status === 'queued')) {
+  const s = run.value?.status
+  if (s === 'running' || s === 'queued' || s === 'waiting_approval') {
     startSse()
   }
 })
@@ -344,6 +391,7 @@ interface StatusConfig {
 const STATUS_CONFIG: Record<RunStatus, StatusConfig> = {
   queued:        { label: '排队中',   dot: 'var(--color-faint)',  bg: 'var(--color-card-2)',     border: 'var(--color-border-strong)', text: 'var(--color-dim)',   pulse: false },
   running:       { label: '进行中',   dot: 'var(--color-amber)',  bg: 'var(--color-amber-soft)', border: 'transparent',               text: 'var(--color-amber)', pulse: true  },
+  waiting_approval:{ label: '等待审批', dot: 'var(--color-amber)', bg: 'var(--color-amber-soft)', border: 'var(--color-amber-line)',   text: 'var(--color-amber)', pulse: true  },
   success:       { label: '成功',     dot: 'var(--color-green)',  bg: 'var(--color-green-soft)', border: 'transparent',               text: 'var(--color-green)', pulse: false },
   failed:        { label: '失败',     dot: 'var(--color-red)',    bg: 'var(--color-red-soft)',   border: 'var(--color-red-line)',     text: 'var(--color-red)',   pulse: false },
   partial_failed:{ label: '部分失败', dot: 'var(--color-red)',    bg: 'var(--color-red-soft)',   border: 'var(--color-red-line)',     text: 'var(--color-red)',   pulse: false },
@@ -505,6 +553,33 @@ function nodeClass(status: StepStatus): string {
             <circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h.01"/>
           </svg>
           {{ cancelError }}
+        </div>
+
+        <!-- ── Approval gate (Story 8-4): waiting for manual approval ── -->
+        <div
+          v-if="run.status === 'waiting_approval' && pendingApproval"
+          class="approval-gate"
+          role="region"
+          aria-label="等待人工审批"
+        >
+          <div class="approval-gate-icon" aria-hidden="true">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+            </svg>
+          </div>
+          <div class="approval-gate-body">
+            <div class="approval-gate-title">阶段「{{ pendingApproval.stageName }}」等待人工审批</div>
+            <div class="approval-gate-sub">批准后继续执行,拒绝则该阶段失败、运行终止。</div>
+            <div v-if="approvalError" class="approval-gate-error" role="alert">{{ approvalError }}</div>
+          </div>
+          <div class="approval-gate-actions">
+            <button class="approval-btn approval-btn--reject" :disabled="approving" @click="decideApproval(false)">
+              拒绝
+            </button>
+            <button class="approval-btn approval-btn--approve" :disabled="approving" @click="decideApproval(true)">
+              {{ approving ? '处理中…' : '批准' }}
+            </button>
+          </div>
         </div>
 
         <!-- ── Meta strip: trigger / branch / commit / duration ──────── -->
@@ -1128,6 +1203,53 @@ function nodeClass(status: StepStatus): string {
 </template>
 
 <style scoped>
+/* ─── approval gate (Story 8-4) ──────────────────────────────────────────── */
+.approval-gate {
+  display: flex;
+  align-items: flex-start;
+  gap: 13px;
+  margin: 14px 0;
+  padding: 14px 16px;
+  background: var(--color-amber-soft);
+  border: 1px solid var(--color-amber);
+  border-radius: var(--rounded);
+}
+.approval-gate-icon {
+  flex-shrink: 0;
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--rounded-md);
+  background: var(--color-amber);
+  color: #fff;
+}
+.approval-gate-body { flex: 1; min-width: 0; }
+.approval-gate-title { font-size: 0.92rem; font-weight: 650; color: var(--color-text); }
+.approval-gate-sub { margin-top: 2px; font-size: 0.8rem; color: var(--color-dim); }
+.approval-gate-error { margin-top: 6px; font-size: 0.78rem; color: var(--color-red); }
+.approval-gate-actions { display: flex; gap: 8px; align-items: center; flex-shrink: 0; }
+.approval-btn {
+  height: 34px;
+  padding: 0 16px;
+  border-radius: var(--rounded-md);
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: filter var(--duration-fast), background-color var(--duration-fast);
+}
+.approval-btn:disabled { opacity: 0.6; cursor: default; }
+.approval-btn--approve { background: var(--color-green); color: #fff; }
+.approval-btn--approve:not(:disabled):hover { filter: brightness(1.06); }
+.approval-btn--reject {
+  background: transparent;
+  border-color: var(--color-border-strong);
+  color: var(--color-dim);
+}
+.approval-btn--reject:not(:disabled):hover { border-color: var(--color-red); color: var(--color-red); }
+
 /* ─── root ───────────────────────────────────────────────────────────────── */
 .run-detail-root {
   display: flex;

--- a/web/src/views/Runs.vue
+++ b/web/src/views/Runs.vue
@@ -208,6 +208,7 @@ interface StatusConfig {
 const STATUS_CONFIG: Record<RunStatus, StatusConfig> = {
   queued:        { label: '排队中',   dot: 'var(--color-faint)',  bg: 'var(--color-card-2)',     border: 'var(--color-border-strong)', text: 'var(--color-dim)',   pulse: false },
   running:       { label: '进行中',   dot: 'var(--color-amber)',  bg: 'var(--color-amber-soft)', border: 'transparent',               text: 'var(--color-amber)', pulse: true  },
+  waiting_approval:{ label: '等待审批', dot: 'var(--color-amber)', bg: 'var(--color-amber-soft)', border: 'var(--color-amber-line)',   text: 'var(--color-amber)', pulse: true  },
   success:       { label: '成功',     dot: 'var(--color-green)',  bg: 'var(--color-green-soft)', border: 'transparent',               text: 'var(--color-green)', pulse: false },
   failed:        { label: '失败',     dot: 'var(--color-red)',    bg: 'var(--color-red-soft)',   border: 'var(--color-red-line)',     text: 'var(--color-red)',   pulse: false },
   partial_failed:{ label: '部分失败', dot: 'var(--color-red)',    bg: 'var(--color-red-soft)',   border: 'var(--color-red-line)',     text: 'var(--color-red)',   pulse: false },


### PR DESCRIPTION
(stacked on feat/dag-approval-gate)手动触发附 key=value 参数 → 注入 script 步骤容器环境。迁移 0026 + run.Trigger.Params + 手动端点 + 执行器注入。真 Docker e2e:容器 echo $PW_PARAM 读回注入值。

🤖 Generated with [Claude Code](https://claude.com/claude-code)