### PR TITLE
feat(run): 并发/队列控制 — 全局+项目级上限(FR-8-10)

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -104,6 +105,10 @@ func main() {
 	// 装配定时(cron)触发配置服务(Story 8-6):每项目一份 cron 表达式 + 分支 + 启用开关。
 	// 调度器(下方,pool 后)按启用配置分钟粒度扫描、到点经 run.Service 创建「定时」触发的运行。
 	cronSvc := cron.NewService(st.DB)
+
+	// 装配项目级并发上限配置服务(FR-8-10 并发/队列控制):每项目一份 max_concurrent。
+	// 注入 worker pool 做准入(下方);经 /api/projects/{id}/concurrency 读写。
+	concurrencySvc := run.NewConcurrencyService(st.DB)
 
 	// 装配运行服务(Story 3.1):本期桩 runner 跑占位步骤打通状态机;真实构建/部署=3-3/4-x。
 	// worker pool 在 aiSvc 装配后创建(以便注入 best-effort 自动诊断钩子,Story 7.2)。
@@ -218,6 +223,18 @@ func main() {
 		log.Printf("[prstatus] PR 状态回写已启用(PIPEWRIGHT_PR_STATUS=1;GitHub/Gitee,经项目凭据,best-effort)")
 	}
 
+	// 并发/队列控制(FR-8-10):全局上限经 PIPEWRIGHT_MAX_CONCURRENT 设置(默认 = worker 数);
+	// 项目级上限经 concurrencySvc(/api/projects/{id}/concurrency 配置)。突发超限的运行保持 queued
+	// 排队,待槽位释放再调度(FIFO)。非法/未设 env → 0,pool 回落到默认行为(仅受全局上限)。
+	maxConcurrent := 0
+	if v := strings.TrimSpace(os.Getenv("PIPEWRIGHT_MAX_CONCURRENT")); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil && n > 0 {
+			maxConcurrent = n
+		} else {
+			log.Printf("[run] 警告:PIPEWRIGHT_MAX_CONCURRENT=%q 非法(须为正整数),忽略", v)
+		}
+	}
+
 	pool := run.NewWorkerPool(runSvc,
 		append(runnerOpts,
 			run.WithDiagnoseHook(httpapi.NewDiagnoseHook(runSvc, aiSvc, secretSrc)),
@@ -225,6 +242,9 @@ func main() {
 			run.WithLogMaskerFunc(secretSrc.MaskerForRun),
 			// best-effort 终态钩子(通知 + 可选 PR 状态回写)。未配路由的事件不发送;绝不阻断 run 终态。
 			run.WithNotifyHook(terminalHook),
+			// 并发/队列控制(FR-8-10):全局上限 + 项目级上限准入。
+			run.WithMaxConcurrent(maxConcurrent),
+			run.WithConcurrencyLimits(concurrencySvc),
 		)...,
 	)
 	pool.Start()
@@ -268,7 +288,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithServers(targetSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithApprovals(approvalCoord, approvalStore)),
+		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithServers(targetSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc)),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		// WriteTimeout 置 0:SSE 长连接(/api/runs/{id}/events)不可被写超时切断;

