### PR TITLE
feat(pipeline): 流水线串联 — 成功后触发下游流水线(FR-8-11)

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/audit"
 	"github.com/huangchengsir/pipewright/internal/auth"
 	"github.com/huangchengsir/pipewright/internal/build"
+	"github.com/huangchengsir/pipewright/internal/chain"
 	"github.com/huangchengsir/pipewright/internal/config"
 	"github.com/huangchengsir/pipewright/internal/cron"
 	"github.com/huangchengsir/pipewright/internal/dagrun"
@@ -110,6 +111,11 @@ func main() {
 	// 装配项目级并发上限配置服务(FR-8-10 并发/队列控制):每项目一份 max_concurrent。
 	// 注入 worker pool 做准入(下方);经 /api/projects/{id}/concurrency 读写。
 	concurrencySvc := run.NewConcurrencyService(st.DB)
+
+	// 装配流水线串联配置服务(FR-8-11):每项目一份「成功后触发的下游目标」列表。
+	// 串联终态钩子(下方,与通知钩子同槽组合)在 run 落 success 时据此创建下游运行;
+	// 经 /api/projects/{id}/chain 读写。环路安全在 chain.NewHook(深度门 + 路径门)。
+	chainSvc := chain.NewService(st.DB)
 
 	// 装配运行服务(Story 3.1):本期桩 runner 跑占位步骤打通状态机;真实构建/部署=3-3/4-x。
 	// worker pool 在 aiSvc 装配后创建(以便注入 best-effort 自动诊断钩子,Story 7.2)。
@@ -230,6 +236,25 @@ func main() {
 		log.Printf("[prstatus] PR 状态回写已启用(PIPEWRIGHT_PR_STATUS=1;GitHub/Gitee,经项目凭据,best-effort)")
 	}
 
+	// 流水线串联终态钩子(FR-8-11):复用同一终态槽,叠加到 terminalHook 之上。
+	// run 落 success → 据上游项目串联配置创建下游运行(TriggerChain);环路安全(深度门 + 路径门)
+	// 在 chain.NewHook 内。深度上限经 PIPEWRIGHT_CHAIN_MAX_DEPTH 覆盖(默认 5);best-effort,
+	// 失败仅记日志,绝不阻断 run 终态。
+	chainMaxDepth := chain.DefaultMaxDepth
+	if v := strings.TrimSpace(os.Getenv("PIPEWRIGHT_CHAIN_MAX_DEPTH")); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil && n > 0 {
+			chainMaxDepth = n
+		} else {
+			log.Printf("[chain] 警告:PIPEWRIGHT_CHAIN_MAX_DEPTH=%q 非法(须为正整数),用默认 %d", v, chain.DefaultMaxDepth)
+		}
+	}
+	chainHook := chain.NewHook(chainSvc, runSvc, chainMaxDepth)
+	priorTerminal := terminalHook
+	terminalHook = func(ctx context.Context, runID, finalStatus string) {
+		priorTerminal(ctx, runID, finalStatus)
+		chainHook(ctx, runID, finalStatus)
+	}
+
 	// 并发/队列控制(FR-8-10):全局上限经 PIPEWRIGHT_MAX_CONCURRENT 设置(默认 = worker 数);
 	// 项目级上限经 concurrencySvc(/api/projects/{id}/concurrency 配置)。突发超限的运行保持 queued
 	// 排队,待槽位释放再调度(FIFO)。非法/未设 env → 0,pool 回落到默认行为(仅受全局上限)。
@@ -295,7 +320,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithServers(targetSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc), httpapi.WithPromotion(promotionStore)),
+		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithServers(targetSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithChain(chainSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc), httpapi.WithPromotion(promotionStore)),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		// WriteTimeout 置 0:SSE 长连接(/api/runs/{id}/events)不可被写超时切断;

