### PR TITLE
feat(pipeline): 8-4 人工审批门 + 8-8 运行详情审批 UI

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -18,6 +18,7 @@ import (
 	root "github.com/huangchengsir/pipewright"
 	"github.com/huangchengsir/pipewright/internal/ai"
 	"github.com/huangchengsir/pipewright/internal/anomaly"
+	"github.com/huangchengsir/pipewright/internal/approval"
 	"github.com/huangchengsir/pipewright/internal/audit"
 	"github.com/huangchengsir/pipewright/internal/auth"
 	"github.com/huangchengsir/pipewright/internal/build"
@@ -108,6 +109,17 @@ func main() {
 	// worker pool 在 aiSvc 装配后创建(以便注入 best-effort 自动诊断钩子,Story 7.2)。
 	runSvc := run.New(st.DB)
 
+	// 装配人工审批门协调器 + 持久层(Story 8-4):DAG 调度到 Gate 阶段时阻塞等待批准/拒绝。
+	// 协调器为进程内(零持久状态);记录落 run_approvals 供 UI/审计/重启清理。
+	approvalCoord := approval.New()
+	approvalStore := approval.NewStore(st.DB)
+	// 重启清理:进程重启会丢失内存等待者,把残留 waiting_approval 运行清为 failed(孤儿不可恢复)。
+	if n, err := runSvc.FailOrphanedRuns(context.Background()); err != nil {
+		log.Printf("[run] 警告:清理孤儿运行失败:%v", err)
+	} else if n > 0 {
+		log.Printf("[run] 启动清理孤儿运行(waiting_approval/running):%d 条 → failed", n)
+	}
+
 	// 装配诊断反馈服务(Story 7.5;FR-26):诊断 👍/👎(👎 可附正确根因)持久化 + 准确率统计(知识库种子)。
 	// 复用同一 *sql.DB(参数化 SQL);correctRootCause 脱敏在 httpapi 层(过 mask)+ 领域层长度上限兜底。
 	// upsert by run_id(同 run 改判覆盖)。无 init 副作用、不抬高空载内存。
@@ -174,6 +186,8 @@ func main() {
 		// 阶段执行体(Story 8-2):探测到容器 CLI → 注入真实阶段执行器(script 类型 job 在隔离
 		// 容器内真实跑命令,复用 Builder 的 cloner+driver);否则回退 stub(优雅降级,NFR-10)。
 		var dagOpts []dagrun.Option
+		// 审批门 hook(Story 8-4):Gate 阶段阻塞等待人工批准/拒绝。
+		dagOpts = append(dagOpts, dagrun.WithGate(httpapi.NewApprovalGate(runSvc, approvalCoord, approvalStore)))
 		if b, berr := build.NewBuilder(projectSvc, pipelineSettingsSvc, credVault); berr == nil {
 			dagOpts = append(dagOpts, dagrun.WithStageExecutor(build.NewStageExecutor(b)))
 			log.Printf("[run] PIPEWRIGHT_RUNNER=dag:DAG 调度执行器已启用(阶段按 needs 编排;script 类型 job 在隔离容器真实执行,CLI=%s;build_image/push_image/deploy_ssh 真实化=后续)", b.DriverBinary())
@@ -254,7 +268,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithServers(targetSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc)),
+		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithServers(targetSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithApprovals(approvalCoord, approvalStore)),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		// WriteTimeout 置 0:SSE 长连接(/api/runs/{id}/events)不可被写超时切断;

--- a/internal/approval/coordinator.go
+++ b/internal/approval/coordinator.go
@@ -1,0 +1,84 @@
+// Package approval 是人工审批门(Epic 8 · Story 8-4)的进程内协调器 + 持久化。
+//
+// 模型:阶段声明 Gate=true 时,执行该阶段前运行阻塞、状态置 waiting_approval;阻塞在门内的
+// worker 经 Coordinator.Wait 注册等待,审批端点经 Coordinator.Resolve 投递「批准/拒绝」决定。
+// 决定 + 待批记录持久化到 run_approvals(供 UI 展示 / 审计 / 重启清理)。
+//
+// 边界(诚实):审批期间 worker 仍持有该 run(在门内阻塞),不释放回池——故 worker 上限即「同时
+// 可挂起的待批运行数」;设审批超时兜底(默认),超时自动拒绝以释放 worker。进程重启会丢失内存
+// 等待者:重启时把残留 waiting_approval/running 运行清理为 failed(孤儿,无法恢复)。
+package approval
+
+import "sync"
+
+// Decision 是一次审批结果。
+type Decision struct {
+	Approved bool
+	Actor    string // 审批人(展示/审计;绝无敏感数据)
+}
+
+// Coordinator 是进程内审批门协调器(零持久状态;持久化在 Store)。
+type Coordinator struct {
+	mu      sync.Mutex
+	waiters map[string]chan Decision
+}
+
+// New 构造协调器。
+func New() *Coordinator {
+	return &Coordinator{waiters: make(map[string]chan Decision)}
+}
+
+// Key 由 runID + stageID 组成审批门唯一键。
+func Key(runID, stageID string) string { return runID + "|" + stageID }
+
+// Wait 为 key 注册一个等待,返回接收决定的只读 channel(缓冲 1,Resolve 不阻塞)。
+// 同 key 重复 Wait 覆盖旧等待者(旧 channel 永不收到决定;调用方应在 defer 里 Cancel 清理)。
+func (c *Coordinator) Wait(key string) <-chan Decision {
+	ch := make(chan Decision, 1)
+	c.mu.Lock()
+	c.waiters[key] = ch
+	c.mu.Unlock()
+	return ch
+}
+
+// Resolve 把决定投递给等待 key 的 worker。无等待者(未到门 / 已超时 / 已决) → false。
+// 投递后移除等待者(同一门只决一次)。
+func (c *Coordinator) Resolve(key string, d Decision) bool {
+	c.mu.Lock()
+	ch, ok := c.waiters[key]
+	if ok {
+		delete(c.waiters, key)
+	}
+	c.mu.Unlock()
+	if !ok {
+		return false
+	}
+	ch <- d // 缓冲 1,不阻塞
+	return true
+}
+
+// Cancel 移除 key 的等待者(worker 退出 / 取消 / 超时时清理)。幂等。
+func (c *Coordinator) Cancel(key string) {
+	c.mu.Lock()
+	delete(c.waiters, key)
+	c.mu.Unlock()
+}
+
+// IsWaiting 报告 key 是否有等待者(端点据此区分 404「未在审批」)。
+func (c *Coordinator) IsWaiting(key string) bool {
+	c.mu.Lock()
+	_, ok := c.waiters[key]
+	c.mu.Unlock()
+	return ok
+}
+
+// PendingKeys 返回当前所有等待中的 key(调试/列举)。
+func (c *Coordinator) PendingKeys() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, 0, len(c.waiters))
+	for k := range c.waiters {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/approval/coordinator_test.go
+++ b/internal/approval/coordinator_test.go
@@ -1,0 +1,82 @@
+package approval
+
+import (
+	"testing"
+	"time"
+)
+
+func TestKeyComposition(t *testing.T) {
+	if Key("r1", "s1") != "r1|s1" {
+		t.Errorf("Key = %q", Key("r1", "s1"))
+	}
+}
+
+func TestResolveDelivers(t *testing.T) {
+	c := New()
+	key := Key("r1", "s1")
+	ch := c.Wait(key)
+	if !c.IsWaiting(key) {
+		t.Fatal("应在等待")
+	}
+	go func() {
+		// 给主协程时间进入接收。
+		time.Sleep(5 * time.Millisecond)
+		if !c.Resolve(key, Decision{Approved: true, Actor: "admin"}) {
+			t.Errorf("Resolve 应成功")
+		}
+	}()
+	select {
+	case d := <-ch:
+		if !d.Approved || d.Actor != "admin" {
+			t.Errorf("决定不符:%+v", d)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("超时未收到决定")
+	}
+	if c.IsWaiting(key) {
+		t.Error("决定后应移除等待者")
+	}
+}
+
+func TestResolveNoWaiter(t *testing.T) {
+	c := New()
+	if c.Resolve(Key("x", "y"), Decision{Approved: true}) {
+		t.Error("无等待者时 Resolve 应返回 false")
+	}
+}
+
+func TestResolveTwiceSecondFails(t *testing.T) {
+	c := New()
+	key := Key("r", "s")
+	ch := c.Wait(key)
+	if !c.Resolve(key, Decision{Approved: true, Actor: "a"}) {
+		t.Fatal("首次 Resolve 应成功")
+	}
+	<-ch
+	if c.Resolve(key, Decision{Approved: false, Actor: "b"}) {
+		t.Error("二次 Resolve 应失败(同门只决一次)")
+	}
+}
+
+func TestCancelRemovesWaiter(t *testing.T) {
+	c := New()
+	key := Key("r", "s")
+	c.Wait(key)
+	c.Cancel(key)
+	if c.IsWaiting(key) {
+		t.Error("Cancel 后不应仍在等待")
+	}
+	if c.Resolve(key, Decision{}) {
+		t.Error("Cancel 后 Resolve 应失败")
+	}
+	c.Cancel(key) // 幂等
+}
+
+func TestPendingKeys(t *testing.T) {
+	c := New()
+	c.Wait(Key("r1", "s1"))
+	c.Wait(Key("r2", "s2"))
+	if len(c.PendingKeys()) != 2 {
+		t.Errorf("PendingKeys = %v", c.PendingKeys())
+	}
+}

--- a/internal/approval/store.go
+++ b/internal/approval/store.go
@@ -1,0 +1,85 @@
+package approval
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// 审批状态枚举。
+const (
+	StatusPending  = "pending"
+	StatusApproved = "approved"
+	StatusRejected = "rejected"
+)
+
+// Record 是一条审批门记录(供 UI 展示 / 审计)。
+type Record struct {
+	StageID   string `json:"stageId"`
+	StageName string `json:"stageName"`
+	Status    string `json:"status"`
+	DecidedBy string `json:"decidedBy"`
+	DecidedAt string `json:"decidedAt"`
+	CreatedAt string `json:"createdAt"`
+}
+
+// Store 持久化审批门记录(参数化 SQL)。
+type Store struct {
+	db *sql.DB
+}
+
+// NewStore 构造审批记录持久层。
+func NewStore(db *sql.DB) *Store { return &Store{db: db} }
+
+// CreatePending 登记一条待批记录(同 run+stage upsert,重入时复位为 pending)。
+func (s *Store) CreatePending(ctx context.Context, runID, stageID, stageName string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO run_approvals (id, run_id, stage_id, stage_name, status, decided_by, decided_at, created_at)
+		 VALUES (?, ?, ?, ?, 'pending', '', '', ?)
+		 ON CONFLICT(run_id, stage_id) DO UPDATE SET
+		   status = 'pending', decided_by = '', decided_at = '', stage_name = excluded.stage_name`,
+		uuid.NewString(), runID, stageID, stageName, now,
+	)
+	if err != nil {
+		return fmt.Errorf("approval: create pending: %w", err)
+	}
+	return nil
+}
+
+// Decide 记录一次决定(approved/rejected/其它如 timeout|canceled 走 status=rejected + decidedBy 标注)。
+func (s *Store) Decide(ctx context.Context, runID, stageID, status, decidedBy string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE run_approvals SET status = ?, decided_by = ?, decided_at = ?
+		 WHERE run_id = ? AND stage_id = ?`,
+		status, decidedBy, now, runID, stageID,
+	)
+	if err != nil {
+		return fmt.Errorf("approval: decide: %w", err)
+	}
+	return nil
+}
+
+// ListForRun 返回某运行的全部审批记录(按 created_at 升序)。
+func (s *Store) ListForRun(ctx context.Context, runID string) ([]Record, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT stage_id, stage_name, status, decided_by, decided_at, created_at
+		 FROM run_approvals WHERE run_id = ? ORDER BY created_at ASC`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("approval: list: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []Record
+	for rows.Next() {
+		var r Record
+		if err := rows.Scan(&r.StageID, &r.StageName, &r.Status, &r.DecidedBy, &r.DecidedAt, &r.CreatedAt); err != nil {
+			return nil, fmt.Errorf("approval: scan: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}

--- a/internal/dagrun/dagrun.go
+++ b/internal/dagrun/dagrun.go
@@ -16,6 +16,7 @@ package dagrun
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -57,15 +58,34 @@ func StubStageExecutor(ctx context.Context, _ *run.Run, stage pipeline.Stage, re
 	return nil
 }
 
+// GateFunc 在进入「审批门」阶段(Gate=true)前阻塞等待人工决定(Story 8-4)。
+// 返回 (true,nil)=批准继续;(false,nil)=拒绝(该阶段失败);(_,err)=取消/超时等(阶段失败)。
+// 实现(在 main/httpapi 装配)负责:登记待批 + 置 run 状态 waiting_approval + 阻塞协调器 +
+// 决定后置回 running。dagrun 经此 hook 解耦,不直接 import run.Service / approval。
+type GateFunc func(ctx context.Context, r *run.Run, stage pipeline.Stage) (approved bool, err error)
+
+// ErrGateRejected 表示审批门被人工拒绝(该阶段失败 → 运行终止)。
+var ErrGateRejected = errors.New("dagrun: approval gate rejected")
+
 // Runner 是 DAG 感知的 run.Runner 实现。
 type Runner struct {
 	loader      SpecLoader
 	exec        StageExecutor
+	gate        GateFunc
 	concurrency int
 }
 
 // Option 配置 Runner。
 type Option func(*Runner)
+
+// WithGate 注入审批门 hook(Story 8-4)。nil 忽略(无门:Gate 阶段直接执行)。
+func WithGate(g GateFunc) Option {
+	return func(r *Runner) {
+		if g != nil {
+			r.gate = g
+		}
+	}
+}
 
 // WithConcurrency 设阶段并行上限(<=0 用阶段总数,即「能并行的全并行」)。
 func WithConcurrency(n int) Option {
@@ -153,6 +173,26 @@ func (r *Runner) Run(ctx context.Context, rn *run.Run, sink run.StepSink) error 
 		}
 		if err := lockedSink(func() error { return sink.StepRunning(ctx, ord) }); err != nil {
 			return err
+		}
+		// 人工审批门(Story 8-4):进入该阶段前阻塞等待批准。run 状态由 gate 置 waiting_approval。
+		if stage.Gate && r.gate != nil {
+			_ = lockedSink(func() error {
+				return sink.Log(ctx, "stdout", ord, fmt.Sprintf("⏸ 阶段「%s」等待人工审批…", stage.Name))
+			})
+			approved, gerr := r.gate(ctx, rn, stage)
+			if gerr != nil {
+				_ = lockedSink(func() error {
+					return sink.Log(ctx, "stderr", ord, fmt.Sprintf("审批门中断:%v", gerr))
+				})
+				_ = lockedSink(func() error { return sink.StepDone(ctx, ord, run.StepFailed) })
+				return gerr
+			}
+			if !approved {
+				_ = lockedSink(func() error { return sink.Log(ctx, "stderr", ord, "⛔ 审批被拒绝,终止该阶段") })
+				_ = lockedSink(func() error { return sink.StepDone(ctx, ord, run.StepFailed) })
+				return ErrGateRejected
+			}
+			_ = lockedSink(func() error { return sink.Log(ctx, "stdout", ord, "✅ 审批通过,继续执行") })
 		}
 		rep := &stageReporter{sink: sink, mu: &mu, ordinal: ord}
 		execErr := r.exec(ctx, rn, stage, rep)

--- a/internal/dagrun/dagrun_test.go
+++ b/internal/dagrun/dagrun_test.go
@@ -107,6 +107,68 @@ func TestRunnerWhenSkipsStageAndDownstreamWithoutFailing(t *testing.T) {
 	}
 }
 
+func TestRunnerGateApprovedRunsStage(t *testing.T) {
+	cfg := cfgWith(
+		pipeline.Stage{ID: "src", Name: "源"},
+		pipeline.Stage{ID: "deploy", Name: "部署", Needs: []string{"src"}, Gate: true},
+	)
+	var ran bool
+	r := New(fakeLoader{cfg},
+		WithGate(func(_ context.Context, _ *run.Run, _ pipeline.Stage) (bool, error) {
+			return true, nil // 批准
+		}),
+		WithStageExecutor(func(_ context.Context, _ *run.Run, st pipeline.Stage, _ StageReporter) error {
+			if st.ID == "deploy" {
+				ran = true
+			}
+			return nil
+		}))
+	sink := newFakeSink()
+	if err := r.Run(context.Background(), &run.Run{ProjectID: "p"}, sink); err != nil {
+		t.Fatalf("批准后 Run 不应失败:%v", err)
+	}
+	if !ran {
+		t.Error("批准后 deploy 应执行")
+	}
+}
+
+func TestRunnerGateRejectedFailsStage(t *testing.T) {
+	cfg := cfgWith(
+		pipeline.Stage{ID: "src", Name: "源"},
+		pipeline.Stage{ID: "deploy", Name: "部署", Needs: []string{"src"}, Gate: true},
+	)
+	var ran bool
+	r := New(fakeLoader{cfg},
+		WithGate(func(_ context.Context, _ *run.Run, _ pipeline.Stage) (bool, error) {
+			return false, nil // 拒绝
+		}),
+		WithStageExecutor(func(_ context.Context, _ *run.Run, st pipeline.Stage, _ StageReporter) error {
+			if st.ID == "deploy" {
+				ran = true
+			}
+			return nil
+		}))
+	sink := newFakeSink()
+	err := r.Run(context.Background(), &run.Run{ProjectID: "p"}, sink)
+	if err == nil {
+		t.Fatal("拒绝应使 Run 失败")
+	}
+	if ran {
+		t.Error("拒绝后 deploy executor 不应被调用")
+	}
+	ord := func(name string) int {
+		for i, n := range sink.planned {
+			if n == name {
+				return i
+			}
+		}
+		return -1
+	}
+	if sink.done[ord("部署")] != run.StepFailed {
+		t.Errorf("部署 step = %q, want failed(被拒绝)", sink.done[ord("部署")])
+	}
+}
+
 func TestRunnerWhenMatchedRunsStage(t *testing.T) {
 	cfg := cfgWith(
 		pipeline.Stage{ID: "src", Name: "源"},

--- a/internal/httpapi/approvals.go
+++ b/internal/httpapi/approvals.go
@@ -1,0 +1,132 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/approval"
+	"github.com/huangchengsir/pipewright/internal/audit"
+	"github.com/huangchengsir/pipewright/internal/dagrun"
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// approvals.go 实现人工审批门(Epic 8 · Story 8-4)的 gate hook 与审批端点。
+//
+// gate hook(NewApprovalGate)注入 dagrun:进入 Gate 阶段前登记待批 + 置 run 状态 waiting_approval +
+// 阻塞协调器,直到端点投递批准/拒绝(或取消/超时)。端点(approve/reject)经协调器解析决定 + 审计。
+
+// defaultGateTimeout 是审批门兜底超时:超时自动拒绝以释放被该运行占用的 worker。
+// 审批人节奏可较慢,故取较长值;运行亦可经取消端点立即释放。
+const defaultGateTimeout = 24 * time.Hour
+
+// NewApprovalGate 构造注入 dagrun 的审批门 hook(供 main 装配)。
+func NewApprovalGate(runs run.Service, coord *approval.Coordinator, store *approval.Store) dagrun.GateFunc {
+	return func(ctx context.Context, r *run.Run, stage pipeline.Stage) (bool, error) {
+		key := approval.Key(r.ID, stage.ID)
+		_ = store.CreatePending(ctx, r.ID, stage.ID, stage.Name)
+		ch := coord.Wait(key)
+		defer coord.Cancel(key)
+
+		// 先注册等待者再置 waiting,确保端点在状态切换后总能解析到该门。
+		if err := runs.MarkWaitingApproval(ctx, r.ID); err != nil {
+			// 已终态/被取消:无法进入等待,退化失败让 worker 收尾。
+			return false, err
+		}
+
+		var (
+			approved bool
+			status   = approval.StatusRejected
+			by       string
+		)
+		select {
+		case d := <-ch:
+			approved = d.Approved
+			by = d.Actor
+			if approved {
+				status = approval.StatusApproved
+			}
+		case <-ctx.Done():
+			by = "canceled"
+			_ = store.Decide(context.Background(), r.ID, stage.ID, status, by)
+			_ = runs.ResumeFromApproval(context.Background(), r.ID)
+			return false, ctx.Err()
+		case <-time.After(defaultGateTimeout):
+			by = "timeout"
+			_ = store.Decide(context.Background(), r.ID, stage.ID, status, by)
+			_ = runs.ResumeFromApproval(context.Background(), r.ID)
+			return false, fmt.Errorf("approval gate timed out after %s", defaultGateTimeout)
+		}
+		_ = store.Decide(context.Background(), r.ID, stage.ID, status, by)
+		// 决定后置回 running,让 worker 在收尾时按 running→终态 落定。
+		_ = runs.ResumeFromApproval(context.Background(), r.ID)
+		return approved, nil
+	}
+}
+
+// makeApprovalDecisionHandler 返回 approve(approve=true)/reject(false)端点 handler。
+// body {stageId};经协调器投递决定。该阶段当前不在等待 → 409。
+func makeApprovalDecisionHandler(coord *approval.Coordinator, store *approval.Store, rec audit.Recorder, approve bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if coord == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "审批门服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<13)
+		var req struct {
+			StageID string `json:"stageId"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		stageID := strings.TrimSpace(req.StageID)
+		if stageID == "" {
+			writeError(w, http.StatusUnprocessableEntity, "missing_stage", "缺少 stageId")
+			return
+		}
+		key := approval.Key(id, stageID)
+		if !coord.Resolve(key, approval.Decision{Approved: approve, Actor: auditActor}) {
+			writeError(w, http.StatusConflict, "not_waiting", "该运行阶段当前不在等待审批")
+			return
+		}
+		action := "run.approve"
+		if !approve {
+			action = "run.reject"
+		}
+		recordAudit(r.Context(), rec, audit.Entry{
+			Actor:      auditActor,
+			Action:     action,
+			TargetType: "run",
+			TargetID:   id,
+			Detail:     map[string]any{"stageId": stageID},
+			IP:         clientIP(r),
+		})
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "approved": approve})
+	}
+}
+
+// makeListApprovalsHandler 返回 GET /api/runs/{id}/approvals(某运行的审批门记录列表)。
+func makeListApprovalsHandler(store *approval.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if store == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "审批门服务未初始化")
+			return
+		}
+		recs, err := store.ListForRun(r.Context(), chi.URLParam(r, "id"))
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+			return
+		}
+		if recs == nil {
+			recs = []approval.Record{}
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"items": recs})
+	}
+}