--- a/internal/httpapi/concurrency.go
+++ b/internal/httpapi/concurrency.go
@@ -1,0 +1,76 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// concurrency.go 暴露项目级并发上限配置端点(FR-8-10 并发/队列控制)。
+//
+// GET /api/projects/{id}/concurrency  → { maxConcurrent }
+// PUT /api/projects/{id}/concurrency  → 同上(需 CSRF)。校验在 run.ConcurrencyService。
+//
+// maxConcurrent 是该项目同时 running 的运行数上限;0 = 不限项目级(仅受全局
+// PIPEWRIGHT_MAX_CONCURRENT 约束)。超限的运行保持 queued 排队,待该项目有空槽再调度。
+
+type concurrencyDTO struct {
+	MaxConcurrent int `json:"maxConcurrent"`
+}
+
+func toConcurrencyDTO(c *run.ConcurrencyConfig) concurrencyDTO {
+	return concurrencyDTO{MaxConcurrent: c.MaxConcurrent}
+}
+
+func writeConcurrencyError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, run.ErrConcProjectNotFound):
+		writeError(w, http.StatusNotFound, "project_not_found", "项目不存在")
+	case errors.Is(err, run.ErrInvalidConcurrency):
+		writeError(w, http.StatusUnprocessableEntity, "invalid_concurrency", "并发上限非法(须为 0..64 的整数;0 表示不限项目级)")
+	default:
+		writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+	}
+}
+
+func makeGetConcurrencyHandler(svc run.ConcurrencyService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "并发配置服务未初始化")
+			return
+		}
+		cfg, err := svc.Get(r.Context(), chi.URLParam(r, "id"))
+		if err != nil {
+			writeConcurrencyError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, toConcurrencyDTO(cfg))
+	}
+}
+
+func makeSaveConcurrencyHandler(svc run.ConcurrencyService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "并发配置服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<14)
+		var req struct {
+			MaxConcurrent int `json:"maxConcurrent"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		cfg, err := svc.Save(r.Context(), id, req.MaxConcurrent)
+		if err != nil {
+			writeConcurrencyError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, toConcurrencyDTO(cfg))
+	}
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -52,6 +52,7 @@ type options struct {
 	projects         project.Service
 	triggers         trigger.Service
 	cron             cron.Service
+	concurrency      run.ConcurrencyService
 	pipelines        pipeline.Service
 	pipelineSettings pipeline.SettingsService
 	runs             run.Service
@@ -98,6 +99,12 @@ func WithProjects(s project.Service) Option {
 // WithCron 注入定时触发配置服务,挂载 /api/projects/{id}/cron 路由(Story 8-6)。
 func WithCron(s cron.Service) Option {
 	return func(o *options) { o.cron = s }
+}
+
+// WithConcurrency 注入项目级并发上限配置服务,挂载 /api/projects/{id}/concurrency 路由(FR-8-10)。
+// 不传则该端点返回 503(服务未初始化)。GET 过 auth;PUT 过 auth + CSRF。
+func WithConcurrency(s run.ConcurrencyService) Option {
+	return func(o *options) { o.concurrency = s }
 }
 
 // WithTriggers 注入触发配置服务,挂载 /api/projects/{id}/trigger* 路由。
@@ -304,6 +311,10 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		// 定时(cron)触发配置(Story 8-6)。o.cron 为 nil 时 handler 返回 503。GET 过 auth;PUT 过 auth + CSRF。
 		ar.Get("/projects/{id}/cron", makeGetCronHandler(o.cron))
 		ar.Put("/projects/{id}/cron", makeSaveCronHandler(o.cron))
+
+		// 项目级并发上限(FR-8-10)。o.concurrency 为 nil 时 handler 返回 503。GET 过 auth;PUT 过 auth + CSRF。
+		ar.Get("/projects/{id}/concurrency", makeGetConcurrencyHandler(o.concurrency))
+		ar.Put("/projects/{id}/concurrency", makeSaveConcurrencyHandler(o.concurrency))
 
 		// 流水线编排配置(Story 2.2)。pl 为 nil 时 handler 返回 503。
 		// 与 /projects/{id}/trigger 同在 {id} 路由组内并存(不会被 /projects/{id} 吞)。

--- a/internal/run/concurrency.go
+++ b/internal/run/concurrency.go
@@ -1,0 +1,110 @@
+package run
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// concurrency.go 实现项目级并发上限配置(FR-8-10 并发/队列控制)。
+//
+// 每项目一份 max_concurrent:该项目同时处于 running 的运行数上限。0 = 不限项目级
+// (仅受全局 PIPEWRIGHT_MAX_CONCURRENT 约束)。超限的运行保持 queued 直到该项目有空槽。
+// WorkerPool 在调度前经 ConcurrencyLimits.LimitFor 取项目上限做准入判断(FIFO 队列)。
+
+// maxProjectConcurrency 是项目级上限的 sane 上界(防误填巨值耗尽全局槽 / 资源)。
+const maxProjectConcurrency = 64
+
+// 并发配置领域错误(错误体不含敏感数据)。
+var (
+	// ErrConcProjectNotFound 表示引用的项目不存在。
+	ErrConcProjectNotFound = errors.New("run: concurrency project not found")
+	// ErrInvalidConcurrency 表示并发上限非法(<0 或 > maxProjectConcurrency)。
+	ErrInvalidConcurrency = errors.New("run: invalid concurrency limit")
+)
+
+// ConcurrencyConfig 是项目并发配置领域模型。
+type ConcurrencyConfig struct {
+	// MaxConcurrent 是项目级同时运行上限;0 = 不限项目级(沿用全局上限)。
+	MaxConcurrent int
+	UpdatedAt     time.Time
+}
+
+// ConcurrencyLimits 是 WorkerPool 调度准入所需的只读端(查项目上限)。
+// 经此接口解耦:pool 不直接触库、纯单测可注入内存 fake。
+type ConcurrencyLimits interface {
+	// LimitFor 返回某项目的并发上限(0 = 不限项目级)。查不到/出错时返回 0(优雅降级:
+	// 不让配置读失败阻断调度,退化为仅受全局上限约束)。
+	LimitFor(ctx context.Context, projectID string) int
+}
+
+// ConcurrencyService 定义项目并发配置领域接口(HTTP 读写 + 调度准入只读)。
+type ConcurrencyService interface {
+	ConcurrencyLimits
+	// Get 返回项目并发配置;无配置 → 返回 0(不限项目级)空配置(非错误)。
+	Get(ctx context.Context, projectID string) (*ConcurrencyConfig, error)
+	// Save 校验(0..maxProjectConcurrency)→ 持久化(upsert)→ 回读。
+	// 项目不存在 → ErrConcProjectNotFound;非法值 → ErrInvalidConcurrency。
+	Save(ctx context.Context, projectID string, maxConcurrent int) (*ConcurrencyConfig, error)
+}
+
+type concurrencyService struct {
+	db *sql.DB
+}
+
+// NewConcurrencyService 构造项目并发配置 Service(经参数化 SQL 触库;无 init 副作用、不驻留)。
+func NewConcurrencyService(db *sql.DB) ConcurrencyService { return &concurrencyService{db: db} }
+
+func (s *concurrencyService) Get(ctx context.Context, projectID string) (*ConcurrencyConfig, error) {
+	var (
+		maxc    int
+		updated string
+	)
+	err := s.db.QueryRowContext(ctx,
+		`SELECT max_concurrent, updated_at FROM project_concurrency WHERE project_id = ?`,
+		strings.TrimSpace(projectID),
+	).Scan(&maxc, &updated)
+	if errors.Is(err, sql.ErrNoRows) {
+		return &ConcurrencyConfig{}, nil // 未配置 → 不限项目级
+	}
+	if err != nil {
+		return nil, fmt.Errorf("run: load concurrency config: %w", err)
+	}
+	t, _ := time.Parse(time.RFC3339, updated)
+	return &ConcurrencyConfig{MaxConcurrent: maxc, UpdatedAt: t}, nil
+}
+
+func (s *concurrencyService) Save(ctx context.Context, projectID string, maxConcurrent int) (*ConcurrencyConfig, error) {
+	projectID = strings.TrimSpace(projectID)
+	if maxConcurrent < 0 || maxConcurrent > maxProjectConcurrency {
+		return nil, ErrInvalidConcurrency
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO project_concurrency (project_id, max_concurrent, created_at, updated_at)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(project_id) DO UPDATE SET
+		   max_concurrent = excluded.max_concurrent,
+		   updated_at     = excluded.updated_at`,
+		projectID, maxConcurrent, now, now,
+	)
+	if err != nil {
+		if isForeignKeyErr(err) {
+			return nil, ErrConcProjectNotFound
+		}
+		return nil, fmt.Errorf("run: upsert concurrency config: %w", err)
+	}
+	return s.Get(ctx, projectID)
+}
+
+// LimitFor 实现 ConcurrencyLimits:取项目上限(0 = 不限项目级;读失败优雅降级为 0)。
+func (s *concurrencyService) LimitFor(ctx context.Context, projectID string) int {
+	cfg, err := s.Get(ctx, projectID)
+	if err != nil || cfg == nil {
+		return 0
+	}
+	return cfg.MaxConcurrent
+}

