### PR TITLE
feat(trigger): tag 上下文 + release 事件触发(FR-8-11)

### DIFF
--- a/internal/httpapi/triggers.go
+++ b/internal/httpapi/triggers.go
@@ -27,6 +27,7 @@ type eventsDTO struct {
 	Push        bool `json:"push"`
 	Tag         bool `json:"tag"`
 	PullRequest bool `json:"pullRequest"`
+	Release     bool `json:"release"`
 }
 
 type branchMappingDTO struct {
@@ -58,6 +59,7 @@ func toTriggerDTO(c *trigger.Config) triggerDTO {
 			Push:        c.Events.Push,
 			Tag:         c.Events.Tag,
 			PullRequest: c.Events.PullRequest,
+			Release:     c.Events.Release,
 		},
 		BranchMappings:  mappings,
 		UnmatchedPolicy: c.UnmatchedPolicy,
@@ -115,6 +117,7 @@ func makeSaveTriggerHandler(svc trigger.Service) http.HandlerFunc {
 				Push        bool `json:"push"`
 				Tag         bool `json:"tag"`
 				PullRequest bool `json:"pullRequest"`
+				Release     bool `json:"release"`
 			} `json:"events"`
 			BranchMappings []struct {
 				ID              string   `json:"id"`
@@ -143,6 +146,7 @@ func makeSaveTriggerHandler(svc trigger.Service) http.HandlerFunc {
 				Push:        req.Events.Push,
 				Tag:         req.Events.Tag,
 				PullRequest: req.Events.PullRequest,
+				Release:     req.Events.Release,
 			},
 			BranchMappings:  mappings,
 			UnmatchedPolicy: req.UnmatchedPolicy,

--- a/internal/trigger/receiver.go
+++ b/internal/trigger/receiver.go
@@ -39,6 +39,8 @@ const (
 	eventPush         = "Push Hook"
 	eventTag          = "Tag Push Hook"
 	eventMergeRequest = "Merge Request Hook"
+	// eventRelease 是 Gitee「发行版」事件(Story 8-11 / FR-8-11)。
+	eventRelease = "Release Hook"
 )
 
 // 投递处理结果(accepted / 各 ignored 原因枚举,冻结契约)。
@@ -385,6 +387,8 @@ func eventSubscribed(event string, ev Events) bool {
 		return ev.Tag
 	case eventMergeRequest:
 		return ev.PullRequest
+	case eventRelease:
+		return ev.Release
 	default:
 		return false
 	}
@@ -396,7 +400,7 @@ type parsedPayload struct {
 	Commit string
 }
 
-// giteePayload 是 Gitee push/tag/MR webhook 的部分字段(只取所需,容忍多余字段)。
+// giteePayload 是 Gitee push/tag/MR/release webhook 的部分字段(只取所需,容忍多余字段)。
 type giteePayload struct {
 	Ref         string `json:"ref"`
 	After       string `json:"after"`
@@ -410,15 +414,30 @@ type giteePayload struct {
 			SHA string `json:"sha"`
 		} `json:"head"`
 	} `json:"pull_request"`
+	// Release 是 Gitee「Release Hook」/ GitHub「release」事件载荷:tag 名在 tag_name,
+	// 目标 commit-ish(分支名或 SHA)在 target_commitish(Story 8-11 / FR-8-11)。
+	Release struct {
+		TagName         string `json:"tag_name"`
+		TargetCommitish string `json:"target_commitish"`
+	} `json:"release"`
 }
 
-// parsePayload 用 encoding/json 解析投递体,提取分支(从 ref 取 refs/heads/<x> 末段)与 commit。
+// parsePayload 用 encoding/json 解析投递体,提取分支/标签(从 ref 取 refs/heads|tags/<x>
+// 末段;release 事件取 release.tag_name)与 commit。
 // 解析失败/字段缺失返回零值(匹配阶段据空分支不命中,不 panic)。
+//
+// 标签语义(tag push 与 release 一致):标签名落入 Branch 字段,沿用既有
+// branch→环境映射(如模式 v* 命中 v1.2.3),保持下游处理统一简单——上游对
+// Branch 的语义是「触发引用名」,push 为分支名、tag/release 为标签名。
 func parsePayload(body []byte) parsedPayload {
 	var p giteePayload
 	_ = json.Unmarshal(body, &p)
 
+	// 触发引用名:push/tag 取 ref 末段;release 事件 ref 缺省,取 release.tag_name。
 	branch := refToBranch(p.Ref)
+	if branch == "" {
+		branch = strings.TrimSpace(p.Release.TagName)
+	}
 	if branch == "" {
 		branch = strings.TrimSpace(p.PullRequest.Head.Ref)
 	}
@@ -432,6 +451,10 @@ func parsePayload(body []byte) parsedPayload {
 	}
 	if commit == "" {
 		commit = strings.TrimSpace(p.PullRequest.Head.SHA)
+	}
+	// release 事件无 head_commit:回退到 target_commitish(分支名或 SHA)作为 commit 上下文。
+	if commit == "" {
+		commit = strings.TrimSpace(p.Release.TargetCommitish)
 	}
 	return parsedPayload{Branch: branch, Commit: commit}
 }

--- a/internal/trigger/receiver_test.go
+++ b/internal/trigger/receiver_test.go
@@ -371,6 +371,129 @@ func TestWebhookUnmatchedRecordIdempotent(t *testing.T) {
 	}
 }
 