--- a/internal/httpapi/pipelines.go
+++ b/internal/httpapi/pipelines.go
@@ -26,6 +26,7 @@ type stageDTO struct {
 	Needs        []string `json:"needs"`
 	AllowFailure bool     `json:"allowFailure"`
 	When         whenDTO  `json:"when"`
+	Gate         bool     `json:"gate"`
 	Jobs         []jobDTO `json:"jobs"`
 }
 
@@ -75,7 +76,7 @@ func toPipelineDTO(c *pipeline.Config) pipelineDTO {
 		if needs == nil {
 			needs = []string{}
 		}
-		stages = append(stages, stageDTO{ID: st.ID, Name: st.Name, Kind: st.Kind, Needs: needs, AllowFailure: st.AllowFailure, When: toWhenDTO(st.When), Jobs: jobs})
+		stages = append(stages, stageDTO{ID: st.ID, Name: st.Name, Kind: st.Kind, Needs: needs, AllowFailure: st.AllowFailure, When: toWhenDTO(st.When), Gate: st.Gate, Jobs: jobs})
 	}
 	return pipelineDTO{
 		Stages:    stages,
@@ -141,6 +142,7 @@ func makeSavePipelineHandler(svc pipeline.Service) http.HandlerFunc {
 					Branches []string `json:"branches"`
 					Events   []string `json:"events"`
 				} `json:"when"`
+				Gate bool `json:"gate"`
 				Jobs []struct {
 					ID      string         `json:"id"`
 					Name    string         `json:"name"`
@@ -174,6 +176,7 @@ func makeSavePipelineHandler(svc pipeline.Service) http.HandlerFunc {
 				Needs:        st.Needs,
 				AllowFailure: st.AllowFailure,
 				When:         pipeline.When{Branches: st.When.Branches, Events: st.When.Events},
+				Gate:         st.Gate,
 				Jobs:         jobs,
 			})
 		}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/huangchengsir/pipewright/internal/ai"
 	"github.com/huangchengsir/pipewright/internal/anomaly"
