### PR TITLE
feat(web): 流水线编辑器 UI 补齐 — when/gate/参数化/cron

### DIFF
--- a/web/src/api/cron.ts
+++ b/web/src/api/cron.ts
@@ -1,0 +1,38 @@
+/**
+ * Cron (scheduled trigger) API — Epic 8 · Story 8-6.
+ *
+ * GET  /api/projects/{id}/cron  → CronConfig
+ * PUT  /api/projects/{id}/cron  → CronConfig  (needs CSRF)
+ *
+ * `expression` is a 5-field Vixie cron string (分 时 日 月 周). `nextRun` is
+ * server-computed (RFC3339) from the current expression when enabled; empty when
+ * disabled / invalid / no upcoming fire. Validation lives in the backend
+ * cron.Service — a bad expression returns 422 invalid_cron.
+ */
+
+import { http } from './http'
+
+export interface CronConfig {
+  /** 5-field cron expression (分 时 日 月 周); empty = unset. */
+  expression: string
+  /** Branch to build on each fire; empty = project default branch. */
+  branch: string
+  /** Whether the schedule is active. */
+  enabled: boolean
+  /** Next fire time (RFC3339); empty when disabled / invalid / none. Read-only. */
+  nextRun: string
+}
+
+export interface SaveCronInput {
+  expression: string
+  branch: string
+  enabled: boolean
+}
+
+export async function getCron(projectId: string): Promise<CronConfig> {
+  return http.get<CronConfig>(`/api/projects/${projectId}/cron`)
+}
+
+export async function saveCron(projectId: string, input: SaveCronInput): Promise<CronConfig> {
+  return http.put<CronConfig>(`/api/projects/${projectId}/cron`, input)
+}