+// newTagReleaseReceiver 装配 Receiver + 已配 tag+release 事件 + 分支映射 v*→prod 的项目;
+// 返回 token、明文密钥(供 tag/release 上下文与订阅用例复用)。
+func newTagReleaseReceiver(t *testing.T) (*Receiver, *fakeRunCreator, string, string) {
+	t.Helper()
+	db, _ := testDB(t)
+	v := vault.New(db, testMasterKey())
+	svc := New(db, v)
+	projID := seedProject(t, db)
+
+	ctx := context.Background()
+	cfg, err := svc.Get(ctx, projID)
+	if err != nil {
+		t.Fatalf("get config: %v", err)
+	}
+	token := cfg.WebhookToken
+
+	reset, err := svc.ResetSecret(ctx, projID)
+	if err != nil {
+		t.Fatalf("reset secret: %v", err)
+	}
+	secret := reset.Secret
+
+	if _, err := svc.Save(ctx, projID, SaveInput{
+		Events: Events{Tag: true, Release: true},
+		BranchMappings: []BranchMapping{
+			{BranchPattern: "v*", Environment: "prod", TargetServerIDs: []string{"srv-1"}},
+		},
+		UnmatchedPolicy: PolicyIgnore,
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	fake := &fakeRunCreator{}
+	rc := NewReceiver(db, v, fake)
+	return rc, fake, token, secret
+}
+
+// TestWebhookTagPushCarriesTagRefAndCommit 验证 Tag Push Hook 命中后:
+// 运行携带标签名(refs/tags/v1.2.3 → v1.2.3,落入 Branch)与 commit,并经 v* 映射到 prod。
+func TestWebhookTagPushCarriesTagRefAndCommit(t *testing.T) {
+	rc, fake, token, secret := newTagReleaseReceiver(t)
+	res, err := rc.Handle(context.Background(), Delivery{
+		Token:      token,
+		Event:      eventTag,
+		TokenHdr:   secret,
+		DeliveryID: "d-tagpush",
+		RawBody:    []byte(`{"ref":"refs/tags/v1.2.3","after":"tagsha123"}`),
+	})
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if !res.Accepted || res.RunID == "" {
+		t.Fatalf("expected accepted run for tag push, got %+v", res)
+	}
+	if fake.count() != 1 {
+		t.Fatalf("expected 1 run, got %d", fake.count())
+	}
+	got := fake.calls[0]
+	if got.Branch != "v1.2.3" {
+		t.Fatalf("expected tag name v1.2.3 in Branch, got %q", got.Branch)
+	}
+	if got.Commit != "tagsha123" {
+		t.Fatalf("expected commit tagsha123, got %q", got.Commit)
+	}
+	if got.ResolvedEnvironment != "prod" {
+		t.Fatalf("expected env prod via v* mapping, got %q", got.ResolvedEnvironment)
+	}
+}
+
+// TestWebhookReleaseHookCreatesRunWithTagName 验证 Release Hook 命中后:
+// 运行携带 release.tag_name(落入 Branch),commit 回退到 target_commitish,经 v* 映射到 prod。
+func TestWebhookReleaseHookCreatesRunWithTagName(t *testing.T) {
+	rc, fake, token, secret := newTagReleaseReceiver(t)
+	res, err := rc.Handle(context.Background(), Delivery{
+		Token:      token,
+		Event:      eventRelease,
+		TokenHdr:   secret,
+		DeliveryID: "d-release",
+		RawBody:    []byte(`{"action":"published","release":{"tag_name":"v2.0.0","target_commitish":"main"}}`),
+	})
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if !res.Accepted || res.RunID == "" {
+		t.Fatalf("expected accepted run for release, got %+v", res)
+	}
+	if fake.count() != 1 {
+		t.Fatalf("expected 1 run, got %d", fake.count())
+	}
+	got := fake.calls[0]
+	if got.Branch != "v2.0.0" {
+		t.Fatalf("expected release tag v2.0.0 in Branch, got %q", got.Branch)
+	}
+	if got.Commit != "main" {
+		t.Fatalf("expected commit fallback to target_commitish 'main', got %q", got.Commit)
+	}
+	if got.ResolvedEnvironment != "prod" {
+		t.Fatalf("expected env prod via v* mapping, got %q", got.ResolvedEnvironment)
+	}
+}
+
+// TestWebhookReleaseNotSubscribed 验证未勾选 Release 时,Release Hook 投递被忽略(不创建运行)。
+func TestWebhookReleaseNotSubscribed(t *testing.T) {
+	// newReceiver 只开 Push(Release=false)。
+	rc, fake, token, secret := newReceiver(t)
+	res, err := rc.Handle(context.Background(), Delivery{
+		Token:      token,
+		Event:      eventRelease,
+		TokenHdr:   secret,
+		DeliveryID: "d-rel-nosub",
+		RawBody:    []byte(`{"release":{"tag_name":"v9","target_commitish":"main"}}`),
+	})
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if res.Accepted || res.Ignored != IgnoredEventNotSubscribed {
+		t.Fatalf("expected event_not_subscribed, got %+v", res)
+	}
+	if fake.count() != 0 {
+		t.Fatalf("expected no run, got %d", fake.count())
+	}
+}
+
 func TestWebhookTokenNotFound(t *testing.T) {
 	rc, _, _, secret := newReceiver(t)
 	_, err := rc.Handle(context.Background(), Delivery{

--- a/internal/trigger/trigger.go
+++ b/internal/trigger/trigger.go
@@ -54,10 +54,14 @@ var (
 )
 
 // Events 是触发事件开关(手动触发常开,不建模为字段)。
+//
+// Release 为 Story 8-11 新增(FR-8-11):向后兼容——旧 events_json 缺该字段时
+// JSON 反序列化为零值 false,无需迁移(events 以 JSON 整体入库)。
 type Events struct {
 	Push        bool `json:"push"`
 	Tag         bool `json:"tag"`
 	PullRequest bool `json:"pullRequest"`
+	Release     bool `json:"release"`
 }
 
 // BranchMapping 是一条分支映射:分支(通配)模式 → 环境名 + 目标服务器引用 id 列表。
@@ -276,7 +280,7 @@ func (s *service) createDefault(ctx context.Context, projectID string) (*Config,
 	res, err := s.db.ExecContext(ctx,
 		`INSERT INTO pipeline_triggers
 		   (project_id, webhook_token, webhook_secret_ciphertext, events_json, branch_mappings_json, unmatched_policy, created_at, updated_at)
-		 VALUES (?, ?, ?, '{"push":false,"tag":false,"pullRequest":false}', '[]', ?, ?, ?)
+		 VALUES (?, ?, ?, '{"push":false,"tag":false,"pullRequest":false,"release":false}', '[]', ?, ?, ?)
 		 ON CONFLICT(project_id) DO NOTHING`,
 		projectID, token, sealed, PolicyRecord, nowStr, nowStr,
 	)

--- a/web/src/api/triggers.ts
+++ b/web/src/api/triggers.ts
@@ -21,6 +21,7 @@ export interface TriggerEvents {
   push: boolean
   tag: boolean
   pullRequest: boolean
+  release: boolean
 }
 
 export interface BranchMapping {

--- a/web/src/components/TriggersPanel.vue
+++ b/web/src/components/TriggersPanel.vue
@@ -41,6 +41,7 @@ const webhookSecretMasked = ref('')
 const eventPush = ref(false)
 const eventTag = ref(false)
 const eventPullRequest = ref(false)
+const eventRelease = ref(false)
 
 interface MappingRow {
   _key: number
@@ -194,7 +195,7 @@ async function handleSave(): Promise<void> {
 
   try {
     const updated = await saveTrigger(props.projectId, {
-      events: { push: eventPush.value, tag: eventTag.value, pullRequest: eventPullRequest.value },
+      events: { push: eventPush.value, tag: eventTag.value, pullRequest: eventPullRequest.value, release: eventRelease.value },
       branchMappings: mappings.value.map((r) => ({
         branchPattern: r.branchPattern.trim(),
         environment:   r.environment.trim(),
@@ -229,6 +230,7 @@ function applyConfig(config: TriggerConfig): void {
   eventPush.value             = config.events.push
   eventTag.value              = config.events.tag
   eventPullRequest.value      = config.events.pullRequest
+  eventRelease.value          = config.events.release ?? false
   unmatchedPolicy.value       = config.unmatchedPolicy
   mappings.value = config.branchMappings.map((m) => ({
     _key: ++_keySeq,
@@ -383,7 +385,7 @@ const displayWebhookUrl = computed(() => {
           </div>
           <div class="webhook-row">
             <span class="wk-label">推送配置</span>
-            <p class="wk-hint">在 Gitee 仓库 → 管理 → WebHooks 粘贴以上地址与密钥,事件勾选 Push / Tag Push / Pull Request。</p>
+            <p class="wk-hint">在 Gitee 仓库 → 管理 → WebHooks 粘贴以上地址与密钥,事件勾选 Push / Tag Push / Release / Pull Request。</p>
           </div>
         </div>
       </section>
@@ -413,6 +415,13 @@ const displayWebhookUrl = computed(() => {
             </button>
             <div class="ev-text"><span class="ev-name">Tag</span><span class="ev-desc">打 tag 触发(常用于 release 分支发版)</span></div>
             <span class="ev-code mono">tag</span>
+          </div>
+          <div class="event-row">
+            <button class="ev-toggle" :class="{ 'ev-toggle--on': eventRelease }" role="switch" :aria-checked="eventRelease" aria-label="Release 事件触发" @click="eventRelease = !eventRelease">
+              <span class="ev-toggle-knob" aria-hidden="true"/>
+            </button>
+            <div class="ev-text"><span class="ev-name">Release</span><span class="ev-desc">发布 Release 触发(按 tag 名匹配分支映射)</span></div>
+            <span class="ev-code mono">release</span>
           </div>
           <div class="event-row">
             <button class="ev-toggle" :class="{ 'ev-toggle--on': eventPullRequest }" role="switch" :aria-checked="eventPullRequest" aria-label="Pull Request 事件触发" @click="eventPullRequest = !eventPullRequest">


### PR DESCRIPTION
## 背景

实现 **FR-8-11 tag/release 触发**:补齐 tag 上下文、新增 release 事件端到端支持、前端 release 开关。

## 发现的 tag 上下文缺口与处理

逐行核对后:**tag 上下文实际已闭合**——`Tag Push Hook` 的 `refs/tags/v1.2.3` 经 `refToBranch` 取末段落入 `Branch`(`v1.2.3`),commit 从 `after`/`checkout_sha`/`head_commit.id` 取,不为空。tag 标签名沿用既有 `branch→环境` 映射(模式 `v*` 命中 `v1.2.3`),语义统一:`Branch` = 「触发引用名」,push 为分支名、tag/release 为标签名。新增测试 `TestWebhookTagPushCarriesTagRefAndCommit` 固化该行为(此前无 tag 命中创建运行的断言,仅有「tag 未订阅」用例)。

真正的缺口在 **release 事件**:Gitee `Release Hook` / GitHub `release` 的 tag 在 `release.tag_name`(不在 `ref`),且原先 `Events`/`eventSubscribed`/payload 解析均无 release 通路。

## Release 事件接线

- `Events` 增 `Release bool`(JSON `release`);新增 `eventRelease = "Release Hook"` 常量,接入 `eventSubscribed`。
- `giteePayload` 增 `release.tag_name` / `release.target_commitish`;`parsePayload`:tag 名落 `Branch`、`target_commitish` 作 commit 回退。
- HTTP DTO 三处补 `release`:响应 `eventsDTO`、PUT 请求体解析结构、`SaveInput` 映射——保证前端开关 round-trip。

## 前端

- `web/src/api/triggers.ts` `TriggerEvents` 增 `release`。
- `TriggersPanel.vue` 事件区新增 Release 开关(镜像 tag 标记 markup),`eventRelease` ref 接入 save/load;旧配置缺字段时 `?? false` 降级。webhook 提示文案补 Release。

## 迁移

**无需迁移**。events 以 JSON 整体入库(`events_json`),新增字段对历史行反序列化为零值 `false`,完全向后兼容。`createDefault` 默认 JSON 同步补 `"release":false`(显式化,非强制)。

## 绿灯证据

后端:`gofmt -l`(空)· `go vet ./...`(空)· `go build ./...`(ok)· `go test ./...` 全 ok(trigger / httpapi 含新用例)。
前端:`npm run typecheck`(clean)· `npm run test`(18 文件 152 用例全过)· `npm run build`(✓ built)。`web/dist/index.html` 已 `git checkout` 复位,未入库。

🤖 Generated with [Claude Code](https://claude.com/claude-code)