--- a/internal/run/concurrency_test.go
+++ b/internal/run/concurrency_test.go
@@ -1,0 +1,237 @@
+package run
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// gatedRunner 在进入 Run 时经 entered 通知,然后阻塞在 release 上(或 ctx 取消)。
+// 用于精确控制「同时有几个 run 在执行中」,无真实 sleep(不 flake)。
+// 进入时记录峰值并发(经 mu 保护),供断言「上限成立」。
+type gatedRunner struct {
+	entered chan struct{} // 每个 run 进入 Run 时投递一次
+	release chan struct{} // 关闭后放行全部阻塞中的 run
+	mu      sync.Mutex
+	cur     int
+	peak    int
+}
+
+func (g *gatedRunner) Run(ctx context.Context, _ *Run, sink StepSink) error {
+	g.mu.Lock()
+	g.cur++
+	if g.cur > g.peak {
+		g.peak = g.cur
+	}
+	g.mu.Unlock()
+
+	g.entered <- struct{}{}
+	select {
+	case <-g.release:
+	case <-ctx.Done():
+	}
+
+	g.mu.Lock()
+	g.cur--
+	g.mu.Unlock()
+	if err := sink.Plan(ctx, []string{"s"}); err != nil {
+		return err
+	}
+	_ = sink.StepRunning(ctx, 0)
+	_ = sink.StepDone(ctx, 0, StepSuccess)
+	return nil
+}
+
+func (g *gatedRunner) peakConcurrency() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.peak
+}
+
+// drainEntered 在期限内尝试收 want 个「已进入执行」信号,返回实际收到数(超时即返回)。
+func drainEntered(t *testing.T, g *gatedRunner, want int, timeout time.Duration) int {
+	t.Helper()
+	got := 0
+	deadline := time.After(timeout)
+	for got < want {
+		select {
+		case <-g.entered:
+			got++
+		case <-deadline:
+			return got
+		}
+	}
+	return got
+}
+
+// TestGlobalConcurrencyLimitHolds 验证全局上限成立:提交 N>limit 个 run,断言同时执行的
+// run 数绝不超过 globalLimit(其余保持 queued 排队)。用 gatedRunner 卡住执行中 run,
+// 精确观察峰值并发,无真实 sleep(确定性、不 flake)。
+func TestGlobalConcurrencyLimitHolds(t *testing.T) {
+	const limit = 2
+	const total = 6
+
+	db := testDB(t)
+	svc := New(db)
+	g := &gatedRunner{entered: make(chan struct{}, total), release: make(chan struct{})}
+	pool := NewWorkerPool(svc, WithMaxConcurrent(limit), WithRunner(g))
+	pool.Start()
+	t.Cleanup(func() {
+		safeClose(g.release)
+		pool.Stop(context.Background())
+	})
+
+	projID := seedProject(t, db)
+	ids := make([]string, 0, total)
+	for i := 0; i < total; i++ {
+		r, err := svc.Create(context.Background(), projID, Trigger{Type: TriggerManual})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		ids = append(ids, r.ID)
+	}
+
+	// 至多 limit 个会进入执行;断言恰好 limit 个进入、不多一个。
+	if got := drainEntered(t, g, limit, time.Second); got != limit {
+		t.Fatalf("应有 %d 个 run 进入执行, got %d", limit, got)
+	}
+	// 再尝试收第 (limit+1) 个进入信号:应超时(被排队挡住,绝不超限)。
+	if extra := drainEntered(t, g, 1, 150*time.Millisecond); extra != 0 {
+		t.Fatalf("超过全局上限 %d 仍有 run 进入执行(读到额外 %d 个)", limit, extra)
+	}
+	if peak := g.peakConcurrency(); peak > limit {
+		t.Fatalf("峰值并发 %d 超过全局上限 %d", peak, limit)
+	}
+
+	// 放行:全部应陆续完成为 success(排队者递补)。safeClose 幂等(Cleanup 再调跳过)。
+	safeClose(g.release)
+	for _, id := range ids {
+		waitForStatus(t, svc, id, StatusSuccess)
+	}
+	if peak := g.peakConcurrency(); peak > limit {
+		t.Fatalf("全程峰值并发 %d 超过全局上限 %d", peak, limit)
+	}
+}
+
+// fakeLimits 是 ConcurrencyLimits 的内存 fake:按 projectID 返回固定上限。
+type fakeLimits map[string]int
+
+func (f fakeLimits) LimitFor(_ context.Context, projectID string) int { return f[projectID] }
+
+// TestPerProjectConcurrencyLimitHolds 验证项目级上限成立:两个项目,A 限 1、B 不限。
+// 同时提交 A 的多个 run + B 的多个 run;断言 A 同时至多 1 个在执行,B 不受 A 拖累照常放行
+// (受全局上限约束)。证明项目级准入正确且不发生队头阻塞。
+func TestPerProjectConcurrencyLimitHolds(t *testing.T) {
+	db := testDB(t)
+	svc := New(db)
+	g := &gatedRunner{entered: make(chan struct{}, 16), release: make(chan struct{})}
+
+	projA := seedProject(t, db)
+	projB := seedProject(t, db)
+	limits := fakeLimits{projA: 1} // A 限 1;B 缺省 0 = 不限项目级。
+
+	// 全局上限给足(4),让项目级成为约束源。
+	pool := NewWorkerPool(svc, WithMaxConcurrent(4), WithRunner(g), WithConcurrencyLimits(limits))
+	pool.Start()
+	t.Cleanup(func() {
+		safeClose(g.release)
+		pool.Stop(context.Background())
+	})
+
+	// 先入 3 个 A(项目级限 1),再入 2 个 B(不限,受全局 4 约束)。
+	var aIDs, bIDs []string
+	for i := 0; i < 3; i++ {
+		r, _ := svc.Create(context.Background(), projA, Trigger{Type: TriggerManual})
+		aIDs = append(aIDs, r.ID)
+	}
+	for i := 0; i < 2; i++ {
+		r, _ := svc.Create(context.Background(), projB, Trigger{Type: TriggerManual})
+		bIDs = append(bIDs, r.ID)
+	}
+
+	// 全局有 4 槽:A 占 1(项目限),B 占 2 → 共 3 个进入执行。断言恰好 3 个、不更多。
+	if got := drainEntered(t, g, 3, time.Second); got != 3 {
+		t.Fatalf("应有 3 个 run 进入执行(A=1 + B=2), got %d", got)
+	}
+	if extra := drainEntered(t, g, 1, 150*time.Millisecond); extra != 0 {
+		t.Fatalf("项目级/全局上限被突破(读到额外 %d 个)", extra)
+	}
+
+	// 断言执行中恰有 1 个属于 A(项目级上限成立),其余属于 B。
+	assertRunningCountForProject(t, svc, projA, 1)
+
+	// 放行全部 → 排队者递补,全部 success;A 始终至多 1 个并发(峰值不超)。
+	safeClose(g.release)
+	all := append(append([]string{}, aIDs...), bIDs...)
+	for _, id := range all {
+		waitForStatus(t, svc, id, StatusSuccess)
+	}
+}
+
+// assertRunningCountForProject 断言某项目当前处于 running 的运行数等于 want。
+func assertRunningCountForProject(t *testing.T, svc Service, projectID string, want int) {
+	t.Helper()
+	res, err := svc.List(context.Background(), ListFilter{ProjectID: projectID, Status: StatusRunning, PageSize: 100})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if res.Total != want {
+		t.Fatalf("项目 %s running 数应为 %d, got %d", projectID, want, res.Total)
+	}
+}
+
+// safeCloseMu 串行化 safeClose 的检查-关闭,避免并发双关 panic。
+var safeCloseMu sync.Mutex
+
+// safeClose 幂等关闭 ch(测试中可能放行后又在 Cleanup 关闭)。
+func safeClose(ch chan struct{}) {
+	safeCloseMu.Lock()
+	defer safeCloseMu.Unlock()
+	select {
+	case <-ch:
+		// 已关闭(关闭的 channel 接收立即返回零值)。
+	default:
+		close(ch)
+	}
+}
+
+// TestConcurrencyServiceSaveGet 验证项目并发配置的校验 + 持久化 + 回读。
+func TestConcurrencyServiceSaveGet(t *testing.T) {
+	db := testDB(t)
+	svc := NewConcurrencyService(db)
+	projID := seedProject(t, db)
+
+	// 缺省未配置 → 0(不限项目级)。
+	cfg, err := svc.Get(context.Background(), projID)
+	if err != nil || cfg.MaxConcurrent != 0 {
+		t.Fatalf("缺省应为 0,得 cfg=%+v err=%v", cfg, err)
+	}
+
+	// 保存合法值 → 回读一致。
+	if _, err := svc.Save(context.Background(), projID, 3); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	cfg, _ = svc.Get(context.Background(), projID)
+	if cfg.MaxConcurrent != 3 {
+		t.Fatalf("应为 3, got %d", cfg.MaxConcurrent)
+	}
+	if svc.LimitFor(context.Background(), projID) != 3 {
+		t.Fatalf("LimitFor 应为 3")
+	}
+
+	// 非法值被拒。
+	if _, err := svc.Save(context.Background(), projID, -1); err != ErrInvalidConcurrency {
+		t.Fatalf("负值应 ErrInvalidConcurrency, got %v", err)
+	}
+	if _, err := svc.Save(context.Background(), projID, maxProjectConcurrency+1); err != ErrInvalidConcurrency {
+		t.Fatalf("超上界应 ErrInvalidConcurrency, got %v", err)
+	}
+
+	// 项目不存在 → ErrConcProjectNotFound。
+	if _, err := svc.Save(context.Background(), uuid.NewString(), 2); err != ErrConcProjectNotFound {
+		t.Fatalf("未知项目应 ErrConcProjectNotFound, got %v", err)
+	}
+}