+	"github.com/huangchengsir/pipewright/internal/approval"
 	"github.com/huangchengsir/pipewright/internal/audit"
 	"github.com/huangchengsir/pipewright/internal/auth"
 	"github.com/huangchengsir/pipewright/internal/cron"
@@ -69,6 +70,17 @@ type options struct {
 	deployer         deploy.Service
 	anomaly          anomaly.Service
 	oauth            oauth.Service
+	approvalCoord    *approval.Coordinator
+	approvalStore    *approval.Store
+}
+
+// WithApprovals 注入审批门协调器 + 持久层(Story 8-4),挂载 /api/runs/{id}/{approve,reject,approvals} 路由。
+// 不传则审批端点返回 503。
+func WithApprovals(coord *approval.Coordinator, store *approval.Store) Option {
+	return func(o *options) {
+		o.approvalCoord = coord
+		o.approvalStore = store
+	}
 }
 
 // WithVault 注入凭据保险库,挂载 /api/credentials* 路由。
@@ -324,6 +336,11 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		// 构建产物契约(Story 3.4 / FR-6):只读 + 认证;按 (type, reference) 供 Epic 4 消费。
 		ar.Get("/runs/{id}/artifacts", makeRunArtifactsHandler(rs))
 		ar.Post("/runs/{id}/cancel", makeCancelRunHandler(rs))