--- a/internal/chain/chain_test.go
+++ b/internal/chain/chain_test.go
@@ -1,0 +1,170 @@
+package chain
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/huangchengsir/pipewright/internal/store"
+)
+
+// testDB 打开临时 SQLite(含全部迁移,含 0030 串联表/列)。
+func testDB(t *testing.T) *sql.DB {
+	t.Helper()
+	st, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st.DB
+}
+
+// seedProject 插一个项目(满足外键),返回 project id。
+func seedProject(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	credID := uuid.NewString()
+	if _, err := db.Exec(
+		`INSERT INTO credentials (id, name, type, scope, ciphertext, masked_value, created_at, updated_at)
+		 VALUES (?, 'c', 'git_token', '', X'00', 'm', ?, ?)`,
+		credID, now, now); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+	projID := uuid.NewString()
+	if _, err := db.Exec(
+		`INSERT INTO projects (id, name, repo_url, default_branch, credential_id, created_at, updated_at)
+		 VALUES (?, ?, 'https://example.com/p.git', 'main', ?, ?, ?)`,
+		projID, "proj-"+projID[:8], credID, now, now); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	return projID
+}
+
+func TestSaveAndGet(t *testing.T) {
+	db := testDB(t)
+	svc := NewService(db)
+	up := seedProject(t, db)
+	d1 := seedProject(t, db)
+	d2 := seedProject(t, db)
+
+	cfg, err := svc.Save(context.Background(), up, []Target{
+		{DownstreamProjectID: d1, Branch: "main", Enabled: true},
+		{DownstreamProjectID: d2, Branch: "", Enabled: false},
+	})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if len(cfg.Targets) != 2 {
+		t.Fatalf("期望 2 个目标,得 %d", len(cfg.Targets))
+	}
+
+	got, err := svc.Get(context.Background(), up)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(got.Targets) != 2 {
+		t.Fatalf("Get 期望 2 个目标,得 %d", len(got.Targets))
+	}
+
+	enabled, err := svc.ListEnabled(context.Background(), up)
+	if err != nil {
+		t.Fatalf("ListEnabled: %v", err)
+	}
+	if len(enabled) != 1 || enabled[0].DownstreamProjectID != d1 {
+		t.Fatalf("ListEnabled 应只含启用的 d1,得 %+v", enabled)
+	}
+}
+
+func TestSaveReplacesAll(t *testing.T) {
+	db := testDB(t)
+	svc := NewService(db)
+	up := seedProject(t, db)
+	d1 := seedProject(t, db)
+	d2 := seedProject(t, db)
+
+	if _, err := svc.Save(context.Background(), up, []Target{{DownstreamProjectID: d1, Enabled: true}}); err != nil {
+		t.Fatalf("Save#1: %v", err)
+	}
+	// 第二次保存应整批替换(d1 消失,只剩 d2)。
+	if _, err := svc.Save(context.Background(), up, []Target{{DownstreamProjectID: d2, Enabled: true}}); err != nil {
+		t.Fatalf("Save#2: %v", err)
+	}
+	got, _ := svc.Get(context.Background(), up)
+	if len(got.Targets) != 1 || got.Targets[0].DownstreamProjectID != d2 {
+		t.Fatalf("Save 应全量替换,得 %+v", got.Targets)
+	}
+}
+
+func TestSaveEmptyClears(t *testing.T) {
+	db := testDB(t)
+	svc := NewService(db)
+	up := seedProject(t, db)
+	d1 := seedProject(t, db)
+	_, _ = svc.Save(context.Background(), up, []Target{{DownstreamProjectID: d1, Enabled: true}})
+	if _, err := svc.Save(context.Background(), up, nil); err != nil {
+		t.Fatalf("Save empty: %v", err)
+	}
+	got, _ := svc.Get(context.Background(), up)
+	if len(got.Targets) != 0 {
+		t.Fatalf("空保存应清空,得 %+v", got.Targets)
+	}
+}
+
+func TestSaveRejectsSelfChain(t *testing.T) {
+	db := testDB(t)
+	svc := NewService(db)
+	up := seedProject(t, db)
+	_, err := svc.Save(context.Background(), up, []Target{{DownstreamProjectID: up, Enabled: true}})
+	if err != ErrSelfChain {
+		t.Fatalf("自环应被拒,得 %v", err)
+	}
+}
+
+func TestSaveRejectsMissingDownstream(t *testing.T) {
+	db := testDB(t)
+	svc := NewService(db)
+	up := seedProject(t, db)
+	_, err := svc.Save(context.Background(), up, []Target{{DownstreamProjectID: "no-such-project", Enabled: true}})
+	if err != ErrDownstreamNotFound {
+		t.Fatalf("不存在下游应被拒,得 %v", err)
+	}
+}
+
+func TestSaveRejectsDuplicate(t *testing.T) {
+	db := testDB(t)
+	svc := NewService(db)
+	up := seedProject(t, db)
+	d1 := seedProject(t, db)
+	_, err := svc.Save(context.Background(), up, []Target{
+		{DownstreamProjectID: d1, Branch: "main", Enabled: true},
+		{DownstreamProjectID: d1, Branch: "main", Enabled: false},
+	})
+	if err != ErrDuplicateTarget {
+		t.Fatalf("重复 (下游,分支) 应被拒,得 %v", err)
+	}
+}
+
+func TestSaveRejectsMissingUpstream(t *testing.T) {
+	db := testDB(t)
+	svc := NewService(db)
+	_, err := svc.Save(context.Background(), "no-such-upstream", nil)
+	if err != ErrProjectNotFound {
+		t.Fatalf("不存在上游应被拒,得 %v", err)
+	}
+}
+
+func TestGetUnconfiguredEmpty(t *testing.T) {
+	db := testDB(t)
+	svc := NewService(db)
+	up := seedProject(t, db)
+	got, err := svc.Get(context.Background(), up)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(got.Targets) != 0 {
+		t.Fatalf("未配置应返回空列表,得 %+v", got.Targets)
+	}
+}

--- a/internal/chain/hook.go
+++ b/internal/chain/hook.go
@@ -1,0 +1,115 @@
+package chain
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// DefaultMaxDepth 是默认串联深度上限(根运行 depth=0;每向下游串联一层 +1)。
+// 超过此深度的串联被钩子拒绝,作为无限链的硬性兜底。
+const DefaultMaxDepth = 5
+
+// hookTimeout 限制单次串联钩子的总耗时(查目标 + 建下游运行),防慢 DB 把钩子 goroutine 挂死。
+const hookTimeout = 30 * time.Second
+
+// NewHook 把 chain.Service + run.Service 适配为 run.WorkerPool 的 best-effort 终态钩子
+// (与 WithNotifyHook 同签名,供 main 在装配时与通知钩子组合到同一终态槽;run 包不 import chain)。
+//
+// 行为:仅在 run 落 **success** 终态时动作。读上游运行 → 取其 chain_depth → 环路安全门:
+//   - 深度门:上游 depth+1 > maxDepth → 拒绝(不再串联),记日志返回。
+//   - 路径门:沿 chain_source_run_id 上溯祖先链,若上游项目已在本链路径中(自环 / 互环)→ 拒绝。
+//
+// 通过后,查该上游项目「启用」的下游目标,逐个经 run.Service.Create 以 TriggerChain 创建下游运行,
+// 携带 ChainSourceRunID = 上游 runID、ChainDepth = 上游 depth+1(溯源 + 深度递增)。
+//
+// best-effort:自带超时;任一下游创建失败仅记日志续建其余;**绝不影响上游 run 终态**。
+// maxDepth ≤ 0 时回落 DefaultMaxDepth。
+func NewHook(chains Service, runs run.Service, maxDepth int) func(ctx context.Context, runID, finalStatus string) {
+	if maxDepth <= 0 {
+		maxDepth = DefaultMaxDepth
+	}
+	return func(ctx context.Context, runID, finalStatus string) {
+		if chains == nil || runs == nil {
+			return
+		}
+		if finalStatus != run.StatusSuccess {
+			return // 仅成功触发串联;其余终态不串联。
+		}
+
+		hookCtx, cancel := context.WithTimeout(ctx, hookTimeout)
+		defer cancel()
+
+		upstream, err := runs.Get(hookCtx, runID)
+		if err != nil {
+			log.Printf("[chain] run %s: 取上游运行失败(跳过串联):%v", runID, err)
+			return
+		}
+
+		nextDepth := upstream.Trigger.ChainDepth + 1
+		if nextDepth > maxDepth {
+			// 深度门:硬性兜底,拒绝继续串联(防无限链 / 配置成环)。
+			log.Printf("[chain] run %s(项目 %s):串联深度达上限 %d,停止串联(环路安全)",
+				runID, upstream.ProjectID, maxDepth)
+			return
+		}
+
+		targets, err := chains.ListEnabled(hookCtx, upstream.ProjectID)
+		if err != nil {
+			log.Printf("[chain] 项目 %s:查下游目标失败(跳过串联):%v", upstream.ProjectID, err)
+			return
+		}
+		if len(targets) == 0 {
+			return // 无启用目标:无串联。
+		}
+
+		// 路径门:收集本串联链已出现的祖先项目(含上游自身),沿 chain_source_run_id 上溯。
+		// 用于二次兜底自环 / 互环:即便深度未到上限,也拒绝触发「已在本链路径中」的下游项目。
+		ancestors := ancestorProjects(hookCtx, runs, upstream, maxDepth)
+
+		for _, t := range targets {
+			if ancestors[t.DownstreamProjectID] {
+				log.Printf("[chain] run %s:下游项目 %s 已在本串联链路径中,跳过(环路安全)",
+					runID, t.DownstreamProjectID)
+				continue
+			}
+			created, cerr := runs.Create(hookCtx, t.DownstreamProjectID, run.Trigger{
+				Type:             run.TriggerChain,
+				Branch:           t.Branch,
+				Actor:            "chain",
+				ChainSourceRunID: runID,
+				ChainDepth:       nextDepth,
+			})
+			if cerr != nil {
+				log.Printf("[chain] run %s → 下游项目 %s:创建下游运行失败(续建其余):%v",
+					runID, t.DownstreamProjectID, cerr)
+				continue
+			}
+			log.Printf("[chain] run %s(项目 %s)成功 → 串联触发下游运行 %s(项目 %s,深度 %d)",
+				runID, upstream.ProjectID, created.ID, t.DownstreamProjectID, nextDepth)
+		}
+	}
+}
+
+// ancestorProjects 沿 chain_source_run_id 上溯,收集本串联链中已出现的项目 id 集合
+// (含当前上游项目自身)。上溯步数受 maxDepth+1 钳制(深度门已保证链不超此长度),
+// 任一上溯取数失败即停(best-effort)。该集合用于路径门二次环路检测。
+func ancestorProjects(ctx context.Context, runs run.Service, upstream *run.Run, maxDepth int) map[string]bool {
+	seen := map[string]bool{upstream.ProjectID: true}
+	srcID := upstream.Trigger.ChainSourceRunID
+	// 钳制上溯步数:深度门保证 depth ≤ maxDepth,故祖先不超过 maxDepth 层;+1 余量防御。
+	for steps := 0; srcID != "" && steps <= maxDepth; steps++ {
+		anc, err := runs.Get(ctx, srcID)
+		if err != nil {
+			break
+		}
+		if seen[anc.ProjectID] {
+			break // 已见(防御性早停;正常链不应重复)。
+		}
+		seen[anc.ProjectID] = true
+		srcID = anc.Trigger.ChainSourceRunID
+	}
+	return seen
+}