--- a/internal/run/pool.go
+++ b/internal/run/pool.go
@@ -25,15 +25,37 @@ const maxConcurrentDiagnoses = 2
 // 批量 run 同时落终态会瞬时堆起大量发送 goroutine 各占一条 HTTP 连接。超限跳过(通知 best-effort)。
 const maxConcurrentNotifies = 4
 
-// WorkerPool 是进程内 goroutine 池调度器:从内存队列取 queued 运行 → 转 running →
+// WorkerPool 是进程内 goroutine 池调度器:从内存 FIFO 队列取 queued 运行 → 转 running →
 // 经 Runner 执行 → 按结果转终态。多 run 并行、非事务、结果独立:单 run 失败/panic
 // 不连累其它(每 run 独立 goroutine + recover)。优雅停机随 HTTP server(Stop)。
 //
-// 不轮询 DB 取队列:Create 经 Enqueue 推入内存 channel;状态变更经事件总线推 SSE。
+// 不轮询 DB 取队列:Create 经 Enqueue 推入内存 FIFO;状态变更经事件总线推 SSE。
+//
+// 并发/队列控制(FR-8-10):单 dispatcher goroutine 按 FIFO 扫描待调度队列,对每个待调度
+// 运行做**双重准入**——全局在途 < globalLimit(PIPEWRIGHT_MAX_CONCURRENT)且 该项目在途 <
+// 项目级上限(ConcurrencyLimits.LimitFor,0=不限)。准入则计数 +1 并起独立 goroutine 执行;
+// 否则保持 queued 留在队列,待某运行收尾释放槽位后重扫(FIFO 序;某项目满则跳过该项目的
+// 后续运行继续放行其它项目,避免队头阻塞拖垮全局吞吐)。计数器经 mu 串行化(并发正确)。
 type WorkerPool struct {
 	svc    *service
 	runner Runner
-	queue  chan string
+
+	// 待调度 FIFO:Enqueue 追加 runID,dispatcher 按序做准入并出队。受 mu 保护。
+	pending []string
+	// signal 唤醒 dispatcher 重扫(Enqueue 入队 / run 收尾释放槽位时各发一次,带缓冲不阻塞)。
+	signal chan struct{}
+
+	// globalLimit 是全局同时 running 上限(PIPEWRIGHT_MAX_CONCURRENT;<1 时回落 workers)。
+	globalLimit int
+	// limits 查项目级并发上限(nil 则仅受全局上限约束);经接口解耦,pool 不直接触库。
+	limits ConcurrencyLimits
+
+	// mu 保护 pending / globalInflight / projInflight / stopped(并发计数正确性铁律)。
+	mu             sync.Mutex
+	globalInflight int
+	projInflight   map[string]int
+	// stopped 在 Stop 后置位:Enqueue 返回 ErrPoolStopped、takeAdmissible 不再放行新活。
+	stopped bool
 
 	workers int
 	wg      sync.WaitGroup
@@ -76,6 +98,26 @@ func WithConcurrency(n int) PoolOption {
 	return func(p *WorkerPool) {
 		if n > 0 {
 			p.workers = n
+		}
+	}
+}
+
+// WithMaxConcurrent 设置全局同时 running 上限(FR-8-10;PIPEWRIGHT_MAX_CONCURRENT)。
+// <1 时不生效(回落到 workers 数)。突发创建超此上限的运行保持 queued,待槽位释放再调度。
+func WithMaxConcurrent(n int) PoolOption {
+	return func(p *WorkerPool) {
+		if n > 0 {
+			p.globalLimit = n
+		}
+	}
+}
+
+// WithConcurrencyLimits 注入项目级并发上限查询(FR-8-10)。nil 则仅受全局上限约束。
+// dispatcher 对每个待调度运行经此查该项目上限(0=不限项目级)做准入。
+func WithConcurrencyLimits(l ConcurrencyLimits) PoolOption {
+	return func(p *WorkerPool) {
+		if l != nil {
+			p.limits = l
 		}
 	}
 }
@@ -146,15 +188,20 @@ func NewWorkerPool(svc Service, opts ...PoolOption) *WorkerPool {
 		panic("run: NewWorkerPool requires the Service returned by run.New")
 	}
 	p := &WorkerPool{
-		svc:         s,
-		runner:      NewStubRunner(),
-		queue:       make(chan string, 256),
-		workers:     defaultConcurrency,
-		diagnoseSem: make(chan struct{}, maxConcurrentDiagnoses),
-		notifySem:   make(chan struct{}, maxConcurrentNotifies),
+		svc:          s,
+		runner:       NewStubRunner(),
+		signal:       make(chan struct{}, 1),
+		projInflight: make(map[string]int),
+		workers:      defaultConcurrency,
+		diagnoseSem:  make(chan struct{}, maxConcurrentDiagnoses),
+		notifySem:    make(chan struct{}, maxConcurrentNotifies),
 	}
 	for _, opt := range opts {
 		opt(p)
+	}
+	// 全局上限缺省回落到 workers 数(保持既有「至多 workers 个并行」行为;FR-8-10 默认)。
+	if p.globalLimit < 1 {
+		p.globalLimit = p.workers
 	}
 	// 注入调度回调:Service.Create 入库后据此把 run 推入队列。
 	s.setEnqueue(p.Enqueue)
@@ -166,54 +213,60 @@ func (p *WorkerPool) Subscribe(runID string) (<-chan Event, func()) {
 	return p.svc.bus.subscribe(runID)
 }
 
-// Enqueue 把已入库的 queued 运行推入调度队列(永不阻塞调用方)。
+// maxQueueDepth 是待调度 FIFO 的有界深度(NFR-4 内存约束;突发创建超此返回 ErrQueueFull)。
+const maxQueueDepth = 1024
+
+// Enqueue 把已入库的 queued 运行追加到待调度 FIFO(永不阻塞调用方)。
 // 由 Service.Create 之后调用(或测试直接调用)。
 //
 // 绝不阻塞:队列满或池已停机时返回错误(ErrQueueFull / ErrPoolStopped),
-// 让 Create→HTTP handler 能失败返回而非永久挂死(突发 >256 创建 / 停机后入队)。
+// 让 Create→HTTP handler 能失败返回而非永久挂死(突发 >maxQueueDepth 创建 / 停机后入队)。
 // run 仍在库中保持 queued,可经后续重启/重试调度。
 func (p *WorkerPool) Enqueue(runID string) error {
-	// 未 Start 时 ctx 为 nil:仅尝试非阻塞投递(测试场景先 Create+订阅再 Start)。
-	if p.ctx == nil {
-		select {
-		case p.queue <- runID:
-			return nil
-		default:
-			return ErrQueueFull
-		}
-	}
-	select {
-	case <-p.ctx.Done():
+	p.mu.Lock()
+	if p.stopped {
+		p.mu.Unlock()
 		return ErrPoolStopped
-	default:
 	}
-	select {
-	case p.queue <- runID:
-		return nil
-	case <-p.ctx.Done():
-		return ErrPoolStopped
-	default:
+	if len(p.pending) >= maxQueueDepth {
+		p.mu.Unlock()
 		return ErrQueueFull
+	}
+	p.pending = append(p.pending, runID)
+	p.mu.Unlock()
+	p.wake()
+	return nil
+}
+
+// wake 非阻塞地唤醒 dispatcher 重扫待调度队列(signal 带缓冲 1:合并多次唤醒)。
+func (p *WorkerPool) wake() {
+	select {
+	case p.signal <- struct{}{}:
+	default:
 	}
 }
 
-// Start 启动 worker goroutine(幂等)。停机用 Stop。
+// Start 启动 dispatcher goroutine(幂等)。停机用 Stop。
 func (p *WorkerPool) Start() {
 	p.startOnce.Do(func() {
 		p.ctx, p.cancel = context.WithCancel(context.Background())
-		for i := 0; i < p.workers; i++ {
-			p.wg.Add(1)
-			go p.worker()
-		}
+		p.wg.Add(1)
+		go p.dispatch()
+		// Start 前可能已 Enqueue(测试/启动恢复):立即触发一次调度。
+		p.wake()
 	})
 }
 
-// Stop 优雅停机:停止取新活、取消在途运行执行、等 worker 退出。随 HTTP server 调用。
+// Stop 优雅停机:停止取新活、取消在途运行执行、等在途 run 与 dispatcher 退出。随 HTTP server 调用。
 func (p *WorkerPool) Stop(ctx context.Context) {
 	p.stopOnce.Do(func() {
+		p.mu.Lock()
+		p.stopped = true
+		p.mu.Unlock()
 		if p.cancel != nil {
-			p.cancel() // 取消池上下文:worker 退出;在途 run 经派生 ctx 取消
+			p.cancel() // 取消池上下文:dispatcher 退出;在途 run 经派生 ctx 取消
 		}
+		p.wake() // 唤醒 dispatcher 让其观察到 ctx.Done 后退出
 	})
 	done := make(chan struct{})
 	go func() { p.wg.Wait(); close(done) }()
@@ -224,17 +277,100 @@ func (p *WorkerPool) Stop(ctx context.Context) {
 	}
 }
 
-// worker 是单个 goroutine 循环:取队列 → 执行一次运行。池上下文取消则退出。
-func (p *WorkerPool) worker() {
+// dispatch 是单 dispatcher 循环:被唤醒后按 FIFO 扫描待调度队列,对每个运行做全局 + 项目级
+// 双重准入;准入则计数并起独立 goroutine 执行,否则保持 queued 待下次唤醒重扫。
+// 池上下文取消则退出(已起的在途 run 经其派生 ctx 取消、由 wg 等待收尾)。
+func (p *WorkerPool) dispatch() {
 	defer p.wg.Done()
 	for {
 		select {
 		case <-p.ctx.Done():
 			return
-		case runID := <-p.queue:
-			p.execute(runID)
+		case <-p.signal:
+			p.drain()
 		}
 	}
+}
+
+// drain 按 FIFO 扫描待调度队列一遍,放行所有当前可准入的运行(全局未满 且 项目未满);
+// 某项目本轮已满则跳过其后续运行继续放行其它项目(避免队头阻塞)。受 mu 串行保证计数正确。
+func (p *WorkerPool) drain() {
+	for {
+		runID, projectID, ok := p.takeAdmissible()
+		if !ok {
+			return
+		}
+		p.wg.Add(1)
+		go func() {
+			defer p.wg.Done()
+			defer p.release(projectID)
+			p.execute(runID)
+		}()
+	}
+}
+
+// takeAdmissible 在锁内扫描 pending,取出**第一个**满足全局 + 项目级双重准入的运行并计数 +1;
+// 找到返回 (runID, projectID, true) 并已从 pending 摘除;无可放行返回 ("","",false)。
+//
+// 全局已满 → 直接返回(本轮无人可放行)。某项目满则跳过其在 pending 中的后续运行继续往后找,
+// 既保证项目级上限,又不让该项目的队头拖住其它项目(FIFO 序在各项目内仍保持)。
+func (p *WorkerPool) takeAdmissible() (string, string, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.stopped {
+		return "", "", false
+	}
+	if p.globalInflight >= p.globalLimit {
+		return "", "", false
+	}
+	for i, runID := range p.pending {
+		projectID := p.projectIDFor(runID)
+		limit := p.limitFor(projectID)
+		if limit > 0 && p.projInflight[projectID] >= limit {
+			continue // 该项目本轮已满:跳过,继续找其它项目的运行。
+		}
+		// 准入:计数 +1 并从 pending 摘除该元素(保持其余顺序)。
+		p.globalInflight++
+		p.projInflight[projectID]++
+		p.pending = append(p.pending[:i], p.pending[i+1:]...)
+		return runID, projectID, true
+	}
+	return "", "", false
+}
+
+// projectIDFor 查某 run 的 project_id(用于项目级准入)。读失败/不存在返回空串
+// (空串项目不参与项目级限流,仅受全局约束;优雅降级,绝不卡死调度)。锁内调用、查询轻量。
+func (p *WorkerPool) projectIDFor(runID string) string {
+	var pid string
+	_ = p.svc.db.QueryRowContext(context.Background(),
+		`SELECT project_id FROM pipeline_runs WHERE id = ?`, runID).Scan(&pid)
+	return pid
+}
+
+// limitFor 查项目级并发上限(未注入 limits 或空项目 → 0 不限项目级)。锁内调用,实现须无阻塞重活。
+func (p *WorkerPool) limitFor(projectID string) int {
+	if p.limits == nil || projectID == "" {
+		return 0
+	}
+	return p.limits.LimitFor(context.Background(), projectID)
+}
+
+// release 在某运行收尾后释放全局 + 项目级计数,并唤醒 dispatcher 重扫(空出的槽位让排队者递补)。
+func (p *WorkerPool) release(projectID string) {
+	p.mu.Lock()
+	if p.globalInflight > 0 {
+		p.globalInflight--
+	}
+	if projectID != "" {
+		if n := p.projInflight[projectID]; n > 0 {
+			p.projInflight[projectID] = n - 1
+		}
+		if p.projInflight[projectID] == 0 {
+			delete(p.projInflight, projectID)
+		}
+	}
+	p.mu.Unlock()
+	p.wake()
 }
 
 // execute 执行单次运行的完整生命周期:queued→running→(Runner)→终态。

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -295,15 +295,15 @@ func TestListFilterAndPaging(t *testing.T) {
 func TestEnqueueNonBlocking(t *testing.T) {
 	db := testDB(t)
 	svc := New(db)
-	pool := NewWorkerPool(svc) // 不 Start:worker 不消费,队列会被填满。
+	pool := NewWorkerPool(svc) // 不 Start:dispatcher 不消费,队列会被填满。
 
-	// 填满队列(cap 256)。
-	for i := 0; i < 256; i++ {
+	// 填满待调度 FIFO(深度 maxQueueDepth)。
+	for i := 0; i < maxQueueDepth; i++ {
 		if err := pool.Enqueue(uuid.NewString()); err != nil {
 			t.Fatalf("第 %d 次入队应成功: %v", i, err)
 		}
 	}
-	// 第 257 次:队列满 → ErrQueueFull(不阻塞)。
+	// 再入一个:队列满 → ErrQueueFull(不阻塞)。
 	done := make(chan error, 1)
 	go func() { done <- pool.Enqueue(uuid.NewString()) }()
 	select {

--- a/internal/store/migrations/0029_concurrency_limits.sql
+++ b/internal/store/migrations/0029_concurrency_limits.sql
@@ -1,0 +1,14 @@
+-- 0029 project_concurrency:项目级并发上限配置(FR-8-10 并发/队列控制)。
+-- 每项目至多一行(project_id 既是主键也是外键)。max_concurrent 为该项目同时 running 的运行数上限;
+-- 0 = 不限项目级(仅受全局 PIPEWRIGHT_MAX_CONCURRENT 约束)。超限的运行保持 queued 直到该项目有空槽。
+-- 不存敏感信息;删项目级联删并发配置。
+--   project_id     : FK → projects.id;PK;ON DELETE CASCADE
+--   max_concurrent : >=0 项目级同时运行上限(0 = 不限项目级,沿用全局上限)
+
+CREATE TABLE IF NOT EXISTS project_concurrency (
+    project_id     TEXT PRIMARY KEY,
+    max_concurrent INTEGER NOT NULL DEFAULT 0,
+    created_at     TEXT NOT NULL,
+    updated_at     TEXT NOT NULL,
+    FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## 背景

为 in-process worker pool 增加**并发/队列控制**(FR-8-10):突发创建的运行不再一次性全部并行,而是受上限约束、超限者保持 `queued` 排队,待槽位释放再按 FIFO 递补调度。

## 设计

worker pool 由原「N 个 worker goroutine 抢同一 channel」改为**单 dispatcher goroutine + FIFO 待调度队列 + 双重准入**:

- **全局上限**:同时处于执行中的运行数 `globalInflight < globalLimit`。
- **项目级上限**:`projInflight[projectID] < 项目上限`(0 = 不限项目级)。
- dispatcher 被唤醒(入队 / 某运行收尾释放槽位)后按 FIFO 扫描待调度队列,对**第一个满足双重准入**的运行计数 +1 并起独立 goroutine 执行;某项目本轮已满则**跳过其后续运行继续放行其它项目**,既守住项目级上限又不让某项目队头拖垮全局吞吐。
- 所有计数器经单个 `mu` 串行化 —— 并发计数正确性铁律。
- `Enqueue` 仍**非阻塞**(队列满 `ErrQueueFull`、停机 `ErrPoolStopped`,Create 据此回滚不挂死);`FailOrphanedRuns` 启动清理语义不变,重启后残留 `queued` 仍可经清理/重新创建恢复。

每个 run 收尾(含 panic recover 路径)经 `defer release(projectID)` 释放计数并唤醒 dispatcher,绝不漏放槽位。

## 配置入口

| 维度 | 入口 | 默认 |
|------|------|------|
| 全局上限 | env **`PIPEWRIGHT_MAX_CONCURRENT`**(正整数) | = worker 数(保持既有「至多 workers 个并行」行为) |
| 项目级上限 | **`GET`/`PUT /api/projects/{id}/concurrency`**(`{ "maxConcurrent": n }`,auth + CSRF) | 0(不限项目级,仅受全局约束) |

- 项目级取值范围 `0..64`,越界 → `422 invalid_concurrency`;未知项目 → `404 project_not_found`。
- 持久化:迁移 **`0029_concurrency_limits.sql`** 新建 `project_concurrency` 表(`project_id` PK + FK `ON DELETE CASCADE`,删项目级联删配置)。
- env 非法值仅告警忽略并回落默认,不致命。

## 上限如何被证明(测试)

注入 `gatedRunner`(进入 Run 即通知 + 阻塞在 release,精确卡住「执行中」的运行数)+ 内存 `fakeLimits`,**无真实 sleep、确定性、`-race` 通过**:

- `TestGlobalConcurrencyLimitHolds`:提交 N=6 > limit=2,断言**恰好** 2 个进入执行、第 3 个进入信号超时(被排队挡住),峰值并发 ≤ 2,放行后全部 success。
- `TestPerProjectConcurrencyLimitHolds`:项目 A 限 1、B 不限,全局 4;断言 A 同时**至多 1 个** running、B 不被 A 拖累照常放行(证明项目级准入 + 无队头阻塞)。
- `TestConcurrencyServiceSaveGet`:校验 / 持久化 / 回读 / 非法值 / 未知项目。

## 协调说明

`cmd/pipewright/main.go` 与 `internal/httpapi/router.go` 改动**最小且加性**(一处 option block + 一组路由);迁移用 **0029** 前缀(独立文件名,与并行 agent 的 0027/0028 无冲突)。未触碰 `internal/dagrun/*`、未改前端、未改冻结 run-detail DTO。

## 绿门

```
gofmt -l .   → (空)
go vet ./... → OK
go build ./... → OK
go test ./... → 全 ok(internal/run 含新并发测试,-race 通过)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)