### PR TITLE
feat(pipeline): 环境晋级流 dev→staging→prod + 逐环境审批(FR-8-7)

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/oauth"
 	"github.com/huangchengsir/pipewright/internal/pipeline"
 	"github.com/huangchengsir/pipewright/internal/project"
+	"github.com/huangchengsir/pipewright/internal/promotion"
 	"github.com/huangchengsir/pipewright/internal/prstatus"
 	"github.com/huangchengsir/pipewright/internal/run"
 	"github.com/huangchengsir/pipewright/internal/store"
@@ -118,6 +119,10 @@ func main() {
 	// 协调器为进程内(零持久状态);记录落 run_approvals 供 UI/审计/重启清理。
 	approvalCoord := approval.New()
 	approvalStore := approval.NewStore(st.DB)
+
+	// 装配环境晋级流持久层(Story 8-7 / FR-8-7):环境链 + 逐环境变量/密钥 + 晋级记录。
+	// 晋级审批门复用上面的 approvalCoord/approvalStore(不另起协调器)。
+	promotionStore := promotion.NewStore(st.DB)
 	// 重启清理:进程重启会丢失内存等待者,把残留 waiting_approval 运行清为 failed(孤儿不可恢复)。
 	if n, err := runSvc.FailOrphanedRuns(context.Background()); err != nil {
 		log.Printf("[run] 警告:清理孤儿运行失败:%v", err)
@@ -288,7 +293,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithServers(targetSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc)),
+		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithServers(targetSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc), httpapi.WithPromotion(promotionStore)),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		// WriteTimeout 置 0:SSE 长连接(/api/runs/{id}/events)不可被写超时切断;