--- a/web/src/api/runs.ts
+++ b/web/src/api/runs.ts
@@ -291,6 +291,8 @@ export function submitDiagnosisFeedback(
 export interface TriggerManualInput {
   branch?: string
   commit?: string
+  /** Parameterized run (Story 8-11): key=value injected as container env (PW_<KEY>). */
+  params?: Record<string, string>
 }
 
 export function triggerManual(projectId: string, input: TriggerManualInput): Promise<RunDetail> {

--- a/web/src/components/CronPanel.vue
+++ b/web/src/components/CronPanel.vue
@@ -1,0 +1,329 @@
+<script setup lang="ts">
+/**
+ * CronPanel — scheduled (cron) trigger config for a project (Epic 8 · Story 8-6).
+ *
+ * Self-contained card with its own load/save against /api/projects/{id}/cron
+ * (separate endpoint from the webhook trigger config). 5-field Vixie cron string;
+ * quick-pick presets fill common schedules. nextRun is server-computed and shown
+ * read-only after a successful save / load.
+ *
+ * Embedded inside TriggersPanel so it appears in both the standalone triggers page
+ * and the pipeline "触发设置" tab.
+ */
+import { ref, computed, onMounted, watch } from 'vue'
+import { getCron, saveCron, type CronConfig } from '../api/cron'
+import { HttpError } from '../api/http'
+
+const props = defineProps<{
+  projectId: string
+}>()
+
+type LoadState = 'idle' | 'loading' | 'error'
+
+const loadState = ref<LoadState>('idle')
+const loadError = ref('')
+
+const enabled = ref(false)
+const expression = ref('')
+const branch = ref('')
+const nextRun = ref('')
+
+const saveSubmitting = ref(false)
+const saveBanner = ref('')
+const saveSuccess = ref(false)
+
+// ─── Quick-pick presets (5-field 分 时 日 月 周) ───────────────────────────────
+const presets: ReadonlyArray<{ label: string; expr: string }> = [
+  { label: '每 5 分钟', expr: '*/5 * * * *' },
+  { label: '每小时', expr: '0 * * * *' },
+  { label: '每天 02:00', expr: '0 2 * * *' },
+  { label: '每周一 09:00', expr: '0 9 * * 1' },
+  { label: '每月 1 号 00:00', expr: '0 0 1 * *' },
+]
+
+/** Format an RFC3339 nextRun into a local, readable string (empty stays empty). */
+const nextRunLabel = computed<string>(() => {
+  if (!nextRun.value) return ''
+  const d = new Date(nextRun.value)
+  if (Number.isNaN(d.getTime())) return nextRun.value
+  return d.toLocaleString()
+})
+
+function applyConfig(c: CronConfig): void {
+  enabled.value = c.enabled
+  expression.value = c.expression
+  branch.value = c.branch
+  nextRun.value = c.nextRun
+}
+
+async function load(): Promise<void> {
+  loadState.value = 'loading'
+  loadError.value = ''
+  try {
+    applyConfig(await getCron(props.projectId))
+    loadState.value = 'idle'
+  } catch (err) {
+    loadState.value = 'error'
+    loadError.value = err instanceof HttpError ? err.message : '加载定时配置失败'
+  }
+}
+
+function pickPreset(expr: string): void {
+  expression.value = expr
+  if (!enabled.value) enabled.value = true
+  saveSuccess.value = false
+  saveBanner.value = ''
+}
+
+async function handleSave(): Promise<void> {
+  saveBanner.value = ''
+  saveSuccess.value = false
+  // Client guard mirrors backend: enabling requires a non-empty expression.
+  if (enabled.value && !expression.value.trim()) {
+    saveBanner.value = '启用定时触发须填写 cron 表达式'
+    return
+  }
+  saveSubmitting.value = true
+  try {
+    applyConfig(
+      await saveCron(props.projectId, {
+        expression: expression.value.trim(),
+        branch: branch.value.trim(),
+        enabled: enabled.value,
+      }),
+    )
+    saveSuccess.value = true
+    saveBanner.value = '定时配置已保存'
+  } catch (err) {
+    saveSuccess.value = false
+    if (err instanceof HttpError) {
+      saveBanner.value =
+        err.apiError?.code === 'invalid_cron'
+          ? 'cron 表达式非法(须为 5 字段:分 时 日 月 周)'
+          : err.message
+    } else {
+      saveBanner.value = '保存失败,请重试'
+    }
+  } finally {
+    saveSubmitting.value = false
+  }
+}
+
+onMounted(load)
+watch(() => props.projectId, load)
+</script>
+
+<template>
+  <section class="config-card" aria-labelledby="cron-heading">
+    <div class="card-head">
+      <span class="card-icon" aria-hidden="true">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9">
+          <circle cx="12" cy="12" r="9" /><polyline points="12 7 12 12 15.5 14" />
+        </svg>
+      </span>
+      <h2 id="cron-heading" class="card-title">定时触发</h2>
+      <span class="card-sub">按 cron 表达式周期性自动触发流水线</span>
+      <label class="cron-switch" :title="enabled ? '已启用' : '已停用'">
+        <input type="checkbox" v-model="enabled" :disabled="loadState !== 'idle'" />
+        <span class="cron-switch-track" aria-hidden="true"><span class="cron-switch-thumb" /></span>
+        <span class="cron-switch-label">{{ enabled ? '启用' : '停用' }}</span>
+      </label>
+    </div>
+
+    <div class="card-body card-body--pad">
+      <p v-if="loadState === 'loading'" class="cron-loading">加载中…</p>
+      <p v-else-if="loadState === 'error'" class="cron-error" role="alert">{{ loadError }}</p>
+
+      <template v-else>
+        <!-- Expression -->
+        <div class="cron-field">
+          <label class="cron-label" for="cron-expr">
+            cron 表达式
+            <span class="cron-hint-inline">分 时 日 月 周</span>
+          </label>
+          <input
+            id="cron-expr"
+            v-model="expression"
+            class="cron-input cron-input--mono"
+            type="text"
+            placeholder="0 2 * * *"
+            autocomplete="off"
+            spellcheck="false"
+            :disabled="!enabled"
+            @input="saveSuccess = false"
+          />
+          <div class="cron-presets">
+            <button
+              v-for="p in presets"
+              :key="p.expr"
+              type="button"
+              class="cron-preset"
+              :class="{ 'cron-preset--active': expression.trim() === p.expr }"
+              :disabled="!enabled"
+              @click="pickPreset(p.expr)"
+            >{{ p.label }}</button>
+          </div>
+        </div>
+
+        <!-- Branch -->
+        <div class="cron-field">
+          <label class="cron-label" for="cron-branch">
+            分支
+            <span class="cron-hint-inline">留空用项目默认分支</span>
+          </label>
+          <input
+            id="cron-branch"
+            v-model="branch"
+            class="cron-input cron-input--mono"
+            type="text"
+            placeholder="main"
+            autocomplete="off"
+            :disabled="!enabled"
+          />
+        </div>
+
+        <!-- Next run preview -->
+        <p class="cron-next" :class="{ 'cron-next--muted': !nextRunLabel }">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <circle cx="12" cy="12" r="9" /><polyline points="12 7 12 12 15.5 14" />
+          </svg>
+          <template v-if="nextRunLabel">下次触发:<strong>{{ nextRunLabel }}</strong></template>
+          <template v-else-if="enabled">保存后显示下次触发时间</template>
+          <template v-else>定时触发已停用</template>
+        </p>
+
+        <!-- Save banner -->
+        <p
+          v-if="saveBanner"
+          class="cron-banner"
+          :class="saveSuccess ? 'cron-banner--ok' : 'cron-banner--err'"
+          role="status"
+        >{{ saveBanner }}</p>
+
+        <div class="cron-save">
+          <button class="btn-primary" :disabled="saveSubmitting" :aria-busy="saveSubmitting" @click="handleSave">
+            <span v-if="saveSubmitting" class="spinner" aria-hidden="true" />
+            {{ saveSubmitting ? '保存中…' : '保存定时配置' }}
+          </button>
+        </div>
+      </template>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.config-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-lg, 12px);
+  background: var(--color-card);
+  overflow: hidden;
+}
+.card-head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--color-border);
+}
+.card-icon {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border-radius: var(--rounded-md);
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  flex: none;
+}
+.card-title { font-size: 0.92rem; font-weight: 650; color: var(--color-text); }
+.card-sub { font-size: 0.76rem; color: var(--color-faint); flex: 1; min-width: 0; }
+
+/* ─── Enable switch ───────────────────────────────────────────────────────── */
+.cron-switch { display: inline-flex; align-items: center; gap: 7px; cursor: pointer; flex: none; }
+.cron-switch input { position: absolute; opacity: 0; width: 0; height: 0; }
+.cron-switch-track {
+  position: relative;
+  width: 34px;
+  height: 19px;
+  border-radius: 10px;
+  background: var(--color-border-strong);
+  transition: background-color var(--duration-fast);
+}
+.cron-switch-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  transition: transform var(--duration-fast);
+}
+.cron-switch input:checked + .cron-switch-track { background: var(--color-primary); }
+.cron-switch input:checked + .cron-switch-track .cron-switch-thumb { transform: translateX(15px); }
+.cron-switch input:focus-visible + .cron-switch-track { outline: 2px solid var(--color-primary); outline-offset: 2px; }
+.cron-switch-label { font-size: 0.78rem; font-weight: 600; color: var(--color-dim); }
+
+.card-body--pad { padding: 16px; display: flex; flex-direction: column; gap: 14px; }
+.cron-loading, .cron-error { margin: 0; font-size: 0.82rem; }
+.cron-error { color: var(--color-danger, #dc2626); }
+.cron-loading { color: var(--color-faint); }
+
+.cron-field { display: flex; flex-direction: column; gap: 7px; }
+.cron-label { font-size: 0.8rem; font-weight: 600; color: var(--color-text); }
+.cron-hint-inline { font-weight: 400; color: var(--color-faint); margin-left: 6px; }
+.cron-input {
+  width: 100%;
+  height: 36px;
+  padding: 0 11px;
+  font: inherit;
+  font-size: 0.85rem;
+  color: var(--color-text);
+  background: var(--color-bg-subtle, var(--color-card));
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded-md);
+  box-sizing: border-box;
+  transition: border-color var(--duration-fast);
+}
+.cron-input:focus { outline: none; border-color: var(--color-primary); }
+.cron-input:disabled { opacity: 0.55; cursor: not-allowed; }
+.cron-input--mono { font-family: var(--font-mono, ui-monospace, monospace); letter-spacing: 0.02em; }
+
+.cron-presets { display: flex; flex-wrap: wrap; gap: 6px; }
+.cron-preset {
+  height: 26px;
+  padding: 0 10px;
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 500;
+  color: var(--color-dim);
+  background: none;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 13px;
+  cursor: pointer;
+  transition: border-color var(--duration-fast), color var(--duration-fast), background-color var(--duration-fast);
+}
+.cron-preset:hover:not(:disabled) { border-color: var(--color-primary); color: var(--color-primary); }
+.cron-preset--active { border-color: var(--color-primary); color: var(--color-primary); background: var(--color-primary-soft); }
+.cron-preset:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.cron-next {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-text);
+}
+.cron-next svg { flex: none; color: var(--color-primary); }
+.cron-next strong { font-weight: 650; }
+.cron-next--muted { color: var(--color-faint); }
+.cron-next--muted svg { color: var(--color-faint); }
+
+.cron-banner { margin: 0; font-size: 0.8rem; font-weight: 500; }
+.cron-banner--ok { color: var(--color-success, #16a34a); }
+.cron-banner--err { color: var(--color-danger, #dc2626); }
+
+.cron-save { display: flex; justify-content: flex-end; }
+</style>

--- a/web/src/components/RunParamsEditor.vue
+++ b/web/src/components/RunParamsEditor.vue
@@ -1,0 +1,192 @@
+<script setup lang="ts">
+/**
+ * RunParamsEditor — key=value rows for a parameterized manual run (Story 8-11).
+ *
+ * Self-contained row state; emits the normalized `Record<string,string>` via
+ * v-model on every edit. Blank-key rows are dropped on normalize; later keys win
+ * on collision. Remount (via :key) to reset — the editor seeds its rows from the
+ * initial modelValue once on mount and owns them thereafter.
+ *
+ * Values are plain text injected as container env (PW_<KEY>); secrets should use
+ * a vault reference, never a raw param — surfaced in the hint below.
+ */
+import { ref } from 'vue'
+
+interface Row {
+  /** Stable client key for v-for (params have no natural id). */
+  rid: number
+  key: string
+  value: string
+}
+
+const props = defineProps<{
+  modelValue: Record<string, string>
+  disabled?: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: Record<string, string>): void
+}>()
+
+let ridSeq = 0
+const rows = ref<Row[]>(
+  Object.entries(props.modelValue).map(([key, value]) => ({ rid: ++ridSeq, key, value })),
+)
+
+/** Collapse rows into the wire record: trim keys, drop blanks, last key wins. */
+function normalize(): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const r of rows.value) {
+    const k = r.key.trim()
+    if (k) out[k] = r.value
+  }
+  return out
+}
+
+function commit(): void {
+  emit('update:modelValue', normalize())
+}
+
+function addRow(): void {
+  rows.value.push({ rid: ++ridSeq, key: '', value: '' })
+}
+
+function removeRow(rid: number): void {
+  rows.value = rows.value.filter((r) => r.rid !== rid)
+  commit()
+}
+</script>
+
+<template>
+  <div class="params-editor">
+    <div v-if="rows.length" class="params-rows">
+      <div v-for="row in rows" :key="row.rid" class="params-row">
+        <input
+          v-model="row.key"
+          class="params-input params-input--key"
+          type="text"
+          placeholder="KEY"
+          autocomplete="off"
+          spellcheck="false"
+          aria-label="参数名"
+          :disabled="disabled"
+          @input="commit"
+        />
+        <span class="params-eq" aria-hidden="true">=</span>
+        <input
+          v-model="row.value"
+          class="params-input params-input--val"
+          type="text"
+          placeholder="value"
+          autocomplete="off"
+          aria-label="参数值"
+          :disabled="disabled"
+          @input="commit"
+        />
+        <button
+          type="button"
+          class="params-del"
+          :aria-label="`删除参数 ${row.key || '(空)'}`"
+          :disabled="disabled"
+          @click="removeRow(row.rid)"
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true">
+            <path d="M18 6L6 18M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <p v-else class="params-empty">无参数</p>
+
+    <button type="button" class="params-add" :disabled="disabled" @click="addRow">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
+        <path d="M12 5v14M5 12h14" />
+      </svg>
+      添加参数
+    </button>
+    <p class="params-hint">运行时注入容器环境变量 <code>PW_&lt;KEY&gt;</code>;敏感值请走凭据引用,勿明文填此处</p>
+  </div>
+</template>
+
+<style scoped>
+.params-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.params-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.params-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.params-input {
+  height: 30px;
+  padding: 0 9px;
+  font: inherit;
+  font-size: 0.8rem;
+  color: var(--color-text);
+  background: var(--color-bg-subtle, var(--color-card));
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded-md);
+  box-sizing: border-box;
+  transition: border-color var(--duration-fast);
+}
+.params-input:focus { outline: none; border-color: var(--color-primary); }
+.params-input--key {
+  flex: 0 0 38%;
+  min-width: 0;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-weight: 600;
+  text-transform: none;
+}
+.params-input--val { flex: 1; min-width: 0; }
+.params-eq { color: var(--color-faint); font-weight: 700; }
+.params-del {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--rounded-md);
+  color: var(--color-faint);
+  cursor: pointer;
+  transition: color var(--duration-fast), background-color var(--duration-fast);
+}
+.params-del:hover:not(:disabled) { color: var(--color-danger, #dc2626); background: var(--color-danger-soft, rgba(220, 38, 38, 0.1)); }
+.params-del:disabled { opacity: 0.4; cursor: default; }
+.params-empty { margin: 0; font-size: 0.78rem; color: var(--color-faint); font-style: italic; }
+.params-add {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  align-self: flex-start;
+  height: 28px;
+  padding: 0 11px;
+  background: none;
+  border: 1px dashed var(--color-border-strong);
+  border-radius: var(--rounded-md);
+  color: var(--color-dim);
+  font: inherit;
+  font-size: 0.76rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color var(--duration-fast), color var(--duration-fast);
+}
+.params-add:hover:not(:disabled) { border-color: var(--color-primary); color: var(--color-primary); }
+.params-add:disabled { opacity: 0.5; cursor: default; }
+.params-hint { margin: 0; font-size: 0.7rem; color: var(--color-faint); line-height: 1.45; }
+.params-hint code {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.92em;
+  padding: 0 3px;
+  border-radius: 3px;
+  background: var(--color-bg-subtle, rgba(0, 0, 0, 0.05));
+}
+</style>

--- a/web/src/components/TriggersPanel.vue
+++ b/web/src/components/TriggersPanel.vue
@@ -18,6 +18,7 @@ import {
   type UnmatchedPolicy,
 } from '../api/triggers'
 import { HttpError } from '../api/http'
+import CronPanel from './CronPanel.vue'
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -506,6 +507,9 @@ const displayWebhookUrl = computed(() => {
           </p>
         </div>
       </section>
+
+      <!-- ═══ Scheduled (cron) trigger · Story 8-6 ════════════════════════ -->
+      <CronPanel :project-id="props.projectId" />
 
       <!-- ═══ Save bar ════════════════════════════════════════════════════ -->
       <div class="save-bar">

--- a/web/src/components/pipeline/PipelineCanvas.vue
+++ b/web/src/components/pipeline/PipelineCanvas.vue
@@ -281,6 +281,8 @@ function handleDrawerUpdate(patch: Partial<PipelineJob>): void {
             @reorder-job="(p) => reorderJob(stage.id, p.from, p.to)"
             @update-needs="(needs) => updateStage(stage.id, { needs })"
             @update-allow-failure="(v) => updateStage(stage.id, { allowFailure: v })"
+            @update-when="(when) => updateStage(stage.id, { when })"
+            @update-gate="(v) => updateStage(stage.id, { gate: v })"
           />
         </template>
 

--- a/web/src/components/pipeline/StageColumn.vue
+++ b/web/src/components/pipeline/StageColumn.vue
@@ -1,8 +1,19 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import type { PipelineStage } from '../../api/pipeline'
+import type { PipelineStage, StageWhen } from '../../api/pipeline'
 import JobCard from './JobCard.vue'
 import { eligibleNeeds, toggleNeed } from './stageDeps'
+import {
+  WHEN_EVENTS,
+  WHEN_EVENT_LABELS,
+  parseBranches,
+  branchesToText,
+  toggleWhenEvent,
+  normalizeWhen,
+  hasWhen,
+  whenSummary,
+  type WhenEvent,
+} from './stageSettings'
 
 const props = defineProps<{
   stage: PipelineStage
@@ -20,6 +31,8 @@ const emit = defineEmits<{
   (e: 'reorder-job', payload: { from: number; to: number }): void
   (e: 'update-needs', needs: string[]): void
   (e: 'update-allow-failure', value: boolean): void
+  (e: 'update-when', when: StageWhen | undefined): void
+  (e: 'update-gate', value: boolean): void
 }>()
 
 function stageLabel(index: number): string {
@@ -45,6 +58,31 @@ const needLabels = computed(() =>
 
 function toggleDep(needId: string): void {
   emit('update-needs', toggleNeed(currentNeeds.value, needId))
+}
+
+// ─── Stage settings (when 条件 · 8-5 / gate 审批门 · 8-4) ──────────────────────
+
+const settingsOpen = ref(false)
+
+/** Editable branch-glob text (parsed → array only on commit). */
+const branchText = computed<string>(() => branchesToText(props.stage.when?.branches))
+
+const currentEvents = computed<string[]>(() => props.stage.when?.events ?? [])
+
+/** Active when settings or gate → highlight the settings button. */
+const hasStageRules = computed(() => hasWhen(props.stage.when) || props.stage.gate === true)
+
+const whenChip = computed(() => whenSummary(props.stage.when))
+
+/** Commit a new branch-glob set, preserving the current events. */
+function commitBranches(text: string): void {
+  emit('update-when', normalizeWhen(parseBranches(text), currentEvents.value))
+}
+
+/** Toggle a trigger event, preserving the current branch globs. */
+function toggleEvent(ev: WhenEvent): void {
+  const events = toggleWhenEvent(currentEvents.value, ev)
+  emit('update-when', normalizeWhen(props.stage.when?.branches ?? [], events))
 }
 
 // ─── Drag-to-reorder (within this stage) ──────────────────────────────────────
@@ -95,6 +133,21 @@ function resetDrag(): void {
       </button>
       <button
         v-if="stage.kind !== 'source'"
+        class="stage-deps-btn"
+        :class="{ 'stage-deps-btn--active': settingsOpen || hasStageRules }"
+        :aria-label="`编辑阶段 ${stage.name} 的条件与审批门`"
+        :aria-expanded="settingsOpen"
+        title="条件执行 / 审批门"
+        @click="settingsOpen = !settingsOpen"
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <circle cx="12" cy="12" r="3"/>
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
+        </svg>
+        条件<span v-if="hasStageRules" class="stage-deps-count stage-deps-count--dot" aria-hidden="true"></span>
+      </button>
+      <button
+        v-if="stage.kind !== 'source'"
         class="stage-add-job"
         :aria-label="`在阶段 ${stage.name} 中添加任务`"
         @click="emit('add-job')"
@@ -119,6 +172,18 @@ function resetDrag(): void {
       <span v-for="label in needLabels" :key="label" class="stage-need-chip">{{ label }}</span>
     </div>
 
+    <!-- Condition / gate chips (when · 8-5 / gate · 8-4) -->
+    <div v-if="hasStageRules" class="stage-rule-chips" aria-label="阶段条件与审批门">
+      <span v-if="whenChip" class="stage-rule-chip stage-rule-chip--when" title="仅满足条件时执行">
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>
+        {{ whenChip }}
+      </span>
+      <span v-if="stage.gate" class="stage-rule-chip stage-rule-chip--gate" title="进入前需人工审批">
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+        审批门
+      </span>
+    </div>
+
     <!-- Dependency editor popover -->
     <div v-if="depsOpen && stage.kind !== 'source'" class="deps-popover" role="group" aria-label="阶段依赖编辑">
       <div class="deps-popover-title">依赖的上游阶段</div>
@@ -141,6 +206,44 @@ function resetDrag(): void {
         <span>失败不阻断下游(allowFailure)</span>
       </label>
       <p class="deps-hint">留空 = 无显式依赖;全流水线无依赖时按从左到右线性执行</p>
+    </div>
+
+    <!-- Stage settings popover (when 条件 + gate 审批门) -->
+    <div v-if="settingsOpen && stage.kind !== 'source'" class="deps-popover settings-popover" role="group" aria-label="阶段条件与审批门编辑">
+      <div class="deps-popover-title">条件执行(when)</div>
+      <label class="settings-field-label" :for="`branches-${stage.id}`">分支(glob,空格/逗号分隔)</label>
+      <input
+        :id="`branches-${stage.id}`"
+        class="settings-input"
+        type="text"
+        :value="branchText"
+        placeholder="如 main release/*"
+        @change="commitBranches(($event.target as HTMLInputElement).value)"
+      />
+      <div class="settings-events-label">触发事件</div>
+      <div class="settings-events">
+        <label v-for="ev in WHEN_EVENTS" :key="ev" class="settings-event">
+          <input
+            type="checkbox"
+            :checked="currentEvents.includes(ev)"
+            @change="toggleEvent(ev)"
+          />
+          <span>{{ WHEN_EVENT_LABELS[ev] }}</span>
+        </label>
+      </div>
+      <p class="deps-hint">两者都留空 = 始终执行;不满足时本阶段及下游跳过(不计失败)</p>
+
+      <div class="deps-divider"></div>
+      <div class="deps-popover-title">审批门(gate)</div>
+      <label class="deps-option deps-option--toggle">
+        <input
+          type="checkbox"
+          :checked="stage.gate === true"
+          @change="emit('update-gate', ($event.target as HTMLInputElement).checked)"
+        />
+        <span>进入本阶段前需人工审批</span>
+      </label>
+      <p class="deps-hint">开启后运行将暂停在此,等待批准/拒绝</p>
     </div>
 
     <!-- Job cards -->
@@ -267,4 +370,71 @@ function resetDrag(): void {
 .deps-option--toggle { color: var(--color-dim); }
 .deps-divider { height: 1px; background: var(--color-border); margin: 8px 0; }
 .deps-hint { margin: 7px 0 0; font-size: 0.68rem; color: var(--color-faint); line-height: 1.4; }
+
+/* ─── Condition / gate chips ──────────────────────────────────────────────── */
+.stage-deps-count--dot {
+  min-width: 7px;
+  width: 7px;
+  height: 7px;
+  padding: 0;
+  border-radius: 50%;
+}
+.stage-rule-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: -4px 0 8px;
+}
+.stage-rule-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.66rem;
+  font-weight: 600;
+  padding: 1px 7px 1px 6px;
+  border-radius: 8px;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.stage-rule-chip svg { flex: none; }
+.stage-rule-chip--when { background: var(--color-primary-soft); color: var(--color-primary); }
+.stage-rule-chip--gate { background: var(--color-amber-soft, rgba(217, 119, 6, 0.14)); color: var(--color-amber, #b45309); }
+
+/* ─── Settings popover fields ─────────────────────────────────────────────── */
+.settings-popover { width: 232px; }
+.settings-field-label,
+.settings-events-label {
+  display: block;
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: var(--color-dim);
+  margin: 2px 0 5px;
+}
+.settings-events-label { margin-top: 10px; }
+.settings-input {
+  width: 100%;
+  height: 28px;
+  padding: 0 8px;
+  font: inherit;
+  font-size: 0.76rem;
+  color: var(--color-text);
+  background: var(--color-bg-subtle, var(--color-card));
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded-md);
+  box-sizing: border-box;
+  transition: border-color var(--duration-fast);
+}
+.settings-input:focus { outline: none; border-color: var(--color-primary); }
+.settings-events { display: flex; flex-wrap: wrap; gap: 6px 12px; }
+.settings-event {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.76rem;
+  color: var(--color-text);
+  cursor: pointer;
+}
+.settings-event input { width: 14px; height: 14px; accent-color: var(--color-primary); cursor: pointer; }
 </style>

--- a/web/src/components/pipeline/stageSettings.test.ts
+++ b/web/src/components/pipeline/stageSettings.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseBranches,
+  branchesToText,
+  toggleWhenEvent,
+  normalizeWhen,
+  hasWhen,
+  whenSummary,
+} from './stageSettings'
+
+describe('parseBranches', () => {
+  it('splits on commas / whitespace / newlines and trims', () => {
+    expect(parseBranches('main, develop\nrelease/*  hotfix')).toEqual([
+      'main',
+      'develop',
+      'release/*',
+      'hotfix',
+    ])
+  })
+
+  it('drops empties and duplicates (order-preserving)', () => {
+    expect(parseBranches('main,,main,  , develop ,main')).toEqual(['main', 'develop'])
+  })
+
+  it('returns [] for blank input', () => {
+    expect(parseBranches('   \n  ')).toEqual([])
+  })
+})
+
+describe('branchesToText', () => {
+  it('joins with spaces and tolerates undefined', () => {
+    expect(branchesToText(['main', 'release/*'])).toBe('main release/*')
+    expect(branchesToText(undefined)).toBe('')
+  })
+
+  it('round-trips with parseBranches', () => {
+    const arr = ['main', 'develop', 'release/*']
+    expect(parseBranches(branchesToText(arr))).toEqual(arr)
+  })
+})
+
+describe('toggleWhenEvent', () => {
+  it('adds an event in canonical order', () => {
+    expect(toggleWhenEvent(['schedule'], 'manual')).toEqual(['manual', 'schedule'])
+  })
+
+  it('removes an already-present event', () => {
+    expect(toggleWhenEvent(['manual', 'webhook'], 'manual')).toEqual(['webhook'])
+  })
+
+  it('toggling the last event off yields []', () => {
+    expect(toggleWhenEvent(['webhook'], 'webhook')).toEqual([])
+  })
+
+  it('tolerates undefined input', () => {
+    expect(toggleWhenEvent(undefined, 'manual')).toEqual(['manual'])
+  })
+})
+
+describe('normalizeWhen', () => {
+  it('drops empty keys and returns undefined when no constraint', () => {
+    expect(normalizeWhen([], [])).toBeUndefined()
+  })
+
+  it('keeps only the non-empty constraints', () => {
+    expect(normalizeWhen(['main'], [])).toEqual({ branches: ['main'] })
+    expect(normalizeWhen([], ['manual'])).toEqual({ events: ['manual'] })
+    expect(normalizeWhen(['main'], ['webhook'])).toEqual({
+      branches: ['main'],
+      events: ['webhook'],
+    })
+  })
+})
+
+describe('hasWhen / whenSummary', () => {
+  it('hasWhen reflects whether anything is constrained', () => {
+    expect(hasWhen(undefined)).toBe(false)
+    expect(hasWhen({})).toBe(false)
+    expect(hasWhen({ branches: [] })).toBe(false)
+    expect(hasWhen({ branches: ['main'] })).toBe(true)
+    expect(hasWhen({ events: ['manual'] })).toBe(true)
+  })
+
+  it('whenSummary renders branches and localized events', () => {
+    expect(whenSummary(undefined)).toBe('')
+    expect(whenSummary({ branches: ['main', 'develop'] })).toBe('main, develop')
+    expect(whenSummary({ events: ['manual', 'schedule'] })).toBe('手动/定时')
+    expect(whenSummary({ branches: ['main'], events: ['webhook'] })).toBe('main · Webhook')
+  })
+})

--- a/web/src/components/pipeline/stageSettings.ts
+++ b/web/src/components/pipeline/stageSettings.ts
@@ -1,0 +1,85 @@
+/**
+ * Pure helpers for the stage settings editor (Epic 8 · 8-4 gate / 8-5 when).
+ *
+ * Kept framework-free and side-effect-free so the parsing / toggling logic is
+ * unit-testable in isolation (mirrors stageDeps.ts). The Vue component owns only
+ * the markup and event wiring; all branch-glob / event-set math lives here.
+ */
+
+import type { StageWhen } from '../../api/pipeline'
+
+/** Trigger event types a stage's `when` can gate on (backend枚举 in stage_when.go). */
+export const WHEN_EVENTS = ['manual', 'webhook', 'schedule'] as const
+export type WhenEvent = (typeof WHEN_EVENTS)[number]
+
+/** Human label for each trigger event (UI display only). */
+export const WHEN_EVENT_LABELS: Record<WhenEvent, string> = {
+  manual: '手动',
+  webhook: 'Webhook',
+  schedule: '定时',
+}
+
+/**
+ * Parse a free-text branch field into a clean glob list.
+ * Splits on commas / whitespace / newlines, trims, and drops empties + dups
+ * (order-preserving). Empty input → [] (meaning "any branch").
+ */
+export function parseBranches(text: string): string[] {
+  const out: string[] = []
+  const seen = new Set<string>()
+  for (const raw of text.split(/[\s,]+/)) {
+    const b = raw.trim()
+    if (b && !seen.has(b)) {
+      seen.add(b)
+      out.push(b)
+    }
+  }
+  return out
+}
+
+/** Render a branch glob list back to the editable text field (space-joined). */
+export function branchesToText(branches: string[] | undefined): string {
+  return (branches ?? []).join(' ')
+}
+
+/**
+ * Toggle a single event in the `when.events` set (order follows WHEN_EVENTS).
+ * Returns a new array; toggling the last-on event off yields [] (= "any event").
+ */
+export function toggleWhenEvent(events: string[] | undefined, ev: WhenEvent): string[] {
+  const set = new Set(events ?? [])
+  if (set.has(ev)) {
+    set.delete(ev)
+  } else {
+    set.add(ev)
+  }
+  return WHEN_EVENTS.filter((e) => set.has(e))
+}
+
+/**
+ * Normalize an edited `when` into the wire shape, or `undefined` when empty
+ * (no branch/event constraint = "always run", so we drop the key entirely to
+ * keep the saved spec minimal).
+ */
+export function normalizeWhen(branches: string[], events: string[]): StageWhen | undefined {
+  const w: StageWhen = {}
+  if (branches.length) w.branches = branches
+  if (events.length) w.events = events
+  return w.branches || w.events ? w : undefined
+}
+
+/** Report whether a `when` rule actually constrains anything (for badges/labels). */
+export function hasWhen(when: StageWhen | undefined): boolean {
+  return Boolean((when?.branches?.length ?? 0) || (when?.events?.length ?? 0))
+}
+
+/** Short human summary of a when rule for chip display (empty = ""). */
+export function whenSummary(when: StageWhen | undefined): string {
+  if (!hasWhen(when)) return ''
+  const parts: string[] = []
+  if (when?.branches?.length) parts.push(when.branches.join(', '))
+  if (when?.events?.length) {
+    parts.push(when.events.map((e) => WHEN_EVENT_LABELS[e as WhenEvent] ?? e).join('/'))
+  }
+  return parts.join(' · ')
+}

--- a/web/src/views/Projects.vue
+++ b/web/src/views/Projects.vue
@@ -13,7 +13,8 @@ import {
   type UpdateProjectInput,
 } from '../api/projects'
 import { listCredentials, type Credential } from '../api/credentials'
-import { triggerManual, type RunDetail } from '../api/runs'
+import { triggerManual, type RunDetail, type TriggerManualInput } from '../api/runs'
+import RunParamsEditor from '../components/RunParamsEditor.vue'
 import { HttpError } from '../api/http'
 
 // ─── router ───────────────────────────────────────────────────────────────────
@@ -379,6 +380,7 @@ async function confirmDelete(): Promise<void> {
 const triggerModalOpen   = ref(false)
 const triggerProject     = ref<Project | null>(null)
 const triggerForm        = ref({ branch: '', commit: '' })
+const triggerParams      = ref<Record<string, string>>({})
 const triggerBranchError = ref('')
 const triggerBanner      = ref('')
 const triggerSubmitting  = ref(false)
@@ -386,6 +388,7 @@ const triggerSubmitting  = ref(false)
 function openTriggerModal(p: Project): void {
   triggerProject.value     = p
   triggerForm.value        = { branch: p.defaultBranch || '', commit: '' }
+  triggerParams.value      = {}
   triggerBranchError.value = ''
   triggerBanner.value      = ''
   triggerSubmitting.value  = false
@@ -409,10 +412,11 @@ async function handleTriggerSubmit(): Promise<void> {
   triggerSubmitting.value = true
 
   try {
-    const input: { branch?: string; commit?: string } = {}
+    const input: TriggerManualInput = {}
     if (branch) input.branch = branch
     const commit = triggerForm.value.commit.trim()
     if (commit) input.commit = commit
+    if (Object.keys(triggerParams.value).length) input.params = triggerParams.value
 
     const run: RunDetail = await triggerManual(triggerProject.value.id, input)
     triggerModalOpen.value = false
@@ -866,6 +870,19 @@ const STATUS_CONFIG: Record<RunStatus, StatusConfig> = {
               type="text"
               placeholder="例:a3f1c2d"
               autocomplete="off"
+              :disabled="triggerSubmitting"
+            />
+          </div>
+
+          <!-- Parameters (optional · Story 8-11) -->
+          <div class="field">
+            <label class="field-label">
+              参数
+              <span class="field-hint-inline">（可选,注入流水线为环境变量）</span>
+            </label>
+            <RunParamsEditor
+              :key="triggerProject.id"
+              v-model="triggerParams"
               :disabled="triggerSubmitting"
             />
           </div>

--- a/web/src/views/Runs.vue
+++ b/web/src/views/Runs.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
-import { listRuns, triggerManual, type RunListItem, type RunStatus, type RunDetail, type ListRunsParams } from '../api/runs'
+import { listRuns, triggerManual, type RunListItem, type RunStatus, type RunDetail, type ListRunsParams, type TriggerManualInput } from '../api/runs'
+import RunParamsEditor from '../components/RunParamsEditor.vue'
 import { listProjects, type Project } from '../api/projects'
 import { HttpError } from '../api/http'
 
@@ -72,6 +73,7 @@ const triggerModalOpen    = ref(false)
 const projects            = ref<Project[]>([])
 const projectsLoading     = ref(false)
 const triggerForm         = ref({ projectId: '', branch: '', commit: '' })
+const triggerParams       = ref<Record<string, string>>({})
 const triggerBranchError  = ref('')
 const triggerProjectError = ref('')
 const triggerBanner       = ref('')
@@ -95,6 +97,7 @@ async function loadProjectsForTrigger(): Promise<void> {
 
 function openTriggerModal(): void {
   triggerForm.value        = { projectId: '', branch: '', commit: '' }
+  triggerParams.value       = {}
   triggerBranchError.value  = ''
   triggerProjectError.value = ''
   triggerBanner.value       = ''
@@ -136,9 +139,10 @@ async function handleTriggerSubmit(): Promise<void> {
 
   triggerSubmitting.value = true
   try {
-    const input: { branch: string; commit?: string } = { branch }
+    const input: TriggerManualInput = { branch }
     const commit = triggerForm.value.commit.trim()
     if (commit) input.commit = commit
+    if (Object.keys(triggerParams.value).length) input.params = triggerParams.value
 
     const run: RunDetail = await triggerManual(triggerForm.value.projectId, input)
     triggerModalOpen.value = false
@@ -598,6 +602,15 @@ function isFailedStatus(status: RunStatus): boolean {
               autocomplete="off"
               :disabled="triggerSubmitting"
             />
+          </div>
+
+          <!-- Parameters (optional · Story 8-11) -->
+          <div class="field">
+            <label class="field-label">
+              参数
+              <span class="field-hint-inline">（可选,注入流水线为环境变量）</span>
+            </label>
+            <RunParamsEditor v-model="triggerParams" :disabled="triggerSubmitting" />
           </div>
 
           <!-- Footer -->


### PR DESCRIPTION
## 背景

Epic 8 多项后端能力(8-4 审批门 / 8-5 条件执行 / 8-6 cron 定时 / 8-11 参数化运行)此前已合入 master,但前端缺编辑入口 —— 用户在画布/触发页看不到、也配不了。本 PR 补齐四块编辑 UI,**纯前端,后端契约不变**。

## 改动

### 1. 阶段设置:when 条件 + gate 审批门(8-5 / 8-4)
- `StageColumn.vue` 新增「条件」齿轮按钮 → 弹层,编辑 `when`(分支 glob 文本 + 触发事件 手动/Webhook/定时 多选)与 `gate`(审批门开关)
- 活跃时在阶段下显 `条件` / `审批门` chip
- 经 `PipelineCanvas.updateStage` 透传,随 `savePipeline` 保存
- 纯解析/切换逻辑下沉 `stageSettings.ts`(parseBranches/toggleWhenEvent/normalizeWhen…),**13 个单测**

### 2. 参数化触发:params 输入(8-11)
- 新 `RunParamsEditor.vue`:key=value 行编辑,v-model 出 `Record<string,string>`,提示注入容器环境变量 `PW_<KEY>` + 敏感值走凭据
- 接入 `Projects.vue` 与 `Runs.vue` 两处手动触发弹窗
- `runs.ts` `TriggerManualInput` 加 `params`

### 3. 定时触发:cron 编辑(8-6)
- 新 `cron.ts` API(GET/PUT `/api/projects/{id}/cron`)
- 新 `CronPanel.vue` 卡片:表达式输入 + 5 个快捷预设 chip + 分支 + `nextRun` 预览 + 启用开关 + 独立保存
- 嵌入 `TriggersPanel.vue`,标准触发页与流水线「触发设置」Tab 两处均可见

## 验收

- ✅ `typecheck` 净 · **133** 前端单测全过 · `build` 绿
- ✅ 真二进制(`PIPEWRIGHT_RUNNER=dag` + 保险库)+ playwright 截图:四块 UI 渲染正常
- ✅ API round-trip 全通:
  - cron 保存后算出 `nextRun=2026-06-01T02:00:00Z`
  - `when`/`gate` 持久化并读回一致
  - 参数化运行 `params_json={"DEPLOY_ENV":"staging","RELEASE":"v1.2.3"}` 落库

🤖 Generated with [Claude Code](https://claude.com/claude-code)