### PR TITLE
feat(pipeline): 测试报告 + 质量门禁(FR-8-6)

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -199,7 +199,9 @@ func main() {
 		// 审批门 hook(Story 8-4):Gate 阶段阻塞等待人工批准/拒绝。
 		dagOpts = append(dagOpts, dagrun.WithGate(httpapi.NewApprovalGate(runSvc, approvalCoord, approvalStore)))
 		if b, berr := build.NewBuilder(projectSvc, pipelineSettingsSvc, credVault); berr == nil {
-			dagOpts = append(dagOpts, dagrun.WithStageExecutor(build.NewStageExecutor(b)))
+			// runSvc 作测试报告持久层注入(Story 8-6 / FR-8-6):script 步骤产报告 → 解析 →
+			// 落库 → 质量门禁裁决(不过则阶段失败,阻断下游部署)。
+			dagOpts = append(dagOpts, dagrun.WithStageExecutor(build.NewStageExecutor(b, runSvc)))
 			log.Printf("[run] PIPEWRIGHT_RUNNER=dag:DAG 调度执行器已启用(阶段按 needs 编排;script 类型 job 在隔离容器真实执行,CLI=%s;build_image/push_image/deploy_ssh 真实化=后续)", b.DriverBinary())
 		} else {
 			log.Printf("[run] PIPEWRIGHT_RUNNER=dag:DAG 调度执行器已启用(阶段按 needs 编排;⚠ 未探测到容器 CLI,阶段执行体回退 stub:%v)", berr)

--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -39,7 +39,8 @@ func isScriptJob(jobType string) bool {
 
 // NewStageExecutor 返回一个复用 Builder 容器基建的真实 dagrun.StageExecutor。
 // 仅对 script/custom 类型 job 做真实容器执行;其余类型打占位日志放行。
-func NewStageExecutor(b *Builder) dagrun.StageExecutor {
+// reportSink 可选(nil = 不持久化测试报告,但质量门禁阻断仍生效;Story 8-6 / FR-8-6)。
+func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecutor {
 	return func(ctx context.Context, r *run.Run, stage pipeline.Stage, rep dagrun.StageReporter) error {
 		scriptJobs := make([]pipeline.Job, 0, len(stage.Jobs))
 		for _, jb := range stage.Jobs {
@@ -101,6 +102,13 @@ func NewStageExecutor(b *Builder) dagrun.StageExecutor {
 			if err := b.runScriptStep(ctx, sink, 0, step, workspace); err != nil {
 				return err // ErrBuildFailed / run.ErrCanceled
 			}
+		}
+
+		// 测试报告采集 + 质量门禁(Story 8-6 / FR-8-6):阶段 script job 全部成功后,据声明的
+		// 报告配置读工作区内的 JUnit/覆盖率文件 → 解析 → 持久化汇总 → 门禁裁决。门禁不过 →
+		// ErrQualityGate 令本阶段失败,阻断下游部署阶段(复用 dagrun「阶段失败→下游不执行」语义)。
+		if err := collectStageReport(ctx, reportSink, r, stage, workspace, rep); err != nil {
+			return err
 		}
 		return nil
 	}

--- a/internal/build/dag_stage_exec_test.go
+++ b/internal/build/dag_stage_exec_test.go
@@ -136,7 +136,7 @@ func TestScriptStepFromJobMissing(t *testing.T) {
 func TestStageExecutorRunsScriptJobInContainer(t *testing.T) {
 	drv := &recordingDriver{code: 0, emit: []string{"hello from container"}}
 	b := newDAGTestBuilder(drv, &markerCloner{})
-	exec := NewStageExecutor(b)
+	exec := NewStageExecutor(b, nil)
 	rep := &fakeReporter{}
 
 	err := exec(context.Background(), &run.Run{ProjectID: "p1"},
@@ -162,7 +162,7 @@ func TestStageExecutorRunsScriptJobInContainer(t *testing.T) {
 func TestStageExecutorInjectsRunParams(t *testing.T) {
 	drv := &recordingDriver{code: 0}
 	b := newDAGTestBuilder(drv, &markerCloner{})
-	exec := NewStageExecutor(b)
+	exec := NewStageExecutor(b, nil)
 	r := &run.Run{ProjectID: "p1", Trigger: run.Trigger{Params: map[string]string{"DEPLOY_ENV": "staging", "VER": "1.2"}}}
 	if err := exec(context.Background(), r, scriptStage(scriptJob("unit", "busybox", "echo hi")), &fakeReporter{}); err != nil {
 		t.Fatalf("exec: %v", err)
@@ -176,7 +176,7 @@ func TestStageExecutorInjectsRunParams(t *testing.T) {
 func TestStageExecutorNonScriptPlaceholder(t *testing.T) {
 	drv := &recordingDriver{}
 	b := newDAGTestBuilder(drv, &markerCloner{})
-	exec := NewStageExecutor(b)
+	exec := NewStageExecutor(b, nil)
 	rep := &fakeReporter{}
 
 	stage := pipeline.Stage{ID: "s", Name: "构建", Kind: pipeline.KindBuild,
@@ -195,7 +195,7 @@ func TestStageExecutorNonScriptPlaceholder(t *testing.T) {
 func TestStageExecutorScriptFailureNonZero(t *testing.T) {
 	drv := &recordingDriver{code: 1} // 容器非零退出
 	b := newDAGTestBuilder(drv, &markerCloner{})
-	exec := NewStageExecutor(b)
+	exec := NewStageExecutor(b, nil)
 	if err := exec(context.Background(), &run.Run{ProjectID: "p1"},
 		scriptStage(scriptJob("unit", "busybox", "false")), &fakeReporter{}); err == nil {
 		t.Error("expected ErrBuildFailed on nonzero container exit")
@@ -205,7 +205,7 @@ func TestStageExecutorScriptFailureNonZero(t *testing.T) {
 func TestStageExecutorInvalidScriptConfig(t *testing.T) {
 	drv := &recordingDriver{}
 	b := newDAGTestBuilder(drv, &markerCloner{})
-	exec := NewStageExecutor(b)
+	exec := NewStageExecutor(b, nil)
 	// script job 缺 image。
 	bad := pipeline.Job{Name: "x", Type: "script", Config: map[string]any{"commands": "echo hi"}}
 	if err := exec(context.Background(), &run.Run{ProjectID: "p1"}, scriptStage(bad), &fakeReporter{}); err == nil {
@@ -218,7 +218,7 @@ func TestStageExecutorInvalidScriptConfig(t *testing.T) {
 func TestE2EDockerStageExecutorParamsReal(t *testing.T) {
 	drv := dockerReadyOrSkip(t)
 	b := newDAGTestBuilder(drv, &markerCloner{})
-	exec := NewStageExecutor(b)
+	exec := NewStageExecutor(b, nil)
 	rep := &fakeReporter{}
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
@@ -237,7 +237,7 @@ func TestE2EDockerStageExecutorParamsReal(t *testing.T) {
 func TestE2EDockerStageExecutorReal(t *testing.T) {
 	drv := dockerReadyOrSkip(t)
 	b := newDAGTestBuilder(drv, &markerCloner{file: "marker.txt", content: "PIPEWRIGHT_DAG_OK"})
-	exec := NewStageExecutor(b)
+	exec := NewStageExecutor(b, nil)
 	rep := &fakeReporter{}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)

--- a/internal/build/dag_test_report.go
+++ b/internal/build/dag_test_report.go
@@ -1,0 +1,239 @@
+package build
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/huangchengsir/pipewright/internal/dagrun"
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/qualitygate"
+	"github.com/huangchengsir/pipewright/internal/run"
+	"github.com/huangchengsir/pipewright/internal/testreport"
+)
+
+// dag_test_report.go 实现「测试报告采集 + 质量门禁」(Epic 8 · Story 8-6 / FR-8-6)。
+//
+// 采集模型(复用已有挂载,不另造):script 步骤把测试报告写进克隆工作区(容器 /workspace
+// 挂载的就是宿主 workspace 目录),容器退出后报告文件即在宿主 workspace/<reportPath> 可读。
+// 阶段所有 script job 成功执行后,本层据该阶段任一 job 声明的报告配置读文件 → 解析 → 持久化
+// 汇总 → 据门禁阈值裁决。门禁不过 → 返回 ErrQualityGate,令阶段失败,从而**阻断下游部署阶段**
+// (复用 dagrun「阶段失败 → 下游不执行」语义,零新机制)。
+//
+// 门禁原因串只含计数/阈值数字,不含报告原文(无 secret 外泄)。报告文件不存在但声明了门禁 →
+// 阻断(声明了要求却拿不到证据,宁阻断不放过);仅声明展示(无门禁)时文件缺失 → 跳过不报错。
+
+// ErrQualityGate 表示质量门禁未通过(该阶段失败 → 运行终止,下游部署不执行)。
+var ErrQualityGate = errors.New("build: quality gate not satisfied")
+
+// TestReportSink 抽象「持久化一条测试报告汇总」的能力(由 run.Service 实现;测试可注入 fake)。
+// 解耦 internal/build 对 run.Service 全表面的依赖。
+type TestReportSink interface {
+	SaveTestReport(ctx context.Context, tr run.TestReport) (*run.TestReport, error)
+}
+
+// job.Config 报告/门禁键(对齐前端 script 节点表单;均为可选字符串值):
+//
+//	testReport      报告格式开关:值为 "junit" 时启用测试报告采集(其它/缺省 = 不采集)。
+//	reportPath      JUnit XML 报告路径(相对工作区根;testReport=junit 时必填)。
+//	coverageReport  覆盖率格式:值为 "cobertura" 时启用覆盖率采集(可选)。
+//	coveragePath    Cobertura XML 覆盖率路径(相对工作区根;coverageReport=cobertura 时读)。
+//	gateMaxFailures 门禁:允许的最大失败用例数(整数;缺省/空 = 不检查)。
+//	gateMinCoverage 门禁:要求的最小行覆盖率%(数字;缺省/空 = 不检查)。
+const (
+	cfgTestReport      = "testReport"
+	cfgReportPath      = "reportPath"
+	cfgCoverageReport  = "coverageReport"
+	cfgCoveragePath    = "coveragePath"
+	cfgGateMaxFailures = "gateMaxFailures"
+	cfgGateMinCoverage = "gateMinCoverage"
+)
+
+// reportSpec 是从一个阶段的 job 配置里抽取的报告采集声明。
+type reportSpec struct {
+	reportPath   string
+	coveragePath string // 为空 = 不采集覆盖率
+	thresholds   qualitygate.Thresholds
+}
+
+// reportSpecFromStage 从阶段的 script job 里找出第一个声明了 testReport=junit 的报告配置。
+// 无声明 → (nil, nil)(该阶段不采集报告)。
+func reportSpecFromStage(stage pipeline.Stage) *reportSpec {
+	for _, jb := range stage.Jobs {
+		if !strings.EqualFold(cfgString(jb.Config, cfgTestReport), "junit") {
+			continue
+		}
+		rp := cfgString(jb.Config, cfgReportPath)
+		if rp == "" {
+			continue
+		}
+		spec := &reportSpec{
+			reportPath: rp,
+			thresholds: qualitygate.Thresholds{
+				MaxFailures: cfgIntDefault(jb.Config, cfgGateMaxFailures, qualitygate.NoCheck),
+				MinCoverage: cfgFloatDefault(jb.Config, cfgGateMinCoverage, float64(qualitygate.NoCheck)),
+			},
+		}
+		if strings.EqualFold(cfgString(jb.Config, cfgCoverageReport), "cobertura") {
+			spec.coveragePath = cfgString(jb.Config, cfgCoveragePath)
+		}
+		return spec
+	}
+	return nil
+}
+
+// collectStageReport 在阶段 script job 成功执行后采集/解析/持久化测试报告并裁决门禁。
+//
+// 返回值:门禁不过 → ErrQualityGate(调用方据此令阶段失败);其余错误(配置缺失文件 + 声明了门禁)
+// 同样阻断。仅展示(无门禁)时解析失败/文件缺失 → 仅记日志,返回 nil(不阻断)。
+// sink 为 nil(未注入持久层)时:仍解析 + 评估门禁(阻断仍生效),只是不落库。
+func collectStageReport(ctx context.Context, sink TestReportSink, r *run.Run, stage pipeline.Stage, workspace string, rep dagrun.StageReporter) error {
+	spec := reportSpecFromStage(stage)
+	if spec == nil {
+		return nil // 该阶段未声明测试报告
+	}
+
+	gated := spec.thresholds.Enabled()
+
+	// 读 + 解析 JUnit。
+	xmlPath := safeJoinWorkspace(workspace, spec.reportPath)
+	data, rerr := os.ReadFile(xmlPath)
+	if rerr != nil {
+		msg := fmt.Sprintf("测试报告文件未找到或不可读:%s", spec.reportPath)
+		_ = rep.Log(ctx, streamStderr, msg)
+		if gated {
+			_ = rep.Log(ctx, streamStderr, "⛔ 已声明质量门禁但缺测试报告,阻断后续阶段")
+			return ErrQualityGate
+		}
+		return nil // 仅展示:软失败
+	}
+	summary, perr := testreport.ParseJUnit(data)
+	if perr != nil {
+		_ = rep.Log(ctx, streamStderr, fmt.Sprintf("测试报告解析失败:%v", perr))
+		if gated {
+			_ = rep.Log(ctx, streamStderr, "⛔ 已声明质量门禁但报告无法解析,阻断后续阶段")
+			return ErrQualityGate
+		}
+		return nil
+	}
+
+	// 可选覆盖率(次要项;失败软处理)。
+	if spec.coveragePath != "" {
+		covPath := safeJoinWorkspace(workspace, spec.coveragePath)
+		if cdata, cerr := os.ReadFile(covPath); cerr == nil {
+			if pct, cperr := testreport.ParseCoberturaCoverage(cdata); cperr == nil {
+				summary.Coverage = pct
+			} else {
+				_ = rep.Log(ctx, streamStdout, "覆盖率报告无法解析,按未提供覆盖率处理")
+			}
+		} else {
+			_ = rep.Log(ctx, streamStdout, "覆盖率报告未找到,按未提供覆盖率处理")
+		}
+	}
+
+	// 门禁裁决。
+	verdict := qualitygate.Evaluate(summary, spec.thresholds)
+
+	// 报告概要日志(无 secret;仅数字)。
+	covText := "n/a"
+	if summary.Coverage != testreport.CoverageUnknown {
+		covText = fmt.Sprintf("%.1f%%", summary.Coverage)
+	}
+	_ = rep.Log(ctx, streamStdout, fmt.Sprintf(
+		"📊 测试报告:通过 %d · 失败 %d · 跳过 %d(共 %d)· 覆盖率 %s",
+		summary.Passed, summary.Failed, summary.Skipped, summary.Total, covText))
+
+	// 持久化汇总(best-effort:落库失败不改变门禁裁决;仅记日志)。
+	if sink != nil {
+		tr := run.TestReport{
+			RunID:       r.ID,
+			StageID:     stage.ID,
+			StageName:   stage.Name,
+			Format:      "junit",
+			Total:       summary.Total,
+			Passed:      summary.Passed,
+			Failed:      summary.Failed,
+			Skipped:     summary.Skipped,
+			DurationSec: summary.DurationSeconds,
+			Coverage:    summary.Coverage,
+			GateEnabled: gated,
+			GatePassed:  verdict.Passed,
+			GateReason:  verdict.Reason(),
+		}
+		if _, serr := sink.SaveTestReport(ctx, tr); serr != nil {
+			_ = rep.Log(ctx, streamStderr, "测试报告汇总持久化失败(不影响门禁裁决)")
+		}
+	}
+
+	if gated && !verdict.Passed {
+		_ = rep.Log(ctx, streamStderr, "⛔ 质量门禁未通过:"+verdict.Reason())
+		_ = rep.Log(ctx, streamStderr, "已阻断后续阶段(含部署)")
+		return ErrQualityGate
+	}
+	if gated {
+		_ = rep.Log(ctx, streamStdout, "✅ 质量门禁通过")
+	}
+	return nil
+}
+
+// safeJoinWorkspace 把工作区根与用户给的相对报告路径拼成宿主绝对路径,清洗 `.`/`..`/前导斜杠
+// 防穿越逃出工作区(读文件前的纵深防御)。
+func safeJoinWorkspace(workspace, rel string) string {
+	parts := []string{}
+	for _, seg := range strings.Split(filepath.ToSlash(rel), "/") {
+		seg = strings.TrimSpace(seg)
+		if seg == "" || seg == "." || seg == ".." {
+			continue
+		}
+		parts = append(parts, seg)
+	}
+	return filepath.Join(append([]string{workspace}, parts...)...)
+}
+
+// cfgIntDefault 从 config 取整数值(字符串/数字皆容;缺失/非法 → def)。
+func cfgIntDefault(cfg map[string]any, key string, def int) int {
+	if cfg == nil {
+		return def
+	}
+	switch v := cfg[key].(type) {
+	case string:
+		s := strings.TrimSpace(v)
+		if s == "" {
+			return def
+		}
+		if n, err := strconv.Atoi(s); err == nil {
+			return n
+		}
+	case float64:
+		return int(v)
+	case int:
+		return v
+	}
+	return def
+}
+
+// cfgFloatDefault 从 config 取浮点值(字符串/数字皆容;缺失/非法 → def)。
+func cfgFloatDefault(cfg map[string]any, key string, def float64) float64 {
+	if cfg == nil {
+		return def
+	}
+	switch v := cfg[key].(type) {
+	case string:
+		s := strings.TrimSpace(v)
+		if s == "" {
+			return def
+		}
+		if f, err := strconv.ParseFloat(s, 64); err == nil {
+			return f
+		}
+	case float64:
+		return v
+	case int:
+		return float64(v)
+	}
+	return def
+}

--- a/internal/build/dag_test_report_test.go
+++ b/internal/build/dag_test_report_test.go
@@ -1,0 +1,162 @@
+package build
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// fakeReportSink 记录 SaveTestReport 调用(替代真 run.Service)。
+type fakeReportSink struct {
+	saved []run.TestReport
+}
+
+func (s *fakeReportSink) SaveTestReport(_ context.Context, tr run.TestReport) (*run.TestReport, error) {
+	s.saved = append(s.saved, tr)
+	out := tr
+	return &out, nil
+}
+
+// reportStage 构造一个声明了测试报告 + 门禁的阶段。
+func reportStage(cfg map[string]any) pipeline.Stage {
+	base := map[string]any{"image": "node:20", "commands": "echo run"}
+	for k, v := range cfg {
+		base[k] = v
+	}
+	return pipeline.Stage{ID: "s1", Name: "测试", Jobs: []pipeline.Job{{
+		ID: "j1", Name: "test", Type: pipeline.StepTypeScript, Config: base,
+	}}}
+}
+
+const junitPass = `<testsuites tests="3" failures="0" errors="0" skipped="0" time="1.0">
+  <testsuite name="a" tests="3" failures="0" errors="0" skipped="0"/>
+</testsuites>`
+
+const junitFail = `<testsuites tests="3" failures="1" errors="0" skipped="0" time="1.0">
+  <testsuite name="a" tests="3" failures="1" errors="0" skipped="0"/>
+</testsuites>`
+
+func writeReport(t *testing.T, ws, rel, content string) {
+	t.Helper()
+	p := filepath.Join(ws, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCollectStageReport_NoDeclaration(t *testing.T) {
+	ws := t.TempDir()
+	rep := &fakeReporter{}
+	sink := &fakeReportSink{}
+	stage := pipeline.Stage{ID: "s1", Name: "x", Jobs: []pipeline.Job{
+		{Type: pipeline.StepTypeScript, Config: map[string]any{"image": "x", "commands": "y"}},
+	}}
+	if err := collectStageReport(context.Background(), sink, &run.Run{ID: "r1"}, stage, ws, rep); err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if len(sink.saved) != 0 {
+		t.Errorf("saved %d reports, want 0 (no declaration)", len(sink.saved))
+	}
+}
+
+func TestCollectStageReport_PassPersists(t *testing.T) {
+	ws := t.TempDir()
+	writeReport(t, ws, "reports/junit.xml", junitPass)
+	rep := &fakeReporter{}
+	sink := &fakeReportSink{}
+	stage := reportStage(map[string]any{
+		"testReport": "junit", "reportPath": "reports/junit.xml", "gateMaxFailures": "0",
+	})
+	if err := collectStageReport(context.Background(), sink, &run.Run{ID: "r1"}, stage, ws, rep); err != nil {
+		t.Fatalf("err = %v, want nil (gate passes)", err)
+	}
+	if len(sink.saved) != 1 {
+		t.Fatalf("saved %d reports, want 1", len(sink.saved))
+	}
+	got := sink.saved[0]
+	if got.Total != 3 || got.Passed != 3 || got.Failed != 0 {
+		t.Errorf("summary = %+v, want total=3 passed=3 failed=0", got)
+	}
+	if !got.GateEnabled || !got.GatePassed {
+		t.Errorf("gate = enabled=%v passed=%v, want both true", got.GateEnabled, got.GatePassed)
+	}
+}
+
+func TestCollectStageReport_GateBlocks(t *testing.T) {
+	ws := t.TempDir()
+	writeReport(t, ws, "reports/junit.xml", junitFail)
+	rep := &fakeReporter{}
+	sink := &fakeReportSink{}
+	stage := reportStage(map[string]any{
+		"testReport": "junit", "reportPath": "reports/junit.xml", "gateMaxFailures": "0",
+	})
+	err := collectStageReport(context.Background(), sink, &run.Run{ID: "r1"}, stage, ws, rep)
+	if !errors.Is(err, ErrQualityGate) {
+		t.Fatalf("err = %v, want ErrQualityGate", err)
+	}
+	// 仍应持久化汇总(记录门禁不过)。
+	if len(sink.saved) != 1 || sink.saved[0].GatePassed {
+		t.Errorf("saved = %+v, want 1 report with GatePassed=false", sink.saved)
+	}
+}
+
+func TestCollectStageReport_MissingFileWithGateBlocks(t *testing.T) {
+	ws := t.TempDir() // 不写报告文件
+	rep := &fakeReporter{}
+	stage := reportStage(map[string]any{
+		"testReport": "junit", "reportPath": "reports/junit.xml", "gateMaxFailures": "0",
+	})
+	err := collectStageReport(context.Background(), nil, &run.Run{ID: "r1"}, stage, ws, rep)
+	if !errors.Is(err, ErrQualityGate) {
+		t.Fatalf("err = %v, want ErrQualityGate (gate declared but no report)", err)
+	}
+}
+
+func TestCollectStageReport_MissingFileNoGateSoftSkip(t *testing.T) {
+	ws := t.TempDir()
+	rep := &fakeReporter{}
+	sink := &fakeReportSink{}
+	stage := reportStage(map[string]any{
+		"testReport": "junit", "reportPath": "reports/junit.xml", // 无门禁
+	})
+	if err := collectStageReport(context.Background(), sink, &run.Run{ID: "r1"}, stage, ws, rep); err != nil {
+		t.Fatalf("err = %v, want nil (display-only, soft skip)", err)
+	}
+	if len(sink.saved) != 0 {
+		t.Errorf("saved %d, want 0", len(sink.saved))
+	}
+}
+
+func TestCollectStageReport_Coverage(t *testing.T) {
+	ws := t.TempDir()
+	writeReport(t, ws, "junit.xml", junitPass)
+	writeReport(t, ws, "cobertura.xml", `<coverage line-rate="0.92"/>`)
+	rep := &fakeReporter{}
+	sink := &fakeReportSink{}
+	stage := reportStage(map[string]any{
+		"testReport": "junit", "reportPath": "junit.xml",
+		"coverageReport": "cobertura", "coveragePath": "cobertura.xml",
+		"gateMinCoverage": "80",
+	})
+	if err := collectStageReport(context.Background(), sink, &run.Run{ID: "r1"}, stage, ws, rep); err != nil {
+		t.Fatalf("err = %v, want nil (92%% >= 80%%)", err)
+	}
+	if len(sink.saved) != 1 || sink.saved[0].Coverage < 91 || sink.saved[0].Coverage > 93 {
+		t.Errorf("coverage = %v, want ~92", sink.saved[0].Coverage)
+	}
+}
+
+func TestSafeJoinWorkspace_NoTraversal(t *testing.T) {
+	got := safeJoinWorkspace("/ws", "../../etc/passwd")
+	if got != filepath.Join("/ws", "etc", "passwd") {
+		t.Errorf("safeJoinWorkspace traversal not contained: %q", got)
+	}
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -362,6 +362,8 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		ar.Get("/runs/{id}/logs", makeRunLogsHandler(rs))
 		// 构建产物契约(Story 3.4 / FR-6):只读 + 认证;按 (type, reference) 供 Epic 4 消费。
 		ar.Get("/runs/{id}/artifacts", makeRunArtifactsHandler(rs))
+		// 测试报告 + 质量门禁(Story 8-6 / FR-8-6):只读 + 认证;通过/失败/跳过 + 覆盖率 + 门禁裁决。
+		ar.Get("/runs/{id}/test-report", makeRunTestReportHandler(rs))
 		ar.Post("/runs/{id}/cancel", makeCancelRunHandler(rs))
 		// 人工审批门(Story 8-4):批准/拒绝某运行的审批门阶段 + 列审批记录。
 		// approve/reject 为写方法,过 auth + CSRF;coord/store 为 nil → 503。

--- a/internal/httpapi/run_test_report.go
+++ b/internal/httpapi/run_test_report.go
@@ -1,0 +1,105 @@
+package httpapi
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// run_test_report.go 暴露测试报告 + 质量门禁汇总只读端点(Epic 8 · Story 8-6 / FR-8-6)。
+//
+// GET /api/runs/{id}/test-report → { reports: [...], gate: {...} }
+// reports 为各阶段产出的测试报告汇总(通过/失败/跳过/覆盖率);gate 为整次运行的门禁裁决聚合
+// (任一阶段门禁不过 → 整体 blocked,reason 汇总)。run 不存在 → 404。
+
+// testReportDTO 是单条阶段测试报告(camelCase)。
+type testReportDTO struct {
+	ID          string  `json:"id"`
+	StageID     string  `json:"stageId"`
+	StageName   string  `json:"stageName"`
+	Format      string  `json:"format"`      // junit
+	Total       int     `json:"total"`       // 用例总数
+	Passed      int     `json:"passed"`      //
+	Failed      int     `json:"failed"`      //
+	Skipped     int     `json:"skipped"`     //
+	DurationSec float64 `json:"durationSec"` // 套件总耗时(秒)
+	Coverage    float64 `json:"coverage"`    // 行覆盖率%(-1 = 未提供)
+	GateEnabled bool    `json:"gateEnabled"`
+	GatePassed  bool    `json:"gatePassed"`
+	GateReason  string  `json:"gateReason"` // 门禁阻断原因(无 secret;仅数字)
+	CreatedAt   string  `json:"createdAt"`  // RFC3339
+}
+
+// gateVerdictDTO 是整次运行的门禁聚合裁决。
+type gateVerdictDTO struct {
+	Enabled bool     `json:"enabled"` // 是否有任一阶段声明了门禁
+	Passed  bool     `json:"passed"`  // 全部门禁是否通过(无门禁 → true)
+	Reasons []string `json:"reasons"` // 各阶段阻断原因(通过 → [])
+}
+
+// runTestReportDTO 是 GET /api/runs/{id}/test-report 响应体。
+type runTestReportDTO struct {
+	Reports []testReportDTO `json:"reports"`
+	Gate    gateVerdictDTO  `json:"gate"`
+}
+
+func toTestReportDTO(tr run.TestReport) testReportDTO {
+	return testReportDTO{
+		ID:          tr.ID,
+		StageID:     tr.StageID,
+		StageName:   tr.StageName,
+		Format:      tr.Format,
+		Total:       tr.Total,
+		Passed:      tr.Passed,
+		Failed:      tr.Failed,
+		Skipped:     tr.Skipped,
+		DurationSec: tr.DurationSec,
+		Coverage:    tr.Coverage,
+		GateEnabled: tr.GateEnabled,
+		GatePassed:  tr.GatePassed,
+		GateReason:  tr.GateReason,
+		CreatedAt:   tr.CreatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+// makeRunTestReportHandler 返回 GET /api/runs/{id}/test-report handler(认证;只读)。
+// run 不存在 → 404 run_not_found。无报告 → { reports: [], gate: {enabled:false, passed:true} }。
+func makeRunTestReportHandler(svc run.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "运行服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+
+		// run 存在性:不存在 → 404(ListTestReports 对不存在 run 返回空,不报错)。
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeRunError(w, err)
+			return
+		}
+
+		reports, err := svc.ListTestReports(r.Context(), id)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+			return
+		}
+
+		dtos := make([]testReportDTO, 0, len(reports))
+		gate := gateVerdictDTO{Passed: true, Reasons: []string{}}
+		for i := range reports {
+			dtos = append(dtos, toTestReportDTO(reports[i]))
+			if reports[i].GateEnabled {
+				gate.Enabled = true
+				if !reports[i].GatePassed {
+					gate.Passed = false
+					if reports[i].GateReason != "" {
+						gate.Reasons = append(gate.Reasons, reports[i].GateReason)
+					}
+				}
+			}
+		}
+		writeJSON(w, http.StatusOK, runTestReportDTO{Reports: dtos, Gate: gate})
+	}
+}

--- a/internal/httpapi/run_test_report_test.go
+++ b/internal/httpapi/run_test_report_test.go
@@ -1,0 +1,114 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// TestRunTestReportEndpoint_Empty 验证无报告 run → { reports: [], gate:{enabled:false,passed:true} }。
+func TestRunTestReportEndpoint_Empty(t *testing.T) {
+	srv, client, csrf, projID, rsvc := setupRunServer(t)
+	r, err := rsvc.Create(context.Background(), projID,
+		run.Trigger{Type: run.TriggerManual, Branch: "main", Commit: "deadbeef", Actor: "admin"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	waitRunStatus(t, client, srv, csrf, r.ID, run.StatusSuccess)
+
+	resp := doJSON(t, client, http.MethodGet, srv.URL+"/api/runs/"+r.ID+"/test-report", csrf, "")
+	raw, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d: %s", resp.StatusCode, raw)
+	}
+	var body struct {
+		Reports []map[string]any `json:"reports"`
+		Gate    struct {
+			Enabled bool     `json:"enabled"`
+			Passed  bool     `json:"passed"`
+			Reasons []string `json:"reasons"`
+		} `json:"gate"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("decode: %v (%s)", err, raw)
+	}
+	if len(body.Reports) != 0 {
+		t.Errorf("reports = %v, want empty", body.Reports)
+	}
+	if body.Gate.Enabled || !body.Gate.Passed {
+		t.Errorf("gate = %+v, want enabled=false passed=true", body.Gate)
+	}
+}
+
+// TestRunTestReportEndpoint_WithReports 验证持久化的阶段报告 + 门禁聚合裁决正确出口。
+func TestRunTestReportEndpoint_WithReports(t *testing.T) {
+	srv, client, csrf, projID, rsvc := setupRunServer(t)
+	r, err := rsvc.Create(context.Background(), projID,
+		run.Trigger{Type: run.TriggerManual, Branch: "main", Commit: "deadbeef", Actor: "admin"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	waitRunStatus(t, client, srv, csrf, r.ID, run.StatusSuccess)
+
+	// 一条通过门禁,一条阻断门禁。
+	if _, err := rsvc.SaveTestReport(context.Background(), run.TestReport{
+		RunID: r.ID, StageID: "s1", StageName: "单元测试", Format: "junit",
+		Total: 10, Passed: 10, Failed: 0, Skipped: 0, Coverage: 85,
+		GateEnabled: true, GatePassed: true,
+	}); err != nil {
+		t.Fatalf("SaveTestReport pass: %v", err)
+	}
+	if _, err := rsvc.SaveTestReport(context.Background(), run.TestReport{
+		RunID: r.ID, StageID: "s2", StageName: "集成测试", Format: "junit",
+		Total: 5, Passed: 3, Failed: 2, Coverage: -1,
+		GateEnabled: true, GatePassed: false, GateReason: "失败用例 2 个,超过门禁上限 0",
+	}); err != nil {
+		t.Fatalf("SaveTestReport block: %v", err)
+	}
+
+	resp := doJSON(t, client, http.MethodGet, srv.URL+"/api/runs/"+r.ID+"/test-report", csrf, "")
+	raw, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d: %s", resp.StatusCode, raw)
+	}
+	var body struct {
+		Reports []struct {
+			StageName  string  `json:"stageName"`
+			Total      int     `json:"total"`
+			Failed     int     `json:"failed"`
+			Coverage   float64 `json:"coverage"`
+			GatePassed bool    `json:"gatePassed"`
+		} `json:"reports"`
+		Gate struct {
+			Enabled bool     `json:"enabled"`
+			Passed  bool     `json:"passed"`
+			Reasons []string `json:"reasons"`
+		} `json:"gate"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("decode: %v (%s)", err, raw)
+	}
+	if len(body.Reports) != 2 {
+		t.Fatalf("reports = %d, want 2", len(body.Reports))
+	}
+	// 整体门禁:有阶段阻断 → enabled=true, passed=false, reasons 非空。
+	if !body.Gate.Enabled || body.Gate.Passed || len(body.Gate.Reasons) != 1 {
+		t.Errorf("gate = %+v, want enabled=true passed=false 1 reason", body.Gate)
+	}
+}
+
+// TestRunTestReportEndpoint_NotFound 验证不存在 run → 404。
+func TestRunTestReportEndpoint_NotFound(t *testing.T) {
+	srv, client, csrf, _, _ := setupRunServer(t)
+	resp := doJSON(t, client, http.MethodGet, srv.URL+"/api/runs/no-such-run/test-report", csrf, "")
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}

--- a/internal/qualitygate/gate.go
+++ b/internal/qualitygate/gate.go
@@ -1,0 +1,77 @@
+// Package qualitygate 是质量门禁的纯评估层(Epic 8 · FR-8-6)。
+//
+// 输入:一份测试报告汇总(testreport.Summary)+ 一组门禁阈值(Thresholds)。
+// 输出:门禁裁决(Verdict:通过 / 阻断 + 人读原因)。阻断时,调用方(阶段执行器)据此
+// 令该阶段失败,从而**阻断下游部署阶段**——复用既有「阶段失败 → 下游不执行」语义,不另造机制。
+//
+// 本包零 I/O、零依赖运行时,便于穷举单测;原因串不含 secret(只含计数/阈值数字)。
+package qualitygate
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/huangchengsir/pipewright/internal/testreport"
+)
+
+// Thresholds 是质量门禁阈值(取自 script job 的 config)。
+//
+//   - MaxFailures   : 允许的最大失败用例数(含 errors);超过即阻断。-1 = 不检查失败数。
+//   - MinCoverage   : 要求的最小行覆盖率百分比(0~100);低于即阻断。-1 = 不检查覆盖率。
+//
+// 任一阈值为「不检查」哨兵(-1)时跳过该维度;两维都不检查 → 门禁恒通过(等于无门禁)。
+type Thresholds struct {
+	MaxFailures int
+	MinCoverage float64
+}
+
+// NoCheck 是「该维度不检查」的哨兵值。
+const NoCheck = -1
+
+// Enabled 报告是否声明了任一门禁维度(否则评估恒通过,可省略门禁展示)。
+func (t Thresholds) Enabled() bool {
+	return t.MaxFailures != NoCheck || t.MinCoverage != float64(NoCheck)
+}
+
+// Verdict 是门禁裁决结果。
+//
+//   - Passed     : 是否通过(未声明任何阈值 → 视为通过)。
+//   - Violations : 未通过的具体原因(人读;通过时为空)。
+type Verdict struct {
+	Passed     bool
+	Violations []string
+}
+
+// Reason 返回违规原因的单行汇总(通过时为空串)。不含 secret(仅数字)。
+func (v Verdict) Reason() string {
+	return strings.Join(v.Violations, "; ")
+}
+
+// Evaluate 据阈值评估一份测试报告,返回裁决。
+//
+// 失败数检查:Summary.Failed > MaxFailures → 违规。
+// 覆盖率检查:仅当报告提供了覆盖率(Coverage != CoverageUnknown);若声明了 MinCoverage
+// 但报告**未提供**覆盖率 → 视为违规(声明了要求却拿不到证据,宁阻断不放过)。
+func Evaluate(s testreport.Summary, t Thresholds) Verdict {
+	v := Verdict{Passed: true}
+
+	if t.MaxFailures != NoCheck && s.Failed > t.MaxFailures {
+		v.Passed = false
+		v.Violations = append(v.Violations, fmt.Sprintf(
+			"失败用例 %d 个,超过门禁上限 %d", s.Failed, t.MaxFailures))
+	}
+
+	if t.MinCoverage != float64(NoCheck) {
+		if s.Coverage == testreport.CoverageUnknown {
+			v.Passed = false
+			v.Violations = append(v.Violations, fmt.Sprintf(
+				"门禁要求覆盖率 ≥ %.1f%%,但本次未产出覆盖率报告", t.MinCoverage))
+		} else if s.Coverage < t.MinCoverage {
+			v.Passed = false
+			v.Violations = append(v.Violations, fmt.Sprintf(
+				"覆盖率 %.1f%%,低于门禁要求 %.1f%%", s.Coverage, t.MinCoverage))
+		}
+	}
+
+	return v
+}

--- a/internal/qualitygate/gate_test.go
+++ b/internal/qualitygate/gate_test.go
@@ -1,0 +1,73 @@
+package qualitygate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/testreport"
+)
+
+func TestEvaluate_NoThresholds_AlwaysPass(t *testing.T) {
+	th := Thresholds{MaxFailures: NoCheck, MinCoverage: float64(NoCheck)}
+	if th.Enabled() {
+		t.Error("Enabled() = true, want false for no-check thresholds")
+	}
+	v := Evaluate(testreport.Summary{Total: 3, Failed: 2}, th)
+	if !v.Passed {
+		t.Errorf("verdict = %+v, want passed even with failures (no gate)", v)
+	}
+}
+
+func TestEvaluate_FailuresExceed(t *testing.T) {
+	th := Thresholds{MaxFailures: 0, MinCoverage: float64(NoCheck)}
+	v := Evaluate(testreport.Summary{Total: 5, Failed: 2, Passed: 3}, th)
+	if v.Passed {
+		t.Fatalf("verdict = %+v, want blocked", v)
+	}
+	if !strings.Contains(v.Reason(), "失败用例 2") {
+		t.Errorf("reason = %q, want mention of 2 failures", v.Reason())
+	}
+}
+
+func TestEvaluate_FailuresWithinLimit(t *testing.T) {
+	th := Thresholds{MaxFailures: 3, MinCoverage: float64(NoCheck)}
+	v := Evaluate(testreport.Summary{Total: 10, Failed: 2}, th)
+	if !v.Passed {
+		t.Errorf("verdict = %+v, want passed (2 <= 3)", v)
+	}
+}
+
+func TestEvaluate_CoverageBelowMin(t *testing.T) {
+	th := Thresholds{MaxFailures: NoCheck, MinCoverage: 80}
+	v := Evaluate(testreport.Summary{Total: 4, Coverage: 72.5}, th)
+	if v.Passed {
+		t.Fatalf("verdict = %+v, want blocked for low coverage", v)
+	}
+	if !strings.Contains(v.Reason(), "72.5") {
+		t.Errorf("reason = %q, want mention of 72.5%%", v.Reason())
+	}
+}
+
+func TestEvaluate_CoverageMetExactly(t *testing.T) {
+	th := Thresholds{MaxFailures: NoCheck, MinCoverage: 80}
+	v := Evaluate(testreport.Summary{Total: 4, Coverage: 80}, th)
+	if !v.Passed {
+		t.Errorf("verdict = %+v, want passed (80 >= 80)", v)
+	}
+}
+
+func TestEvaluate_CoverageRequiredButMissing(t *testing.T) {
+	th := Thresholds{MaxFailures: NoCheck, MinCoverage: 80}
+	v := Evaluate(testreport.Summary{Total: 4, Coverage: testreport.CoverageUnknown}, th)
+	if v.Passed {
+		t.Fatalf("verdict = %+v, want blocked when coverage required but absent", v)
+	}
+}
+
+func TestEvaluate_BothViolated(t *testing.T) {
+	th := Thresholds{MaxFailures: 0, MinCoverage: 90}
+	v := Evaluate(testreport.Summary{Total: 5, Failed: 1, Coverage: 50}, th)
+	if v.Passed || len(v.Violations) != 2 {
+		t.Errorf("verdict = %+v, want blocked with 2 violations", v)
+	}
+}

--- a/internal/run/service.go
+++ b/internal/run/service.go
@@ -77,6 +77,14 @@ type Service interface {
 	// run 不存在不报错(返回空切片);由 HTTP 层据 run 存在性决定 404(仿 GetLogs 语义)。
 	ListArtifacts(ctx context.Context, runID string) ([]Artifact, error)
 
+	// SaveTestReport 持久化一条测试报告汇总(Story 8-6 / FR-8-6)。
+	// 计数 + 可选覆盖率 + 门禁裁决;同 run 多阶段产报告时各存一条(按 stage 区分)。
+	// run 不存在 → ErrNotFound(外键失败)。
+	SaveTestReport(ctx context.Context, tr TestReport) (*TestReport, error)
+	// ListTestReports 取某次运行的全部测试报告汇总(按 created_at 升序;无 → 空切片)。
+	// run 不存在不报错(返回空切片);由 HTTP 层据 run 存在性决定 404(仿 ListArtifacts 语义)。
+	ListTestReports(ctx context.Context, runID string) ([]TestReport, error)
+
 	// SaveDeployTargets 持久化一次部署的多机结果(Story 4.2 / FR-10;参数化 SQL,单事务)。
 	// status 须为冻结枚举(pending|deploying|success|failed|rolled_back),否则 ErrInvalidTargetStatus;
 	// run 不存在 → ErrNotFound。供 internal/deploy 写;httpapi run-detail 读填 targets slot。

--- a/internal/run/test_report.go
+++ b/internal/run/test_report.go
@@ -1,0 +1,120 @@
+package run
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// test_report.go 是「测试报告 + 质量门禁」的持久层(Epic 8 · Story 8-6 / FR-8-6)。
+//
+// script 步骤产出测试报告(JUnit XML / 可选 Cobertura 覆盖率)后,阶段执行器解析出
+// 通过/失败/跳过计数 + 覆盖率% + 门禁裁决,经本层存一条汇总(每阶段一条)。
+// httpapi run-detail 子端点据此展示;门禁阻断语义由阶段失败本身承载,本层只搬运形状。
+
+// TestReport 是一次运行(某阶段)的测试报告汇总领域模型。
+//
+//   - Format       : 报告格式(目前固定 "junit")。
+//   - Total/Passed/Failed/Skipped : 用例计数。
+//   - DurationSec  : 套件总耗时(秒)。
+//   - Coverage     : 行覆盖率百分比(0~100;-1 = 未提供)。
+//   - GateEnabled  : 是否声明了质量门禁阈值。
+//   - GatePassed   : 门禁是否通过(无门禁视为通过)。
+//   - GateReason   : 门禁阻断原因(人读;不含 secret;仅计数/阈值数字)。
+type TestReport struct {
+	ID          string
+	RunID       string
+	StageID     string
+	StageName   string
+	Format      string
+	Total       int
+	Passed      int
+	Failed      int
+	Skipped     int
+	DurationSec float64
+	Coverage    float64
+	GateEnabled bool
+	GatePassed  bool
+	GateReason  string
+	CreatedAt   time.Time
+}
+
+// SaveTestReport 持久化一条测试报告汇总(参数化 SQL)。
+func (s *service) SaveTestReport(ctx context.Context, tr TestReport) (*TestReport, error) {
+	if tr.ID == "" {
+		tr.ID = uuid.NewString()
+	}
+	if tr.CreatedAt.IsZero() {
+		tr.CreatedAt = time.Now().UTC()
+	}
+	if strings.TrimSpace(tr.Format) == "" {
+		tr.Format = "junit"
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO run_test_reports
+		   (id, run_id, stage_id, stage_name, format, total, passed, failed, skipped,
+		    duration_sec, coverage_pct, gate_enabled, gate_passed, gate_reason, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		tr.ID, tr.RunID, tr.StageID, tr.StageName, tr.Format,
+		tr.Total, tr.Passed, tr.Failed, tr.Skipped, tr.DurationSec, tr.Coverage,
+		boolToInt(tr.GateEnabled), boolToInt(tr.GatePassed), tr.GateReason,
+		tr.CreatedAt.UTC().Format(time.RFC3339),
+	)
+	if err != nil {
+		if isForeignKeyErr(err) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("run: insert test report: %w", err)
+	}
+	out := tr
+	out.CreatedAt = tr.CreatedAt.UTC()
+	return &out, nil
+}
+
+// ListTestReports 取某次运行的全部测试报告汇总(按 created_at 升序,rowid tiebreaker)。
+func (s *service) ListTestReports(ctx context.Context, runID string) ([]TestReport, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, run_id, stage_id, stage_name, format, total, passed, failed, skipped,
+		        duration_sec, coverage_pct, gate_enabled, gate_passed, gate_reason, created_at
+		 FROM run_test_reports WHERE run_id = ? ORDER BY created_at ASC, rowid ASC`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("run: load test reports: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := []TestReport{}
+	for rows.Next() {
+		var (
+			tr          TestReport
+			gateEnabled int
+			gatePassed  int
+			createdStr  string
+		)
+		if err := rows.Scan(&tr.ID, &tr.RunID, &tr.StageID, &tr.StageName, &tr.Format,
+			&tr.Total, &tr.Passed, &tr.Failed, &tr.Skipped, &tr.DurationSec, &tr.Coverage,
+			&gateEnabled, &gatePassed, &tr.GateReason, &createdStr); err != nil {
+			return nil, fmt.Errorf("run: scan test report: %w", err)
+		}
+		tr.GateEnabled = gateEnabled != 0
+		tr.GatePassed = gatePassed != 0
+		if t, perr := time.Parse(time.RFC3339, createdStr); perr == nil {
+			tr.CreatedAt = t.UTC()
+		}
+		out = append(out, tr)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("run: iterate test reports: %w", err)
+	}
+	return out, nil
+}
+
+// boolToInt 把布尔映射为 0/1(sqlite 无原生布尔)。
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/store/migrations/0027_test_reports.sql
+++ b/internal/store/migrations/0027_test_reports.sql
@@ -1,0 +1,27 @@
+-- 0027 test_reports:测试报告 + 质量门禁(Epic 8 · Story 8-6 / FR-8-6)。
+-- script 步骤声明产出测试报告(JUnit XML,可选 Cobertura 覆盖率)后,平台解析其
+-- 通过/失败/跳过计数 + 覆盖率%,持久化一条汇总,并据声明的门禁阈值裁决是否阻断下游部署。
+--
+-- 每个 run 一条汇总(同 run 多阶段产报告时按 (run_id, stage_id) 区分,聚合展示)。
+-- 计数为整数;coverage_pct 为 REAL(-1 = 未提供覆盖率)。gate_* 记录门禁裁决(无门禁则
+-- gate_enabled=0)。reason 为人读阻断原因(不含 secret;仅计数/阈值数字)。
+CREATE TABLE IF NOT EXISTS run_test_reports (
+    id             TEXT PRIMARY KEY,
+    run_id         TEXT NOT NULL,
+    stage_id       TEXT NOT NULL DEFAULT '',
+    stage_name     TEXT NOT NULL DEFAULT '',
+    format         TEXT NOT NULL DEFAULT 'junit',
+    total          INTEGER NOT NULL DEFAULT 0,
+    passed         INTEGER NOT NULL DEFAULT 0,
+    failed         INTEGER NOT NULL DEFAULT 0,
+    skipped        INTEGER NOT NULL DEFAULT 0,
+    duration_sec   REAL NOT NULL DEFAULT 0,
+    coverage_pct   REAL NOT NULL DEFAULT -1,
+    gate_enabled   INTEGER NOT NULL DEFAULT 0,
+    gate_passed    INTEGER NOT NULL DEFAULT 1,
+    gate_reason    TEXT NOT NULL DEFAULT '',
+    created_at     TEXT NOT NULL,
+    FOREIGN KEY (run_id) REFERENCES pipeline_runs (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_run_test_reports_run ON run_test_reports (run_id);

--- a/internal/testreport/coverage.go
+++ b/internal/testreport/coverage.go
@@ -1,0 +1,49 @@
+package testreport
+
+import (
+	"encoding/xml"
+	"errors"
+	"strconv"
+	"strings"
+)
+
+// coverage.go 解析 Cobertura XML 的行覆盖率(line-rate)。
+//
+// 只取根 <coverage line-rate="0.83"> 的 line-rate(0~1),换算成百分比(0~100)。
+// jacoco/gocover-cobertura/coverage.py 均能产 Cobertura 格式;lcov/jacoco 原生格式本期不支持。
+
+// ErrNoCoverage 表示 XML 里找不到可用的 line-rate。
+var ErrNoCoverage = errors.New("testreport: no line-rate found in coverage xml")
+
+// coberturaCoverage 对应 Cobertura 根 <coverage>。
+type coberturaCoverage struct {
+	XMLName  xml.Name `xml:"coverage"`
+	LineRate string   `xml:"line-rate,attr"`
+}
+
+// ParseCoberturaCoverage 解析 Cobertura XML,返回行覆盖率百分比(0~100)。
+// 无 <coverage> 根或 line-rate 缺失/非法 → ErrNoCoverage;XML 非法 → 解析错误。
+func ParseCoberturaCoverage(data []byte) (float64, error) {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return 0, ErrNoCoverage
+	}
+	var cov coberturaCoverage
+	if err := xml.Unmarshal([]byte(trimmed), &cov); err != nil {
+		// 覆盖率是次要项(失败软处理):根非 <coverage> / 空根 / 形状不符 → 一律视为「无覆盖率」,
+		// 不把次要解析问题升级为硬错误。语法层完全无法解析也归此(由门禁层据「未提供覆盖率」处置)。
+		return 0, ErrNoCoverage
+	}
+	if cov.XMLName.Local != "coverage" || strings.TrimSpace(cov.LineRate) == "" {
+		return 0, ErrNoCoverage
+	}
+	rate, err := strconv.ParseFloat(strings.TrimSpace(cov.LineRate), 64)
+	if err != nil || rate < 0 {
+		return 0, ErrNoCoverage
+	}
+	pct := rate * 100
+	if pct > 100 {
+		pct = 100
+	}
+	return pct, nil
+}

--- a/internal/testreport/junit.go
+++ b/internal/testreport/junit.go
@@ -1,0 +1,161 @@
+// Package testreport 解析测试报告(JUnit XML)与代码覆盖率(Cobertura XML),产出汇总
+// (通过/失败/跳过计数 + 可选覆盖率%),供「测试报告展示 + 质量门禁」消费(Epic 8 · FR-8-6)。
+//
+// 设计取舍(不过度扩张):
+//   - 测试报告:仅支持 JUnit XML(行业事实标准;pytest/jest/go-junit-report/maven-surefire 皆可产)。
+//     聚合 <testsuites>/<testsuite> 的 tests/failures/errors/skipped/time 计数,不深挖单条用例。
+//   - 覆盖率:仅支持 Cobertura XML 的根 line-rate(0~1 → 百分比;jacoco/gocover-cobertura/coverage.py
+//     皆可产 Cobertura)。lcov/jacoco 原生格式本期不支持(文档已注明)。
+//
+// 解析铁律:报告内容是测试输出,可能含路径/堆栈,但**不含 secret 责任在本层**——调用方在
+// 落库/出网前仍走既有 per-run Masker;本层只把 XML 形状解析成数字汇总,不回显原文。
+package testreport
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// ErrEmptyReport 表示报告内容为空(无可解析的 testsuite)。
+var ErrEmptyReport = errors.New("testreport: empty or no testsuite found")
+
+// Summary 是一份测试报告的聚合结果(展示 + 门禁共用)。
+//
+//   - Total/Passed/Failed/Skipped:用例计数(Passed = Total - Failed - Skipped,非负)。
+//   - DurationSeconds:套件总耗时(秒;无则 0)。
+//   - Coverage:行覆盖率百分比(0~100;-1 表示「未提供覆盖率」)。
+type Summary struct {
+	Total           int
+	Passed          int
+	Failed          int
+	Skipped         int
+	DurationSeconds float64
+	Coverage        float64
+}
+
+// CoverageUnknown 是 Summary.Coverage 的「未提供」哨兵值。
+const CoverageUnknown = -1.0
+
+// junitTestSuites 对应 JUnit XML 的 <testsuites> 根(部分产物直接以 <testsuite> 为根)。
+type junitTestSuites struct {
+	XMLName  xml.Name         `xml:"testsuites"`
+	Tests    *int             `xml:"tests,attr"`
+	Failures *int             `xml:"failures,attr"`
+	Errors   *int             `xml:"errors,attr"`
+	Skipped  *int             `xml:"skipped,attr"`
+	Time     string           `xml:"time,attr"`
+	Suites   []junitTestSuite `xml:"testsuite"`
+}
+
+// junitTestSuite 对应单个 <testsuite>。
+type junitTestSuite struct {
+	XMLName  xml.Name `xml:"testsuite"`
+	Tests    int      `xml:"tests,attr"`
+	Failures int      `xml:"failures,attr"`
+	Errors   int      `xml:"errors,attr"`
+	Skipped  int      `xml:"skipped,attr"`
+	Time     string   `xml:"time,attr"`
+}
+
+// ParseJUnit 解析 JUnit XML 字节流为 Summary(不含覆盖率;Coverage = CoverageUnknown)。
+//
+// 兼容两种根形态:<testsuites> 聚合根、或直接 <testsuite> 单套件根。
+// 聚合规则:
+//   - 优先用 <testsuites> 根属性的 tests/failures/errors/skipped(若产物给了);
+//   - 否则把各 <testsuite> 的计数逐项相加。
+//   - failures + errors 统一计入 Failed(errors = 异常/未捕获失败,门禁同等看待)。
+//
+// 无任何 testsuite → ErrEmptyReport;XML 非法 → 解析错误。
+func ParseJUnit(data []byte) (Summary, error) {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return Summary{}, ErrEmptyReport
+	}
+
+	// 先按 <testsuites> 根尝试。
+	var suites junitTestSuites
+	if err := xml.Unmarshal([]byte(trimmed), &suites); err == nil && suites.XMLName.Local == "testsuites" {
+		return summarizeSuites(suites)
+	}
+
+	// 退化:根是单个 <testsuite>。
+	var single junitTestSuite
+	if err := xml.Unmarshal([]byte(trimmed), &single); err != nil {
+		// EOF = 只有 XML 声明/无根元素;根元素不是 testsuite → 视为空报告(非解析错误)。
+		if err == io.EOF {
+			return Summary{}, ErrEmptyReport
+		}
+		if _, ok := err.(*xml.UnmarshalError); ok {
+			return Summary{}, ErrEmptyReport
+		}
+		return Summary{}, fmt.Errorf("testreport: parse junit xml: %w", err)
+	}
+	if single.XMLName.Local != "testsuite" {
+		return Summary{}, ErrEmptyReport
+	}
+	return summarizeSuites(junitTestSuites{Suites: []junitTestSuite{single}})
+}
+
+// summarizeSuites 把 <testsuites> 聚合为 Summary。
+func summarizeSuites(s junitTestSuites) (Summary, error) {
+	if len(s.Suites) == 0 && s.Tests == nil {
+		return Summary{}, ErrEmptyReport
+	}
+
+	var total, failures, errs, skipped int
+	var duration float64
+
+	// 根属性给全了 → 直接采信(避免与子套件重复累加)。
+	if s.Tests != nil {
+		total = *s.Tests
+		if s.Failures != nil {
+			failures = *s.Failures
+		}
+		if s.Errors != nil {
+			errs = *s.Errors
+		}
+		if s.Skipped != nil {
+			skipped = *s.Skipped
+		}
+		duration = parseSeconds(s.Time)
+	} else {
+		for _, sub := range s.Suites {
+			total += sub.Tests
+			failures += sub.Failures
+			errs += sub.Errors
+			skipped += sub.Skipped
+			duration += parseSeconds(sub.Time)
+		}
+	}
+
+	failed := failures + errs
+	passed := total - failed - skipped
+	if passed < 0 {
+		passed = 0
+	}
+	return Summary{
+		Total:           total,
+		Passed:          passed,
+		Failed:          failed,
+		Skipped:         skipped,
+		DurationSeconds: duration,
+		Coverage:        CoverageUnknown,
+	}, nil
+}
+
+// parseSeconds 把 time 属性(秒,可空/非法)解析为 float(失败 → 0)。
+func parseSeconds(s string) float64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil || v < 0 {
+		return 0
+	}
+	return v
+}

--- a/internal/testreport/junit_test.go
+++ b/internal/testreport/junit_test.go
@@ -1,0 +1,120 @@
+package testreport
+
+import (
+	"errors"
+	"math"
+	"testing"
+)
+
+// 夹具:全部通过(<testsuites> 聚合根)。
+const junitAllPass = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="5" failures="0" errors="0" skipped="0" time="1.250">
+  <testsuite name="pkg/foo" tests="3" failures="0" errors="0" skipped="0" time="0.500"/>
+  <testsuite name="pkg/bar" tests="2" failures="0" errors="0" skipped="0" time="0.750"/>
+</testsuites>`
+
+// 夹具:含失败 + 错误 + 跳过(无根属性,靠子套件累加)。
+const junitWithFailures = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="pkg/foo" tests="4" failures="1" errors="1" skipped="1" time="0.300">
+    <testcase name="ok"/>
+    <testcase name="bad"><failure message="boom"/></testcase>
+    <testcase name="err"><error message="panic"/></testcase>
+    <testcase name="skip"><skipped/></testcase>
+  </testsuite>
+  <testsuite name="pkg/bar" tests="2" failures="0" errors="0" skipped="0" time="0.200"/>
+</testsuites>`
+
+// 夹具:根直接是单个 <testsuite>(maven-surefire 单文件常见形态)。
+const junitSingleSuite = `<?xml version="1.0"?>
+<testsuite name="solo" tests="2" failures="1" errors="0" skipped="0" time="0.42">
+  <testcase name="a"/>
+  <testcase name="b"><failure/></testcase>
+</testsuite>`
+
+func almostEqual(a, b float64) bool { return math.Abs(a-b) < 1e-6 }
+
+func TestParseJUnit_AllPass(t *testing.T) {
+	s, err := ParseJUnit([]byte(junitAllPass))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.Total != 5 || s.Passed != 5 || s.Failed != 0 || s.Skipped != 0 {
+		t.Errorf("counts = %+v, want total=5 passed=5 failed=0 skipped=0", s)
+	}
+	if !almostEqual(s.DurationSeconds, 1.250) {
+		t.Errorf("duration = %v, want 1.250", s.DurationSeconds)
+	}
+	if s.Coverage != CoverageUnknown {
+		t.Errorf("coverage = %v, want CoverageUnknown", s.Coverage)
+	}
+}
+
+func TestParseJUnit_WithFailures(t *testing.T) {
+	s, err := ParseJUnit([]byte(junitWithFailures))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 子套件累加:tests=6, failures=1, errors=1, skipped=1 → failed=2, passed=3.
+	if s.Total != 6 {
+		t.Errorf("total = %d, want 6", s.Total)
+	}
+	if s.Failed != 2 {
+		t.Errorf("failed = %d, want 2 (failures+errors)", s.Failed)
+	}
+	if s.Skipped != 1 {
+		t.Errorf("skipped = %d, want 1", s.Skipped)
+	}
+	if s.Passed != 3 {
+		t.Errorf("passed = %d, want 3", s.Passed)
+	}
+	if !almostEqual(s.DurationSeconds, 0.500) {
+		t.Errorf("duration = %v, want 0.500", s.DurationSeconds)
+	}
+}
+
+func TestParseJUnit_SingleSuiteRoot(t *testing.T) {
+	s, err := ParseJUnit([]byte(junitSingleSuite))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.Total != 2 || s.Failed != 1 || s.Passed != 1 {
+		t.Errorf("counts = %+v, want total=2 failed=1 passed=1", s)
+	}
+}
+
+func TestParseJUnit_Empty(t *testing.T) {
+	for _, in := range []string{"", "   ", `<?xml version="1.0"?>`} {
+		if _, err := ParseJUnit([]byte(in)); !errors.Is(err, ErrEmptyReport) {
+			t.Errorf("ParseJUnit(%q) err = %v, want ErrEmptyReport", in, err)
+		}
+	}
+}
+
+func TestParseJUnit_Malformed(t *testing.T) {
+	if _, err := ParseJUnit([]byte(`<testsuite tests="oops</bad`)); err == nil {
+		t.Error("expected error for malformed xml, got nil")
+	}
+}
+
+func TestParseCoberturaCoverage(t *testing.T) {
+	const cobertura = `<?xml version="1.0"?>
+<coverage line-rate="0.8342" branch-rate="0.5" version="1.9">
+  <packages/>
+</coverage>`
+	pct, err := ParseCoberturaCoverage([]byte(cobertura))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !almostEqual(pct, 83.42) {
+		t.Errorf("coverage = %v, want 83.42", pct)
+	}
+}
+
+func TestParseCoberturaCoverage_Missing(t *testing.T) {
+	for _, in := range []string{"", `<coverage version="1"/>`, `<other line-rate="0.5"/>`} {
+		if _, err := ParseCoberturaCoverage([]byte(in)); !errors.Is(err, ErrNoCoverage) {
+			t.Errorf("ParseCoberturaCoverage(%q) err = %v, want ErrNoCoverage", in, err)
+		}
+	}
+}

--- a/web/src/api/runs.ts
+++ b/web/src/api/runs.ts
@@ -348,6 +348,46 @@ export function getRunArtifacts(id: string): Promise<RunArtifactsResponse> {
   return http.get<RunArtifactsResponse>(`/api/runs/${id}/artifacts`)
 }
 
+// ─── Test report + quality gate (Epic 8 · Story 8-6 — FR-8-6) ────────────────
+//
+// GET /api/runs/{id}/test-report → { reports: TestReportDTO[], gate: GateVerdict }
+// Read-only, authenticated. A script step can declare it produces a JUnit report
+// (+ optional Cobertura coverage); the platform parses pass/fail/skip counts and
+// coverage%, and a quality gate can block downstream deploy when thresholds fail.
+// 404 run_not_found if the run does not exist. coverage = -1 means "not provided".
+
+export interface TestReportDTO {
+  id: string
+  stageId: string
+  stageName: string
+  format: string // junit
+  total: number
+  passed: number
+  failed: number
+  skipped: number
+  durationSec: number
+  coverage: number // line coverage %, -1 when not provided
+  gateEnabled: boolean
+  gatePassed: boolean
+  gateReason: string // human-readable block reason (no secrets — counts/thresholds only)
+  createdAt: string // RFC3339
+}
+
+export interface GateVerdict {
+  enabled: boolean // any stage declared a gate
+  passed: boolean // all gates passed (no gate ⇒ true)
+  reasons: string[] // per-stage block reasons (empty when passed)
+}
+
+export interface RunTestReportResponse {
+  reports: TestReportDTO[]
+  gate: GateVerdict
+}
+
+export function getRunTestReport(id: string): Promise<RunTestReportResponse> {
+  return http.get<RunTestReportResponse>(`/api/runs/${id}/test-report`)
+}
+
 // ─── SSH deploy execution (Story 4-2 frozen contract — FR-10) ─────────────────
 //
 // POST /api/runs/{id}/deploy  body { artifactId, serverIds, deployConfig? }

--- a/web/src/components/run/TestReportPanel.vue
+++ b/web/src/components/run/TestReportPanel.vue
@@ -1,0 +1,386 @@
+<!--
+  TestReportPanel.vue — Epic 8 · Story 8-6: 测试报告 + 质量门禁(FR-8-6)
+
+  展示一次运行各阶段产出的测试报告:通过/失败/跳过计数 + 覆盖率条 + 门禁裁决。
+  script 步骤声明 testReport=junit + reportPath 后,后端解析 JUnit XML(可选 Cobertura 覆盖率),
+  并据 gateMaxFailures / gateMinCoverage 阈值裁决是否阻断下游部署。
+
+  自取数据(container):测试报告不在冻结 run-detail DTO 内,经 GET /api/runs/{id}/test-report 拉取。
+  无报告 → 不渲染(返回 null),不占视觉。门禁阻断时以醒目状态条标注原因(无 secret,仅数字)。
+-->
+<script setup lang="ts">
+import { ref, watch, computed } from 'vue'
+import { getRunTestReport } from '../../api/runs'
+import type { TestReportDTO, GateVerdict, RunTestReportResponse } from '../../api/runs'
+import { HttpError } from '../../api/http'
+
+const props = defineProps<{
+  runId: string
+}>()
+
+const reports = ref<TestReportDTO[]>([])
+const gate = ref<GateVerdict>({ enabled: false, passed: true, reasons: [] })
+const loaded = ref(false)
+const error = ref<string | null>(null)
+
+async function load(id: string): Promise<void> {
+  loaded.value = false
+  error.value = null
+  try {
+    const res: RunTestReportResponse = await getRunTestReport(id)
+    reports.value = res.reports
+    gate.value = res.gate
+  } catch (err: unknown) {
+    // 404 / 未就绪 → 静默(无报告等价空);其它错误给一行提示。
+    if (err instanceof HttpError && err.status === 404) {
+      reports.value = []
+      gate.value = { enabled: false, passed: true, reasons: [] }
+    } else {
+      error.value = '测试报告加载失败'
+    }
+  } finally {
+    loaded.value = true
+  }
+}
+
+watch(() => props.runId, (id) => { if (id) void load(id) }, { immediate: true })
+
+const hasReports = computed(() => reports.value.length > 0)
+
+// 跨阶段聚合(总览条):合计通过/失败/跳过 + 覆盖率取「最低的有效值」(最保守视图)。
+const totals = computed(() => {
+  let passed = 0, failed = 0, skipped = 0, total = 0
+  let minCoverage = -1
+  for (const r of reports.value) {
+    passed += r.passed
+    failed += r.failed
+    skipped += r.skipped
+    total += r.total
+    if (r.coverage >= 0) {
+      minCoverage = minCoverage < 0 ? r.coverage : Math.min(minCoverage, r.coverage)
+    }
+  }
+  return { passed, failed, skipped, total, coverage: minCoverage }
+})
+
+function coverageText(pct: number): string {
+  return pct < 0 ? 'n/a' : `${pct.toFixed(1)}%`
+}
+
+function passRate(r: { passed: number; total: number }): number {
+  if (r.total <= 0) return 0
+  return Math.round((r.passed / r.total) * 100)
+}
+</script>
+
+<template>
+  <section
+    v-if="loaded && (hasReports || error)"
+    class="test-report"
+    :class="{ 'test-report--blocked': gate.enabled && !gate.passed }"
+    role="region"
+    aria-label="测试报告与质量门禁"
+  >
+    <header class="tr-head">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+        <path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>
+      </svg>
+      <h3 class="tr-title">测试报告</h3>
+
+      <!-- 门禁裁决徽标 -->
+      <span
+        v-if="gate.enabled"
+        class="gate-badge"
+        :class="gate.passed ? 'gate-badge--pass' : 'gate-badge--block'"
+        :aria-label="gate.passed ? '质量门禁通过' : '质量门禁阻断'"
+      >
+        <svg v-if="gate.passed" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>
+        <svg v-else width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12"/></svg>
+        {{ gate.passed ? '门禁通过' : '门禁阻断' }}
+      </span>
+    </header>
+
+    <p v-if="error" class="tr-error" role="alert">{{ error }}</p>
+
+    <template v-else>
+      <!-- 门禁阻断原因(醒目) -->
+      <div v-if="gate.enabled && !gate.passed" class="gate-reasons" role="alert">
+        <strong class="gate-reasons-title">质量门禁未通过,已阻断后续部署:</strong>
+        <ul class="gate-reasons-list">
+          <li v-for="(reason, i) in gate.reasons" :key="i">{{ reason }}</li>
+        </ul>
+      </div>
+
+      <!-- 总览统计条 -->
+      <div class="tr-summary">
+        <div class="stat stat--pass">
+          <span class="stat-num">{{ totals.passed }}</span>
+          <span class="stat-label">通过</span>
+        </div>
+        <div class="stat stat--fail" :class="{ 'stat--zero': totals.failed === 0 }">
+          <span class="stat-num">{{ totals.failed }}</span>
+          <span class="stat-label">失败</span>
+        </div>
+        <div class="stat stat--skip" :class="{ 'stat--zero': totals.skipped === 0 }">
+          <span class="stat-num">{{ totals.skipped }}</span>
+          <span class="stat-label">跳过</span>
+        </div>
+        <div class="stat stat--total">
+          <span class="stat-num">{{ totals.total }}</span>
+          <span class="stat-label">总用例</span>
+        </div>
+      </div>
+
+      <!-- 覆盖率条(总览取各阶段最低) -->
+      <div v-if="totals.coverage >= 0" class="coverage">
+        <div class="coverage-head">
+          <span class="coverage-label">行覆盖率</span>
+          <span class="coverage-val mono">{{ coverageText(totals.coverage) }}</span>
+        </div>
+        <div class="coverage-track" role="meter" :aria-valuenow="Math.round(totals.coverage)" aria-valuemin="0" aria-valuemax="100">
+          <div
+            class="coverage-fill"
+            :class="{ 'coverage-fill--low': totals.coverage < 60, 'coverage-fill--mid': totals.coverage >= 60 && totals.coverage < 80 }"
+            :style="{ width: `${Math.min(100, Math.max(0, totals.coverage))}%` }"
+          />
+        </div>
+      </div>
+
+      <!-- 各阶段明细(多阶段时) -->
+      <ul v-if="reports.length > 1" class="stage-list" role="list">
+        <li v-for="r in reports" :key="r.id" class="stage-row">
+          <span class="stage-name">{{ r.stageName || '阶段' }}</span>
+          <span class="stage-counts mono">
+            <span class="sc-pass">{{ r.passed }}✓</span>
+            <span v-if="r.failed > 0" class="sc-fail">{{ r.failed }}✗</span>
+            <span v-if="r.skipped > 0" class="sc-skip">{{ r.skipped }}⊘</span>
+          </span>
+          <span class="stage-rate mono">{{ passRate(r) }}%</span>
+          <span v-if="r.coverage >= 0" class="stage-cov mono">cov {{ coverageText(r.coverage) }}</span>
+          <span
+            v-if="r.gateEnabled"
+            class="stage-gate"
+            :class="r.gatePassed ? 'stage-gate--pass' : 'stage-gate--block'"
+            :title="r.gateReason"
+          >{{ r.gatePassed ? '门禁✓' : '门禁✗' }}</span>
+        </li>
+      </ul>
+    </template>
+  </section>
+</template>
+
+<style scoped>
+.test-report {
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded);
+  background: var(--color-card);
+  overflow: hidden;
+}
+
+.test-report--blocked {
+  border-color: var(--color-red-line, var(--color-amber-line));
+}
+
+.tr-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 16px;
+  background: var(--color-inset);
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-dim);
+}
+
+.tr-title {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--color-text);
+  letter-spacing: -0.01em;
+  flex: 1;
+}
+
+.gate-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 9px;
+  border-radius: var(--rounded-full);
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.gate-badge--pass { color: var(--color-green); background: var(--color-green-soft); }
+.gate-badge--block { color: var(--color-red, #c0392b); background: var(--color-red-soft, var(--color-amber-soft)); }
+
+.tr-error {
+  padding: 18px 16px;
+  font-size: 0.82rem;
+  color: var(--color-faint);
+  text-align: center;
+}
+
+/* ─── gate reasons (blocked) ─────────────────────────────────────────────── */
+.gate-reasons {
+  margin: 14px 16px 0;
+  padding: 12px 14px;
+  border-radius: var(--rounded-md);
+  background: var(--color-red-soft, var(--color-amber-soft));
+  border: 1px solid var(--color-red-line, var(--color-amber-line));
+}
+
+.gate-reasons-title {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-red, #c0392b);
+  margin-bottom: 6px;
+}
+
+.gate-reasons-list {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 0.8rem;
+  color: var(--color-dim);
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+/* ─── summary stat strip ─────────────────────────────────────────────────── */
+.tr-summary {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  padding: 16px;
+  background: var(--color-border);
+  margin: 16px;
+  border-radius: var(--rounded-md);
+  overflow: hidden;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  padding: 12px 8px;
+  background: var(--color-card);
+}
+
+.stat-num {
+  font-size: 1.5rem;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+
+.stat-label {
+  font-size: 0.7rem;
+  color: var(--color-faint);
+  font-weight: 500;
+}
+
+.stat--pass .stat-num { color: var(--color-green); }
+.stat--fail .stat-num { color: var(--color-red, #c0392b); }
+.stat--skip .stat-num { color: var(--color-amber); }
+.stat--total .stat-num { color: var(--color-text); }
+.stat--zero .stat-num { color: var(--color-faint); }
+
+/* ─── coverage bar ───────────────────────────────────────────────────────── */
+.coverage {
+  padding: 0 16px 16px;
+}
+
+.coverage-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.coverage-label {
+  font-size: 0.78rem;
+  color: var(--color-dim);
+  font-weight: 500;
+}
+
+.coverage-val {
+  font-size: 0.86rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.coverage-track {
+  height: 8px;
+  border-radius: var(--rounded-full);
+  background: var(--color-inset);
+  overflow: hidden;
+}
+
+.coverage-fill {
+  height: 100%;
+  border-radius: var(--rounded-full);
+  background: var(--color-green);
+  transition: width var(--duration-normal) var(--ease-out, ease);
+}
+
+.coverage-fill--mid { background: var(--color-amber); }
+.coverage-fill--low { background: var(--color-red, #c0392b); }
+
+/* ─── per-stage detail ───────────────────────────────────────────────────── */
+.stage-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 16px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.stage-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 0;
+  border-top: 1px solid var(--color-border);
+  font-size: 0.8rem;
+}
+
+.stage-name {
+  flex: 1;
+  font-weight: 600;
+  color: var(--color-text);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stage-counts { display: inline-flex; gap: 8px; }
+.sc-pass { color: var(--color-green); }
+.sc-fail { color: var(--color-red, #c0392b); }
+.sc-skip { color: var(--color-amber); }
+
+.stage-rate, .stage-cov {
+  color: var(--color-dim);
+  font-size: 0.76rem;
+}
+
+.stage-gate {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: var(--rounded-sm);
+}
+
+.stage-gate--pass { color: var(--color-green); background: var(--color-green-soft); }
+.stage-gate--block { color: var(--color-red, #c0392b); background: var(--color-red-soft, var(--color-amber-soft)); }
+
+.mono { font-family: var(--font-mono); }
+
+@media (max-width: 640px) {
+  .tr-summary { grid-template-columns: repeat(2, 1fr); }
+  .stage-row { flex-wrap: wrap; gap: 6px 10px; }
+}
+</style>

--- a/web/src/views/RunDetail.vue
+++ b/web/src/views/RunDetail.vue
@@ -39,6 +39,7 @@ import DiagnosisPanel from '../components/run/DiagnosisPanel.vue'
 import SuccessFailDiff from '../components/run/SuccessFailDiff.vue'
 import RunTerminal from '../components/run/RunTerminal.vue'
 import ArtifactList from '../components/run/ArtifactList.vue'
+import TestReportPanel from '../components/run/TestReportPanel.vue'
 import DeployTargets from '../components/run/DeployTargets.vue'
 import RunDagView from '../components/run/RunDagView.vue'
 
@@ -723,6 +724,16 @@ function nodeClass(status: StepStatus): string {
               ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
             -->
             <ArtifactList :artifacts="run.artifacts" />
+
+            <!--
+              ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+              测试报告 + 质量门禁 (Story 8-6 / FR-8-6 实现)
+              script 步骤声明 testReport=junit + reportPath → 后端解析 JUnit XML(可选 Cobertura
+              覆盖率)→ 通过/失败/跳过计数 + 覆盖率条 + 门禁裁决。门禁不过则阻断下游部署。
+              自取数据(不在冻结 run-detail DTO 内);无报告 → 不渲染。
+              ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+            -->
+            <TestReportPanel :run-id="run.id" />
 
             <!-- 历史日志回放(只读,Story 3-6) -->
             <div class="log-history" role="region" aria-label="历史运行日志">


### PR DESCRIPTION
## 摘要

为 script 步骤增加「产出测试报告 → 解析展示 → 质量门禁阻断部署」闭环(Epic 8 · FR-8-6)。

script 步骤可声明产出测试报告(JUnit XML,可选 Cobertura 覆盖率)。阶段执行后,平台从克隆
工作区读取报告文件(容器挂载的就是宿主 workspace,退出后即可读),解析通过/失败/跳过计数
+ 覆盖率%,持久化一条阶段汇总,并在运行详情页展示。质量门禁据声明的阈值裁决,不达标则令该
阶段失败 —— 复用 dagrun 既有「阶段失败 → 下游不执行」语义,**阻断下游部署阶段**,零新机制。

## 解析器(`internal/testreport`)

- **JUnit XML**:聚合 `<testsuites>`/`<testsuite>` 的 tests/failures/errors/skipped/time。兼容
  聚合根与单 `<testsuite>` 根;failures+errors 统一计入 Failed。是必备项。
- **Cobertura XML**:取根 `<coverage line-rate>` 换算行覆盖率%(jacoco/gocover-cobertura/
  coverage.py 皆可产)。覆盖率是次要项,缺失/无法解析按「未提供」软处理。lcov/jacoco 原生格式
  本期不支持(已文档化)。
- 含成功 + 含失败 + 单套件根 + 覆盖率 等夹具单测。

## `job.Config` 报告 / 门禁键

| 键 | 含义 |
|---|---|
| `testReport` | 值为 `junit` 时启用测试报告采集 |
| `reportPath` | JUnit XML 路径(相对工作区根;启用时必填) |
| `coverageReport` | 值为 `cobertura` 时启用覆盖率采集(可选) |
| `coveragePath` | Cobertura XML 路径(相对工作区根) |
| `gateMaxFailures` | 门禁:允许的最大失败用例数(缺省/空 = 不检查) |
| `gateMinCoverage` | 门禁:要求的最小行覆盖率%(缺省/空 = 不检查) |

## 门禁语义(`internal/qualitygate`)

纯评估层(零 I/O,穷举单测):`Evaluate(summary, thresholds) → verdict`。
- `Failed > gateMaxFailures` → 阻断。
- 声明了 `gateMinCoverage` 但覆盖率 `< 阈值` → 阻断;**声明了门禁却拿不到报告/覆盖率证据 → 阻断**(宁阻断不放过)。
- 两维都不检查 → 等于无门禁,恒通过。
- 阻断原因串只含计数/阈值数字,**无 secret**。
- 仅声明展示(无门禁)时报告缺失/解析失败 → 软跳过,不阻断。

## 持久化 + 采集

- 迁移 `internal/store/migrations/0027_test_reports.sql`:`run_test_reports` 表(每阶段一条;计数 + coverage_pct + gate_*;FK→pipeline_runs ON DELETE CASCADE)。
- `internal/run/test_report.go`:`SaveTestReport` / `ListTestReports`(参数化 SQL,仿 artifacts)。
- `internal/build/dag_test_report.go`:阶段 script job 全部成功后采集报告;读路径经 `safeJoinWorkspace` 清洗 `..` 防穿越;落库 best-effort(失败不改门禁裁决);门禁不过返回 `ErrQualityGate` 令阶段失败。
- `NewStageExecutor(b, reportSink)` 新增可选持久层参数(main 注入 `runSvc`);dagrun.go **未改动**(门禁经阶段失败承载,不动协调器)。

## 端点

`GET /api/runs/{id}/test-report` → `{ reports: TestReportDTO[], gate: GateVerdict }`(认证只读)。
- `reports`:各阶段汇总(stageName / total / passed / failed / skipped / coverage / gate*)。
- `gate`:整次运行聚合裁决(任一阶段门禁不过 → `enabled:true, passed:false, reasons:[…]`)。
- run 不存在 → 404;无报告 → `{ reports:[], gate:{enabled:false,passed:true} }`。

## UI

`web/src/components/run/TestReportPanel.vue`(container,自取数据;测试报告不在冻结 run-detail DTO 内):
- 通过/失败/跳过/总用例统计条 + 行覆盖率进度条(<60 红 / <80 琥珀 / 否则绿,语义着色)。
- 门禁裁决徽标(通过 / 阻断);阻断时醒目原因块。
- 多阶段时逐阶段明细行。无报告 → 不渲染。RunDetail 成功态在产物列表后挂载。

## 绿灯证据

后端(`PATH` 含 go sdk):
- `gofmt -l`(改动文件)→ 空
- `go vet ./...` → 干净
- `go build ./...` → 通过
- `go test ./...` → 全绿(新增 testreport / qualitygate / build / run / httpapi 用例)

前端(`web/`):
- `npm run typecheck`(vue-tsc --noEmit)→ 通过
- `npm run test` → 16 文件 120 用例全绿
- `npm run build` → 通过;`web/dist/index.html` churn 已还原

## 协调

仅对共享文件 `cmd/pipewright/main.go` / `internal/httpapi/router.go` 做最小附加编辑;实质逻辑全在新包/新文件。迁移前缀 **0027**。未触 `internal/dagrun/dagrun.go` / `internal/run/pool.go`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)