+		// 人工审批门(Story 8-4):批准/拒绝某运行的审批门阶段 + 列审批记录。
+		// approve/reject 为写方法,过 auth + CSRF;coord/store 为 nil → 503。
+		ar.Post("/runs/{id}/approve", makeApprovalDecisionHandler(o.approvalCoord, o.approvalStore, aud, true))
+		ar.Post("/runs/{id}/reject", makeApprovalDecisionHandler(o.approvalCoord, o.approvalStore, aud, false))
+		ar.Get("/runs/{id}/approvals", makeListApprovalsHandler(o.approvalStore))
 		// SSH 部署执行(Story 4.2 / FR-10):认证 + CSRF(写方法)。dep 为 nil → 503。
 		// 取 run + 产物 + 服务器 → deploy.Deploy(逐机经 SSH 执行部署命令,array 不拼 shell)
 		// → 据结果更新 run 终态 → 返回填好的 targets。部署执行失败不 500(每机 status=failed)。

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -79,7 +79,10 @@ type Stage struct {
 	Needs        []string `json:"needs,omitempty"`
 	AllowFailure bool     `json:"allowFailure,omitempty"`
 	When         When     `json:"when,omitempty"`
-	Jobs         []Job    `json:"jobs"`
+	// Gate 为 true 时,进入该阶段前需人工审批(Story 8-4):运行阻塞、状态置 waiting_approval,
+	// 批准→继续,拒绝→该阶段失败(运行终止)。
+	Gate bool  `json:"gate,omitempty"`
+	Jobs []Job `json:"jobs"`
 }
 
 // Spec 是流水线编排声明式配置(阶段集合)。