--- a/internal/httpapi/promotion.go
+++ b/internal/httpapi/promotion.go
@@ -1,0 +1,323 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/approval"
+	"github.com/huangchengsir/pipewright/internal/audit"
+	"github.com/huangchengsir/pipewright/internal/promotion"
+	"github.com/huangchengsir/pipewright/internal/run"
+	"github.com/huangchengsir/pipewright/internal/vault"
+)
+
+// promotion.go 装配环境晋级流(Epic 8 · Story 8-7 / FR-8-7)的 HTTP 端点与适配器。
+//
+// 复用:晋级审批门复用 FR-8-4 的 approval.Coordinator + run_approvals(promotionGate);
+// 源运行状态/归属经 run.Service 适配(runLookup);secret 变量经 vault.Vault 解密(secretReveal)。
+
+// promotionGateTimeout 是晋级审批门兜底超时(超时自动拒绝)。审批节奏可较慢,取较长值。
+const promotionGateTimeout = 24 * time.Hour
+
+// runLookup 把 run.Service 适配为 promotion.RunLookup(只取状态/归属,不引入循环依赖)。
+type runLookup struct{ runs run.Service }
+
+func (l runLookup) LookupRun(ctx context.Context, runID string) (promotion.RunInfo, error) {
+	r, err := l.runs.Get(ctx, runID)
+	if err != nil {
+		if errors.Is(err, run.ErrNotFound) {
+			return promotion.RunInfo{}, promotion.ErrRunNotFound
+		}
+		return promotion.RunInfo{}, err
+	}
+	return promotion.RunInfo{ID: r.ID, ProjectID: r.ProjectID, Status: r.Status}, nil
+}
+
+// secretReveal 把 vault.Vault 适配为 promotion.SecretResolver(Reveal 不刷新 last_used_at)。
+type secretReveal struct{ v vault.Vault }
+
+func (s secretReveal) Reveal(credentialID string) (string, error) {
+	if s.v == nil {
+		return "", errors.New("vault unconfigured")
+	}
+	return s.v.Reveal(credentialID)
+}
+
+// promotionGate 复用审批门内核(approval.Coordinator + Store)实现 promotion.Gate:
+// 对 gated 目标环境,登记待批 + 阻塞协调器等待端点投递批准/拒绝(或超时)。
+//
+// 复用而非复制:Wait/Resolve/Cancel 全走既有 approval.Coordinator;待批/决定落 run_approvals
+// (stageId = "promote:<env>"),晋级端点(approve/reject)直接复用既有 /runs/{id}/approve|reject。
+type promotionGate struct {
+	coord *approval.Coordinator
+	store *approval.Store
+	runID string // 审批门内核以 (runID, stageId) 组合键;晋级门挂在源运行上
+}
+
+func (g promotionGate) Await(ctx context.Context, stageID string, info promotion.GateInfo) (bool, string, error) {
+	key := approval.Key(g.runID, stageID)
+	stageName := "晋级到「" + info.TargetEnvironment + "」"
+	_ = g.store.CreatePending(ctx, g.runID, stageID, stageName)
+	ch := g.coord.Wait(key)
+	defer g.coord.Cancel(key)
+
+	select {
+	case d := <-ch:
+		status := approval.StatusRejected
+		if d.Approved {
+			status = approval.StatusApproved
+		}
+		_ = g.store.Decide(context.Background(), g.runID, stageID, status, d.Actor)
+		return d.Approved, d.Actor, nil
+	case <-ctx.Done():
+		_ = g.store.Decide(context.Background(), g.runID, stageID, approval.StatusRejected, "canceled")
+		return false, "canceled", ctx.Err()
+	case <-time.After(promotionGateTimeout):
+		_ = g.store.Decide(context.Background(), g.runID, stageID, approval.StatusRejected, "timeout")
+		return false, "timeout", context.DeadlineExceeded
+	}
+}
+
+// makeGetEnvironmentsHandler 返回 GET /api/projects/{id}/environments(环境链 + 各环境变量掩码视图)。
+func makeGetEnvironmentsHandler(store *promotion.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if store == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "晋级服务未初始化")
+			return
+		}
+		projectID := chi.URLParam(r, "id")
+		chain, err := store.GetChain(r.Context(), projectID)
+		if err != nil && !errors.Is(err, promotion.ErrChainNotConfigured) {
+			writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+			return
+		}
+		envs := chain.Environments
+		if envs == nil {
+			envs = []promotion.EnvStage{}
+		}
+		// 每环境附其变量掩码视图(secret 仅 credentialId,绝无明文)。
+		varsByEnv := map[string][]promotion.Variable{}
+		for _, e := range envs {
+			vs, verr := store.ListVariables(r.Context(), projectID, e.Name)
+			if verr != nil {
+				writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+				return
+			}
+			varsByEnv[e.Name] = vs
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"environments": envs,
+			"variables":    varsByEnv,
+		})
+	}
+}
+
+// makeSaveEnvironmentsHandler 返回 PUT /api/projects/{id}/environments(配置环境链 + 可选逐环境变量)。
+func makeSaveEnvironmentsHandler(store *promotion.Store, rec audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if store == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "晋级服务未初始化")
+			return
+		}
+		projectID := chi.URLParam(r, "id")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<18)
+		var req struct {
+			Environments []promotion.EnvStage            `json:"environments"`
+			Variables    map[string][]promotion.Variable `json:"variables"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		chain, err := store.SaveChain(r.Context(), projectID, promotion.Chain{Environments: req.Environments})
+		if err != nil {
+			writePromotionError(w, err)
+			return
+		}
+		// 可选:逐环境覆盖变量(仅接受链上环境;未知环境忽略以防悬挂作用域)。
+		for env, vars := range req.Variables {
+			if chain.IndexOf(env) < 0 {
+				continue
+			}
+			if verr := store.SetVariables(r.Context(), projectID, env, vars); verr != nil {
+				writePromotionError(w, verr)
+				return
+			}
+		}
+		recordAudit(r.Context(), rec, audit.Entry{
+			Actor:      auditActor,
+			Action:     "project.environments.save",
+			TargetType: audit.TargetProject,
+			TargetID:   projectID,
+			Detail:     map[string]any{"chain": chain.Names()},
+			IP:         clientIP(r),
+		})
+		writeJSON(w, http.StatusOK, map[string]any{"environments": chain.Environments})
+	}
+}
+
+// makePromoteRunHandler 返回 POST /api/runs/{id}/promote(把源运行晋级到下一环境)。
+// body {targetEnvironment?}:留空取链上下一级;给定则校验恰为下一级(防跳级)。
+// gated 目标会阻塞等待审批(经既有 /runs/{id}/approve|reject 决定)。
+func makePromoteRunHandler(store *promotion.Store, runs run.Service, coord *approval.Coordinator,
+	astore *approval.Store, vlt vault.Vault, rec audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if store == nil || runs == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "晋级服务未初始化")
+			return
+		}
+		runID := chi.URLParam(r, "id")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<13)
+		var req struct {
+			TargetEnvironment string `json:"targetEnvironment"`
+		}
+		// 空 body 合法(取下一级)。
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		target := strings.TrimSpace(req.TargetEnvironment)
+
+		var gate promotion.Gate
+		if coord != nil && astore != nil {
+			gate = promotionGate{coord: coord, store: astore, runID: runID}
+		}
+		coordinator := promotion.NewCoordinator(store, runLookup{runs: runs}, gate, secretReveal{v: vlt})
+
+		res, err := coordinator.Promote(r.Context(), runID, target, auditActor)
+		if err != nil {
+			// 审批被拒/超时/fail-closed:仍返回记录(409),非 500。
+			if res != nil && promotion.IsTerminalErr(err) {
+				recordAudit(r.Context(), rec, audit.Entry{
+					Actor:      auditActor,
+					Action:     "run.promote.reject",
+					TargetType: audit.TargetRun,
+					TargetID:   runID,
+					Detail:     map[string]any{"targetEnvironment": res.Record.TargetEnvironment},
+					IP:         clientIP(r),
+				})
+				writeJSON(w, http.StatusConflict, toPromotionDTO(res.Record))
+				return
+			}
+			writePromotionError(w, err)
+			return
+		}
+		recordAudit(r.Context(), rec, audit.Entry{
+			Actor:      auditActor,
+			Action:     "run.promote",
+			TargetType: audit.TargetRun,
+			TargetID:   runID,
+			Detail: map[string]any{
+				"targetEnvironment": res.Record.TargetEnvironment,
+				"fromEnvironment":   res.Record.FromEnvironment,
+			},
+			IP: clientIP(r),
+		})
+		writeJSON(w, http.StatusOK, toPromotionDTO(res.Record))
+	}
+}
+
+// makeListRunPromotionsHandler 返回 GET /api/runs/{id}/promotions(某运行的晋级历史)。
+func makeListRunPromotionsHandler(store *promotion.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if store == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "晋级服务未初始化")
+			return
+		}
+		recs, err := store.ListRecordsForRun(r.Context(), chi.URLParam(r, "id"))
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"items": toPromotionDTOs(recs)})
+	}
+}
+
+// makeListProjectPromotionsHandler 返回 GET /api/projects/{id}/promotions(项目晋级历史,最近在前)。
+func makeListProjectPromotionsHandler(store *promotion.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if store == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "晋级服务未初始化")
+			return
+		}
+		recs, err := store.ListRecordsForProject(r.Context(), chi.URLParam(r, "id"))
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"items": toPromotionDTOs(recs)})
+	}
+}
+
+// promotionDTO 是晋级记录的对外 JSON 形状(camelCase)。
+type promotionDTO struct {
+	ID                string `json:"id"`
+	ProjectID         string `json:"projectId"`
+	SourceRunID       string `json:"sourceRunId"`
+	FromEnvironment   string `json:"fromEnvironment"`
+	TargetEnvironment string `json:"targetEnvironment"`
+	Status            string `json:"status"`
+	PromotedBy        string `json:"promotedBy"`
+	CreatedAt         string `json:"createdAt"`
+	DecidedAt         string `json:"decidedAt"`
+}
+
+func toPromotionDTO(r promotion.Record) promotionDTO {
+	return promotionDTO{
+		ID:                r.ID,
+		ProjectID:         r.ProjectID,
+		SourceRunID:       r.SourceRunID,
+		FromEnvironment:   r.FromEnvironment,
+		TargetEnvironment: r.TargetEnvironment,
+		Status:            r.Status,
+		PromotedBy:        r.PromotedBy,
+		CreatedAt:         r.CreatedAt,
+		DecidedAt:         r.DecidedAt,
+	}
+}
+
+func toPromotionDTOs(recs []promotion.Record) []promotionDTO {
+	out := make([]promotionDTO, 0, len(recs))
+	for _, r := range recs {
+		out = append(out, toPromotionDTO(r))
+	}
+	return out
+}
+
+// writePromotionError 把晋级领域错误映射为 HTTP 状态码(错误体绝无敏感数据)。
+func writePromotionError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, promotion.ErrRunNotFound):
+		writeError(w, http.StatusNotFound, "not_found", "运行不存在")
+	case errors.Is(err, promotion.ErrProjectNotFound):
+		writeError(w, http.StatusNotFound, "not_found", "项目不存在")
+	case errors.Is(err, promotion.ErrChainNotConfigured):
+		writeError(w, http.StatusUnprocessableEntity, "chain_not_configured", "尚未配置环境链")
+	case errors.Is(err, promotion.ErrEmptyChain):
+		writeError(w, http.StatusUnprocessableEntity, "empty_chain", "环境链不能为空")
+	case errors.Is(err, promotion.ErrDuplicateEnv):
+		writeError(w, http.StatusUnprocessableEntity, "duplicate_env", "环境链含重复环境名")
+	case errors.Is(err, promotion.ErrInvalidEnvName):
+		writeError(w, http.StatusUnprocessableEntity, "invalid_env", "环境名非法")
+	case errors.Is(err, promotion.ErrUnknownEnv):
+		writeError(w, http.StatusUnprocessableEntity, "unknown_env", "目标环境不在链上")
+	case errors.Is(err, promotion.ErrRunNotSuccessful):
+		writeError(w, http.StatusConflict, "run_not_successful", "源运行未成功,不可晋级")
+	case errors.Is(err, promotion.ErrSkipEnv):
+		writeError(w, http.StatusConflict, "skip_env", "不可跳级:只能晋级到下一环境")
+	case errors.Is(err, promotion.ErrAlreadyAtTop):
+		writeError(w, http.StatusConflict, "already_at_top", "已晋级到链尾环境")
+	case errors.Is(err, promotion.ErrAlreadyPromoted):
+		writeError(w, http.StatusConflict, "already_promoted", "该运行已晋级到该环境")
+	case errors.Is(err, promotion.ErrGateRejected):
+		writeError(w, http.StatusConflict, "gate_rejected", "晋级审批被拒绝")
+	case errors.Is(err, promotion.ErrVarKeyEmpty):
+		writeError(w, http.StatusUnprocessableEntity, "var_key_empty", "变量 key 不能为空")
+	case errors.Is(err, promotion.ErrVarKeyDuplicate):
+		writeError(w, http.StatusUnprocessableEntity, "var_key_duplicate", "环境内变量 key 重复")
+	default:
+		writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+	}
+}

--- a/internal/httpapi/promotion_test.go
+++ b/internal/httpapi/promotion_test.go
@@ -1,0 +1,188 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/huangchengsir/pipewright/internal/approval"
+	"github.com/huangchengsir/pipewright/internal/auth"
+	"github.com/huangchengsir/pipewright/internal/project"
+	"github.com/huangchengsir/pipewright/internal/promotion"
+	"github.com/huangchengsir/pipewright/internal/run"
+	"github.com/huangchengsir/pipewright/internal/vault"
+)
+
+// setupPromotionServer 构造带 auth + project + run + approvals + promotion 的测试 server。
+func setupPromotionServer(t *testing.T) (*httptest.Server, *http.Client, string, string, run.Service) {
+	t.Helper()
+	st := testStoreAuth(t)
+	svc := auth.NewService(st.DB, nil)
+	if err := svc.Bootstrap("admin", "testpass"); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	v := vault.New(st.DB, testMasterKey())
+	psvc := project.New(st.DB, v, stubProber{branch: "main"})
+	rsvc := run.New(st.DB)
+	coord := approval.New()
+	astore := approval.NewStore(st.DB)
+	pstore := promotion.NewStore(st.DB)
+	pool := run.NewWorkerPool(rsvc)
+	pool.Start()
+	t.Cleanup(func() { pool.Stop(context.Background()) })
+
+	srv := httptest.NewServer(New(testWebFSAuth(), svc,
+		WithVault(v), WithProjects(psvc), WithRuns(rsvc, pool),
+		WithApprovals(coord, astore), WithPromotion(pstore)))
+	t.Cleanup(srv.Close)
+
+	client := newTestClient(t)
+	csrf := loginWithClient(t, client, srv.URL)
+
+	credID := newGitCred(t, client, srv.URL, csrf, "ghp_promo")
+	resp := doJSON(t, client, http.MethodPost, srv.URL+"/api/projects", csrf,
+		`{"name":"acme","repoUrl":"https://gitee.com/acme/shop.git","credentialId":"`+credID+`"}`)
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	var p map[string]any
+	_ = json.Unmarshal(raw, &p)
+	projID, _ := p["id"].(string)
+	if projID == "" {
+		t.Fatalf("create project failed: %s", raw)
+	}
+	return srv, client, csrf, projID, rsvc
+}
+
+// seedSuccessRun 直接落一个 success 运行(绕过 worker;晋级只需 status=success)。
+func seedSuccessRun(t *testing.T, rsvc run.Service, projID string) string {
+	t.Helper()
+	r, err := rsvc.Create(context.Background(), projID, run.Trigger{Type: run.TriggerManual})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	// 推进到 success(queued→running→success)以满足晋级前置。
+	if err := rsvc.MarkWaitingApproval(context.Background(), r.ID); err == nil {
+		_ = rsvc.ResumeFromApproval(context.Background(), r.ID)
+	}
+	// 强制置 success:复用 SetDeployTerminal(直接覆盖终态)。
+	if err := rsvc.SetDeployTerminal(context.Background(), r.ID, run.StatusSuccess); err != nil {
+		t.Fatalf("force success: %v", err)
+	}
+	return r.ID
+}
+
+func TestEnvironmentsConfigAndPromoteNonGated(t *testing.T) {
+	srv, client, csrf, projID, rsvc := setupPromotionServer(t)
+
+	// 配置链 dev→prod(prod gated)+ dev 变量(含 secret 引用)。
+	body := `{"environments":[{"name":"dev","gated":false},{"name":"prod","gated":true}],
+	          "variables":{"dev":[{"key":"LOG_LEVEL","value":"info"},{"key":"TOKEN","secret":true,"credentialId":"c1"}]}}`
+	resp := doJSON(t, client, http.MethodPut, srv.URL+"/api/projects/"+projID+"/environments", csrf, body)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("PUT environments = %d: %s", resp.StatusCode, raw)
+	}
+
+	// GET 回读:secret 不含明文。
+	gresp, gerr := client.Get(srv.URL + "/api/projects/" + projID + "/environments")
+	if gerr != nil {
+		t.Fatalf("GET environments: %v", gerr)
+	}
+	defer gresp.Body.Close()
+	graw, _ := io.ReadAll(gresp.Body)
+	var got struct {
+		Environments []map[string]any            `json:"environments"`
+		Variables    map[string][]map[string]any `json:"variables"`
+	}
+	_ = json.Unmarshal(graw, &got)
+	if len(got.Environments) != 2 {
+		t.Fatalf("environments len = %d: %s", len(got.Environments), graw)
+	}
+	for _, v := range got.Variables["dev"] {
+		if v["secret"] == true && v["value"] != "" {
+			t.Fatalf("secret var leaked plaintext in API: %v", v)
+		}
+	}
+
+	// 晋级 success 运行到 dev(非 gated → 同步 promoted)。
+	runID := seedSuccessRun(t, rsvc, projID)
+	presp := doJSON(t, client, http.MethodPost, srv.URL+"/api/runs/"+runID+"/promote", csrf, `{"targetEnvironment":"dev"}`)
+	defer presp.Body.Close()
+	praw, _ := io.ReadAll(presp.Body)
+	if presp.StatusCode != http.StatusOK {
+		t.Fatalf("POST promote = %d: %s", presp.StatusCode, praw)
+	}
+	var rec map[string]any
+	_ = json.Unmarshal(praw, &rec)
+	if rec["status"] != "promoted" || rec["targetEnvironment"] != "dev" {
+		t.Fatalf("promote record wrong: %s", praw)
+	}
+
+	// 历史列表含一条。
+	hresp, herr := client.Get(srv.URL + "/api/runs/" + runID + "/promotions")
+	if herr != nil {
+		t.Fatalf("GET promotions: %v", herr)
+	}
+	defer hresp.Body.Close()
+	hraw, _ := io.ReadAll(hresp.Body)
+	var hist struct {
+		Items []map[string]any `json:"items"`
+	}
+	_ = json.Unmarshal(hraw, &hist)
+	if len(hist.Items) != 1 {
+		t.Fatalf("promotion history len = %d: %s", len(hist.Items), hraw)
+	}
+}
+
+func TestPromoteGatedWaitsForApproval(t *testing.T) {
+	srv, client, csrf, projID, rsvc := setupPromotionServer(t)
+
+	// 链只有 prod(gated)。
+	body := `{"environments":[{"name":"prod","gated":true}]}`
+	resp := doJSON(t, client, http.MethodPut, srv.URL+"/api/projects/"+projID+"/environments", csrf, body)
+	resp.Body.Close()
+
+	runID := seedSuccessRun(t, rsvc, projID)
+
+	// 并发:发起晋级(阻塞等待审批),另一协程经 /approve 批准。
+	done := make(chan int, 1)
+	go func() {
+		presp := doJSON(t, client, http.MethodPost, srv.URL+"/api/runs/"+runID+"/promote", csrf, `{"targetEnvironment":"prod"}`)
+		io.Copy(io.Discard, presp.Body)
+		presp.Body.Close()
+		done <- presp.StatusCode
+	}()
+
+	// 轮询直到该晋级门进入等待,再批准(stageId = "promote:prod")。
+	approveDeadline := pollApprove(t, client, srv.URL, csrf, runID, "promote:prod")
+	if !approveDeadline {
+		t.Fatalf("approve never succeeded (gate not waiting)")
+	}
+
+	if code := <-done; code != http.StatusOK {
+		t.Fatalf("gated promote final status = %d; want 200", code)
+	}
+}
+
+// pollApprove 轮询投递 approve 直到成功(门进入等待)或超时。
+func pollApprove(t *testing.T, client *http.Client, srvURL, csrf, runID, stageID string) bool {
+	t.Helper()
+	for i := 0; i < 200; i++ {
+		resp := doJSON(t, client, http.MethodPost, srvURL+"/api/runs/"+runID+"/approve", csrf,
+			`{"stageId":"`+stageID+`"}`)
+		code := resp.StatusCode
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		if code == http.StatusOK {
+			return true
+		}
+		// 409 not_waiting:门尚未进入等待,稍后重试。
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -27,6 +27,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/oauth"
 	"github.com/huangchengsir/pipewright/internal/pipeline"
 	"github.com/huangchengsir/pipewright/internal/project"
+	"github.com/huangchengsir/pipewright/internal/promotion"
 	"github.com/huangchengsir/pipewright/internal/run"
 	"github.com/huangchengsir/pipewright/internal/target"
 	"github.com/huangchengsir/pipewright/internal/trigger"
@@ -73,6 +74,7 @@ type options struct {
 	oauth            oauth.Service
 	approvalCoord    *approval.Coordinator
 	approvalStore    *approval.Store
+	promotionStore   *promotion.Store
 }
 
 // WithApprovals 注入审批门协调器 + 持久层(Story 8-4),挂载 /api/runs/{id}/{approve,reject,approvals} 路由。
@@ -82,6 +84,13 @@ func WithApprovals(coord *approval.Coordinator, store *approval.Store) Option {
 		o.approvalCoord = coord
 		o.approvalStore = store
 	}
+}
+
+// WithPromotion 注入环境晋级流持久层(Story 8-7),挂载环境链配置 / 晋级触发 / 晋级历史路由。
+// 晋级审批门复用既有 WithApprovals 装配的协调器 + 持久层(approve/reject 端点共用)。
+// 不传则晋级端点返回 503。
+func WithPromotion(store *promotion.Store) Option {
+	return func(o *options) { o.promotionStore = store }
 }
 
 // WithVault 注入凭据保险库,挂载 /api/credentials* 路由。
@@ -316,6 +325,13 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		ar.Get("/projects/{id}/concurrency", makeGetConcurrencyHandler(o.concurrency))
 		ar.Put("/projects/{id}/concurrency", makeSaveConcurrencyHandler(o.concurrency))
 
+		// 环境晋级流配置(Story 8-7 / FR-8-7):有序环境链 + 逐环境作用域变量/密钥。
+		// /environments、/promotions 比 /projects/{id} 多一段,不会被吞。
+		// GET 过 auth;PUT 为写方法,过 auth + CSRF。o.promotionStore 为 nil → 503。
+		ar.Get("/projects/{id}/environments", makeGetEnvironmentsHandler(o.promotionStore))
+		ar.Put("/projects/{id}/environments", makeSaveEnvironmentsHandler(o.promotionStore, aud))
+		ar.Get("/projects/{id}/promotions", makeListProjectPromotionsHandler(o.promotionStore))
+
 		// 流水线编排配置(Story 2.2)。pl 为 nil 时 handler 返回 503。
 		// 与 /projects/{id}/trigger 同在 {id} 路由组内并存(不会被 /projects/{id} 吞)。
 		// GET 过 auth;PUT 为写方法,过 auth + CSRF。
@@ -352,6 +368,10 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		ar.Post("/runs/{id}/approve", makeApprovalDecisionHandler(o.approvalCoord, o.approvalStore, aud, true))
 		ar.Post("/runs/{id}/reject", makeApprovalDecisionHandler(o.approvalCoord, o.approvalStore, aud, false))
 		ar.Get("/runs/{id}/approvals", makeListApprovalsHandler(o.approvalStore))
+		// 环境晋级流(Story 8-7 / FR-8-7):把成功运行晋级到下一环境(gated 复用审批门内核)+ 列晋级历史。
+		// promote 为写方法,过 auth + CSRF;o.promotionStore 为 nil → 503。
+		ar.Post("/runs/{id}/promote", makePromoteRunHandler(o.promotionStore, rs, o.approvalCoord, o.approvalStore, o.vault, aud))
+		ar.Get("/runs/{id}/promotions", makeListRunPromotionsHandler(o.promotionStore))
 		// SSH 部署执行(Story 4.2 / FR-10):认证 + CSRF(写方法)。dep 为 nil → 503。
 		// 取 run + 产物 + 服务器 → deploy.Deploy(逐机经 SSH 执行部署命令,array 不拼 shell)
 		// → 据结果更新 run 终态 → 返回填好的 targets。部署执行失败不 500(每机 status=failed)。

--- a/internal/promotion/coordinator.go
+++ b/internal/promotion/coordinator.go
@@ -1,0 +1,231 @@
+package promotion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// RunInfo 是晋级编排所需的源运行最小信息(由 RunLookup 提供)。
+type RunInfo struct {
+	ID        string
+	ProjectID string
+	Status    string // 须为成功终态方可晋级
+}
+
+// RunLookup 给出源运行的状态/归属(run.Service 的最小适配,避免 import 整个 run 包做编排)。
+type RunLookup interface {
+	// LookupRun 返回源运行信息;不存在 → ErrRunNotFound。
+	LookupRun(ctx context.Context, runID string) (RunInfo, error)
+}
+
+// SuccessStatus 是「运行成功」的判定串(对齐 run.StatusSuccess="success",避免反向依赖)。
+const SuccessStatus = "success"
+
+// SecretResolver 把 secret 变量的 credentialId 解密为明文(经保险库)。
+// **仅供进程内注入**;返回明文绝不回 HTTP。credential 不存在/未配置保险库 → 返回 error,
+// 由调用方决定降级(本包把该变量标记为不可解析并跳过注入,不让晋级失败于缺失凭据)。
+type SecretResolver interface {
+	Reveal(credentialID string) (string, error)
+}
+
+// Gate 是晋级审批门(复用 approval 内核):对 gated 目标环境,阻塞等待人工批准/拒绝。
+// 返回 (true,nil)=批准;(false,nil)=拒绝;(_,err)=取消/超时等。key 唯一标识该晋级门。
+// 实现(在 httpapi 装配)负责登记待批 + 阻塞 approval.Coordinator + 决定记录,**不复制审批逻辑**。
+type Gate interface {
+	Await(ctx context.Context, key string, info GateInfo) (approved bool, actor string, err error)
+}
+
+// GateInfo 给审批门展示用上下文(无敏感数据)。
+type GateInfo struct {
+	PromotionID       string
+	SourceRunID       string
+	TargetEnvironment string
+}
+
+// Coordinator 编排一次晋级:校验源运行成功 → 算下一目标 → 防跳级/越尾/重复 →
+// gated 走审批门 → 落记录。复用注入的 Gate(approval 内核)与 RunLookup(run 状态)。
+type Coordinator struct {
+	store  *Store
+	runs   RunLookup
+	gate   Gate // 可为 nil:无 gate 装配时,gated 环境晋级直接拒绝(fail-closed,绝不擅自放行)
+	secret SecretResolver
+}
+
+// NewCoordinator 构造晋级编排器。gate 为 nil 时 gated 环境晋级被拒(fail-closed)。
+// secret 为 nil 时 secret 变量不解析注入(降级:仅注入非 secret 变量)。
+func NewCoordinator(store *Store, runs RunLookup, gate Gate, secret SecretResolver) *Coordinator {
+	return &Coordinator{store: store, runs: runs, gate: gate, secret: secret}
+}
+
+// PromoteResult 是一次晋级请求的结果。
+type PromoteResult struct {
+	Record   Record
+	Approved bool // gated 时表示审批结果;非 gated 恒 true
+}
+
+// Promote 把源运行晋级到「链上下一级」目标环境(可指定 target 做显式校验;空则取下一级)。
+//
+// 流程:
+//  1. 取源运行(须 success)。
+//  2. 取项目环境链(须已配置)。
+//  3. 算当前已达环境 → 下一目标;校验 target(防跳级/越尾)。
+//  4. 防重复:该 run→该环境已有 pending/promoted → ErrAlreadyPromoted。
+//  5. gated 目标:登记 pending 记录 → 经 Gate 阻塞等待 → 批准 promoted / 拒绝 rejected。
+//     非 gated:直接 promoted。
+//
+// actor 为操作者(审计/展示)。注意:gated 路径会阻塞直到审批决定(或 ctx 取消)。
+func (c *Coordinator) Promote(ctx context.Context, runID, target, actor string) (*PromoteResult, error) {
+	info, err := c.runs.LookupRun(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	if info.Status != SuccessStatus {
+		return nil, ErrRunNotSuccessful
+	}
+
+	chain, err := c.store.GetChain(ctx, info.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+
+	curEnv, err := c.store.currentEnvForRun(ctx, runID, chain)
+	if err != nil {
+		return nil, err
+	}
+
+	// target 留空 → 取下一级。给定 target 时:先校验它在链上,再(在防跳级前)查重复——
+	// 这样「重新晋级一个已达环境」明确报 ErrAlreadyPromoted(而非误报 ErrSkipEnv)。
+	if target == "" {
+		target, err = chain.nextTarget(curEnv)
+		if err != nil {
+			return nil, err
+		}
+	} else if chain.IndexOf(target) < 0 {
+		return nil, ErrUnknownEnv
+	}
+
+	active, err := c.store.hasActivePromotion(ctx, runID, target)
+	if err != nil {
+		return nil, err
+	}
+	if active {
+		return nil, ErrAlreadyPromoted
+	}
+
+	// 防跳级/越尾:target 须恰为「当前已达环境的下一级」。
+	if err := chain.validateTarget(curEnv, target); err != nil {
+		return nil, err
+	}
+
+	gated := chain.Gated(target)
+	if !gated {
+		rec := Record{
+			ProjectID:         info.ProjectID,
+			SourceRunID:       runID,
+			FromEnvironment:   curEnv,
+			TargetEnvironment: target,
+			Status:            StatusPromoted,
+			PromotedBy:        actor,
+		}
+		id, cerr := c.store.createRecord(ctx, rec)
+		if cerr != nil {
+			return nil, cerr
+		}
+		rec.ID = id
+		rec.Status = StatusPromoted
+		return &PromoteResult{Record: rec, Approved: true}, nil
+	}
+
+	// gated 目标:无 Gate 装配 → fail-closed(登记 rejected,绝不擅自放行)。
+	stageKey := promotionStageKey(runID, target)
+	rec := Record{
+		ProjectID:         info.ProjectID,
+		SourceRunID:       runID,
+		FromEnvironment:   curEnv,
+		TargetEnvironment: target,
+		Status:            StatusPending,
+		ApprovalStage:     stageKey,
+		PromotedBy:        actor,
+	}
+	id, cerr := c.store.createRecord(ctx, rec)
+	if cerr != nil {
+		return nil, cerr
+	}
+	rec.ID = id
+
+	if c.gate == nil {
+		_ = c.store.decideRecord(ctx, id, StatusRejected, "no_gate")
+		rec.Status = StatusRejected
+		return &PromoteResult{Record: rec, Approved: false}, ErrGateRejected
+	}
+
+	approved, by, gerr := c.gate.Await(ctx, stageKey, GateInfo{
+		PromotionID:       id,
+		SourceRunID:       runID,
+		TargetEnvironment: target,
+	})
+	if by == "" {
+		by = actor
+	}
+	if gerr != nil {
+		_ = c.store.decideRecord(ctx, id, StatusRejected, by)
+		rec.Status = StatusRejected
+		return &PromoteResult{Record: rec, Approved: false}, gerr
+	}
+	if !approved {
+		_ = c.store.decideRecord(ctx, id, StatusRejected, by)
+		rec.Status = StatusRejected
+		return &PromoteResult{Record: rec, Approved: false}, ErrGateRejected
+	}
+	if derr := c.store.decideRecord(ctx, id, StatusPromoted, by); derr != nil {
+		return nil, derr
+	}
+	rec.Status = StatusPromoted
+	rec.PromotedBy = by
+	return &PromoteResult{Record: rec, Approved: true}, nil
+}
+
+// ResolveEnvVars 解析某项目某环境的全部作用域变量为可注入的明文 K=V(secret 经保险库解密)。
+// secret 解密失败(凭据缺失/保险库未配)→ 跳过该变量(不让注入因缺失凭据而崩),但记于返回的
+// unresolved 列表(供调用方记日志/告警,绝不含明文)。无 SecretResolver 时所有 secret 变量进 unresolved。
+func (c *Coordinator) ResolveEnvVars(ctx context.Context, projectID, env string) (vars []ResolvedVar, unresolved []string, err error) {
+	raw, err := c.store.loadRawVariables(ctx, projectID, env)
+	if err != nil {
+		return nil, nil, err
+	}
+	vars = make([]ResolvedVar, 0, len(raw))
+	for _, v := range raw {
+		if !v.Secret {
+			vars = append(vars, ResolvedVar{Key: v.Key, Value: v.Value})
+			continue
+		}
+		if c.secret == nil || v.CredentialID == "" {
+			unresolved = append(unresolved, v.Key)
+			continue
+		}
+		plain, rerr := c.secret.Reveal(v.CredentialID)
+		if rerr != nil {
+			unresolved = append(unresolved, v.Key) // 错误体绝无明文
+			continue
+		}
+		vars = append(vars, ResolvedVar{Key: v.Key, Value: plain, Secret: true})
+	}
+	return vars, unresolved, nil
+}
+
+// promotionStageKey 由 runID + target 组成晋级审批门唯一 stageId(复用 approval.Key 语义)。
+// 形如 "promote:<target>";审批门内核以 (runID, stageId) 组合键解析,故 runID 不必再编入 stageId。
+func promotionStageKey(runID, target string) string {
+	_ = runID
+	return fmt.Sprintf("promote:%s", target)
+}
+
+// IsTerminalErr 报告 err 是否为「晋级被拒/失败」类终态错误(供 HTTP 层区分 409/422)。
+func IsTerminalErr(err error) bool {
+	return errors.Is(err, ErrGateRejected) ||
+		errors.Is(err, ErrRunNotSuccessful) ||
+		errors.Is(err, ErrAlreadyPromoted) ||
+		errors.Is(err, ErrAlreadyAtTop) ||
+		errors.Is(err, ErrSkipEnv)
+}

--- a/internal/promotion/promotion.go
+++ b/internal/promotion/promotion.go
@@ -1,0 +1,188 @@
+// Package promotion 实现环境晋级流(Epic 8 · Story 8-7 / FR-8-7):把一次成功运行/产物
+// 沿一条**有序环境链**(dev → staging → prod)逐级晋级,逐环境可设审批门,逐环境作用域
+// 隔离变量/密钥。
+//
+// 设计要点(诚实):
+//   - 环境链是「每项目一条有序数组」配置(如 ["dev","staging","prod"]),每环境可标 gated。
+//   - 晋级状态机:只能晋级到「链上当前最高已达环境的下一级」;不可跳级、不可越过链尾(prod)。
+//     首次晋级目标须为链首(index 0)。
+//   - gated 目标环境:复用 FR-8-4 的审批门内核(approval.Coordinator + run_approvals),
+//     登记一条待批、阻塞等待批准/拒绝;批准 → 落 promoted,拒绝/超时/取消 → rejected。
+//   - 逐环境变量/密钥:env-scoped key=value;secret 变量只存 credential_id 引用保险库(无明文)。
+//     晋级到某环境时注入该环境作用域变量(consistent 与 build 的参数注入)。
+//
+// 本包**不** import dagrun(晋级编排是 run 执行之上的高层概念,经最小 hook 解耦);
+// 也不复制审批逻辑(经注入的 Gate 复用 approval 内核)。
+package promotion
+
+import (
+	"errors"
+	"strings"
+)
+
+// 晋级记录状态枚举(DB 存小写串)。
+const (
+	// StatusPending 表示晋级待审批(gated 环境,阻塞在审批门)。
+	StatusPending = "pending"
+	// StatusPromoted 表示已成功晋级(终态)。
+	StatusPromoted = "promoted"
+	// StatusRejected 表示晋级被拒/超时/取消(终态)。
+	StatusRejected = "rejected"
+)
+
+// 领域错误。错误体绝无敏感数据(密钥/明文)。
+var (
+	// ErrChainNotConfigured 表示项目尚未配置环境链。
+	ErrChainNotConfigured = errors.New("promotion: environment chain not configured")
+	// ErrEmptyChain 表示配置的环境链为空。
+	ErrEmptyChain = errors.New("promotion: environment chain must not be empty")
+	// ErrDuplicateEnv 表示环境链含重复环境名。
+	ErrDuplicateEnv = errors.New("promotion: duplicate environment in chain")
+	// ErrInvalidEnvName 表示环境名为空或非法。
+	ErrInvalidEnvName = errors.New("promotion: invalid environment name")
+	// ErrUnknownEnv 表示目标环境不在链上。
+	ErrUnknownEnv = errors.New("promotion: target environment not in chain")
+	// ErrRunNotSuccessful 表示源运行未成功,不可晋级。
+	ErrRunNotSuccessful = errors.New("promotion: source run is not successful")
+	// ErrSkipEnv 表示试图跳级(只能晋级到下一级)。
+	ErrSkipEnv = errors.New("promotion: cannot skip environments; promote to the next environment in order")
+	// ErrAlreadyAtTop 表示已在链尾,无更高环境可晋级。
+	ErrAlreadyAtTop = errors.New("promotion: run already promoted to the top environment")
+	// ErrAlreadyPromoted 表示该运行已晋级到该环境(幂等拒绝重复)。
+	ErrAlreadyPromoted = errors.New("promotion: run already promoted to this environment")
+	// ErrRunNotFound 表示源运行不存在。
+	ErrRunNotFound = errors.New("promotion: source run not found")
+	// ErrProjectNotFound 表示项目不存在。
+	ErrProjectNotFound = errors.New("promotion: project not found")
+	// ErrGateRejected 表示 gated 环境审批门被拒绝/超时/取消。
+	ErrGateRejected = errors.New("promotion: approval gate rejected")
+	// ErrVarKeyEmpty 表示变量 key 为空。
+	ErrVarKeyEmpty = errors.New("promotion: variable key must not be empty")
+	// ErrVarKeyDuplicate 表示同环境内变量 key 重复。
+	ErrVarKeyDuplicate = errors.New("promotion: duplicate variable key in environment")
+)
+
+// EnvStage 是环境链上的一级:环境名 + 是否需要审批门。
+type EnvStage struct {
+	Name  string `json:"name"`
+	Gated bool   `json:"gated"`
+}
+
+// Chain 是某项目的有序环境链(index 0 为链首,如 dev)。
+type Chain struct {
+	Environments []EnvStage `json:"environments"`
+}
+
+// IndexOf 返回环境在链上的下标;不在链上 → -1。
+func (c Chain) IndexOf(env string) int {
+	for i := range c.Environments {
+		if c.Environments[i].Name == env {
+			return i
+		}
+	}
+	return -1
+}
+
+// Gated 报告某环境是否需要审批门(不在链上视为非 gated)。
+func (c Chain) Gated(env string) bool {
+	i := c.IndexOf(env)
+	if i < 0 {
+		return false
+	}
+	return c.Environments[i].Gated
+}
+
+// Names 返回链上环境名(有序)。
+func (c Chain) Names() []string {
+	out := make([]string, len(c.Environments))
+	for i := range c.Environments {
+		out[i] = c.Environments[i].Name
+	}
+	return out
+}
+
+// validateChain 校验链:非空、无空名、无重名。返回规整后的链(去首尾空白)。
+func validateChain(c Chain) (Chain, error) {
+	if len(c.Environments) == 0 {
+		return Chain{}, ErrEmptyChain
+	}
+	seen := map[string]struct{}{}
+	out := Chain{Environments: make([]EnvStage, 0, len(c.Environments))}
+	for _, e := range c.Environments {
+		name := strings.TrimSpace(e.Name)
+		if name == "" {
+			return Chain{}, ErrInvalidEnvName
+		}
+		if _, dup := seen[name]; dup {
+			return Chain{}, ErrDuplicateEnv
+		}
+		seen[name] = struct{}{}
+		out.Environments = append(out.Environments, EnvStage{Name: name, Gated: e.Gated})
+	}
+	return out, nil
+}
+
+// Record 是一条晋级记录(供 UI / 审计)。
+type Record struct {
+	ID                string `json:"id"`
+	ProjectID         string `json:"projectId"`
+	SourceRunID       string `json:"sourceRunId"`
+	FromEnvironment   string `json:"fromEnvironment"`
+	TargetEnvironment string `json:"targetEnvironment"`
+	Status            string `json:"status"`
+	ApprovalStage     string `json:"approvalStage"`
+	PromotedBy        string `json:"promotedBy"`
+	CreatedAt         string `json:"createdAt"`
+	DecidedAt         string `json:"decidedAt"`
+}
+
+// Variable 是一条环境作用域变量(对外视图)。secret 变量只暴露 credentialId,绝无明文密钥。
+type Variable struct {
+	Key          string `json:"key"`
+	Value        string `json:"value"` // 仅非 secret 有值;secret 恒为空
+	Secret       bool   `json:"secret"`
+	CredentialID string `json:"credentialId"` // 仅 secret 有值
+}
+
+// ResolvedVar 是注入执行环境的一条解析后变量(明文 K=V)。
+// secret 变量在此已由保险库解密为明文,**仅供进程内注入**,绝不回 HTTP。
+type ResolvedVar struct {
+	Key    string
+	Value  string
+	Secret bool
+}
+
+// nextTarget 给定链与「源运行当前已达环境」,算出下一个可晋级到的目标环境。
+// curEnv 为空表示尚未晋级过(首次晋级目标 = 链首)。
+func (c Chain) nextTarget(curEnv string) (target string, err error) {
+	if len(c.Environments) == 0 {
+		return "", ErrEmptyChain
+	}
+	if strings.TrimSpace(curEnv) == "" {
+		return c.Environments[0].Name, nil
+	}
+	i := c.IndexOf(curEnv)
+	if i < 0 {
+		return "", ErrUnknownEnv
+	}
+	if i >= len(c.Environments)-1 {
+		return "", ErrAlreadyAtTop
+	}
+	return c.Environments[i+1].Name, nil
+}
+
+// validateTarget 校验把当前已达 curEnv 的运行晋级到 target 是否合法(不可跳级/越尾)。
+func (c Chain) validateTarget(curEnv, target string) error {
+	ti := c.IndexOf(target)
+	if ti < 0 {
+		return ErrUnknownEnv
+	}
+	want, err := c.nextTarget(curEnv)
+	if err != nil {
+		return err
+	}
+	if want != target {
+		return ErrSkipEnv
+	}
+	return nil
+}

--- a/internal/promotion/promotion_test.go
+++ b/internal/promotion/promotion_test.go
@@ -1,0 +1,413 @@
+package promotion
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/huangchengsir/pipewright/internal/store"
+
+	"database/sql"
+)
+
+// ---- 测试地基:真 SQLite store + 种子项目/运行 -----------------------------
+
+func testStore(t *testing.T) (*Store, *sql.DB) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return NewStore(st.DB), st.DB
+}
+
+func seedProject(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	credID := uuid.NewString()
+	if _, err := db.Exec(
+		`INSERT INTO credentials (id, name, type, scope, ciphertext, masked_value, created_at, updated_at)
+		 VALUES (?, 'c', 'git_token', '', X'00', 'm', ?, ?)`,
+		credID, now, now,
+	); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+	projID := uuid.NewString()
+	if _, err := db.Exec(
+		`INSERT INTO projects (id, name, repo_url, default_branch, credential_id, created_at, updated_at)
+		 VALUES (?, 'acme', 'https://example.com/p.git', 'main', ?, ?, ?)`,
+		projID, credID, now, now,
+	); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	return projID
+}
+
+func seedRun(t *testing.T, db *sql.DB, projectID, status string) string {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	id := uuid.NewString()
+	if _, err := db.Exec(
+		`INSERT INTO pipeline_runs
+		   (id, project_id, status, trigger_type, trigger_branch, trigger_commit, trigger_actor,
+		    resolved_environment, resolved_target_server_ids, params_json, created_at)
+		 VALUES (?, ?, ?, 'manual', 'main', '', 'admin', '', '[]', '{}', ?)`,
+		id, projectID, status, now,
+	); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	return id
+}
+
+// ---- 测试替身:RunLookup / Gate / SecretResolver ----------------------------
+
+type fakeRuns map[string]RunInfo
+
+func (f fakeRuns) LookupRun(_ context.Context, runID string) (RunInfo, error) {
+	r, ok := f[runID]
+	if !ok {
+		return RunInfo{}, ErrRunNotFound
+	}
+	return r, nil
+}
+
+// approveGate 总是批准;rejectGate 总是拒绝;errGate 返回 ctx 取消错误。
+type approveGate struct{ actor string }
+
+func (g approveGate) Await(_ context.Context, _ string, _ GateInfo) (bool, string, error) {
+	return true, g.actor, nil
+}
+
+type rejectGate struct{}
+
+func (rejectGate) Await(_ context.Context, _ string, _ GateInfo) (bool, string, error) {
+	return false, "boss", nil
+}
+
+type errGate struct{}
+
+func (errGate) Await(_ context.Context, _ string, _ GateInfo) (bool, string, error) {
+	return false, "timeout", context.DeadlineExceeded
+}
+
+type fakeSecret map[string]string
+
+func (f fakeSecret) Reveal(id string) (string, error) {
+	v, ok := f[id]
+	if !ok {
+		return "", errors.New("not found")
+	}
+	return v, nil
+}
+
+// ---- 链模型单测 -------------------------------------------------------------
+
+func TestChainNextTargetAndValidation(t *testing.T) {
+	c := Chain{Environments: []EnvStage{{Name: "dev"}, {Name: "staging"}, {Name: "prod", Gated: true}}}
+
+	// 首次晋级目标 = 链首。
+	if got, err := c.nextTarget(""); err != nil || got != "dev" {
+		t.Fatalf("nextTarget(\"\") = %q, %v; want dev", got, err)
+	}
+	// 中间级。
+	if got, err := c.nextTarget("dev"); err != nil || got != "staging" {
+		t.Fatalf("nextTarget(dev) = %q, %v; want staging", got, err)
+	}
+	// 链尾无下一级。
+	if _, err := c.nextTarget("prod"); !errors.Is(err, ErrAlreadyAtTop) {
+		t.Fatalf("nextTarget(prod) err = %v; want ErrAlreadyAtTop", err)
+	}
+	// 跳级被拒。
+	if err := c.validateTarget("dev", "prod"); !errors.Is(err, ErrSkipEnv) {
+		t.Fatalf("validateTarget(dev→prod) = %v; want ErrSkipEnv", err)
+	}
+	// 未知目标。
+	if err := c.validateTarget("dev", "qa"); !errors.Is(err, ErrUnknownEnv) {
+		t.Fatalf("validateTarget(dev→qa) = %v; want ErrUnknownEnv", err)
+	}
+	// 合法下一级。
+	if err := c.validateTarget("dev", "staging"); err != nil {
+		t.Fatalf("validateTarget(dev→staging) = %v; want nil", err)
+	}
+	if c.Gated("prod") != true || c.Gated("dev") != false {
+		t.Fatalf("Gated wrong: prod=%v dev=%v", c.Gated("prod"), c.Gated("dev"))
+	}
+}
+
+func TestValidateChainRejectsBadInput(t *testing.T) {
+	if _, err := validateChain(Chain{}); !errors.Is(err, ErrEmptyChain) {
+		t.Fatalf("empty chain err = %v", err)
+	}
+	if _, err := validateChain(Chain{Environments: []EnvStage{{Name: "dev"}, {Name: "dev"}}}); !errors.Is(err, ErrDuplicateEnv) {
+		t.Fatalf("dup chain err = %v", err)
+	}
+	if _, err := validateChain(Chain{Environments: []EnvStage{{Name: "  "}}}); !errors.Is(err, ErrInvalidEnvName) {
+		t.Fatalf("blank name err = %v", err)
+	}
+	// 去首尾空白。
+	out, err := validateChain(Chain{Environments: []EnvStage{{Name: " dev "}, {Name: "prod", Gated: true}}})
+	if err != nil {
+		t.Fatalf("valid chain err = %v", err)
+	}
+	if out.Environments[0].Name != "dev" || !out.Environments[1].Gated {
+		t.Fatalf("normalize wrong: %+v", out.Environments)
+	}
+}
+
+// ---- store 单测 -------------------------------------------------------------
+
+func TestSaveAndGetChain(t *testing.T) {
+	st, db := testStore(t)
+	proj := seedProject(t, db)
+	ctx := context.Background()
+
+	if _, err := st.GetChain(ctx, proj); !errors.Is(err, ErrChainNotConfigured) {
+		t.Fatalf("GetChain before save = %v; want ErrChainNotConfigured", err)
+	}
+	saved, err := st.SaveChain(ctx, proj, Chain{Environments: []EnvStage{{Name: "dev"}, {Name: "prod", Gated: true}}})
+	if err != nil {
+		t.Fatalf("SaveChain: %v", err)
+	}
+	if len(saved.Environments) != 2 {
+		t.Fatalf("saved chain len = %d", len(saved.Environments))
+	}
+	got, err := st.GetChain(ctx, proj)
+	if err != nil {
+		t.Fatalf("GetChain: %v", err)
+	}
+	if got.Environments[1].Name != "prod" || !got.Environments[1].Gated {
+		t.Fatalf("round-trip chain wrong: %+v", got.Environments)
+	}
+}
+
+func TestSaveChainUnknownProject(t *testing.T) {
+	st, _ := testStore(t)
+	_, err := st.SaveChain(context.Background(), "no-such-project", Chain{Environments: []EnvStage{{Name: "dev"}}})
+	if !errors.Is(err, ErrProjectNotFound) {
+		t.Fatalf("SaveChain unknown project = %v; want ErrProjectNotFound", err)
+	}
+}
+
+func TestEnvVariablesSecretNeverStoresPlaintext(t *testing.T) {
+	st, db := testStore(t)
+	proj := seedProject(t, db)
+	ctx := context.Background()
+
+	err := st.SetVariables(ctx, proj, "prod", []Variable{
+		{Key: "LOG_LEVEL", Value: "info"},
+		{Key: "DB_PASSWORD", Secret: true, CredentialID: "cred-123", Value: "should-be-dropped"},
+	})
+	if err != nil {
+		t.Fatalf("SetVariables: %v", err)
+	}
+	// 列表视图:secret 不含明文。
+	vs, err := st.ListVariables(ctx, proj, "prod")
+	if err != nil {
+		t.Fatalf("ListVariables: %v", err)
+	}
+	for _, v := range vs {
+		if v.Secret && v.Value != "" {
+			t.Fatalf("secret variable leaked plaintext: %+v", v)
+		}
+	}
+	// 直接查 DB:secret 行 value 列为空。
+	var val string
+	if err := db.QueryRow(
+		`SELECT value FROM environment_variables WHERE project_id=? AND environment='prod' AND var_key='DB_PASSWORD'`,
+		proj).Scan(&val); err != nil {
+		t.Fatalf("query secret row: %v", err)
+	}
+	if val != "" {
+		t.Fatalf("DB stored secret plaintext: %q", val)
+	}
+}
+
+func TestSetVariablesRejectsDuplicateKey(t *testing.T) {
+	st, db := testStore(t)
+	proj := seedProject(t, db)
+	err := st.SetVariables(context.Background(), proj, "dev", []Variable{
+		{Key: "X", Value: "1"}, {Key: "X", Value: "2"},
+	})
+	if !errors.Is(err, ErrVarKeyDuplicate) {
+		t.Fatalf("dup var key = %v; want ErrVarKeyDuplicate", err)
+	}
+}
+
+// ---- 编排状态机单测 ---------------------------------------------------------
+
+func TestPromoteRejectsNonSuccessfulRun(t *testing.T) {
+	st, db := testStore(t)
+	proj := seedProject(t, db)
+	runID := seedRun(t, db, proj, "failed")
+	_, _ = st.SaveChain(context.Background(), proj, Chain{Environments: []EnvStage{{Name: "dev"}}})
+
+	co := NewCoordinator(st, fakeRuns{runID: {ID: runID, ProjectID: proj, Status: "failed"}}, nil, nil)
+	_, err := co.Promote(context.Background(), runID, "", "admin")
+	if !errors.Is(err, ErrRunNotSuccessful) {
+		t.Fatalf("Promote failed run = %v; want ErrRunNotSuccessful", err)
+	}
+}
+
+func TestPromoteSequenceAndNoSkip(t *testing.T) {
+	st, db := testStore(t)
+	proj := seedProject(t, db)
+	runID := seedRun(t, db, proj, "success")
+	ctx := context.Background()
+	_, _ = st.SaveChain(ctx, proj, Chain{Environments: []EnvStage{{Name: "dev"}, {Name: "staging"}, {Name: "prod", Gated: true}}})
+
+	co := NewCoordinator(st, fakeRuns{runID: {ID: runID, ProjectID: proj, Status: "success"}}, approveGate{actor: "boss"}, nil)
+
+	// 不可跳级:首次目标必须是 dev,直接要 prod 被拒。
+	if _, err := co.Promote(ctx, runID, "prod", "admin"); !errors.Is(err, ErrSkipEnv) {
+		t.Fatalf("skip to prod = %v; want ErrSkipEnv", err)
+	}
+
+	// 晋级 dev(非 gated)。
+	res, err := co.Promote(ctx, runID, "", "admin")
+	if err != nil || res.Record.TargetEnvironment != "dev" || res.Record.Status != StatusPromoted {
+		t.Fatalf("promote dev: %+v, %v", res, err)
+	}
+	// 重复晋级 dev 被拒。
+	if _, err := co.Promote(ctx, runID, "dev", "admin"); !errors.Is(err, ErrAlreadyPromoted) {
+		t.Fatalf("re-promote dev = %v; want ErrAlreadyPromoted", err)
+	}
+	// 晋级 staging。
+	res, err = co.Promote(ctx, runID, "staging", "admin")
+	if err != nil || res.Record.FromEnvironment != "dev" || res.Record.TargetEnvironment != "staging" {
+		t.Fatalf("promote staging: %+v, %v", res, err)
+	}
+	// 晋级 prod(gated → approveGate 批准)。
+	res, err = co.Promote(ctx, runID, "prod", "admin")
+	if err != nil || res.Record.Status != StatusPromoted || res.Record.PromotedBy != "boss" {
+		t.Fatalf("promote prod gated: %+v, %v", res, err)
+	}
+	// 已在链尾:再晋级 → ErrAlreadyAtTop。
+	if _, err := co.Promote(ctx, runID, "", "admin"); !errors.Is(err, ErrAlreadyAtTop) {
+		t.Fatalf("promote past prod = %v; want ErrAlreadyAtTop", err)
+	}
+}
+
+func TestPromoteGatedRejected(t *testing.T) {
+	st, db := testStore(t)
+	proj := seedProject(t, db)
+	runID := seedRun(t, db, proj, "success")
+	ctx := context.Background()
+	_, _ = st.SaveChain(ctx, proj, Chain{Environments: []EnvStage{{Name: "prod", Gated: true}}})
+
+	co := NewCoordinator(st, fakeRuns{runID: {ID: runID, ProjectID: proj, Status: "success"}}, rejectGate{}, nil)
+	res, err := co.Promote(ctx, runID, "prod", "admin")
+	if !errors.Is(err, ErrGateRejected) {
+		t.Fatalf("gated reject err = %v; want ErrGateRejected", err)
+	}
+	if res == nil || res.Record.Status != StatusRejected {
+		t.Fatalf("rejected record wrong: %+v", res)
+	}
+	// 被拒后该环境无 active 占用,可重新晋级。
+	if active, _ := st.hasActivePromotion(ctx, runID, "prod"); active {
+		t.Fatalf("rejected promotion should not be active")
+	}
+}
+
+func TestPromoteGatedNoGateFailsClosed(t *testing.T) {
+	st, db := testStore(t)
+	proj := seedProject(t, db)
+	runID := seedRun(t, db, proj, "success")
+	ctx := context.Background()
+	_, _ = st.SaveChain(ctx, proj, Chain{Environments: []EnvStage{{Name: "prod", Gated: true}}})
+
+	// gate=nil:gated 环境 fail-closed(绝不擅自放行)。
+	co := NewCoordinator(st, fakeRuns{runID: {ID: runID, ProjectID: proj, Status: "success"}}, nil, nil)
+	res, err := co.Promote(ctx, runID, "prod", "admin")
+	if !errors.Is(err, ErrGateRejected) {
+		t.Fatalf("no-gate gated promote = %v; want ErrGateRejected", err)
+	}
+	if res.Record.Status != StatusRejected {
+		t.Fatalf("fail-closed record status = %q", res.Record.Status)
+	}
+}
+
+func TestPromoteGatedTimeout(t *testing.T) {
+	st, db := testStore(t)
+	proj := seedProject(t, db)
+	runID := seedRun(t, db, proj, "success")
+	ctx := context.Background()
+	_, _ = st.SaveChain(ctx, proj, Chain{Environments: []EnvStage{{Name: "prod", Gated: true}}})
+
+	co := NewCoordinator(st, fakeRuns{runID: {ID: runID, ProjectID: proj, Status: "success"}}, errGate{}, nil)
+	res, err := co.Promote(ctx, runID, "prod", "admin")
+	if err == nil {
+		t.Fatalf("gated timeout expected error")
+	}
+	if res == nil || res.Record.Status != StatusRejected {
+		t.Fatalf("timeout record wrong: %+v", res)
+	}
+}
+
+func TestResolveEnvVarsDecryptsSecrets(t *testing.T) {
+	st, db := testStore(t)
+	proj := seedProject(t, db)
+	ctx := context.Background()
+	if err := st.SetVariables(ctx, proj, "prod", []Variable{
+		{Key: "LOG_LEVEL", Value: "info"},
+		{Key: "TOKEN", Secret: true, CredentialID: "cred-1"},
+		{Key: "MISSING", Secret: true, CredentialID: "cred-absent"},
+	}); err != nil {
+		t.Fatalf("SetVariables: %v", err)
+	}
+	co := NewCoordinator(st, fakeRuns{}, nil, fakeSecret{"cred-1": "s3cr3t"})
+	vars, unresolved, err := co.ResolveEnvVars(ctx, proj, "prod")
+	if err != nil {
+		t.Fatalf("ResolveEnvVars: %v", err)
+	}
+	got := map[string]string{}
+	for _, v := range vars {
+		got[v.Key] = v.Value
+	}
+	if got["LOG_LEVEL"] != "info" || got["TOKEN"] != "s3cr3t" {
+		t.Fatalf("resolved vars wrong: %+v", got)
+	}
+	if _, ok := got["MISSING"]; ok {
+		t.Fatalf("missing-credential secret should not resolve")
+	}
+	if len(unresolved) != 1 || unresolved[0] != "MISSING" {
+		t.Fatalf("unresolved = %v; want [MISSING]", unresolved)
+	}
+}
+
+func TestPromoteRunNotFound(t *testing.T) {
+	st, db := testStore(t)
+	proj := seedProject(t, db)
+	_, _ = st.SaveChain(context.Background(), proj, Chain{Environments: []EnvStage{{Name: "dev"}}})
+	co := NewCoordinator(st, fakeRuns{}, nil, nil)
+	if _, err := co.Promote(context.Background(), uuid.NewString(), "", "admin"); !errors.Is(err, ErrRunNotFound) {
+		t.Fatalf("promote unknown run = %v; want ErrRunNotFound", err)
+	}
+}
+
+func TestListRecordsForRunAndProject(t *testing.T) {
+	st, db := testStore(t)
+	proj := seedProject(t, db)
+	runID := seedRun(t, db, proj, "success")
+	ctx := context.Background()
+	_, _ = st.SaveChain(ctx, proj, Chain{Environments: []EnvStage{{Name: "dev"}, {Name: "staging"}}})
+	co := NewCoordinator(st, fakeRuns{runID: {ID: runID, ProjectID: proj, Status: "success"}}, nil, nil)
+	if _, err := co.Promote(ctx, runID, "dev", "admin"); err != nil {
+		t.Fatalf("promote dev: %v", err)
+	}
+	if _, err := co.Promote(ctx, runID, "staging", "admin"); err != nil {
+		t.Fatalf("promote staging: %v", err)
+	}
+	runRecs, err := st.ListRecordsForRun(ctx, runID)
+	if err != nil || len(runRecs) != 2 {
+		t.Fatalf("ListRecordsForRun = %d, %v; want 2", len(runRecs), err)
+	}
+	projRecs, err := st.ListRecordsForProject(ctx, proj)
+	if err != nil || len(projRecs) != 2 {
+		t.Fatalf("ListRecordsForProject = %d, %v; want 2", len(projRecs), err)
+	}
+}

--- a/internal/promotion/store.go
+++ b/internal/promotion/store.go
@@ -1,0 +1,313 @@
+package promotion
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Store 持久化环境链 / 环境变量 / 晋级记录(参数化 SQL)。
+type Store struct {
+	db *sql.DB
+}
+
+// NewStore 构造持久层。
+func NewStore(db *sql.DB) *Store { return &Store{db: db} }
+
+// GetChain 取某项目的环境链。未配置 → ErrChainNotConfigured。
+func (s *Store) GetChain(ctx context.Context, projectID string) (Chain, error) {
+	var chainJSON string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT chain_json FROM project_environments WHERE project_id = ?`, projectID).Scan(&chainJSON)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Chain{}, ErrChainNotConfigured
+		}
+		return Chain{}, fmt.Errorf("promotion: get chain: %w", err)
+	}
+	var envs []EnvStage
+	if strings.TrimSpace(chainJSON) != "" {
+		if uerr := json.Unmarshal([]byte(chainJSON), &envs); uerr != nil {
+			return Chain{}, fmt.Errorf("promotion: decode chain: %w", uerr)
+		}
+	}
+	if len(envs) == 0 {
+		return Chain{}, ErrChainNotConfigured
+	}
+	return Chain{Environments: envs}, nil
+}
+
+// SaveChain upsert 某项目的环境链(校验非空/无重名)。项目不存在 → ErrProjectNotFound。
+func (s *Store) SaveChain(ctx context.Context, projectID string, c Chain) (Chain, error) {
+	valid, err := validateChain(c)
+	if err != nil {
+		return Chain{}, err
+	}
+	raw, err := json.Marshal(valid.Environments)
+	if err != nil {
+		return Chain{}, fmt.Errorf("promotion: encode chain: %w", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO project_environments (project_id, chain_json, updated_at)
+		 VALUES (?, ?, ?)
+		 ON CONFLICT(project_id) DO UPDATE SET chain_json = excluded.chain_json, updated_at = excluded.updated_at`,
+		projectID, string(raw), now,
+	)
+	if err != nil {
+		if isForeignKeyErr(err) {
+			return Chain{}, ErrProjectNotFound
+		}
+		return Chain{}, fmt.Errorf("promotion: save chain: %w", err)
+	}
+	return valid, nil
+}
+
+// SetVariables 覆盖某项目某环境的全部作用域变量(整批替换;单事务)。
+// secret 变量须给 credentialId(不存明文);非 secret 存明文 value。空 key → ErrVarKeyEmpty;
+// 同环境内 key 重复 → ErrVarKeyDuplicate。项目不存在 → ErrProjectNotFound。
+func (s *Store) SetVariables(ctx context.Context, projectID, env string, vars []Variable) error {
+	env = strings.TrimSpace(env)
+	if env == "" {
+		return ErrInvalidEnvName
+	}
+	seen := map[string]struct{}{}
+	for i := range vars {
+		vars[i].Key = strings.TrimSpace(vars[i].Key)
+		if vars[i].Key == "" {
+			return ErrVarKeyEmpty
+		}
+		if _, dup := seen[vars[i].Key]; dup {
+			return ErrVarKeyDuplicate
+		}
+		seen[vars[i].Key] = struct{}{}
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("promotion: begin set vars tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM environment_variables WHERE project_id = ? AND environment = ?`,
+		projectID, env); err != nil {
+		return fmt.Errorf("promotion: clear vars: %w", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, v := range vars {
+		value, credID := v.Value, ""
+		isSecret := 0
+		if v.Secret {
+			isSecret = 1
+			value = "" // secret 绝不存明文
+			credID = strings.TrimSpace(v.CredentialID)
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO environment_variables
+			   (id, project_id, environment, var_key, value, is_secret, credential_id, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			uuid.NewString(), projectID, env, v.Key, value, isSecret, credID, now,
+		); err != nil {
+			if isForeignKeyErr(err) {
+				return ErrProjectNotFound
+			}
+			return fmt.Errorf("promotion: insert var: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("promotion: commit set vars: %w", err)
+	}
+	return nil
+}
+
+// ListVariables 取某项目某环境的全部变量(掩码视图:secret 仅 credentialId,绝无明文)。
+func (s *Store) ListVariables(ctx context.Context, projectID, env string) ([]Variable, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT var_key, value, is_secret, credential_id
+		 FROM environment_variables WHERE project_id = ? AND environment = ?
+		 ORDER BY var_key ASC`, projectID, env)
+	if err != nil {
+		return nil, fmt.Errorf("promotion: list vars: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	out := []Variable{}
+	for rows.Next() {
+		var (
+			v        Variable
+			isSecret int
+		)
+		if err := rows.Scan(&v.Key, &v.Value, &isSecret, &v.CredentialID); err != nil {
+			return nil, fmt.Errorf("promotion: scan var: %w", err)
+		}
+		if isSecret == 1 {
+			v.Secret = true
+			v.Value = "" // 双保险:绝不外泄明文
+		}
+		out = append(out, v)
+	}
+	return out, rows.Err()
+}
+
+// rawVariable 是内部读形状(含 is_secret/credential_id)供变量解析注入。
+type rawVariable struct {
+	Key          string
+	Value        string
+	Secret       bool
+	CredentialID string
+}
+
+// loadRawVariables 取某环境全部变量的内部形状(供 Resolver 解密注入)。
+func (s *Store) loadRawVariables(ctx context.Context, projectID, env string) ([]rawVariable, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT var_key, value, is_secret, credential_id
+		 FROM environment_variables WHERE project_id = ? AND environment = ?
+		 ORDER BY var_key ASC`, projectID, env)
+	if err != nil {
+		return nil, fmt.Errorf("promotion: load raw vars: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	out := []rawVariable{}
+	for rows.Next() {
+		var (
+			v        rawVariable
+			isSecret int
+		)
+		if err := rows.Scan(&v.Key, &v.Value, &isSecret, &v.CredentialID); err != nil {
+			return nil, fmt.Errorf("promotion: scan raw var: %w", err)
+		}
+		v.Secret = isSecret == 1
+		out = append(out, v)
+	}
+	return out, rows.Err()
+}
+
+// currentEnvForRun 返回某源运行已晋级到的「最高」环境(按链序)。
+// 无任何 promoted 记录 → 空串(尚未晋级)。
+func (s *Store) currentEnvForRun(ctx context.Context, runID string, c Chain) (string, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT target_environment FROM run_promotions
+		 WHERE source_run_id = ? AND status = ?`, runID, StatusPromoted)
+	if err != nil {
+		return "", fmt.Errorf("promotion: query promoted envs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	best := -1
+	for rows.Next() {
+		var env string
+		if err := rows.Scan(&env); err != nil {
+			return "", fmt.Errorf("promotion: scan promoted env: %w", err)
+		}
+		if i := c.IndexOf(env); i > best {
+			best = i
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	if best < 0 {
+		return "", nil
+	}
+	return c.Environments[best].Name, nil
+}
+
+// hasActivePromotion 报告某源运行到某环境是否已有 pending/promoted 记录(防重复晋级/并发重入)。
+func (s *Store) hasActivePromotion(ctx context.Context, runID, env string) (bool, error) {
+	var n int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(1) FROM run_promotions
+		 WHERE source_run_id = ? AND target_environment = ? AND status IN (?, ?)`,
+		runID, env, StatusPending, StatusPromoted).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("promotion: check active promotion: %w", err)
+	}
+	return n > 0, nil
+}
+
+// createRecord 登记一条晋级记录(初始 status)。
+func (s *Store) createRecord(ctx context.Context, rec Record) (string, error) {
+	id := uuid.NewString()
+	now := time.Now().UTC().Format(time.RFC3339)
+	decided := ""
+	if rec.Status == StatusPromoted || rec.Status == StatusRejected {
+		decided = now
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO run_promotions
+		   (id, project_id, source_run_id, from_environment, target_environment,
+		    status, approval_stage, promoted_by, created_at, decided_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, rec.ProjectID, rec.SourceRunID, rec.FromEnvironment, rec.TargetEnvironment,
+		rec.Status, rec.ApprovalStage, rec.PromotedBy, now, decided,
+	)
+	if err != nil {
+		if isForeignKeyErr(err) {
+			return "", ErrRunNotFound
+		}
+		return "", fmt.Errorf("promotion: create record: %w", err)
+	}
+	return id, nil
+}
+
+// decideRecord 把某记录置为终态(promoted/rejected)+ 记决定时刻 + 决定人。
+func (s *Store) decideRecord(ctx context.Context, id, status, by string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE run_promotions SET status = ?, decided_at = ?, promoted_by = ? WHERE id = ?`,
+		status, now, by, id)
+	if err != nil {
+		return fmt.Errorf("promotion: decide record: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return fmt.Errorf("promotion: decide record: not found")
+	}
+	return nil
+}
+
+// ListRecordsForRun 返回某源运行的全部晋级记录(按 created_at 升序)。
+func (s *Store) ListRecordsForRun(ctx context.Context, runID string) ([]Record, error) {
+	return s.queryRecords(ctx, `WHERE source_run_id = ?`, runID)
+}
+
+// ListRecordsForProject 返回某项目的全部晋级记录(按 created_at 降序,最近在前)。
+func (s *Store) ListRecordsForProject(ctx context.Context, projectID string) ([]Record, error) {
+	return s.queryRecords(ctx, `WHERE project_id = ? ORDER BY created_at DESC, id DESC`, projectID)
+}
+
+func (s *Store) queryRecords(ctx context.Context, clause, arg string) ([]Record, error) {
+	q := `SELECT id, project_id, source_run_id, from_environment, target_environment,
+	             status, approval_stage, promoted_by, created_at, decided_at
+	      FROM run_promotions ` + clause
+	if !strings.Contains(clause, "ORDER BY") {
+		q += " ORDER BY created_at ASC, id ASC"
+	}
+	rows, err := s.db.QueryContext(ctx, q, arg)
+	if err != nil {
+		return nil, fmt.Errorf("promotion: query records: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	out := []Record{}
+	for rows.Next() {
+		var r Record
+		if err := rows.Scan(&r.ID, &r.ProjectID, &r.SourceRunID, &r.FromEnvironment, &r.TargetEnvironment,
+			&r.Status, &r.ApprovalStage, &r.PromotedBy, &r.CreatedAt, &r.DecidedAt); err != nil {
+			return nil, fmt.Errorf("promotion: scan record: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// isForeignKeyErr 判断错误是否为外键约束失败(modernc sqlite 文本含 FOREIGN KEY)。
+func isForeignKeyErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToUpper(err.Error()), "FOREIGN KEY")
+}

--- a/internal/store/migrations/0028_env_promotion.sql
+++ b/internal/store/migrations/0028_env_promotion.sql
@@ -1,0 +1,59 @@
+-- 0028 env_promotion:环境晋级流 dev→staging→prod(Epic 8 · Story 8-7 / FR-8-7)。
+--
+-- 三张表:
+--   project_environments      : 每项目一条有序环境链(JSON 数组,含 name/gated 配置)。
+--   environment_variables     : 逐环境作用域的 key=value 变量;secret 变量经 credential_id 引用保险库(无明文)。
+--   run_promotions            : 晋级记录(哪个 run 晋级到哪个环境、由谁、复用的审批门 stageId)。
+--
+-- 安全:variables 表的 secret 行只存 credential_id(指向 credentials 表),**绝无明文密钥**;
+-- 非 secret 行存明文 value(构建参数级,非密钥)。晋级记录不含敏感数据。
+-- 删项目级联删环境配置/变量/晋级记录。
+
+-- 每项目一条:有序环境链配置(JSON 数组,如 [{"name":"dev","gated":false},{"name":"prod","gated":true}])。
+CREATE TABLE IF NOT EXISTS project_environments (
+    project_id  TEXT PRIMARY KEY,
+    chain_json  TEXT NOT NULL DEFAULT '[]',
+    updated_at  TEXT NOT NULL,
+    FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);
+
+-- 逐环境作用域的变量:
+--   is_secret=0 → value 为明文(非密钥构建变量);credential_id 空。
+--   is_secret=1 → credential_id 引用 credentials 表(保险库),value 空(绝无明文密钥)。
+CREATE TABLE IF NOT EXISTS environment_variables (
+    id            TEXT PRIMARY KEY,
+    project_id    TEXT NOT NULL,
+    environment   TEXT NOT NULL,
+    var_key       TEXT NOT NULL,
+    value         TEXT NOT NULL DEFAULT '',
+    is_secret     INTEGER NOT NULL DEFAULT 0,
+    credential_id TEXT NOT NULL DEFAULT '',
+    updated_at    TEXT NOT NULL,
+    UNIQUE (project_id, environment, var_key),
+    FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_env_vars_proj_env
+    ON environment_variables (project_id, environment);
+
+-- 晋级记录:一次「把 source_run 晋级到 target_environment」的事实。
+--   status        : pending(待批) | promoted(已晋级) | rejected(被拒/超时/取消)
+--   approval_stage: 复用审批门内核(run_approvals)时的 stageId(gated 环境;非 gated 为空)
+--   promoted_by   : 操作者(展示/审计;绝无敏感数据)
+CREATE TABLE IF NOT EXISTS run_promotions (
+    id                 TEXT PRIMARY KEY,
+    project_id         TEXT NOT NULL,
+    source_run_id      TEXT NOT NULL,
+    from_environment   TEXT NOT NULL DEFAULT '',
+    target_environment TEXT NOT NULL,
+    status             TEXT NOT NULL DEFAULT 'pending',
+    approval_stage     TEXT NOT NULL DEFAULT '',
+    promoted_by        TEXT NOT NULL DEFAULT '',
+    created_at         TEXT NOT NULL,
+    decided_at         TEXT NOT NULL DEFAULT '',
+    FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+    FOREIGN KEY (source_run_id) REFERENCES pipeline_runs (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_run_promotions_proj ON run_promotions (project_id);
+CREATE INDEX IF NOT EXISTS idx_run_promotions_run ON run_promotions (source_run_id);


### PR DESCRIPTION
## 概述
实现 **FR-8-7 环境晋级流**:把一次**成功运行**沿一条**有序环境链**(dev → staging → prod)逐级晋级,逐环境可设审批门,逐环境作用域隔离变量/密钥。新增独立 `internal/promotion` 包,经最小 hook 与既有内核集成(不改 dagrun 既有契约)。

## 环境链模型
- 每项目一条**有序数组** `EnvStage{name, gated}`(如 `["dev","staging",{prod,gated}]`),存 `project_environments.chain_json`。
- 晋级**状态机**(`internal/promotion/promotion.go` + `coordinator.go`):
  - 首次晋级目标 = 链首;只能晋级到「当前已达环境的**下一级**」。
  - **禁跳级**(`ErrSkipEnv`)、**禁越链尾**(`ErrAlreadyAtTop`)、**禁重复**(`ErrAlreadyPromoted`)。
  - 源运行非 `success` → `ErrRunNotSuccessful`。

## 复用审批门内核(不重复造)
- gated 目标环境经 `promotionGate` **复用 FR-8-4 的 `approval.Coordinator` + `run_approvals`**(`stageId="promote:<env>"`);批准/拒绝直接走**既有** `POST /runs/{id}/approve|reject` 端点。
- 无 gate 装配时 **fail-closed**(登记 rejected,绝不擅自放行);超时/取消兜底自动拒绝。

## 逐环境变量/密钥隔离
- env-scoped `key=value`;**secret 变量只存 `credential_id` 引用保险库(vault)**,DB 与 HTTP 响应**绝无明文**(单测 + DB 直查双重校验)。
- `ResolveEnvVars` 经 `vault.Reveal` 即取即用解密注入;缺凭据/保险库未配 → 降级跳过该变量(记 `unresolved`,不让晋级因缺凭据而崩),错误体不含明文。

## 迁移
`internal/store/migrations/0028_env_promotion.sql` — 三表(均级联删项目):
- `project_environments`(链配置)
- `environment_variables`(逐环境作用域变量;secret 行仅 credential_id)
- `run_promotions`(晋级记录:源运行→目标环境、操作者、复用的审批门 stageId、状态)

## 端点(auth + CSRF + audit,附加式)
| 方法 | 路径 | 说明 |
|---|---|---|
| `PUT` | `/api/projects/{id}/environments` | 配置环境链 + 逐环境变量 |
| `GET` | `/api/projects/{id}/environments` | 读链 + 各环境变量掩码视图 |
| `GET` | `/api/projects/{id}/promotions` | 项目晋级历史 |
| `POST` | `/api/runs/{id}/promote` | 晋级到下一环境(`targetEnvironment?` 留空取下一级;gated 阻塞等审批) |
| `GET` | `/api/runs/{id}/promotions` | 运行晋级历史 |

## 测试
- `internal/promotion`:链状态机(禁跳级/越尾)、store(secret 不落明文、链 round-trip、未知项目)、编排(非 gated 同步、gated 批准/拒绝/超时/fail-closed、变量解密降级、运行不存在)。
- `internal/httpapi`:配置回读不泄明文、非 gated 同步晋级 + 历史、**gated 并发批准复用审批门**全链路。

## 已延后(明确)
- **前端晋级 UI**(run-detail 上的「晋级到下一环境」按钮 + 审批面、环境链/变量配置页)留作后续。本 PR 仅交付**后端 + API**,前端可直接对接上述端点(`HttpError` 形状不变)。
- 把已解析的 env-scoped 变量真正**注入晋级执行容器**的执行侧落地(`ResolveEnvVars` 已就绪,待与执行编排对接)。

## 绿灯证据(本地)
\`\`\`
gofmt -l .        # 触碰的 Go 文件无输出(干净)
go vet ./...      # OK
go build ./...    # OK
go test ./...     # 全 ok(promotion / httpapi 含新增用例全绿)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)