--- a/internal/chain/hook_test.go
+++ b/internal/chain/hook_test.go
@@ -1,0 +1,239 @@
+package chain
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// setRunSuccess 直接把某 run 置为 success 终态(测试用:绕过桩 runner / 状态机驱动,直击钩子逻辑)。
+func setRunSuccess(t *testing.T, db *sql.DB, id string) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.Exec(
+		`UPDATE pipeline_runs SET status = 'success', finished_at = ? WHERE id = ?`, now, id); err != nil {
+		t.Fatalf("set run success: %v", err)
+	}
+}
+
+// runsForProject 返回某项目全部运行 id(按创建时间升序)。
+func runsForProject(t *testing.T, db *sql.DB, projectID string) []string {
+	t.Helper()
+	rows, err := db.Query(
+		`SELECT id FROM pipeline_runs WHERE project_id = ? ORDER BY created_at ASC, id ASC`, projectID)
+	if err != nil {
+		t.Fatalf("query runs: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan run id: %v", err)
+		}
+		out = append(out, id)
+	}
+	return out
+}
+
+// totalRuns 返回库中全部运行总数(用于无限链兜底:总数有界即证明无 runaway)。
+func totalRuns(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(1) FROM pipeline_runs`).Scan(&n); err != nil {
+		t.Fatalf("count runs: %v", err)
+	}
+	return n
+}
+
+// childRunOf 返回由 sourceID 串联触发的那一个下游运行 id(chain_source_run_id = sourceID)。
+// 确定性取子运行,避免依赖秒粒度 created_at 排序(同秒多运行会非确定)。
+func childRunOf(t *testing.T, db *sql.DB, sourceID string) string {
+	t.Helper()
+	var id string
+	if err := db.QueryRow(
+		`SELECT id FROM pipeline_runs WHERE chain_source_run_id = ? LIMIT 1`, sourceID,
+	).Scan(&id); err != nil {
+		t.Fatalf("child run of %s: %v", sourceID, err)
+	}
+	return id
+}
+
+// TestHookTriggersDownstreamOnSuccess 验证:上游 run 成功 → 钩子为每个启用下游目标创建一次
+// TriggerChain 运行,且携带 chain_source_run_id = 上游 + chain_depth = 上游+1。
+func TestHookTriggersDownstreamOnSuccess(t *testing.T) {
+	db := testDB(t)
+	chains := NewService(db)
+	runs := run.New(db)
+
+	up := seedProject(t, db)
+	down := seedProject(t, db)
+	if _, err := chains.Save(context.Background(), up, []Target{{DownstreamProjectID: down, Branch: "main", Enabled: true}}); err != nil {
+		t.Fatalf("Save chain: %v", err)
+	}
+
+	// 建上游 run(根:depth 0)并置 success。
+	upRun, err := runs.Create(context.Background(), up, run.Trigger{Type: run.TriggerManual, Branch: "main"})
+	if err != nil {
+		t.Fatalf("create upstream run: %v", err)
+	}
+	setRunSuccess(t, db, upRun.ID)
+
+	NewHook(chains, runs, DefaultMaxDepth)(context.Background(), upRun.ID, run.StatusSuccess)
+
+	dRuns := runsForProject(t, db, down)
+	if len(dRuns) != 1 {
+		t.Fatalf("期望下游创建 1 个串联运行,得 %d", len(dRuns))
+	}
+	got, err := runs.Get(context.Background(), dRuns[0])
+	if err != nil {
+		t.Fatalf("get downstream run: %v", err)
+	}
+	if got.Trigger.Type != run.TriggerChain {
+		t.Fatalf("下游运行触发类型应为 chain,得 %q", got.Trigger.Type)
+	}
+	if got.Trigger.ChainSourceRunID != upRun.ID {
+		t.Fatalf("下游 chain_source_run_id 应为上游 %s,得 %q", upRun.ID, got.Trigger.ChainSourceRunID)
+	}
+	if got.Trigger.ChainDepth != 1 {
+		t.Fatalf("下游 chain_depth 应为 1,得 %d", got.Trigger.ChainDepth)
+	}
+}
+
+// TestHookOnlyOnSuccess 验证:非 success 终态不触发任何串联。
+func TestHookOnlyOnSuccess(t *testing.T) {
+	db := testDB(t)
+	chains := NewService(db)
+	runs := run.New(db)
+	up := seedProject(t, db)
+	down := seedProject(t, db)
+	_, _ = chains.Save(context.Background(), up, []Target{{DownstreamProjectID: down, Enabled: true}})
+
+	upRun, _ := runs.Create(context.Background(), up, run.Trigger{Type: run.TriggerManual})
+	hook := NewHook(chains, runs, DefaultMaxDepth)
+	hook(context.Background(), upRun.ID, run.StatusFailed)
+	hook(context.Background(), upRun.ID, run.StatusPartialFailed)
+	hook(context.Background(), upRun.ID, run.StatusRolledBack)
+
+	if n := len(runsForProject(t, db, down)); n != 0 {
+		t.Fatalf("非成功终态不应触发串联,得 %d 个下游运行", n)
+	}
+}
+
+// TestHookDisabledTargetSkipped 验证:禁用的下游目标不触发。
+func TestHookDisabledTargetSkipped(t *testing.T) {
+	db := testDB(t)
+	chains := NewService(db)
+	runs := run.New(db)
+	up := seedProject(t, db)
+	down := seedProject(t, db)
+	_, _ = chains.Save(context.Background(), up, []Target{{DownstreamProjectID: down, Enabled: false}})
+
+	upRun, _ := runs.Create(context.Background(), up, run.Trigger{Type: run.TriggerManual})
+	setRunSuccess(t, db, upRun.ID)
+	NewHook(chains, runs, DefaultMaxDepth)(context.Background(), upRun.ID, run.StatusSuccess)
+
+	if n := len(runsForProject(t, db, down)); n != 0 {
+		t.Fatalf("禁用目标不应触发,得 %d", n)
+	}
+}
+
+// TestHookDepthGuardStopsRunaway 是核心环路安全测试(深度门):一条足够长的「不同项目」串联链
+// P0→P1→…→P9(每个项目都各异,路径门不会触发),反复跑钩子。深度门应在 depth 达 maxDepth 后
+// 停止创建下游 —— 链严格有界(至多 maxDepth 层),绝不无限触发,即便后面仍有可触发的下游配置。
+func TestHookDepthGuardStopsRunaway(t *testing.T) {
+	db := testDB(t)
+	chains := NewService(db)
+	runs := run.New(db)
+
+	const numProjects = 10
+	projs := make([]string, numProjects)
+	for i := range projs {
+		projs[i] = seedProject(t, db)
+	}
+	// 配 P0→P1→…→P8(线性,各项目相异),链长 9 > maxDepth,确保停止靠深度门而非项目耗尽。
+	for i := 0; i < numProjects-1; i++ {
+		if _, err := chains.Save(context.Background(), projs[i],
+			[]Target{{DownstreamProjectID: projs[i+1], Enabled: true}}); err != nil {
+			t.Fatalf("save %d→%d: %v", i, i+1, err)
+		}
+	}
+
+	maxDepth := 3
+	hook := NewHook(chains, runs, maxDepth)
+
+	// 根运行 P0(depth 0)成功 → 沿链触发。每轮取本轮新建下游、置 success、再跑钩子。
+	root, _ := runs.Create(context.Background(), projs[0], run.Trigger{Type: run.TriggerManual, Branch: "main"})
+	setRunSuccess(t, db, root.ID)
+
+	cur := root.ID
+	created := []string{root.ID}
+	for i := 0; i < 50; i++ { // 远超 maxDepth:若深度门失效会一直造到项目耗尽(≥9 层)
+		before := totalRuns(t, db)
+		hook(context.Background(), cur, run.StatusSuccess)
+		after := totalRuns(t, db)
+		if after == before {
+			break // 深度门生效:不再创建下游,链终止。
+		}
+		next := childRunOf(t, db, cur)
+		setRunSuccess(t, db, next)
+		created = append(created, next)
+		cur = next
+	}
+
+	// 总运行数 = 根 + 深度门允许的层数;depth 0..maxDepth → 至多 maxDepth+1 个运行。
+	if n := totalRuns(t, db); n > maxDepth+1 {
+		t.Fatalf("环路安全失败:总运行数 %d 超出上界 %d(深度门未生效)", n, maxDepth+1)
+	}
+	// 最深下游 depth 应恰为 maxDepth(达上限后停止深入)。
+	maxSeen := 0
+	for _, id := range created {
+		r, _ := runs.Get(context.Background(), id)
+		if r.Trigger.ChainDepth > maxSeen {
+			maxSeen = r.Trigger.ChainDepth
+		}
+	}
+	if maxSeen != maxDepth {
+		t.Fatalf("最深串联深度应为 %d,得 %d", maxDepth, maxSeen)
+	}
+}
+
+// TestHookPathGuardStopsCycle 验证路径门:A→B 且 B→A 配置成环时,B 成功触发 A 的串联被
+// 「A 已在本链路径中」拒绝(即便深度未到上限),互环不 runaway。
+func TestHookPathGuardStopsCycle(t *testing.T) {
+	db := testDB(t)
+	chains := NewService(db)
+	runs := run.New(db)
+	a := seedProject(t, db)
+	b := seedProject(t, db)
+	if _, err := chains.Save(context.Background(), a, []Target{{DownstreamProjectID: b, Enabled: true}}); err != nil {
+		t.Fatalf("save A→B: %v", err)
+	}
+	if _, err := chains.Save(context.Background(), b, []Target{{DownstreamProjectID: a, Enabled: true}}); err != nil {
+		t.Fatalf("save B→A: %v", err)
+	}
+
+	maxDepth := 10 // 故意放大,确保停止靠路径门而非深度门
+	hook := NewHook(chains, runs, maxDepth)
+
+	// 根 A 运行成功 → 触发 B(depth 1)。
+	aRun, _ := runs.Create(context.Background(), a, run.Trigger{Type: run.TriggerManual, Branch: "main"})
+	setRunSuccess(t, db, aRun.ID)
+	hook(context.Background(), aRun.ID, run.StatusSuccess)
+
+	bRuns := runsForProject(t, db, b)
+	if len(bRuns) != 1 {
+		t.Fatalf("A 成功应触发 1 个 B 运行,得 %d", len(bRuns))
+	}
+	// B 运行成功 → B→A;但 A 已在 B 运行的祖先链路径中(B.source=A 根)→ 路径门拒绝触发 A。
+	setRunSuccess(t, db, bRuns[0])
+	hook(context.Background(), bRuns[0], run.StatusSuccess)
+
+	// A 应仍只有根那 1 个运行(互环被路径门掐断,没有第二个 A 运行被创建)。
+	if n := len(runsForProject(t, db, a)); n != 1 {
+		t.Fatalf("路径门应阻止 B→A 回环创建新 A 运行,A 运行数应为 1,得 %d", n)
+	}
+}

--- a/internal/chain/store.go
+++ b/internal/chain/store.go
@@ -1,0 +1,209 @@
+// Package chain 实现流水线串联(FR-8-11):上游流水线成功落终态后,按每项目配置的
+// 「下游目标」列表,自动触发一个或多个下游流水线运行(可跨项目 / 同项目不同分支),
+// 用于搭建 CD 链(如「应用构建成功 → 触发部署基础设施流水线」)。
+//
+// 两块:
+//   - Service(本文件):每项目下游目标列表的配置存取(GET/PUT 端点支撑;CRUD 经参数化 SQL)。
+//   - 串联终态钩子(hook.go):复用 run.WorkerPool 既有终态钩子槽(WithNotifyHook 同签名),
+//     在 run 落 success 时查下游目标 → 经 run.Service.Create 以 TriggerChain 创建下游运行。
+//
+// 环路安全(必做):下游运行携带 chain_depth = 上游 +1;钩子拒绝超过 MaxDepth(默认 5)的串联,
+// 并二次检测「项目已在本串联链路径中」兜底自环 / 互环。详见 hook.go。
+//
+// run 包不 import chain;chain 经接口依赖 run.Service(钩子在 main 装配,解耦,仿 notify/diagnose)。
+package chain
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// maxTargetsPerProject 限制单项目下游目标数量(防滥用 / 一次成功扇出过多)。
+const maxTargetsPerProject = 32
+
+// 领域错误。错误体不含敏感数据。
+var (
+	// ErrProjectNotFound 表示(上游)项目不存在。
+	ErrProjectNotFound = errors.New("chain: project not found")
+	// ErrDownstreamNotFound 表示某个下游目标项目不存在。
+	ErrDownstreamNotFound = errors.New("chain: downstream project not found")
+	// ErrSelfChain 表示下游目标指向上游项目自身(直接自环;禁止配置)。
+	ErrSelfChain = errors.New("chain: downstream cannot be the upstream project itself")
+	// ErrTooManyTargets 表示下游目标数量超过上限。
+	ErrTooManyTargets = errors.New("chain: too many downstream targets")
+	// ErrDuplicateTarget 表示同一(下游项目,分支)在一次保存中重复出现。
+	ErrDuplicateTarget = errors.New("chain: duplicate downstream target")
+)
+
+// Target 是一个下游串联目标(上游成功后要触发的一个下游流水线)。
+type Target struct {
+	// DownstreamProjectID 是被触发的下游项目 id。
+	DownstreamProjectID string
+	// Branch 是触发下游时使用的分支;空 = 下游项目默认分支(由 run.Create 解析)。
+	Branch string
+	// Enabled 控制该目标是否参与触发(禁用则保留配置但不触发)。
+	Enabled bool
+}
+
+// Config 是某上游项目的串联配置(下游目标列表)。
+type Config struct {
+	Targets []Target
+}
+
+// Service 定义串联配置领域接口(GET/PUT 端点 + 串联钩子查询共用)。
+type Service interface {
+	// Get 返回某上游项目的串联配置;无配置 → 空列表(非错误)。
+	Get(ctx context.Context, projectID string) (*Config, error)
+	// Save 全量替换某上游项目的下游目标列表(校验后删旧整写;单事务)。
+	// 校验:上游项目存在;每个下游项目存在且非自身;数量 ≤ 上限;(下游,分支)不重复。
+	Save(ctx context.Context, projectID string, targets []Target) (*Config, error)
+	// ListEnabled 返回某上游项目「启用」的下游目标(供串联钩子在成功时查询)。
+	ListEnabled(ctx context.Context, projectID string) ([]Target, error)
+}
+
+type service struct {
+	db *sql.DB
+}
+
+// NewService 构造串联配置 Service(经参数化 SQL 触库;无 init 副作用、不驻留)。
+func NewService(db *sql.DB) Service { return &service{db: db} }
+
+func (s *service) Get(ctx context.Context, projectID string) (*Config, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT downstream_project_id, branch, enabled
+		   FROM project_chain_targets
+		  WHERE project_id = ?
+		  ORDER BY created_at ASC, id ASC`, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("chain: load config: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	cfg := &Config{Targets: []Target{}}
+	for rows.Next() {
+		var (
+			t       Target
+			enabled int
+		)
+		if err := rows.Scan(&t.DownstreamProjectID, &t.Branch, &enabled); err != nil {
+			return nil, fmt.Errorf("chain: scan target: %w", err)
+		}
+		t.Enabled = enabled != 0
+		cfg.Targets = append(cfg.Targets, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("chain: iterate targets: %w", err)
+	}
+	return cfg, nil
+}
+
+func (s *service) Save(ctx context.Context, projectID string, targets []Target) (*Config, error) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return nil, ErrProjectNotFound
+	}
+	if err := s.ensureProjectExists(ctx, projectID); err != nil {
+		return nil, err
+	}
+	if len(targets) > maxTargetsPerProject {
+		return nil, ErrTooManyTargets
+	}
+
+	// 规整 + 校验:trim,自环拒绝,下游存在校验,(下游,分支)去重。
+	seen := map[string]bool{}
+	clean := make([]Target, 0, len(targets))
+	for _, t := range targets {
+		dpid := strings.TrimSpace(t.DownstreamProjectID)
+		branch := strings.TrimSpace(t.Branch)
+		if dpid == "" {
+			return nil, ErrDownstreamNotFound
+		}
+		if dpid == projectID {
+			return nil, ErrSelfChain
+		}
+		key := dpid + "\x00" + branch
+		if seen[key] {
+			return nil, ErrDuplicateTarget
+		}
+		seen[key] = true
+		if err := s.ensureProjectExists(ctx, dpid); err != nil {
+			if errors.Is(err, ErrProjectNotFound) {
+				return nil, ErrDownstreamNotFound
+			}
+			return nil, err
+		}
+		clean = append(clean, Target{DownstreamProjectID: dpid, Branch: branch, Enabled: t.Enabled})
+	}
+
+	// 全量替换:删旧整写,单事务(避免半写)。
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("chain: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM project_chain_targets WHERE project_id = ?`, projectID); err != nil {
+		return nil, fmt.Errorf("chain: delete old targets: %w", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, t := range clean {
+		enabled := 0
+		if t.Enabled {
+			enabled = 1
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO project_chain_targets
+			   (id, project_id, downstream_project_id, branch, enabled, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			uuid.NewString(), projectID, t.DownstreamProjectID, t.Branch, enabled, now, now,
+		); err != nil {
+			return nil, fmt.Errorf("chain: insert target: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("chain: commit: %w", err)
+	}
+	return s.Get(ctx, projectID)
+}
+
+func (s *service) ListEnabled(ctx context.Context, projectID string) ([]Target, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT downstream_project_id, branch
+		   FROM project_chain_targets
+		  WHERE project_id = ? AND enabled = 1
+		  ORDER BY created_at ASC, id ASC`, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("chain: list enabled: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := []Target{}
+	for rows.Next() {
+		t := Target{Enabled: true}
+		if err := rows.Scan(&t.DownstreamProjectID, &t.Branch); err != nil {
+			return nil, fmt.Errorf("chain: scan enabled: %w", err)
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// ensureProjectExists 校验项目存在(上游 / 下游共用)。
+func (s *service) ensureProjectExists(ctx context.Context, projectID string) error {
+	var one int
+	err := s.db.QueryRowContext(ctx, `SELECT 1 FROM projects WHERE id = ?`, projectID).Scan(&one)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrProjectNotFound
+		}
+		return fmt.Errorf("chain: check project: %w", err)
+	}
+	return nil
+}

--- a/internal/httpapi/chain.go
+++ b/internal/httpapi/chain.go
@@ -1,0 +1,103 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/chain"
+)
+
+// chain.go 暴露项目流水线串联配置端点(FR-8-11):上游成功后触发下游流水线。
+//
+// GET /api/projects/{id}/chain  → { downstream: [{ downstreamProjectId, branch, enabled }] }
+// PUT /api/projects/{id}/chain  → 同上(需 CSRF)。校验在 chain.Service。
+//
+// 串联本身的触发在 internal/chain 的终态钩子(run 落 success 时);此处仅配置存取。
+
+type chainTargetDTO struct {
+	DownstreamProjectID string `json:"downstreamProjectId"`
+	Branch              string `json:"branch"`
+	Enabled             bool   `json:"enabled"`
+}
+
+type chainDTO struct {
+	Downstream []chainTargetDTO `json:"downstream"`
+}
+
+func toChainDTO(c *chain.Config) chainDTO {
+	out := chainDTO{Downstream: []chainTargetDTO{}}
+	for _, t := range c.Targets {
+		out.Downstream = append(out.Downstream, chainTargetDTO{
+			DownstreamProjectID: t.DownstreamProjectID,
+			Branch:              t.Branch,
+			Enabled:             t.Enabled,
+		})
+	}
+	return out
+}
+
+func writeChainError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, chain.ErrProjectNotFound):
+		writeError(w, http.StatusNotFound, "project_not_found", "项目不存在")
+	case errors.Is(err, chain.ErrDownstreamNotFound):
+		writeError(w, http.StatusUnprocessableEntity, "downstream_not_found", "下游项目不存在")
+	case errors.Is(err, chain.ErrSelfChain):
+		writeError(w, http.StatusUnprocessableEntity, "self_chain", "下游目标不能是上游项目自身(自环)")
+	case errors.Is(err, chain.ErrTooManyTargets):
+		writeError(w, http.StatusUnprocessableEntity, "too_many_targets", "下游目标数量超过上限")
+	case errors.Is(err, chain.ErrDuplicateTarget):
+		writeError(w, http.StatusUnprocessableEntity, "duplicate_target", "同一下游项目 + 分支不可重复配置")
+	default:
+		writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+	}
+}
+
+func makeGetChainHandler(svc chain.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "流水线串联服务未初始化")
+			return
+		}
+		cfg, err := svc.Get(r.Context(), chi.URLParam(r, "id"))
+		if err != nil {
+			writeChainError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, toChainDTO(cfg))
+	}
+}
+
+func makeSaveChainHandler(svc chain.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "流水线串联服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<15)
+		var req struct {
+			Downstream []chainTargetDTO `json:"downstream"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		targets := make([]chain.Target, 0, len(req.Downstream))
+		for _, t := range req.Downstream {
+			targets = append(targets, chain.Target{
+				DownstreamProjectID: t.DownstreamProjectID,
+				Branch:              t.Branch,
+				Enabled:             t.Enabled,
+			})
+		}
+		cfg, err := svc.Save(r.Context(), id, targets)
+		if err != nil {
+			writeChainError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, toChainDTO(cfg))
+	}
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -21,6 +21,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/approval"
 	"github.com/huangchengsir/pipewright/internal/audit"
 	"github.com/huangchengsir/pipewright/internal/auth"
+	"github.com/huangchengsir/pipewright/internal/chain"
 	"github.com/huangchengsir/pipewright/internal/cron"
 	"github.com/huangchengsir/pipewright/internal/deploy"
 	"github.com/huangchengsir/pipewright/internal/notify"
@@ -53,6 +54,7 @@ type options struct {
 	projects         project.Service
 	triggers         trigger.Service
 	cron             cron.Service
+	chain            chain.Service
 	concurrency      run.ConcurrencyService
 	pipelines        pipeline.Service
 	pipelineSettings pipeline.SettingsService
@@ -108,6 +110,12 @@ func WithProjects(s project.Service) Option {
 // WithCron 注入定时触发配置服务,挂载 /api/projects/{id}/cron 路由(Story 8-6)。
 func WithCron(s cron.Service) Option {
 	return func(o *options) { o.cron = s }
+}
+
+// WithChain 注入流水线串联配置服务,挂载 /api/projects/{id}/chain 路由(FR-8-11)。
+// 不传则该端点返回 503(服务未初始化)。GET 过 auth;PUT 过 auth + CSRF。
+func WithChain(s chain.Service) Option {
+	return func(o *options) { o.chain = s }
 }
 
 // WithConcurrency 注入项目级并发上限配置服务,挂载 /api/projects/{id}/concurrency 路由(FR-8-10)。
@@ -324,6 +332,11 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		// 项目级并发上限(FR-8-10)。o.concurrency 为 nil 时 handler 返回 503。GET 过 auth;PUT 过 auth + CSRF。
 		ar.Get("/projects/{id}/concurrency", makeGetConcurrencyHandler(o.concurrency))
 		ar.Put("/projects/{id}/concurrency", makeSaveConcurrencyHandler(o.concurrency))
+
+		// 流水线串联(FR-8-11):上游成功后触发下游流水线。o.chain 为 nil → handler 返回 503。
+		// GET 过 auth;PUT 为写方法,过 auth + CSRF。
+		ar.Get("/projects/{id}/chain", makeGetChainHandler(o.chain))
+		ar.Put("/projects/{id}/chain", makeSaveChainHandler(o.chain))
 
 		// 环境晋级流配置(Story 8-7 / FR-8-7):有序环境链 + 逐环境作用域变量/密钥。
 		// /environments、/promotions 比 /projects/{id} 多一段,不会被吞。

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -67,6 +67,8 @@ const (
 	TriggerManual = "manual"
 	// TriggerSchedule 表示定时(cron)触发(Story 8-6)。
 	TriggerSchedule = "schedule"
+	// TriggerChain 表示由上游流水线成功后串联触发(Story FR-8-11;由 internal/chain 串联钩子创建)。
+	TriggerChain = "chain"
 )
 
 // 领域错误。错误体不含敏感数据。
@@ -110,6 +112,13 @@ type Trigger struct {
 	// Params 是参数化手动运行的 key=value 参数(Story 8-11);执行时注入 script 步骤容器作环境变量。
 	// 非敏感明文(含密钥应走保险库引用);为空表示无参数。
 	Params map[string]string
+
+	// ChainSourceRunID 是串联触发(TriggerChain)时**触发本次运行的上游运行 id**(溯源;FR-8-11)。
+	// 空 = 非串联触发(根运行)。持久化到 pipeline_runs.chain_source_run_id,经 Get 回读。
+	ChainSourceRunID string
+	// ChainDepth 是串联深度:根运行=0,每向下游串联一层 +1。由串联钩子据上游 depth+1 填入。
+	// 用于环路安全(钩子拒绝超过上限的串联);持久化到 pipeline_runs.chain_depth,经 Get 回读。
+	ChainDepth int
 }
 
 // Step 是穿珠时间线节点(运行步骤)。

--- a/internal/run/service.go
+++ b/internal/run/service.go
@@ -161,8 +161,15 @@ func (s *service) Create(ctx context.Context, projectID string, trigger Trigger)
 	}
 
 	tt := trigger.Type
-	if tt != TriggerWebhook && tt != TriggerManual && tt != TriggerSchedule {
+	if tt != TriggerWebhook && tt != TriggerManual && tt != TriggerSchedule && tt != TriggerChain {
 		tt = TriggerManual
+	}
+
+	// 串联溯源(FR-8-11):chain_source_run_id 记录触发本次运行的上游运行;chain_depth 为串联深度
+	// (根=0,每向下游一层 +1)。非串联触发为空串 / 0。深度负值钳为 0(防御非法入参)。
+	chainDepth := trigger.ChainDepth
+	if chainDepth < 0 {
+		chainDepth = 0
 	}
 
 	// 解析出的目标元数据(webhook 分支映射)持久化为运行内部列;手动触发为空/[]。
@@ -191,10 +198,12 @@ func (s *service) Create(ctx context.Context, projectID string, trigger Trigger)
 	_, err = s.db.ExecContext(ctx,
 		`INSERT INTO pipeline_runs
 		   (id, project_id, status, trigger_type, trigger_branch, trigger_commit, trigger_actor,
-		    resolved_environment, resolved_target_server_ids, params_json, created_at, started_at, finished_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)`,
+		    resolved_environment, resolved_target_server_ids, params_json,
+		    chain_source_run_id, chain_depth, created_at, started_at, finished_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)`,
 		id, projectID, StatusQueued, tt, trigger.Branch, trigger.Commit, trigger.Actor,
 		trigger.ResolvedEnvironment, string(targetIDsJSON), string(paramsJSON),
+		strings.TrimSpace(trigger.ChainSourceRunID), chainDepth,
 		now.Format(time.RFC3339),
 	)
 	if err != nil {
@@ -237,14 +246,16 @@ func (s *service) Get(ctx context.Context, id string) (*Run, error) {
 		`SELECT pr.project_id, COALESCE(p.name, ''), pr.status,
 		        pr.trigger_type, pr.trigger_branch, pr.trigger_commit, pr.trigger_actor,
 		        pr.created_at, pr.started_at, pr.finished_at,
-		        pr.failure_log, pr.diagnosis_json, pr.params_json
+		        pr.failure_log, pr.diagnosis_json, pr.params_json,
+		        pr.chain_source_run_id, pr.chain_depth
 		 FROM pipeline_runs pr
 		 LEFT JOIN projects p ON p.id = pr.project_id
 		 WHERE pr.id = ?`, id,
 	).Scan(&r.ProjectID, &r.ProjectName, &r.Status,
 		&r.Trigger.Type, &r.Trigger.Branch, &r.Trigger.Commit, &r.Trigger.Actor,
 		&createdStr, &startedStr, &finishStr,
-		&failureLog, &diagnosisJSON, &paramsJSON)
+		&failureLog, &diagnosisJSON, &paramsJSON,
+		&r.Trigger.ChainSourceRunID, &r.Trigger.ChainDepth)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound

--- a/internal/store/migrations/0030_pipeline_chains.sql
+++ b/internal/store/migrations/0030_pipeline_chains.sql
@@ -1,0 +1,44 @@
+-- 0030 pipeline_chains:流水线串联(成功后触发下游流水线)配置 + 运行串联溯源(FR-8-11)。
+--
+-- 两部分:
+--   1) project_chain_targets:每项目「成功后要触发的下游目标」列表(0..N 行)。
+--      上游项目成功落终态时,串联终态钩子据此为每个 enabled 目标创建一次「chain」触发的下游运行。
+--   2) pipeline_runs 两列追加:记录某次运行由哪条上游运行串联触发(溯源)+ 串联深度(防无限环)。
+--
+-- 环路安全(必做,见 internal/chain):下游运行携带 chain_depth = 上游 depth + 1;
+-- 钩子拒绝超过 maxChainDepth(默认 5)的串联;并在串联链路上检测「项目已在本链路径中」二次兜底。
+--
+-- project_chain_targets:
+--   id                    : uuid v4;PK
+--   project_id            : 上游项目;FK → projects.id;ON DELETE CASCADE(删上游项目级联删其串联配置)
+--   downstream_project_id : 下游(被触发)项目;FK → projects.id;ON DELETE CASCADE(删下游项目级联清理)
+--   branch                : 触发下游时使用的分支(空 = 下游项目默认分支,由 run.Create 解析)
+--   enabled               : 0/1 是否启用该串联目标
+--   created_at/updated_at : RFC3339
+--   唯一 (project_id, downstream_project_id, branch):同一上游对同一下游同一分支不重复配置。
+--
+-- pipeline_runs 追加列(均有默认值,旧行不受影响):
+--   chain_source_run_id : 触发本次运行的上游运行 id(NULL/'' = 非串联触发)
+--   chain_depth         : 串联深度(根运行=0;每向下游串联一层 +1;防无限链)
+
+CREATE TABLE IF NOT EXISTS project_chain_targets (
+    id                    TEXT PRIMARY KEY,
+    project_id            TEXT NOT NULL,
+    downstream_project_id TEXT NOT NULL,
+    branch                TEXT NOT NULL DEFAULT '',
+    enabled               INTEGER NOT NULL DEFAULT 1,
+    created_at            TEXT NOT NULL,
+    updated_at            TEXT NOT NULL,
+    FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+    FOREIGN KEY (downstream_project_id) REFERENCES projects (id) ON DELETE CASCADE
+);
+
+-- 串联终态钩子按上游 project_id 扫描其启用目标;建索引避免全表扫。
+CREATE INDEX IF NOT EXISTS idx_project_chain_targets_project ON project_chain_targets (project_id);
+-- 同一上游对同一下游同一分支唯一(防重复配置导致一次成功多触发同一下游)。
+CREATE UNIQUE INDEX IF NOT EXISTS uq_project_chain_targets
+    ON project_chain_targets (project_id, downstream_project_id, branch);
+
+-- pipeline_runs 串联溯源列(additive;旧行默认非串联、深度 0)。
+ALTER TABLE pipeline_runs ADD COLUMN chain_source_run_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE pipeline_runs ADD COLUMN chain_depth INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
## 流水线串联(FR-8-11)

当一次运行落 **success** 终态时,按上游项目配置自动**触发一个或多个下游流水线**(跨项目 / 同项目不同分支),用于搭建 CD 链(如「应用构建成功 → 触发部署基础设施流水线」)。**环路安全**(深度门 + 路径门)且**可观察**(下游运行记录由谁串联触发)。

### 复用既有终态钩子(不另造触发机制)
`chain.NewHook` 与 `run.WithNotifyHook` **同签名** `func(ctx, runID, finalStatus)`。在 `main.go` 装配时把它**叠加到既有 `terminalHook`**(与通知钩子、可选 PR 状态钩子同一终态槽),由 worker pool 在 run 落终态后 best-effort 调用。`run` 包不 import `chain`(经 main 装配解耦,与 notify/diagnose 一致)。仅 `success` 触发串联,其余终态不动。

### 配置模型
- 每上游项目一份「下游目标列表」`{ downstreamProjectId, branch?, enabled }`(0..N 条)。
- 新表 `project_chain_targets`(`project_id` / `downstream_project_id` 双外键级联删;唯一索引 `(project_id, downstream_project_id, branch)` 防重复)。
- `pipeline_runs` 追加 **additive** 两列:`chain_source_run_id`(溯源)+ `chain_depth`(深度)。

### 环路安全(双门,必做)
1. **深度门**:下游运行携带 `chain_depth = 上游 + 1`;`nextDepth > maxDepth`(默认 **5**,可经 `PIPEWRIGHT_CHAIN_MAX_DEPTH` 覆盖)即拒绝。链严格有界。
2. **路径门**:沿 `chain_source_run_id` 上溯祖先项目集合,若下游项目**已在本链路径中**(自环 / 互环)则跳过,即便深度未到上限。
3. 配置侧再加一道:`Save` 拒绝下游 = 上游自身、去重、数量上限(32)。

### 端点(仿 cron/concurrency)
- `GET /api/projects/{id}/chain` → `{ downstream: [{ downstreamProjectId, branch, enabled }] }`(过 auth)。
- `PUT /api/projects/{id}/chain` → 同上(过 auth + CSRF);校验下游存在、拒自环、去重、上限,全量替换(单事务)。
- 服务未注入 → 503;错误体不含敏感数据。

### 新增触发类型 + 溯源字段
- `run.TriggerChain = "chain"`(`Create` 白名单)。
- `run.Trigger.ChainSourceRunID` / `ChainDepth`(additive,经 0030 两列持久化、`Get` 回读)。

### 迁移
`internal/store/migrations/0030_pipeline_chains.sql`(独占 0030 前缀)。

### 测试
- store:CRUD、全量替换、空清空、拒自环 / 缺失下游 / 重复 / 缺失上游、未配置空列表。
- 钩子:成功触发下游(校验 type=chain、source、depth=1)、仅成功才触发、禁用目标跳过。
- **环路安全**:深度门长链(10 个相异项目链,maxDepth=3,证总运行数有界、最深 depth=maxDepth、不 runaway)+ 路径门 A⇄B 互环(B→A 回环被掐断)。

### 待办(deferred)
- 前端串联配置面板(可仿 `CronPanel.vue` + `api/cron.ts`)。当前 `concurrency` 同样暂无 UI,与现状一致;后端 + API 已完整,UI 作为明确后续。

### 绿门证据
```
gofmt -l (touched .go)  → 空(clean)
go vet ./...            → 通过
go build ./...          → 通过
go test ./...           → exit=0,27 个包全 ok,无 FAIL
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
