### PR TITLE
feat(web): 环境晋级前端 UI — 环境链配置 + 晋级操作 + 历史(FR-8-7)

### DIFF
--- a/web/src/api/promotion.helpers.test.ts
+++ b/web/src/api/promotion.helpers.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import {
+  promotionStatusConfig,
+  formatPromotionDate,
+  validateEnvName,
+  findDuplicateEnvName,
+} from './promotion.helpers'
+
+describe('promotionStatusConfig', () => {
+  it('returns green tokens for promoted', () => {
+    const cfg = promotionStatusConfig('promoted')
+    expect(cfg.label).toBe('已晋级')
+    expect(cfg.color).toContain('green')
+    expect(cfg.bg).toContain('green')
+  })
+
+  it('returns amber tokens for pending', () => {
+    const cfg = promotionStatusConfig('pending')
+    expect(cfg.label).toBe('待审批')
+    expect(cfg.color).toContain('amber')
+  })
+
+  it('returns red tokens for rejected', () => {
+    const cfg = promotionStatusConfig('rejected')
+    expect(cfg.label).toBe('已拒绝')
+    expect(cfg.color).toContain('red')
+  })
+})
+
+describe('formatPromotionDate', () => {
+  it('returns em-dash for empty string', () => {
+    expect(formatPromotionDate('')).toBe('—')
+  })
+
+  it('returns em-dash for null', () => {
+    expect(formatPromotionDate(null)).toBe('—')
+  })
+
+  it('returns em-dash for undefined', () => {
+    expect(formatPromotionDate(undefined)).toBe('—')
+  })
+
+  it('returns em-dash for invalid date string', () => {
+    expect(formatPromotionDate('not-a-date')).toBe('—')
+  })
+
+  it('returns a non-empty formatted string for a valid ISO date', () => {
+    const result = formatPromotionDate('2026-05-31T10:30:00Z')
+    expect(result).not.toBe('—')
+    expect(typeof result).toBe('string')
+    expect(result.length).toBeGreaterThan(0)
+  })
+})
+
+describe('validateEnvName', () => {
+  it('returns error for empty name', () => {
+    expect(validateEnvName('')).not.toBe('')
+    expect(validateEnvName('  ')).not.toBe('')
+  })
+
+  it('returns empty string for valid names', () => {
+    expect(validateEnvName('dev')).toBe('')
+    expect(validateEnvName('staging')).toBe('')
+    expect(validateEnvName('prod')).toBe('')
+    expect(validateEnvName('prod-01')).toBe('')
+    expect(validateEnvName('my_env')).toBe('')
+  })
+
+  it('returns error for names with special chars', () => {
+    expect(validateEnvName('dev env')).not.toBe('')
+    expect(validateEnvName('dev.env')).not.toBe('')
+    expect(validateEnvName('dev/env')).not.toBe('')
+  })
+
+  it('returns error for names exceeding 64 chars', () => {
+    expect(validateEnvName('a'.repeat(65))).not.toBe('')
+  })
+
+  it('accepts names up to 64 chars', () => {
+    expect(validateEnvName('a'.repeat(64))).toBe('')
+  })
+})
+
+describe('findDuplicateEnvName', () => {
+  it('returns null for empty array', () => {
+    expect(findDuplicateEnvName([])).toBeNull()
+  })
+
+  it('returns null for unique names', () => {
+    expect(findDuplicateEnvName(['dev', 'staging', 'prod'])).toBeNull()
+  })
+
+  it('returns the first duplicate name', () => {
+    expect(findDuplicateEnvName(['dev', 'staging', 'dev'])).toBe('dev')
+  })
+
+  it('is case-insensitive for duplicate detection', () => {
+    expect(findDuplicateEnvName(['Dev', 'Staging', 'dev'])).not.toBeNull()
+  })
+
+  it('returns null for single-item array', () => {
+    expect(findDuplicateEnvName(['prod'])).toBeNull()
+  })
+})