@@ -343,7 +346,7 @@ func normalizeSpec(in Spec) (Spec, error) {
 		// Needs 规范化:trim、去空、去重、剔除自指(自指交由 dag 校验报错以给明确信息)。
 		needs := normalizeNeeds(st.Needs)
 
-		out.Stages = append(out.Stages, Stage{ID: stageID, Name: name, Kind: kind, Needs: needs, AllowFailure: st.AllowFailure, When: normalizeWhen(st.When), Jobs: jobs})
+		out.Stages = append(out.Stages, Stage{ID: stageID, Name: name, Kind: kind, Needs: needs, AllowFailure: st.AllowFailure, When: normalizeWhen(st.When), Gate: st.Gate, Jobs: jobs})
 	}
 
 	// 源阶段不变式:流水线必须恰有一个 source 阶段(引用项目仓库)。前端不渲染删源阶段的入口,

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -30,6 +30,9 @@ const (
 	StatusQueued = "queued"
 	// StatusRunning 表示 worker 正在执行。
 	StatusRunning = "running"
+	// StatusWaitingApproval 表示运行阻塞在人工审批门(Story 8-4),等待批准/拒绝(非终态)。
+	// worker 仍持有该 run(在审批门内阻塞);批准 → 回 running 继续,拒绝/超时 → failed。
+	StatusWaitingApproval = "waiting_approval"
 	// StatusSuccess 表示全部步骤成功(终态)。
 	StatusSuccess = "success"
 	// StatusFailed 表示执行失败或被取消(终态)。
@@ -52,6 +55,8 @@ const (
 	StepFailed = "failed"
 	// StepSkipped 表示步骤被跳过。
 	StepSkipped = "skipped"
+	// StepWaitingApproval 表示步骤(审批门阶段)正等待人工批准(Story 8-4;非终态步骤状态)。
+	StepWaitingApproval = "waiting_approval"
 )
 
 // 触发类型枚举。
@@ -193,10 +198,15 @@ var allowedTransitions = map[string]map[string]bool{
 		StatusFailed:  true, // 入队即取消 / 调度前失败
 	},
 	StatusRunning: {
-		StatusSuccess:       true,
-		StatusFailed:        true,
-		StatusPartialFailed: true,
-		StatusRolledBack:    true,
+		StatusSuccess:         true,
+		StatusFailed:          true,
+		StatusPartialFailed:   true,
+		StatusRolledBack:      true,
+		StatusWaitingApproval: true, // 进入审批门:running → waiting_approval(Story 8-4)
+	},
+	StatusWaitingApproval: {
+		StatusRunning: true, // 批准:waiting_approval → running 继续
+		StatusFailed:  true, // 拒绝/超时/取消:waiting_approval → failed
 	},
 }
 