--- a/web/src/api/promotion.helpers.ts
+++ b/web/src/api/promotion.helpers.ts
@@ -1,0 +1,90 @@
+/**
+ * Pure helpers for promotion UI logic — tested in promotion.helpers.test.ts.
+ */
+
+import type { PromotionStatus } from './promotion'
+
+// ─── Status display ───────────────────────────────────────────────────────────
+
+export interface PromotionStatusConfig {
+  label: string
+  /** CSS var token for the status dot / text color. */
+  color: string
+  /** CSS var token for the soft background. */
+  bg: string
+  /** CSS var token for the border line. */
+  border: string
+}
+
+export function promotionStatusConfig(status: PromotionStatus): PromotionStatusConfig {
+  switch (status) {
+    case 'promoted':
+      return {
+        label: '已晋级',
+        color: 'var(--color-green)',
+        bg: 'var(--color-green-soft)',
+        border: 'var(--color-green-line)',
+      }
+    case 'pending':
+      return {
+        label: '待审批',
+        color: 'var(--color-amber)',
+        bg: 'var(--color-amber-soft)',
+        border: 'var(--color-amber-line)',
+      }
+    case 'rejected':
+      return {
+        label: '已拒绝',
+        color: 'var(--color-red)',
+        bg: 'var(--color-red-soft)',
+        border: 'var(--color-red-line)',
+      }
+  }
+}
+
+// ─── Date formatting ──────────────────────────────────────────────────────────
+
+/**
+ * Format an ISO date string to a short locale string.
+ * Returns '—' for empty/null/invalid dates.
+ */
+export function formatPromotionDate(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleString('zh-CN', {
+    month: 'numeric',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+// ─── Environment chain helpers ────────────────────────────────────────────────
+
+/**
+ * Validate an environment name: non-empty, no leading/trailing whitespace,
+ * only alphanumeric, dash, underscore.
+ * Returns an error string, or '' if valid.
+ */
+export function validateEnvName(name: string): string {
+  const n = name.trim()
+  if (!n) return '环境名不能为空'
+  if (!/^[\w-]+$/.test(n)) return '环境名只能含字母、数字、连字符、下划线'
+  if (n.length > 64) return '环境名不能超过 64 个字符'
+  return ''
+}
+
+/**
+ * Check an ordered array of environment names for duplicates.
+ * Returns the first duplicate name found, or null if no duplicates.
+ */
+export function findDuplicateEnvName(names: string[]): string | null {
+  const seen = new Set<string>()
+  for (const n of names) {
+    const key = n.trim().toLowerCase()
+    if (seen.has(key)) return n.trim()
+    seen.add(key)
+  }
+  return null
+}

--- a/web/src/api/promotion.ts
+++ b/web/src/api/promotion.ts
@@ -1,0 +1,122 @@
+/**
+ * Promotion API — Epic 8 · Story 8-7 (FR-8-7).
+ *
+ * GET  /api/projects/{id}/environments       → EnvironmentsResponse
+ * PUT  /api/projects/{id}/environments       → { environments: EnvStage[] }  (CSRF)
+ * POST /api/runs/{id}/promote                → PromotionDTO                  (CSRF)
+ * GET  /api/runs/{id}/promotions             → { items: PromotionDTO[] }
+ * GET  /api/projects/{id}/promotions         → { items: PromotionDTO[] }
+ *
+ * Secret variables are never returned in plaintext — the backend only exposes
+ * a masked value / credentialId reference. This client mirrors that guarantee
+ * by typing `value` as a plain string (empty for secrets) and exposing
+ * `credentialId` separately.
+ *
+ * Gated environments enter a waiting-approval state on promote; the caller
+ * reuses the existing /runs/{id}/approve|reject endpoints (see api/runs.ts).
+ * A 409 is returned for already-promoted / gated-rejected promotions — the
+ * response body is still a PromotionDTO (not an error envelope) so callers
+ * should read the record's `status` field.
+ */
+
+import { http } from './http'
+
+// ─── Domain types ─────────────────────────────────────────────────────────────
+
+/** One stage in the ordered environment chain. */
+export interface EnvStage {
+  name: string
+  /** Whether this stage requires manual approval before promotion proceeds. */
+  gated: boolean
+}
+
+/**
+ * A per-environment variable.
+ * Secret variables expose only `credentialId` (never plaintext); `value` is
+ * empty for secrets.
+ */
+export interface EnvVariable {
+  key: string
+  /** Plaintext value for non-secret variables; empty string for secrets. */
+  value: string
+  secret: boolean
+  /** Credential ID reference (only set when secret === true). */
+  credentialId: string
+}
+
+/** Full response from GET /api/projects/{id}/environments. */
+export interface EnvironmentsResponse {
+  environments: EnvStage[]
+  /** Map from environment name → list of variables (masked for secrets). */
+  variables: Record<string, EnvVariable[]>
+}
+
+/** Promotion record DTO (matches Go's promotionDTO camelCase json tags). */
+export interface PromotionDTO {
+  id: string
+  projectId: string
+  sourceRunId: string
+  fromEnvironment: string
+  targetEnvironment: string
+  /** "pending" | "promoted" | "rejected" */
+  status: PromotionStatus
+  promotedBy: string
+  createdAt: string
+  decidedAt: string
+}
+
+export type PromotionStatus = 'pending' | 'promoted' | 'rejected'
+
+// ─── Input types ──────────────────────────────────────────────────────────────
+
+export interface SaveEnvironmentsInput {
+  environments: EnvStage[]
+  variables?: Record<string, EnvVariableInput[]>
+}
+
+export interface EnvVariableInput {
+  key: string
+  /** Plaintext for non-secret; empty for secret (backend uses credentialId). */
+  value: string
+  secret: boolean
+  /** Must be set when secret === true. */
+  credentialId?: string
+}
+
+export interface PromoteRunInput {
+  /** Leave empty to auto-advance to the next environment in the chain. */
+  targetEnvironment?: string
+}
+
+// ─── API functions ────────────────────────────────────────────────────────────
+
+export async function getEnvironments(projectId: string): Promise<EnvironmentsResponse> {
+  return http.get<EnvironmentsResponse>(`/api/projects/${projectId}/environments`)
+}
+
+export async function saveEnvironments(
+  projectId: string,
+  input: SaveEnvironmentsInput,
+): Promise<{ environments: EnvStage[] }> {
+  return http.put<{ environments: EnvStage[] }>(
+    `/api/projects/${projectId}/environments`,
+    input,
+  )
+}
+
+export async function promoteRun(
+  runId: string,
+  input: PromoteRunInput = {},
+): Promise<PromotionDTO> {
+  return http.post<PromotionDTO>(`/api/runs/${runId}/promote`, input)
+}
+
+export async function listRunPromotions(runId: string): Promise<{ items: PromotionDTO[] }> {
+  return http.get<{ items: PromotionDTO[] }>(`/api/runs/${runId}/promotions`)
+}
+
+export async function listProjectPromotions(
+  projectId: string,
+): Promise<{ items: PromotionDTO[] }> {
+  return http.get<{ items: PromotionDTO[] }>(`/api/projects/${projectId}/promotions`)
+}

--- a/web/src/components/EnvironmentsPanel.vue
+++ b/web/src/components/EnvironmentsPanel.vue
@@ -1,0 +1,1058 @@
+<script setup lang="ts">
+/**
+ * EnvironmentsPanel — environment chain configuration (Epic 8 · Story 8-7 / FR-8-7).
+ *
+ * Lets the user define an ordered promotion chain (e.g. dev → staging → prod)
+ * with per-stage gated toggle and per-environment plain variables.
+ *
+ * Secret variables are intentionally read-only here (they reference vault
+ * credentials by ID; editing them is out of scope for this panel).
+ *
+ * Used by:
+ *   - TriggersPanel.vue (embedded as a card after cron config)
+ *   - Potentially the pipeline settings tab
+ */
+import { ref, onMounted, watch } from 'vue'
+import {
+  getEnvironments,
+  saveEnvironments,
+  type EnvStage,
+  type EnvVariable,
+} from '../api/promotion'
+import { validateEnvName, findDuplicateEnvName } from '../api/promotion.helpers'
+import { HttpError } from '../api/http'
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+const props = defineProps<{
+  projectId: string
+}>()
+
+// ─── Load state ───────────────────────────────────────────────────────────────
+
+type LoadState = 'idle' | 'loading' | 'error'
+const loadState = ref<LoadState>('idle')
+const loadError = ref('')
+
+// ─── Environment chain state ──────────────────────────────────────────────────
+
+interface EnvRow {
+  _key: number
+  name: string
+  gated: boolean
+  nameError: string
+}
+
+let _keySeq = 0
+const envRows = ref<EnvRow[]>([])
+
+// Per-env variables (keyed by env name)
+const variablesByEnv = ref<Record<string, EnvVariable[]>>({})
+// Which env has its variables expanded
+const expandedEnv = ref<string | null>(null)
+
+// ─── Variable editing ─────────────────────────────────────────────────────────
+
+interface VarDraft {
+  key: string
+  value: string
+}
+
+// Draft vars for currently expanded env
+const varDrafts = ref<VarDraft[]>([])
+let _varKeySeq = 0
+
+function expandVars(envName: string): void {
+  if (expandedEnv.value === envName) {
+    expandedEnv.value = null
+    varDrafts.value = []
+    return
+  }
+  expandedEnv.value = envName
+  // Populate drafts from existing vars (non-secret only)
+  const existing = (variablesByEnv.value[envName] ?? []).filter((v) => !v.secret)
+  varDrafts.value = existing.map((v) => ({ key: v.key, value: v.value }))
+  if (varDrafts.value.length === 0) {
+    addVarRow()
+  }
+}
+
+function addVarRow(): void {
+  _varKeySeq++
+  varDrafts.value.push({ key: '', value: '' })
+}
+
+function removeVarRow(idx: number): void {
+  varDrafts.value.splice(idx, 1)
+}
+
+// ─── Chain editing ────────────────────────────────────────────────────────────
+
+function addEnvRow(): void {
+  envRows.value.push({ _key: ++_keySeq, name: '', gated: false, nameError: '' })
+}
+
+function removeEnvRow(key: number): void {
+  const row = envRows.value.find((r) => r._key === key)
+  if (row && expandedEnv.value === row.name) {
+    expandedEnv.value = null
+    varDrafts.value = []
+  }
+  envRows.value = envRows.value.filter((r) => r._key !== key)
+}
+
+function moveUp(idx: number): void {
+  if (idx <= 0) return
+  const arr = [...envRows.value]
+  ;[arr[idx - 1], arr[idx]] = [arr[idx], arr[idx - 1]]
+  envRows.value = arr
+}
+
+function moveDown(idx: number): void {
+  if (idx >= envRows.value.length - 1) return
+  const arr = [...envRows.value]
+  ;[arr[idx], arr[idx + 1]] = [arr[idx + 1], arr[idx]]
+  envRows.value = arr
+}
+
+function onNameInput(row: EnvRow): void {
+  if (row.nameError) row.nameError = validateEnvName(row.name)
+}
+
+// ─── Save ─────────────────────────────────────────────────────────────────────
+
+const saveSubmitting = ref(false)
+const saveBanner = ref('')
+const saveSuccess = ref(false)
+let saveSuccessTimer: ReturnType<typeof setTimeout> | null = null
+
+function showSaveSuccess(): void {
+  saveSuccess.value = true
+  if (saveSuccessTimer) clearTimeout(saveSuccessTimer)
+  saveSuccessTimer = setTimeout(() => {
+    saveSuccess.value = false
+  }, 3200)
+}
+
+// Flush current varDrafts back into variablesByEnv before saving
+function flushVarDrafts(): void {
+  if (!expandedEnv.value) return
+  const env = expandedEnv.value
+  const existing = (variablesByEnv.value[env] ?? []).filter((v) => v.secret)
+  const nonEmpty = varDrafts.value.filter((d) => d.key.trim() !== '')
+  variablesByEnv.value = {
+    ...variablesByEnv.value,
+    [env]: [
+      ...existing,
+      ...nonEmpty.map((d) => ({
+        key: d.key.trim(),
+        value: d.value,
+        secret: false,
+        credentialId: '',
+      })),
+    ],
+  }
+}
+
+async function handleSave(): Promise<void> {
+  // Validate all env names
+  let hasError = false
+  for (const row of envRows.value) {
+    row.nameError = validateEnvName(row.name)
+    if (row.nameError) hasError = true
+  }
+  if (hasError) return
+
+  // Check for duplicates
+  const dup = findDuplicateEnvName(envRows.value.map((r) => r.name))
+  if (dup) {
+    saveBanner.value = `环境名重复:「${dup}」`
+    return
+  }
+
+  // Flush draft vars
+  flushVarDrafts()
+
+  saveSubmitting.value = true
+  saveBanner.value = ''
+  saveSuccess.value = false
+
+  const stages: EnvStage[] = envRows.value.map((r) => ({
+    name: r.name.trim(),
+    gated: r.gated,
+  }))
+
+  // Build variables map — only include envs that are in the chain
+  const variables: Record<string, Array<{ key: string; value: string; secret: boolean; credentialId?: string }>> = {}
+  for (const s of stages) {
+    const vars = variablesByEnv.value[s.name] ?? []
+    if (vars.length > 0) {
+      variables[s.name] = vars.map((v) => ({
+        key: v.key,
+        value: v.value,
+        secret: v.secret,
+        credentialId: v.credentialId || undefined,
+      }))
+    }
+  }
+
+  try {
+    const res = await saveEnvironments(props.projectId, {
+      environments: stages,
+      variables: Object.keys(variables).length > 0 ? variables : undefined,
+    })
+    // Update from server response
+    applyChain(res.environments, variablesByEnv.value)
+    showSaveSuccess()
+  } catch (err) {
+    if (err instanceof HttpError) {
+      if (err.status === 0) {
+        saveBanner.value = '无法连接到服务器,请稍后重试。'
+      } else if (err.status === 422 || err.status === 400) {
+        saveBanner.value = err.apiError?.message ?? `保存失败(${err.status}):配置数据不合法`
+      } else {
+        saveBanner.value = err.apiError?.message ?? `保存失败(${err.status})`
+      }
+    } else {
+      saveBanner.value = '保存失败,请稍后重试。'
+    }
+  } finally {
+    saveSubmitting.value = false
+  }
+}
+
+// ─── Data loading ─────────────────────────────────────────────────────────────
+
+function applyChain(
+  envs: EnvStage[],
+  vars: Record<string, EnvVariable[]>,
+): void {
+  envRows.value = envs.map((e) => ({
+    _key: ++_keySeq,
+    name: e.name,
+    gated: e.gated,
+    nameError: '',
+  }))
+  variablesByEnv.value = vars
+}
+
+async function loadEnvironments(): Promise<void> {
+  loadState.value = 'loading'
+  loadError.value = ''
+  try {
+    const res = await getEnvironments(props.projectId)
+    applyChain(res.environments, res.variables)
+    loadState.value = 'idle'
+  } catch (err) {
+    if (err instanceof HttpError) {
+      if (err.status === 0) {
+        loadError.value = '无法连接到服务器,请检查后端是否运行后重试。'
+      } else if (err.status === 404) {
+        loadError.value = '项目不存在,请确认项目 ID 正确。'
+      } else {
+        loadError.value = err.apiError?.message ?? `加载环境配置失败(${err.status})`
+      }
+    } else {
+      loadError.value = '加载环境配置失败,请稍后重试。'
+    }
+    loadState.value = 'error'
+  }
+}
+
+watch(() => props.projectId, loadEnvironments)
+onMounted(loadEnvironments)
+</script>
+
+<template>
+  <div class="env-panel">
+
+    <!-- ─── Load error ──────────────────────────────────────────────────── -->
+    <div v-if="loadState === 'error'" class="ep-banner ep-banner--error" role="alert">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+        <circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h.01"/>
+      </svg>
+      <span>{{ loadError }}</span>
+      <button class="ep-banner-retry" @click="loadEnvironments">↻ 重试</button>
+    </div>
+
+    <!-- ─── Loading skeleton ────────────────────────────────────────────── -->
+    <template v-if="loadState === 'loading'">
+      <div class="ep-skel-card" aria-busy="true" aria-label="加载中">
+        <div class="ep-skel ep-skel--title" aria-hidden="true" />
+        <div class="ep-skel ep-skel--row" aria-hidden="true" />
+        <div class="ep-skel ep-skel--row" aria-hidden="true" />
+      </div>
+    </template>
+
+    <!-- ─── Main config ─────────────────────────────────────────────────── -->
+    <template v-else-if="loadState === 'idle'">
+
+      <!-- Save error/success banners -->
+      <div v-if="saveBanner" class="ep-banner ep-banner--error" role="alert" aria-live="assertive">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h.01"/>
+        </svg>
+        <span>{{ saveBanner }}</span>
+      </div>
+      <div v-if="saveSuccess" class="ep-banner ep-banner--success" role="status" aria-live="polite">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true">
+          <path d="M20 6 9 17l-5-5"/>
+        </svg>
+        <span>环境链已保存</span>
+      </div>
+
+      <!-- ═══ Environment chain card ══════════════════════════════════════ -->
+      <section class="config-card" aria-labelledby="ep-chain-heading">
+        <div class="card-head">
+          <span class="card-icon" aria-hidden="true">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9">
+              <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="M22 4 12 14.01l-3-3"/>
+            </svg>
+          </span>
+          <h2 id="ep-chain-heading" class="card-title">环境晋级链</h2>
+          <span class="card-sub">定义有序的晋级路径 · 可选审批门</span>
+        </div>
+
+        <!-- Chain flow diagram (read-only visual) -->
+        <div v-if="envRows.length > 0" class="chain-flow" aria-label="环境链顺序预览" role="img">
+          <template v-for="(row, idx) in envRows" :key="row._key">
+            <div
+              class="chain-node"
+              :class="{ 'chain-node--gated': row.gated }"
+              :aria-label="`环境 ${row.name || '(未命名)'}${row.gated ? ' · 需审批' : ''}`"
+            >
+              <span class="chain-node-name">{{ row.name || '…' }}</span>
+              <span v-if="row.gated" class="chain-node-gate" aria-hidden="true">
+                <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2">
+                  <rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+                </svg>
+              </span>
+            </div>
+            <div v-if="idx < envRows.length - 1" class="chain-arrow" aria-hidden="true">
+              <svg width="16" height="10" viewBox="0 0 16 10" fill="none">
+                <path d="M0 5h14M10 1l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </div>
+          </template>
+        </div>
+        <div v-else class="chain-flow chain-flow--empty">
+          <span class="chain-empty-text">尚未定义环境链，请在下方添加</span>
+        </div>
+
+        <!-- Chain rows (editable) -->
+        <div class="chain-table-head" aria-hidden="true">
+          <span>序号</span><span>环境名</span><span>审批门</span><span>变量</span><span>排序</span><span></span>
+        </div>
+
+        <div v-if="envRows.length === 0" class="chain-empty-rows">
+          <span>暂无环境,点下方「添加环境」开始配置</span>
+        </div>
+
+        <div
+          v-for="(row, idx) in envRows"
+          :key="row._key"
+          class="chain-row"
+          :class="{ 'chain-row--expanded': expandedEnv === row.name }"
+        >
+          <!-- Main row -->
+          <div class="chain-row-main">
+            <!-- Index badge -->
+            <div class="chain-idx">
+              <span class="chain-idx-num">{{ idx + 1 }}</span>
+            </div>
+
+            <!-- Name input -->
+            <div class="chain-cell chain-cell--name">
+              <input
+                v-model="row.name"
+                type="text"
+                class="chain-input"
+                :class="{ 'chain-input--error': row.nameError }"
+                :placeholder="`env-${idx + 1}`"
+                :aria-label="`环境名称(第 ${idx + 1} 行)`"
+                :aria-invalid="row.nameError ? 'true' : undefined"
+                maxlength="64"
+                @input="onNameInput(row)"
+                @blur="row.nameError = validateEnvName(row.name)"
+              />
+              <span v-if="row.nameError" class="chain-field-error" role="alert">{{ row.nameError }}</span>
+            </div>
+
+            <!-- Gated toggle -->
+            <div class="chain-cell chain-cell--gated">
+              <button
+                class="gate-toggle"
+                :class="{ 'gate-toggle--on': row.gated }"
+                role="switch"
+                :aria-checked="row.gated"
+                :aria-label="`${row.name || '该环境'}审批门:${row.gated ? '已开启' : '已关闭'}`"
+                @click="row.gated = !row.gated"
+              >
+                <span class="gate-toggle-knob" aria-hidden="true" />
+              </button>
+              <span class="gate-label">{{ row.gated ? '需审批' : '直通' }}</span>
+            </div>
+
+            <!-- Variables toggle -->
+            <div class="chain-cell chain-cell--vars">
+              <button
+                class="vars-btn"
+                :class="{ 'vars-btn--active': expandedEnv === row.name }"
+                :aria-expanded="expandedEnv === row.name"
+                :aria-label="`${row.name || '该环境'}变量 · ${(variablesByEnv[row.name] ?? []).length} 条`"
+                @click="expandVars(row.name)"
+              >
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                  <circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/>
+                </svg>
+                <span class="vars-btn-count">{{ (variablesByEnv[row.name] ?? []).length }}</span>
+              </button>
+            </div>
+
+            <!-- Move up / down -->
+            <div class="chain-cell chain-cell--order">
+              <button
+                class="order-btn"
+                :disabled="idx === 0"
+                :aria-label="`将 ${row.name || '该环境'} 上移`"
+                @click="moveUp(idx)"
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true">
+                  <path d="M18 15l-6-6-6 6"/>
+                </svg>
+              </button>
+              <button
+                class="order-btn"
+                :disabled="idx === envRows.length - 1"
+                :aria-label="`将 ${row.name || '该环境'} 下移`"
+                @click="moveDown(idx)"
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true">
+                  <path d="M6 9l6 6 6-6"/>
+                </svg>
+              </button>
+            </div>
+
+            <!-- Delete -->
+            <div class="chain-cell chain-cell--del">
+              <button
+                class="del-btn"
+                :aria-label="`删除环境「${row.name || '(未命名)'}」`"
+                @click="removeEnvRow(row._key)"
+              >
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" aria-hidden="true">
+                  <path d="M3 6h18M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2"/>
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <!-- Expanded variables panel -->
+          <div v-if="expandedEnv === row.name" class="vars-panel" role="region" :aria-label="`${row.name} 变量`">
+            <!-- Secret vars (read-only display) -->
+            <div
+              v-for="sv in (variablesByEnv[row.name] ?? []).filter(v => v.secret)"
+              :key="sv.key"
+              class="var-row var-row--secret"
+            >
+              <span class="var-key mono">{{ sv.key }}</span>
+              <span class="var-val-placeholder">
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                  <rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+                </svg>
+                密钥 · 引用 vault 凭据
+              </span>
+              <span class="var-secret-badge">Secret</span>
+            </div>
+
+            <!-- Plain var drafts (editable) -->
+            <div v-for="(draft, dIdx) in varDrafts" :key="dIdx" class="var-row var-row--edit">
+              <input
+                v-model="draft.key"
+                type="text"
+                class="var-input var-input--key mono"
+                placeholder="KEY"
+                :aria-label="`变量键(第 ${dIdx + 1} 行)`"
+              />
+              <span class="var-eq" aria-hidden="true">=</span>
+              <input
+                v-model="draft.value"
+                type="text"
+                class="var-input var-input--val"
+                placeholder="VALUE"
+                :aria-label="`变量值(第 ${dIdx + 1} 行)`"
+              />
+              <button
+                class="var-del-btn"
+                :aria-label="`删除变量行 ${dIdx + 1}`"
+                @click="removeVarRow(dIdx)"
+              >
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                  <path d="M18 6 6 18M6 6l12 12"/>
+                </svg>
+              </button>
+            </div>
+
+            <button class="var-add-btn" @click="addVarRow">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
+                <path d="M12 5v14M5 12h14"/>
+              </svg>
+              添加变量
+            </button>
+            <p class="vars-hint">Secret 变量须在保险库中创建凭据后引用;此处只可编辑明文变量。</p>
+          </div>
+        </div>
+
+        <button class="add-env-btn" @click="addEnvRow">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
+            <path d="M12 5v14M5 12h14"/>
+          </svg>
+          添加环境
+        </button>
+
+        <p class="chain-note">
+          链上顺序即晋级顺序;开启审批门的环境在晋级时须有人批准后方可继续。
+          变量仅注入到对应环境的运行,互不透传。
+        </p>
+      </section>
+
+      <!-- ═══ Save bar ═══════════════════════════════════════════════════ -->
+      <div class="ep-save-bar">
+        <button
+          class="ep-btn-primary"
+          :disabled="saveSubmitting"
+          :aria-busy="saveSubmitting"
+          @click="handleSave"
+        >
+          <span v-if="saveSubmitting" class="ep-spinner" aria-hidden="true" />
+          {{ saveSubmitting ? '保存中…' : '保存环境配置' }}
+        </button>
+      </div>
+
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.env-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--card-gap);
+}
+
+/* ─── Banner ──────────────────────────────────────── */
+.ep-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  padding: 11px 14px;
+  border-radius: var(--rounded);
+  font-size: 0.83rem;
+  line-height: 1.5;
+}
+.ep-banner--error {
+  background: var(--color-red-soft);
+  border: 1px solid var(--color-red-line);
+  color: var(--color-red);
+}
+.ep-banner--success {
+  background: var(--color-green-soft);
+  border: 1px solid var(--color-green-line);
+  color: var(--color-green);
+}
+.ep-banner-retry {
+  margin-left: auto;
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--color-red);
+  font-size: 0.83rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* ─── Skeleton ────────────────────────────────────── */
+.ep-skel-card {
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-card);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.ep-skel {
+  display: block;
+  background: linear-gradient(90deg, var(--color-inset) 0%, oklch(100% 0 0 / 0.06) 50%, var(--color-inset) 100%);
+  background-size: 200% 100%;
+  border-radius: var(--rounded-md);
+  animation: ep-shimmer 1.4s ease-in-out infinite;
+}
+@keyframes ep-shimmer {
+  0%   { background-position: 200% center; }
+  100% { background-position: -200% center; }
+}
+@media (prefers-reduced-motion: reduce) { .ep-skel { animation: none; background: var(--color-inset); } }
+.ep-skel--title { height: 16px; width: 38%; }
+.ep-skel--row   { height: 40px; width: 100%; }
+
+/* ─── Config card ─────────────────────────────────── */
+.config-card {
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-card);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  animation: ep-card-in 0.45s var(--ease-out-expo) both;
+}
+@keyframes ep-card-in {
+  from { opacity: 0; transform: translateY(13px); }
+  to   { opacity: 1; transform: none; }
+}
+@media (prefers-reduced-motion: reduce) { .config-card { animation: none; } }
+
+.card-head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--color-border);
+}
+.card-icon {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+}
+.card-title {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+.card-sub {
+  margin-left: 6px;
+  font-size: 0.75rem;
+  color: var(--color-faint);
+}
+
+/* ─── Chain flow visual ───────────────────────────── */
+.chain-flow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-inset);
+  flex-wrap: wrap;
+  min-height: 56px;
+}
+.chain-flow--empty {
+  justify-content: center;
+}
+.chain-empty-text {
+  font-size: 0.78rem;
+  color: var(--color-faint);
+  font-style: italic;
+}
+.chain-node {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border-radius: var(--rounded-md);
+  background: var(--color-card-2);
+  border: 1px solid var(--color-border-strong);
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--color-text);
+  white-space: nowrap;
+}
+.chain-node--gated {
+  border-color: var(--color-amber-line);
+  background: var(--color-amber-soft);
+  color: var(--color-amber);
+}
+.chain-node-name { }
+.chain-node-gate { color: inherit; display: flex; align-items: center; }
+.chain-arrow {
+  color: var(--color-faint);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+/* ─── Chain table ─────────────────────────────────── */
+.chain-table-head {
+  display: grid;
+  grid-template-columns: 36px 1fr 110px 72px 60px 44px;
+  gap: 10px;
+  padding: 0 18px;
+  height: 36px;
+  align-items: center;
+  background: var(--color-card-2);
+  border-bottom: 1px solid var(--color-border);
+  font-size: var(--text-caps);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-faint);
+}
+.chain-empty-rows {
+  padding: 20px 18px;
+  font-size: 0.82rem;
+  color: var(--color-faint);
+  font-style: italic;
+  text-align: center;
+  border-bottom: 1px solid var(--color-border);
+}
+.chain-row {
+  border-bottom: 1px solid var(--color-border);
+  transition: background-color var(--duration-fast);
+}
+.chain-row--expanded {
+  background: var(--color-inset);
+}
+.chain-row-main {
+  display: grid;
+  grid-template-columns: 36px 1fr 110px 72px 60px 44px;
+  gap: 10px;
+  padding: 8px 18px;
+  align-items: start;
+}
+.chain-row-main:hover {
+  background: var(--color-inset);
+}
+.chain-row--expanded .chain-row-main {
+  background: var(--color-inset);
+}
+
+/* Chain idx badge */
+.chain-idx {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-top: 6px;
+}
+.chain-idx-num {
+  width: 20px;
+  height: 20px;
+  border-radius: var(--rounded-full);
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  font-size: 0.7rem;
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+}
+
+/* Chain cells */
+.chain-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.chain-cell--gated { flex-direction: row; align-items: center; gap: 8px; padding-top: 5px; }
+.chain-cell--vars { align-items: flex-start; padding-top: 5px; }
+.chain-cell--order { flex-direction: row; align-items: center; gap: 3px; padding-top: 4px; }
+.chain-cell--del { align-items: center; padding-top: 4px; }
+
+/* Chain name input */
+.chain-input {
+  width: 100%;
+  height: 34px;
+  background: var(--color-inset);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded);
+  padding: 0 10px;
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: 0.84rem;
+  transition: border-color var(--duration-fast), box-shadow var(--duration-fast);
+}
+.chain-input::placeholder { color: var(--color-faint); }
+.chain-input:focus { outline: none; border-color: var(--color-primary); box-shadow: 0 0 0 3px var(--color-primary-soft); }
+.chain-input--error { border-color: var(--color-red); }
+.chain-field-error { font-size: 0.72rem; color: var(--color-red); line-height: 1.4; }
+
+/* Gated toggle */
+.gate-toggle {
+  position: relative;
+  width: 34px;
+  height: 18px;
+  border-radius: var(--rounded-full);
+  background: var(--color-border-strong);
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background-color var(--duration-fast);
+}
+.gate-toggle--on { background: var(--color-amber); }
+.gate-toggle-knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  border-radius: var(--rounded-full);
+  background: #fff;
+  transition: transform var(--duration-fast);
+  pointer-events: none;
+  box-shadow: 0 1px 3px oklch(0% 0 0 / 0.3);
+}
+.gate-toggle--on .gate-toggle-knob { transform: translateX(16px); }
+@media (prefers-reduced-motion: reduce) { .gate-toggle, .gate-toggle-knob { transition: none; } }
+.gate-label { font-size: 0.75rem; color: var(--color-dim); white-space: nowrap; }
+
+/* Vars toggle button */
+.vars-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--color-border);
+  background: var(--color-card-2);
+  color: var(--color-dim);
+  font-family: var(--font-sans);
+  font-size: 0.76rem;
+  font-weight: 500;
+  border-radius: var(--rounded-md);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color var(--duration-fast), border-color var(--duration-fast), background-color var(--duration-fast);
+}
+.vars-btn:hover { color: var(--color-primary); border-color: var(--color-primary); }
+.vars-btn--active {
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+  background: var(--color-primary-soft);
+}
+.vars-btn-count {
+  display: inline-block;
+  min-width: 16px;
+  height: 16px;
+  line-height: 16px;
+  text-align: center;
+  background: var(--color-border-strong);
+  border-radius: var(--rounded-full);
+  font-size: 0.66rem;
+  font-weight: 700;
+  padding: 0 3px;
+}
+.vars-btn--active .vars-btn-count { background: var(--color-primary); color: #fff; }
+
+/* Order buttons */
+.order-btn {
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-faint);
+  border-radius: var(--rounded-md);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition: color var(--duration-fast), border-color var(--duration-fast), background-color var(--duration-fast);
+}
+.order-btn:hover:not(:disabled) { color: var(--color-primary); border-color: var(--color-primary); background: var(--color-primary-soft); }
+.order-btn:disabled { opacity: 0.25; cursor: not-allowed; }
+
+/* Delete button */
+.del-btn {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-faint);
+  border-radius: var(--rounded-md);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition: color var(--duration-fast), border-color var(--duration-fast), background-color var(--duration-fast);
+}
+.del-btn:hover { color: var(--color-red); border-color: var(--color-red-line); background: var(--color-red-soft); }
+
+/* ─── Variables panel ─────────────────────────────── */
+.vars-panel {
+  padding: 12px 18px 14px;
+  border-top: 1px dashed var(--color-border-strong);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: var(--color-inset);
+}
+
+.var-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.var-row--secret {
+  padding: 7px 10px;
+  background: var(--color-amber-soft);
+  border: 1px solid var(--color-amber-line);
+  border-radius: var(--rounded-md);
+  font-size: 0.79rem;
+}
+.var-key {
+  font-family: var(--font-mono);
+  font-size: 0.79rem;
+  color: var(--color-text);
+  min-width: 80px;
+}
+.var-val-placeholder {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.75rem;
+  color: var(--color-amber);
+  flex: 1;
+}
+.var-secret-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: var(--rounded-sm);
+  background: var(--color-amber-soft);
+  border: 1px solid var(--color-amber-line);
+  color: var(--color-amber);
+  white-space: nowrap;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.var-row--edit { gap: 6px; }
+.var-input {
+  height: 32px;
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-md);
+  padding: 0 8px;
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: 0.82rem;
+  transition: border-color var(--duration-fast), box-shadow var(--duration-fast);
+}
+.var-input:focus { outline: none; border-color: var(--color-primary); box-shadow: 0 0 0 3px var(--color-primary-soft); }
+.var-input--key { width: 140px; font-family: var(--font-mono); font-size: 0.79rem; }
+.var-input--val { flex: 1; }
+.var-eq { font-size: 0.82rem; color: var(--color-faint); flex-shrink: 0; }
+.var-del-btn {
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-faint);
+  border-radius: var(--rounded-md);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  transition: color var(--duration-fast), border-color var(--duration-fast), background-color var(--duration-fast);
+}
+.var-del-btn:hover { color: var(--color-red); border-color: var(--color-red-line); background: var(--color-red-soft); }
+
+.var-add-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  margin-top: 4px;
+  padding: 5px 11px;
+  border: 1px dashed var(--color-border-strong);
+  background: transparent;
+  color: var(--color-primary);
+  font-family: var(--font-sans);
+  font-size: 0.78rem;
+  font-weight: 500;
+  border-radius: var(--rounded-md);
+  cursor: pointer;
+  transition: border-color var(--duration-fast), background-color var(--duration-fast);
+}
+.var-add-btn:hover { border-color: var(--color-primary); background: var(--color-primary-soft); }
+
+.vars-hint {
+  font-size: 0.74rem;
+  color: var(--color-faint);
+  line-height: 1.5;
+  margin-top: 4px;
+}
+
+/* ─── Add env button ──────────────────────────────── */
+.add-env-btn {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 12px 18px;
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: var(--color-primary);
+  font-family: var(--font-sans);
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+  transition: color var(--duration-fast), background-color var(--duration-fast);
+  border-top: 1px solid var(--color-border);
+}
+.add-env-btn:hover { background: var(--color-inset); }
+
+.chain-note {
+  padding: 11px 18px 14px;
+  font-size: 0.75rem;
+  color: var(--color-faint);
+  line-height: 1.6;
+  border-top: 1px solid var(--color-border);
+}
+
+/* ─── Save bar ────────────────────────────────────── */
+.ep-save-bar {
+  display: flex;
+  justify-content: flex-start;
+  padding-bottom: 8px;
+}
+.ep-btn-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 34px;
+  padding: 0 16px;
+  border: none;
+  background: var(--color-primary);
+  color: #fff;
+  font-family: var(--font-sans);
+  font-size: 0.83rem;
+  font-weight: 600;
+  border-radius: var(--rounded);
+  cursor: pointer;
+  box-shadow: 0 5px 16px var(--color-primary-soft);
+  transition: background-color var(--duration-fast), transform var(--duration-fast);
+  white-space: nowrap;
+}
+.ep-btn-primary:hover:not(:disabled) { background: var(--color-primary-press); transform: translateY(-1px); }
+.ep-btn-primary:disabled { opacity: 0.45; cursor: not-allowed; transform: none; box-shadow: none; }
+
+.ep-spinner {
+  display: inline-block;
+  width: 13px;
+  height: 13px;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  border-top-color: #fff;
+  border-radius: var(--rounded-full);
+  animation: ep-spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+@keyframes ep-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) { .ep-spinner { animation: none; border-top-color: currentColor; } }
+
+.mono { font-family: var(--font-mono); }
+</style>

--- a/web/src/components/TriggersPanel.vue
+++ b/web/src/components/TriggersPanel.vue
@@ -19,6 +19,7 @@ import {
 } from '../api/triggers'
 import { HttpError } from '../api/http'
 import CronPanel from './CronPanel.vue'
+import EnvironmentsPanel from './EnvironmentsPanel.vue'
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -519,6 +520,9 @@ const displayWebhookUrl = computed(() => {
 
       <!-- ═══ Scheduled (cron) trigger · Story 8-6 ════════════════════════ -->
       <CronPanel :project-id="props.projectId" />
+
+      <!-- ═══ Environment promotion chain · Story 8-7 / FR-8-7 ════════════ -->
+      <EnvironmentsPanel :project-id="props.projectId" />
 
       <!-- ═══ Save bar ════════════════════════════════════════════════════ -->
       <div class="save-bar">

--- a/web/src/components/run/PromotionPanel.vue
+++ b/web/src/components/run/PromotionPanel.vue
@@ -1,0 +1,772 @@
+<script setup lang="ts">
+/**
+ * PromotionPanel — environment promotion action + history for a run detail page.
+ * (Epic 8 · Story 8-7 / FR-8-7)
+ *
+ * Rendered inside RunDetail.vue on the success state.
+ * Responsibilities:
+ *   - Fetch the run's promotion history on mount
+ *   - Show a "晋级到下一环境" button (or confirmation for gated envs)
+ *   - Surface the gated-promotion waiting-approval banner (reuses approval
+ *     endpoints existing in RunDetail; emits 'promotion-pending' for the parent
+ *     to load its approval gate)
+ *   - Show per-run promotion history timeline
+ *
+ * Props:
+ *   runId       — the run to promote / show history for
+ *   projectId   — used to fetch the environment chain
+ *   runStatus   — current run status; promotion only when 'success'
+ *
+ * Emits:
+ *   promotion-pending — when a gated promotion is submitted (409 status=pending)
+ */
+import { ref, computed, onMounted, watch } from 'vue'
+import {
+  getEnvironments,
+  promoteRun,
+  listRunPromotions,
+  type EnvStage,
+  type PromotionDTO,
+  type PromotionStatus,
+} from '../../api/promotion'
+import { promotionStatusConfig, formatPromotionDate } from '../../api/promotion.helpers'
+import { HttpError } from '../../api/http'
+
+// ─── Props / emits ────────────────────────────────────────────────────────────
+
+const props = defineProps<{
+  runId: string
+  projectId: string
+  runStatus: string
+}>()
+
+const emit = defineEmits<{
+  /** The parent should refresh its approval gate list. */
+  (e: 'promotion-pending'): void
+}>()
+
+// ─── Environment chain ────────────────────────────────────────────────────────
+
+const chain = ref<EnvStage[]>([])
+const chainLoaded = ref(false)
+
+async function loadChain(): Promise<void> {
+  try {
+    const res = await getEnvironments(props.projectId)
+    chain.value = res.environments
+  } catch {
+    chain.value = []
+  } finally {
+    chainLoaded.value = true
+  }
+}
+
+// ─── Promotion history ────────────────────────────────────────────────────────
+
+const promotions = ref<PromotionDTO[]>([])
+const historyLoading = ref(false)
+const historyError = ref('')
+
+async function loadHistory(): Promise<void> {
+  historyLoading.value = true
+  historyError.value = ''
+  try {
+    const res = await listRunPromotions(props.runId)
+    promotions.value = res.items
+  } catch (err) {
+    if (err instanceof HttpError && err.status !== 404) {
+      historyError.value = err.apiError?.message ?? `加载历史失败(${err.status})`
+    }
+    promotions.value = []
+  } finally {
+    historyLoading.value = false
+  }
+}
+
+// ─── Compute next environment ─────────────────────────────────────────────────
+
+/**
+ * Determine the next environment to promote to, based on chain + history.
+ * Returns null if: chain empty, already at top, not configured.
+ */
+const nextEnv = computed<EnvStage | null>(() => {
+  if (!chainLoaded.value || chain.value.length === 0) return null
+  if (promotions.value.length === 0) {
+    // Never promoted — target is chain[0]
+    return chain.value[0]
+  }
+  // Find the highest-index successfully promoted or pending environment
+  let maxIdx = -1
+  for (const p of promotions.value) {
+    if (p.status === 'promoted' || p.status === 'pending') {
+      const idx = chain.value.findIndex((e) => e.name === p.targetEnvironment)
+      if (idx > maxIdx) maxIdx = idx
+    }
+  }
+  if (maxIdx < 0) {
+    // No successful/pending promotions — back to chain[0]
+    return chain.value[0]
+  }
+  if (maxIdx >= chain.value.length - 1) {
+    // Already at top
+    return null
+  }
+  return chain.value[maxIdx + 1]
+})
+
+const isNextGated = computed<boolean>(() => nextEnv.value?.gated ?? false)
+
+// ─── Promotion action ─────────────────────────────────────────────────────────
+
+const promoting = ref(false)
+const promotionError = ref('')
+const promoted = ref(false)
+const showConfirm = ref(false)
+
+function requestPromote(): void {
+  if (isNextGated.value) {
+    showConfirm.value = true
+  } else {
+    void doPromote()
+  }
+}
+
+function cancelConfirm(): void {
+  showConfirm.value = false
+}
+
+async function doPromote(): Promise<void> {
+  showConfirm.value = false
+  if (promoting.value || !nextEnv.value) return
+  promoting.value = true
+  promotionError.value = ''
+  promoted.value = false
+  try {
+    const dto = await promoteRun(props.runId, {
+      targetEnvironment: nextEnv.value.name,
+    })
+    // Regardless of 200 or 409-with-record, push to history
+    promotions.value = [dto, ...promotions.value.filter((p) => p.id !== dto.id)]
+    if (dto.status === 'pending') {
+      // Gated: notify parent to load approval gate
+      emit('promotion-pending')
+    } else if (dto.status === 'promoted') {
+      promoted.value = true
+    }
+  } catch (err) {
+    if (err instanceof HttpError) {
+      const code = err.apiError?.code ?? ''
+      switch (code) {
+        case 'chain_not_configured':
+          promotionError.value = '项目尚未配置环境链,请在「触发设置」中添加环境链后再晋级。'
+          break
+        case 'run_not_successful':
+          promotionError.value = '仅成功完成的运行可晋级。'
+          break
+        case 'already_promoted':
+          promotionError.value = '该运行已晋级到此环境。'
+          break
+        case 'already_at_top':
+          promotionError.value = '已到达链尾,无更高环境可晋级。'
+          break
+        case 'skip_env':
+          promotionError.value = '只能按顺序逐级晋级,不可跳级。'
+          break
+        default:
+          promotionError.value = err.apiError?.message ?? `晋级失败(${err.status})`
+      }
+    } else {
+      promotionError.value = '晋级请求失败,请稍后重试。'
+    }
+  } finally {
+    promoting.value = false
+  }
+}
+
+// ─── Promotion status display ─────────────────────────────────────────────────
+
+function statusCfg(status: PromotionStatus) {
+  return promotionStatusConfig(status)
+}
+
+function fmtDate(iso: string) {
+  return formatPromotionDate(iso)
+}
+
+// ─── Lifecycle ────────────────────────────────────────────────────────────────
+
+async function init(): Promise<void> {
+  await Promise.all([loadChain(), loadHistory()])
+}
+
+watch(() => props.runId, init)
+onMounted(init)
+</script>
+
+<template>
+  <div class="promotion-panel" role="region" aria-labelledby="promo-heading">
+
+    <!-- ─── Promote action section ──────────────────────────────────────── -->
+    <div class="promo-action-card">
+      <div class="promo-action-head">
+        <div class="promo-icon" aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M12 2 2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/>
+          </svg>
+        </div>
+        <h3 id="promo-heading" class="promo-title">环境晋级</h3>
+        <span v-if="chain.length > 0" class="promo-chain-badge" aria-label="环境链">
+          {{ chain.map(e => e.name).join(' → ') }}
+        </span>
+      </div>
+
+      <!-- Chain not loaded / empty -->
+      <div v-if="chainLoaded && chain.length === 0" class="promo-empty">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h.01"/>
+        </svg>
+        <span>尚未配置环境链。请前往「触发设置 → 环境链」配置后再晋级。</span>
+      </div>
+
+      <!-- Already at top -->
+      <div
+        v-else-if="chainLoaded && nextEnv === null && promotions.length > 0"
+        class="promo-empty promo-empty--top"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true">
+          <path d="M20 6 9 17l-5-5"/>
+        </svg>
+        <span>已晋级到链尾环境「{{ chain[chain.length - 1]?.name }}」,无更高级别。</span>
+      </div>
+
+      <!-- Promote button -->
+      <div v-else-if="chainLoaded && nextEnv !== null && props.runStatus === 'success'" class="promo-action-body">
+        <!-- Success flash -->
+        <div v-if="promoted" class="promo-banner promo-banner--success" role="status" aria-live="polite">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true">
+            <path d="M20 6 9 17l-5-5"/>
+          </svg>
+          已成功晋级到「{{ promotions[0]?.targetEnvironment }}」
+        </div>
+
+        <!-- Pending gate banner -->
+        <div
+          v-if="promotions[0]?.status === 'pending'"
+          class="promo-banner promo-banner--pending"
+          role="status"
+          aria-live="polite"
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+          </svg>
+          晋级到「{{ promotions[0]?.targetEnvironment }}」等待审批 · 请在审批门中批准
+        </div>
+
+        <!-- Error banner -->
+        <div v-if="promotionError" class="promo-banner promo-banner--error" role="alert" aria-live="assertive">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h.01"/>
+          </svg>
+          {{ promotionError }}
+        </div>
+
+        <!-- Gated confirm dialog -->
+        <div v-if="showConfirm" class="promo-confirm" role="alertdialog" aria-modal="true" aria-labelledby="promo-confirm-title">
+          <div class="promo-confirm-icon" aria-hidden="true">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+              <rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+            </svg>
+          </div>
+          <div class="promo-confirm-body">
+            <p id="promo-confirm-title" class="promo-confirm-title">
+              晋级到「{{ nextEnv?.name }}」需要人工审批
+            </p>
+            <p class="promo-confirm-sub">
+              提交后晋级进入等待状态,须由有权限的用户批准后方可继续。
+            </p>
+          </div>
+          <div class="promo-confirm-actions">
+            <button class="promo-btn promo-btn--cancel" @click="cancelConfirm">取消</button>
+            <button class="promo-btn promo-btn--gate" :disabled="promoting" :aria-busy="promoting" @click="doPromote">
+              <span v-if="promoting" class="promo-spinner" aria-hidden="true" />
+              {{ promoting ? '提交中…' : '提交晋级申请' }}
+            </button>
+          </div>
+        </div>
+
+        <!-- Main promote button -->
+        <div v-else class="promo-btn-row">
+          <button
+            class="promo-btn promo-btn--promote"
+            :disabled="promoting || promotions[0]?.status === 'pending'"
+            :aria-busy="promoting"
+            @click="requestPromote"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="M12 2 2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/>
+            </svg>
+            <span v-if="promoting" class="promo-spinner" aria-hidden="true" />
+            {{
+              promoting
+                ? '晋级中…'
+                : isNextGated
+                  ? `申请晋级到「${nextEnv?.name}」(需审批)`
+                  : `晋级到「${nextEnv?.name}」`
+            }}
+          </button>
+          <span v-if="isNextGated" class="promo-gated-hint">
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+            </svg>
+            审批门 · 需人工批准
+          </span>
+        </div>
+      </div>
+
+      <!-- Run not successful -->
+      <div v-else-if="props.runStatus !== 'success'" class="promo-empty">
+        <span>仅成功完成的运行可晋级</span>
+      </div>
+
+      <!-- Loading -->
+      <div v-else-if="!chainLoaded" class="promo-loading" aria-busy="true" aria-label="加载环境链">
+        <div class="promo-skel promo-skel--btn" aria-hidden="true" />
+      </div>
+    </div>
+
+    <!-- ─── Promotion history ────────────────────────────────────────────── -->
+    <div class="promo-history" aria-labelledby="promo-hist-heading">
+      <div class="promo-history-head">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <circle cx="12" cy="12" r="9"/><path d="M12 6v6l4 2"/>
+        </svg>
+        <h4 id="promo-hist-heading" class="promo-history-title">晋级历史</h4>
+        <span class="promo-hist-count">{{ promotions.length }}</span>
+      </div>
+
+      <div v-if="historyLoading" class="promo-hist-body promo-hist-loading" aria-busy="true" aria-label="加载历史">
+        <div class="promo-skel promo-skel--row" aria-hidden="true" />
+        <div class="promo-skel promo-skel--row" aria-hidden="true" />
+      </div>
+
+      <div v-else-if="historyError" class="promo-hist-body promo-hist-error" role="alert">
+        {{ historyError }}
+      </div>
+
+      <div v-else-if="promotions.length === 0" class="promo-hist-body promo-hist-empty">
+        <span>暂无晋级记录</span>
+      </div>
+
+      <ol v-else class="promo-hist-list" aria-label="晋级历史列表">
+        <li
+          v-for="p in promotions"
+          :key="p.id"
+          class="promo-hist-item"
+          :aria-label="`晋级到 ${p.targetEnvironment}・${statusCfg(p.status).label}・${fmtDate(p.createdAt)}`"
+        >
+          <!-- Status dot -->
+          <span
+            class="hist-dot"
+            :style="{ background: statusCfg(p.status).color }"
+            aria-hidden="true"
+          />
+
+          <!-- Arrow indicator -->
+          <div class="hist-route">
+            <span v-if="p.fromEnvironment" class="hist-from mono">{{ p.fromEnvironment }}</span>
+            <svg v-if="p.fromEnvironment" width="12" height="8" viewBox="0 0 12 8" fill="none" aria-hidden="true">
+              <path d="M0 4h10M7 1l3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <span class="hist-to mono">{{ p.targetEnvironment }}</span>
+          </div>
+
+          <!-- Status badge -->
+          <span
+            class="hist-status"
+            :style="{
+              color: statusCfg(p.status).color,
+              background: statusCfg(p.status).bg,
+              borderColor: statusCfg(p.status).border,
+            }"
+          >{{ statusCfg(p.status).label }}</span>
+
+          <!-- Meta -->
+          <div class="hist-meta">
+            <span class="hist-by">{{ p.promotedBy }}</span>
+            <span class="hist-sep" aria-hidden="true">·</span>
+            <time :datetime="p.createdAt" class="hist-time">{{ fmtDate(p.createdAt) }}</time>
+          </div>
+        </li>
+      </ol>
+    </div>
+
+  </div>
+</template>
+
+<style scoped>
+.promotion-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-radius: var(--rounded);
+  border: 1px solid var(--color-border);
+  overflow: hidden;
+  background: var(--color-card);
+}
+
+/* ─── Action card ─────────────────────────────────── */
+.promo-action-card {
+  padding: 0;
+}
+
+.promo-action-head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 13px 16px 11px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-inset);
+}
+
+.promo-icon {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+}
+
+.promo-title {
+  font-size: 0.86rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.promo-chain-badge {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--color-faint);
+  background: var(--color-card-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-md);
+  padding: 2px 8px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 300px;
+}
+
+.promo-action-body {
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.promo-empty {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 16px;
+  font-size: 0.81rem;
+  color: var(--color-faint);
+}
+
+.promo-empty--top {
+  color: var(--color-green);
+}
+
+.promo-loading {
+  padding: 14px 16px;
+}
+
+/* ─── Banners ─────────────────────────────────────── */
+.promo-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 13px;
+  border-radius: var(--rounded-md);
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.promo-banner--success {
+  background: var(--color-green-soft);
+  border: 1px solid var(--color-green-line);
+  color: var(--color-green);
+}
+
+.promo-banner--pending {
+  background: var(--color-amber-soft);
+  border: 1px solid var(--color-amber-line);
+  color: var(--color-amber);
+}
+
+.promo-banner--error {
+  background: var(--color-red-soft);
+  border: 1px solid var(--color-red-line);
+  color: var(--color-red);
+}
+
+/* ─── Confirm dialog (inline) ─────────────────────── */
+.promo-confirm {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px;
+  background: var(--color-amber-soft);
+  border: 1px solid var(--color-amber-line);
+  border-radius: var(--rounded);
+}
+
+.promo-confirm-icon {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--rounded-md);
+  background: var(--color-amber);
+  color: #fff;
+  display: grid;
+  place-items: center;
+}
+
+.promo-confirm-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.promo-confirm-title {
+  font-size: 0.86rem;
+  font-weight: 600;
+  color: var(--color-text);
+  line-height: 1.4;
+}
+
+.promo-confirm-sub {
+  margin-top: 3px;
+  font-size: 0.78rem;
+  color: var(--color-dim);
+  line-height: 1.5;
+}
+
+.promo-confirm-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+/* ─── Buttons ─────────────────────────────────────── */
+.promo-btn-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.promo-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 36px;
+  padding: 0 16px;
+  border: none;
+  font-family: var(--font-sans);
+  font-size: 0.84rem;
+  font-weight: 600;
+  border-radius: var(--rounded);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: filter var(--duration-fast), background-color var(--duration-fast), opacity var(--duration-fast);
+}
+
+.promo-btn--promote {
+  background: var(--color-primary);
+  color: #fff;
+  box-shadow: 0 4px 14px var(--color-primary-soft);
+}
+.promo-btn--promote:hover:not(:disabled) { filter: brightness(1.08); }
+.promo-btn--promote:disabled { opacity: 0.45; cursor: not-allowed; box-shadow: none; }
+
+.promo-btn--gate {
+  background: var(--color-amber);
+  color: #fff;
+}
+.promo-btn--gate:hover:not(:disabled) { filter: brightness(1.06); }
+.promo-btn--gate:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.promo-btn--cancel {
+  background: var(--color-card-2);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+}
+.promo-btn--cancel:hover { border-color: var(--color-faint); }
+
+.promo-gated-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.75rem;
+  color: var(--color-amber);
+}
+
+.promo-spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  border-radius: var(--rounded-full);
+  animation: promo-spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+@keyframes promo-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) { .promo-spinner { animation: none; border-top-color: currentColor; } }
+
+/* ─── Skeleton ────────────────────────────────────── */
+.promo-skel {
+  display: block;
+  background: linear-gradient(90deg, var(--color-inset) 0%, oklch(100% 0 0 / 0.06) 50%, var(--color-inset) 100%);
+  background-size: 200% 100%;
+  border-radius: var(--rounded-md);
+  animation: promo-shimmer 1.4s ease-in-out infinite;
+}
+@keyframes promo-shimmer {
+  0%   { background-position: 200% center; }
+  100% { background-position: -200% center; }
+}
+@media (prefers-reduced-motion: reduce) { .promo-skel { animation: none; background: var(--color-inset); } }
+.promo-skel--btn { height: 36px; width: 220px; border-radius: var(--rounded); }
+.promo-skel--row { height: 32px; width: 100%; margin-bottom: 6px; }
+
+/* ─── History section ─────────────────────────────── */
+.promo-history {
+  border-top: 1px solid var(--color-border);
+}
+
+.promo-history-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 10px 16px;
+  background: var(--color-inset);
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-dim);
+}
+
+.promo-history-title {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--color-text);
+  flex: 1;
+}
+
+.promo-hist-count {
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 1px 7px;
+  border-radius: var(--rounded-full);
+  background: var(--color-border-strong);
+  color: var(--color-dim);
+}
+
+.promo-hist-body {
+  padding: 14px 16px;
+}
+
+.promo-hist-loading {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.promo-hist-error {
+  font-size: 0.8rem;
+  color: var(--color-red);
+}
+
+.promo-hist-empty {
+  font-size: 0.8rem;
+  color: var(--color-faint);
+  font-style: italic;
+}
+
+/* History list */
+.promo-hist-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.promo-hist-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--color-border);
+  transition: background-color var(--duration-fast);
+}
+
+.promo-hist-item:last-child { border-bottom: none; }
+.promo-hist-item:hover { background: var(--color-inset); }
+
+.hist-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: var(--rounded-full);
+  flex-shrink: 0;
+}
+
+.hist-route {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  flex: 1;
+  min-width: 0;
+}
+
+.hist-from {
+  font-size: 0.78rem;
+  color: var(--color-faint);
+}
+
+.hist-to {
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.hist-status {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: var(--rounded-md);
+  border: 1px solid transparent;
+  font-size: 0.72rem;
+  font-weight: 600;
+  white-space: nowrap;
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
+
+.hist-meta {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+  font-size: 0.74rem;
+  color: var(--color-faint);
+}
+
+.hist-sep { color: var(--color-border-strong); }
+.hist-by { white-space: nowrap; max-width: 90px; overflow: hidden; text-overflow: ellipsis; }
+.hist-time { white-space: nowrap; }
+
+.mono { font-family: var(--font-mono); }
+</style>

--- a/web/src/views/RunDetail.vue
+++ b/web/src/views/RunDetail.vue
@@ -42,6 +42,7 @@ import ArtifactList from '../components/run/ArtifactList.vue'
 import TestReportPanel from '../components/run/TestReportPanel.vue'
 import DeployTargets from '../components/run/DeployTargets.vue'
 import RunDagView from '../components/run/RunDagView.vue'
+import PromotionPanel from '../components/run/PromotionPanel.vue'
 
 // ─── route ────────────────────────────────────────────────────────────────────
 
@@ -734,6 +735,21 @@ function nodeClass(status: StepStatus): string {
               ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
             -->
             <TestReportPanel :run-id="run.id" />
+
+            <!--
+              ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+              SLOT: 环境晋级 (Story 8-7 / FR-8-7 实现)
+              成功态填 run-detail 晋级 slot:晋级按钮 + gated 审批门联动 + 晋级历史。
+              自取数据(promotion API);不扰其他 slot。
+              ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+            -->
+            <PromotionPanel
+              :run-id="run.id"
+              :project-id="run.projectId"
+              :run-status="run.status"
+              @promotion-pending="loadApprovals"
+            />
+            <!-- END SLOT: 环境晋级 -->
 
             <!-- 历史日志回放(只读,Story 3-6) -->
             <div class="log-history" role="region" aria-label="历史运行日志">


### PR DESCRIPTION
## 本次交付内容

- **`web/src/api/promotion.ts`** — 类型化 API 客户端，覆盖 5 个晋级端点（`getEnvironments`、`saveEnvironments`、`promoteRun`、`listRunPromotions`、`listProjectPromotions`），与已合并后端 `promotion.go` 完全对齐（`EnvStage`/`Variable`/`PromotionDTO` JSON 字段一一映射）
- **`web/src/api/promotion.helpers.ts`** — 纯函数工具层：状态样式 token 映射（`promotionStatusConfig`）、日期格式化、环境名校验、重复检测
- **`web/src/api/promotion.helpers.test.ts`** — 18 个 vitest 单元测试，覆盖所有纯函数的边界情况
- **`web/src/components/EnvironmentsPanel.vue`** — 环境链配置卡：有序拖移（上/下移动）、审批门开关、明文变量行内编辑（Secret 变量只读展示）；一键保存走 `PUT /api/projects/{id}/environments`；嵌入 `TriggersPanel.vue`（CronPanel 之后，minimal 插入一行 + import）
- **`web/src/components/run/PromotionPanel.vue`** — 运行详情晋级面板：自动计算下一级环境、gated 环境行内确认对话框、`@promotion-pending` emit 联动现有审批门（`loadApprovals`）、晋级历史时间线；嵌入 `RunDetail.vue` 成功态（`TestReportPanel` 之后）

## 消费的 API

| 端点 | 方法 | 用途 |
|------|------|------|
| `/api/projects/{id}/environments` | GET | 加载环境链 + 变量掩码视图 |
| `/api/projects/{id}/environments` | PUT | 保存环境链配置 |
| `/api/runs/{id}/promote` | POST | 发起晋级（空 body = 自动下一级）|
| `/api/runs/{id}/promotions` | GET | 该运行的晋级历史 |
| `/api/runs/{id}/approve\|reject` | POST | gated 晋级审批（复用已有端点）|

## 绿灯证据

```
npm run typecheck   → clean（无类型错误）
npm run test        → 170 passed (19 test files)，含新增 18 个 promotion.helpers 测试
npm run build       → ✓ built in 20.74s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)