@@ -216,7 +226,7 @@ func IsStepTerminal(status string) bool {
 // isValidStatus 报告状态是否为已知运行状态枚举。
 func isValidStatus(status string) bool {
 	switch status {
-	case StatusQueued, StatusRunning, StatusSuccess, StatusFailed, StatusPartialFailed, StatusRolledBack:
+	case StatusQueued, StatusRunning, StatusWaitingApproval, StatusSuccess, StatusFailed, StatusPartialFailed, StatusRolledBack:
 		return true
 	default:
 		return false

--- a/internal/run/service.go
+++ b/internal/run/service.go
@@ -33,6 +33,17 @@ type Service interface {
 	// Cancel 取消进行中(queued/running)运行:经 context 传播到 Runner;终态 → ErrNotCancelable。
 	Cancel(ctx context.Context, id string) (*Run, error)
 
+	// MarkWaitingApproval 把运行从 running 置为 waiting_approval(Story 8-4 审批门阻塞)。
+	// 非 running → ErrInvalidTransition。
+	MarkWaitingApproval(ctx context.Context, id string) error
+	// ResumeFromApproval 把运行从 waiting_approval 置回 running(批准/拒绝后让 worker 收尾)。
+	// 非 waiting_approval → ErrInvalidTransition。
+	ResumeFromApproval(ctx context.Context, id string) error
+
+	// FailOrphanedRuns 把启动时残留的非终态运行(queued/running/waiting_approval)清为 failed。
+	// 进程重启会丢失内存队列与审批等待者,这些运行无法恢复,应一次性清理(返回清理条数)。
+	FailOrphanedRuns(ctx context.Context) (int, error)
+
 	// LastSuccessfulRun 查 baseline:同 project + 同 trigger.Branch、created_at 早于 before、
 	// 最近一条 status=success 的运行(Story 7.3 / FR-25 成功/失败差异对比)。
 	// 用于「本次失败运行 → 上一次成功运行」对比的基线选取。无匹配 → ErrNotFound。
@@ -567,6 +578,31 @@ func (s *service) GetLogs(ctx context.Context, runID string, sinceSeq int) ([]Lo
 // transition 校验并持久化运行状态转移:CAS 式更新(WHERE status=from),
 // 顺带按 to 维护 started_at/finished_at;成功后经事件总线发布 status 事件。
 // requireFrom=true 时,当前状态非 from(竞态/非法)→ ErrInvalidTransition。
+// MarkWaitingApproval 实现 Service:running → waiting_approval(审批门进入)。
+func (s *service) MarkWaitingApproval(ctx context.Context, id string) error {
+	return s.transition(ctx, id, StatusRunning, StatusWaitingApproval, true)
+}
+
+// ResumeFromApproval 实现 Service:waiting_approval → running(决定后让 worker 收尾)。
+func (s *service) ResumeFromApproval(ctx context.Context, id string) error {
+	return s.transition(ctx, id, StatusWaitingApproval, StatusRunning, true)
+}
+
+// FailOrphanedRuns 实现 Service:启动时把残留非终态运行清为 failed(孤儿,不可恢复)。
+func (s *service) FailOrphanedRuns(ctx context.Context) (int, error) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE pipeline_runs SET status = ?, finished_at = ?
+		 WHERE status IN (?, ?, ?)`,
+		StatusFailed, now, StatusQueued, StatusRunning, StatusWaitingApproval,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("run: fail orphaned runs: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
 func (s *service) transition(ctx context.Context, id, from, to string, requireFrom bool) error {
 	if !canTransition(from, to) {
 		return ErrInvalidTransition

--- a/internal/store/migrations/0025_run_approvals.sql
+++ b/internal/store/migrations/0025_run_approvals.sql
@@ -1,0 +1,26 @@
+-- 0025 run_approvals:人工审批门记录(Epic 8 · Story 8-4)。
+-- 每个「运行×审批门阶段」一行;记录待批/已批准/已拒绝 + 审批人 + 决定时刻,供 UI 展示 + 审计 + 重启清理。
+-- 不存敏感信息;删运行级联删审批记录。
+--   id          : uuid v4
+--   run_id      : FK → pipeline_runs.id;ON DELETE CASCADE
+--   stage_id    : 审批门阶段 id(spec 内)
+--   stage_name  : 阶段展示名(冗余,便于列表展示)
+--   status      : pending | approved | rejected
+--   decided_by  : 审批人(approved/rejected 时);timeout/canceled 亦记于此
+--   decided_at  : 决定时刻(RFC3339;pending 时空)
+--   created_at  : 待批创建时刻
+
+CREATE TABLE IF NOT EXISTS run_approvals (
+    id         TEXT PRIMARY KEY,
+    run_id     TEXT NOT NULL,
+    stage_id   TEXT NOT NULL,
+    stage_name TEXT NOT NULL DEFAULT '',
+    status     TEXT NOT NULL DEFAULT 'pending',
+    decided_by TEXT NOT NULL DEFAULT '',
+    decided_at TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    UNIQUE (run_id, stage_id),
+    FOREIGN KEY (run_id) REFERENCES pipeline_runs (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_run_approvals_run ON run_approvals (run_id);

--- a/web/src/api/pipeline.ts
+++ b/web/src/api/pipeline.ts
@@ -44,6 +44,8 @@ export interface PipelineStage {
   allowFailure?: boolean
   /** Conditional execution; unmet → stage (and downstream) skipped. */
   when?: StageWhen
+  /** Require manual approval before entering this stage (Epic 8 · 8-4). */
+  gate?: boolean
   jobs: PipelineJob[]
 }
 
@@ -66,6 +68,7 @@ export interface SavePipelineInput {
     needs?: string[]
     allowFailure?: boolean
     when?: StageWhen
+    gate?: boolean
     jobs: Array<{
       id?: string
       name: string

--- a/web/src/api/runs.ts
+++ b/web/src/api/runs.ts
@@ -13,6 +13,7 @@ import { http } from './http'
 export type RunStatus =
   | 'queued'
   | 'running'
+  | 'waiting_approval'
   | 'success'
   | 'failed'
   | 'partial_failed'
@@ -20,7 +21,26 @@ export type RunStatus =
 
 // ─── Step ────────────────────────────────────────────────────────────────────
 
-export type StepStatus = 'pending' | 'running' | 'success' | 'failed' | 'skipped'
+export type StepStatus =
+  | 'pending'
+  | 'running'
+  | 'waiting_approval'
+  | 'success'
+  | 'failed'
+  | 'skipped'
+
+// ─── Approval gate (Epic 8 · 8-4) ──────────────────────────────────────────────
+
+export type ApprovalStatus = 'pending' | 'approved' | 'rejected'
+
+export interface ApprovalRecord {
+  stageId: string
+  stageName: string
+  status: ApprovalStatus
+  decidedBy: string
+  decidedAt: string
+  createdAt: string
+}
 
 export interface RunStep {
   id: string
@@ -177,6 +197,20 @@ export function getRun(id: string): Promise<RunDetail> {
 
 export function cancelRun(id: string): Promise<RunDetail> {
   return http.post<RunDetail>(`/api/runs/${id}/cancel`)
+}
+
+// ─── Approval gate (Epic 8 · 8-4) ──────────────────────────────────────────────
+
+export function listApprovals(runId: string): Promise<{ items: ApprovalRecord[] }> {
+  return http.get<{ items: ApprovalRecord[] }>(`/api/runs/${runId}/approvals`)
+}
+
+export function approveStage(runId: string, stageId: string): Promise<{ ok: boolean }> {
+  return http.post<{ ok: boolean }>(`/api/runs/${runId}/approve`, { stageId })
+}
+
+export function rejectStage(runId: string, stageId: string): Promise<{ ok: boolean }> {
+  return http.post<{ ok: boolean }>(`/api/runs/${runId}/reject`, { stageId })
 }
 
 // ─── (Re-)diagnose a failed run ───────────────────────────────────────────────

--- a/web/src/views/RunDetail.vue
+++ b/web/src/views/RunDetail.vue
@@ -22,12 +22,16 @@ import {
   diagnoseRun,
   deployRun,
   retryFailedDeploy,
+  listApprovals,
+  approveStage,
+  rejectStage,
   type RunDetail,
   type RunStatus,
   type StepStatus,
   type DiagnosisDTO,
   type HealthCheckType,
   type HealthCheckInput,
+  type ApprovalRecord,
 } from '../api/runs'
 import { listServers, type Server } from '../api/servers'
 import { HttpError } from '../api/http'
@@ -71,6 +75,44 @@ async function handleCancel(): Promise<void> {
     }
   } finally {
     cancelling.value = false
+  }
+}
+
+// ─── approval gate (Story 8-4) ──────────────────────────────────────────────────
+// 运行阻塞在审批门(status=waiting_approval)时,展示待批阶段 + 批准/拒绝按钮。
+
+const pendingApproval = ref<ApprovalRecord | null>(null)
+const approving = ref(false)
+const approvalError = ref('')
+
+async function loadApprovals(): Promise<void> {
+  try {
+    const { items } = await listApprovals(runId.value)
+    pendingApproval.value = items.find((a) => a.status === 'pending') ?? null
+  } catch {
+    pendingApproval.value = null
+  }
+}
+
+async function decideApproval(approve: boolean): Promise<void> {
+  const stage = pendingApproval.value
+  if (!stage || approving.value) return
+  approving.value = true
+  approvalError.value = ''
+  try {
+    if (approve) await approveStage(runId.value, stage.stageId)
+    else await rejectStage(runId.value, stage.stageId)
+    pendingApproval.value = null
+    // status flips via SSE (waiting_approval → running → terminal); refresh run + approvals.
+    run.value = await getRun(runId.value)
+    await loadApprovals()
+  } catch (err) {
+    approvalError.value =
+      err instanceof HttpError
+        ? (err.apiError?.message ?? `操作失败(${err.status})`)
+        : '审批请求失败,请稍后重试'
+  } finally {
+    approving.value = false
   }
 }
 
@@ -261,6 +303,7 @@ async function loadRun(): Promise<void> {
   try {
     run.value = await getRun(runId.value)
     loadState.value = 'idle'
+    if (run.value.status === 'waiting_approval') void loadApprovals()
   } catch (err) {
     if (err instanceof HttpError) {
       loadError.value = err.status === 404
@@ -285,6 +328,9 @@ function startSse(): void {
     onStatus({ status }) {
       if (!run.value) return
       run.value = { ...run.value, status }
+      // Approval gate (8-4): load pending stage when blocked; clear once resumed.
+      if (status === 'waiting_approval') void loadApprovals()
+      else pendingApproval.value = null
       // Stop SSE on terminal state
       if (isTerminal(status)) stopSse()
     },
@@ -313,7 +359,7 @@ watch(
   () => run.value?.status,
   (status) => {
     if (!status) return
-    if ((status === 'running' || status === 'queued') && !cleanupSse) {
+    if ((status === 'running' || status === 'queued' || status === 'waiting_approval') && !cleanupSse) {
       startSse()
     } else if (isTerminal(status)) {
       stopSse()
@@ -323,7 +369,8 @@ watch(
 
 onMounted(async () => {
   await loadRun()
-  if (run.value && (run.value.status === 'running' || run.value.status === 'queued')) {
+  const s = run.value?.status
+  if (s === 'running' || s === 'queued' || s === 'waiting_approval') {
     startSse()
   }
 })
@@ -344,6 +391,7 @@ interface StatusConfig {
 const STATUS_CONFIG: Record<RunStatus, StatusConfig> = {
   queued:        { label: '排队中',   dot: 'var(--color-faint)',  bg: 'var(--color-card-2)',     border: 'var(--color-border-strong)', text: 'var(--color-dim)',   pulse: false },
   running:       { label: '进行中',   dot: 'var(--color-amber)',  bg: 'var(--color-amber-soft)', border: 'transparent',               text: 'var(--color-amber)', pulse: true  },
+  waiting_approval:{ label: '等待审批', dot: 'var(--color-amber)', bg: 'var(--color-amber-soft)', border: 'var(--color-amber-line)',   text: 'var(--color-amber)', pulse: true  },
   success:       { label: '成功',     dot: 'var(--color-green)',  bg: 'var(--color-green-soft)', border: 'transparent',               text: 'var(--color-green)', pulse: false },
   failed:        { label: '失败',     dot: 'var(--color-red)',    bg: 'var(--color-red-soft)',   border: 'var(--color-red-line)',     text: 'var(--color-red)',   pulse: false },
   partial_failed:{ label: '部分失败', dot: 'var(--color-red)',    bg: 'var(--color-red-soft)',   border: 'var(--color-red-line)',     text: 'var(--color-red)',   pulse: false },
@@ -505,6 +553,33 @@ function nodeClass(status: StepStatus): string {
             <circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h.01"/>
           </svg>
           {{ cancelError }}
+        </div>
+
+        <!-- ── Approval gate (Story 8-4): waiting for manual approval ── -->
+        <div
+          v-if="run.status === 'waiting_approval' && pendingApproval"
+          class="approval-gate"
+          role="region"
+          aria-label="等待人工审批"
+        >
+          <div class="approval-gate-icon" aria-hidden="true">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+            </svg>
+          </div>
+          <div class="approval-gate-body">
+            <div class="approval-gate-title">阶段「{{ pendingApproval.stageName }}」等待人工审批</div>
+            <div class="approval-gate-sub">批准后继续执行,拒绝则该阶段失败、运行终止。</div>
+            <div v-if="approvalError" class="approval-gate-error" role="alert">{{ approvalError }}</div>
+          </div>
+          <div class="approval-gate-actions">
+            <button class="approval-btn approval-btn--reject" :disabled="approving" @click="decideApproval(false)">
+              拒绝
+            </button>
+            <button class="approval-btn approval-btn--approve" :disabled="approving" @click="decideApproval(true)">
+              {{ approving ? '处理中…' : '批准' }}
+            </button>
+          </div>
         </div>
 
         <!-- ── Meta strip: trigger / branch / commit / duration ──────── -->
@@ -1128,6 +1203,53 @@ function nodeClass(status: StepStatus): string {
 </template>
 
 <style scoped>
+/* ─── approval gate (Story 8-4) ──────────────────────────────────────────── */
+.approval-gate {
+  display: flex;
+  align-items: flex-start;
+  gap: 13px;
+  margin: 14px 0;
+  padding: 14px 16px;
+  background: var(--color-amber-soft);
+  border: 1px solid var(--color-amber);
+  border-radius: var(--rounded);
+}
+.approval-gate-icon {
+  flex-shrink: 0;
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--rounded-md);
+  background: var(--color-amber);
+  color: #fff;
+}
+.approval-gate-body { flex: 1; min-width: 0; }
+.approval-gate-title { font-size: 0.92rem; font-weight: 650; color: var(--color-text); }
+.approval-gate-sub { margin-top: 2px; font-size: 0.8rem; color: var(--color-dim); }
+.approval-gate-error { margin-top: 6px; font-size: 0.78rem; color: var(--color-red); }
+.approval-gate-actions { display: flex; gap: 8px; align-items: center; flex-shrink: 0; }
+.approval-btn {
+  height: 34px;
+  padding: 0 16px;
+  border-radius: var(--rounded-md);
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: filter var(--duration-fast), background-color var(--duration-fast);
+}
+.approval-btn:disabled { opacity: 0.6; cursor: default; }
+.approval-btn--approve { background: var(--color-green); color: #fff; }
+.approval-btn--approve:not(:disabled):hover { filter: brightness(1.06); }
+.approval-btn--reject {
+  background: transparent;
+  border-color: var(--color-border-strong);
+  color: var(--color-dim);
+}
+.approval-btn--reject:not(:disabled):hover { border-color: var(--color-red); color: var(--color-red); }
+
 /* ─── root ───────────────────────────────────────────────────────────────── */
 .run-detail-root {
   display: flex;

--- a/web/src/views/Runs.vue
+++ b/web/src/views/Runs.vue
@@ -208,6 +208,7 @@ interface StatusConfig {
 const STATUS_CONFIG: Record<RunStatus, StatusConfig> = {
   queued:        { label: '排队中',   dot: 'var(--color-faint)',  bg: 'var(--color-card-2)',     border: 'var(--color-border-strong)', text: 'var(--color-dim)',   pulse: false },
   running:       { label: '进行中',   dot: 'var(--color-amber)',  bg: 'var(--color-amber-soft)', border: 'transparent',               text: 'var(--color-amber)', pulse: true  },
+  waiting_approval:{ label: '等待审批', dot: 'var(--color-amber)', bg: 'var(--color-amber-soft)', border: 'var(--color-amber-line)',   text: 'var(--color-amber)', pulse: true  },
   success:       { label: '成功',     dot: 'var(--color-green)',  bg: 'var(--color-green-soft)', border: 'transparent',               text: 'var(--color-green)', pulse: false },
   failed:        { label: '失败',     dot: 'var(--color-red)',    bg: 'var(--color-red-soft)',   border: 'var(--color-red-line)',     text: 'var(--color-red)',   pulse: false },
   partial_failed:{ label: '部分失败', dot: 'var(--color-red)',    bg: 'var(--color-red-soft)',   border: 'var(--color-red-line)',     text: 'var(--color-red)',   pulse: false },


### PR DESCRIPTION
(原 #18,重建于 master)阶段 gate=true 阻塞 waiting_approval,批准/拒绝端点+审计+运行详情按钮。迁移 0025。真二进制+截图全流程验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)