### PR TITLE
feat(pipeline): Pipeline-as-code — .pipewright.yml 解析/校验/导入(FR-8-12)

### DIFF
--- a/internal/httpapi/pipelines.go
+++ b/internal/httpapi/pipelines.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/pipelineyaml"
 )
 
 // pipelineDTO 是流水线配置对外响应体(冻结契约;camelCase)。外层形状定死,
@@ -187,5 +188,69 @@ func makeSavePipelineHandler(svc pipeline.Service) http.HandlerFunc {
 			return
 		}
 		writeJSON(w, http.StatusOK, toPipelineDTO(cfg))
+	}
+}
+
+// makeImportPipelineHandler 返回 POST /api/projects/{id}/pipeline/import handler(FR-8-12)。
+//
+// 收 {yaml:"...", save?:bool};把 `.pipewright.yml` 文档解析+校验为 pipeline.Config:
+//   - 解析失败(语法/结构/领域校验)→ 422,错误码定位(invalid_yaml / invalid_stage / ...)。
+//   - save=false(默认):仅返回解析后的预览 DTO,**不落库**(让用户先在画布看效果再决定)。
+//   - save=true:把解析出的 spec 经 svc.Save 持久化(走与画布 PUT 同一套规范化/校验/渲染)后回读返回。
+//
+// 写方法过 auth + CSRF;请求体限 256KB;错误信息不含任何 secret 明文(env 仅以引用形式出现)。
+func makeImportPipelineHandler(svc pipeline.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "流水线配置服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<18) // 256KB
+		var req struct {
+			YAML string `json:"yaml"`
+			Save bool   `json:"save"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+
+		parsed, err := pipelineyaml.Parse([]byte(req.YAML))
+		if err != nil {
+			writeYAMLParseError(w, err)
+			return
+		}
+
+		// 预览(默认):不落库,直接回解析后的 DTO。
+		if !req.Save {
+			writeJSON(w, http.StatusOK, toPipelineDTO(&parsed))
+			return
+		}
+
+		// 导入并持久化:走与画布 PUT 完全一致的 Save 路径(再校验 + 渲染 + 回读 + 项目存在性)。
+		cfg, err := svc.Save(r.Context(), id, parsed.Spec)
+		if err != nil {
+			writePipelineError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, toPipelineDTO(cfg))
+	}
+}
+
+// writeYAMLParseError 把 pipelineyaml.Parse 的错误映射为契约错误码(422)。
+// 领域校验错误(经 %w 挂在链上)优先精确映射;否则归为 invalid_yaml(message 已脱敏、人读)。
+func writeYAMLParseError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, pipeline.ErrInvalidStage):
+		writeError(w, http.StatusUnprocessableEntity, "invalid_stage", err.Error())
+	case errors.Is(err, pipeline.ErrInvalidJob):
+		writeError(w, http.StatusUnprocessableEntity, "invalid_job", err.Error())
+	case errors.Is(err, pipeline.ErrDuplicateID):
+		writeError(w, http.StatusUnprocessableEntity, "duplicate_id", err.Error())
+	case errors.Is(err, pipelineyaml.ErrParse):
+		writeError(w, http.StatusUnprocessableEntity, "invalid_yaml", err.Error())
+	default:
+		writeError(w, http.StatusUnprocessableEntity, "invalid_yaml", "无法解析 .pipewright.yml")
 	}
 }

--- a/internal/httpapi/pipelines_test.go
+++ b/internal/httpapi/pipelines_test.go
@@ -217,3 +217,115 @@ func assertErrorCode(t *testing.T, resp *http.Response, wantStatus int, wantCode
 		t.Fatalf("error code = %q, want %q, body=%s", body.Error.Code, wantCode, raw)
 	}
 }
+
+// ─── 流水线即代码导入/预览(FR-8-12) ────────────────────────────────────────
+
+const importYAMLDoc = `version: 1
+stages:
+  - id: stg_src
+    name: 流水线源
+    kind: source
+    jobs:
+      - name: Gitee 源
+        type: git_source
+  - id: stg_build
+    name: 构建
+    kind: build
+    needs: [stg_src]
+    jobs:
+      - name: 运行测试
+        type: script
+        script:
+          image: golang:1.23
+          commands:
+            - go vet ./...
+            - go test ./...
+          workdir: .
+  - id: stg_deploy
+    name: 部署
+    kind: deploy
+    needs: [stg_build]
+    gate: true
+    when:
+      branches: [main]
+    jobs:
+      - name: SSH 部署
+        type: deploy_ssh
+`
+
+func TestPipelineImportPreviewNoSave(t *testing.T) {
+	srv, client, csrf, projID := setupPipelineServer(t)
+	body, _ := json.Marshal(map[string]any{"yaml": importYAMLDoc})
+	resp := doJSON(t, client, http.MethodPost, srv.URL+"/api/projects/"+projID+"/pipeline/import", csrf, string(body))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200, body=%s", resp.StatusCode, raw)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	var dto map[string]any
+	_ = json.Unmarshal(raw, &dto)
+	stages, ok := dto["stages"].([]any)
+	if !ok || len(stages) != 3 {
+		t.Fatalf("预览应 3 阶段, got %v", dto["stages"])
+	}
+
+	// 预览不落库:GET 仍是默认 4 阶段种子。
+	g := doJSON(t, client, http.MethodGet, srv.URL+"/api/projects/"+projID+"/pipeline", csrf, "")
+	defer g.Body.Close()
+	graw, _ := io.ReadAll(g.Body)
+	var gd map[string]any
+	_ = json.Unmarshal(graw, &gd)
+	if gs, _ := gd["stages"].([]any); len(gs) != 4 {
+		t.Fatalf("预览不应落库,GET 应仍为默认 4 阶段, got %d", len(gs))
+	}
+}
+
+func TestPipelineImportSavePersists(t *testing.T) {
+	srv, client, csrf, projID := setupPipelineServer(t)
+	body, _ := json.Marshal(map[string]any{"yaml": importYAMLDoc, "save": true})
+	resp := doJSON(t, client, http.MethodPost, srv.URL+"/api/projects/"+projID+"/pipeline/import", csrf, string(body))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200, body=%s", resp.StatusCode, raw)
+	}
+
+	// save=true 应落库:GET 返回导入的 3 阶段。
+	g := doJSON(t, client, http.MethodGet, srv.URL+"/api/projects/"+projID+"/pipeline", csrf, "")
+	defer g.Body.Close()
+	graw, _ := io.ReadAll(g.Body)
+	var gd map[string]any
+	_ = json.Unmarshal(graw, &gd)
+	gs, _ := gd["stages"].([]any)
+	if len(gs) != 3 {
+		t.Fatalf("save=true 应落库 3 阶段, got %d", len(gs))
+	}
+}
+
+func TestPipelineImportInvalidYAML(t *testing.T) {
+	srv, client, csrf, projID := setupPipelineServer(t)
+	body, _ := json.Marshal(map[string]any{"yaml": "not: [valid"})
+	resp := doJSON(t, client, http.MethodPost, srv.URL+"/api/projects/"+projID+"/pipeline/import", csrf, string(body))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("非法 YAML status = %d, want 422", resp.StatusCode)
+	}
+}
+
+func TestPipelineImportInvalidStage(t *testing.T) {
+	srv, client, csrf, projID := setupPipelineServer(t)
+	doc := "stages:\n  - name: x\n    kind: bogus\n    jobs: [{name: j, type: git_source}]\n"
+	body, _ := json.Marshal(map[string]any{"yaml": doc})
+	resp := doJSON(t, client, http.MethodPost, srv.URL+"/api/projects/"+projID+"/pipeline/import", csrf, string(body))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("非法 kind status = %d, want 422", resp.StatusCode)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	var body2 struct{ Error struct{ Code string } }
+	_ = json.Unmarshal(raw, &body2)
+	if body2.Error.Code != "invalid_stage" {
+		t.Fatalf("error code = %q, want invalid_stage, body=%s", body2.Error.Code, raw)
+	}
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -352,6 +352,10 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		ar.Get("/projects/{id}/pipeline", makeGetPipelineHandler(pl))
 		ar.Put("/projects/{id}/pipeline", makeSavePipelineHandler(pl))
 
+		// 流水线即代码导入/预览(FR-8-12):POST 收 .pipewright.yml 文档,解析+校验为同一套 spec。
+		// /pipeline/import 比 /pipeline 多一段,不会被吞;写方法,过 auth + CSRF。
+		ar.Post("/projects/{id}/pipeline/import", makeImportPipelineHandler(pl))
+
 		// 构建/部署配置(Story 2.4):独立表/端点,与 /pipeline(2-2 spec)各自路由;
 		// /pipeline/settings 比 /pipeline 多一段,不会被吞。GET 过 auth;PUT 写方法过 auth + CSRF。
 		ps := o.pipelineSettings

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -108,6 +108,17 @@ type Service interface {
 	Save(ctx context.Context, projectID string, spec Spec) (*Config, error)
 }
 
+// StatusDraft 是本期唯一发布状态(导出供 pipelineyaml 等同包域外构造 Config 时复用)。
+const StatusDraft = statusDraft
+
+// NormalizeSpec 校验并规范化 spec(导出包装 normalizeSpec):trim、补空 id、Config nil 补 {}、
+// 阶段名/kind 枚举/任务名/type 非空、id 全局唯一、恰一个 source 阶段、needs 存在性/自指/环检测。
+// 供「流水线即代码」(pipelineyaml)等域外入口走同一套校验,不另起规则。
+func NormalizeSpec(in Spec) (Spec, error) { return normalizeSpec(in) }
+
+// RenderYAML 把 spec 渲染为确定性 YAML 文本(导出包装 renderYAML),供导入预览回填规范 YAML。
+func RenderYAML(spec Spec) (string, error) { return renderYAML(spec) }
+
 // service 是 store 支撑的 Service 实现。
 type service struct {
 	db *sql.DB

--- a/internal/pipelineyaml/pipelineyaml.go
+++ b/internal/pipelineyaml/pipelineyaml.go
@@ -1,0 +1,380 @@
+// Package pipelineyaml 是「流水线即代码」(`.pipewright.yml`)与领域模型 pipeline.Spec
+// 之间的解析/序列化层(FR-8-12)。
+//
+// 它把一份人类友好的声明式 YAML 文档(stages → jobs,带 needs/when/gate/allowFailure 与
+// 脚本步骤 image/commands/env/workdir)解析为 pipeline.Spec,并可反向序列化回 YAML。
+// 解析后**复用 pipeline 包的现有校验**(经 pipeline.NormalizeSpec:阶段名/kind 枚举/任务名/
+// type 非空、id 全局唯一、恰一个 source 阶段、needs 存在性/自指/环检测),不另起一套规则。
+//
+// 设计取向:
+//   - 与画布持久化的 JSON 解耦——本包只面向「仓库里手写的 YAML」这一表面,字段顺序确定、
+//     省略空字段,读起来像 Jenkins/云效 的流水线文件。
+//   - job 的脚本步骤用一个嵌套 `script:` 块表达(image/commands/env/workdir),解析时摊平进
+//     pipeline.Job.Config 的字符串 KV——**严格对齐画布 jobConfigSchema 的扁平约定**:
+//     image→image、commands→多行命令拼成单个换行连接串、workdir→workDir(驼峰)、env→JSON 对象串;
+//     另允许 `config:` 原样透传任意字符串 KV(两者可并存,script 优先级更高、键冲突时覆盖)。
+//   - 错误信息人读、含阶段/任务定位线索,但**绝不回显任何 secret 明文**(secret env 仅以
+//     credentialId 引用形式出现;本层不接触保险库)。
+//
+// 本包无 init() 副作用、无包级重对象。
+package pipelineyaml
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	yaml "gopkg.in/yaml.v3"
+)
+
+// SchemaVersion 是当前支持的 `.pipewright.yml` 顶层 version。缺省视为 1(向后兼容)。
+const SchemaVersion = 1
+
+// ErrParse 表示 YAML 文档无法解析为合法流水线(语法错误 / 结构错误 / 校验失败)。
+// 调用方据此回 422;Unwrap 链上可能挂 pipeline.ErrInvalidStage 等领域错误以便精确映射。
+var ErrParse = errors.New("pipelineyaml: invalid .pipewright.yml")
+
+// 脚本步骤在 Job.Config 内的约定键(**与前端 jobConfigSchema 的 script 任务严格对齐**)。
+//   - configKeyImage:构建镜像(单值字符串)。
+//   - configKeyCommands:多行命令拼成单个换行连接串(画布 textarea 即如此存,保序)。
+//   - configKeyEnv:非 secret 明文 env(JSON 对象编码进单值)。
+//   - configKeyWorkDir:容器内相对工作目录(驼峰,画布约定)。
+const (
+	configKeyImage    = "image"
+	configKeyCommands = "commands"
+	configKeyEnv      = "env"
+	configKeyWorkDir  = "workDir"
+)
+
+// ---- YAML 文档形状(确定性字段顺序;仅用于解析/序列化,与持久化 JSON 解耦) ----
+
+type doc struct {
+	Version int         `yaml:"version,omitempty"`
+	Stages  []stageNode `yaml:"stages"`
+}
+
+type stageNode struct {
+	ID           string    `yaml:"id,omitempty"`
+	Name         string    `yaml:"name"`
+	Kind         string    `yaml:"kind"`
+	Needs        []string  `yaml:"needs,omitempty"`
+	AllowFailure bool      `yaml:"allowFailure,omitempty"`
+	Gate         bool      `yaml:"gate,omitempty"`
+	When         *whenNode `yaml:"when,omitempty"`
+	Jobs         []jobNode `yaml:"jobs,omitempty"`
+}
+
+type whenNode struct {
+	Branches []string `yaml:"branches,omitempty"`
+	Events   []string `yaml:"events,omitempty"`
+}
+
+type jobNode struct {
+	ID      string            `yaml:"id,omitempty"`
+	Name    string            `yaml:"name"`
+	Type    string            `yaml:"type"`
+	Summary string            `yaml:"summary,omitempty"`
+	Script  *scriptNode       `yaml:"script,omitempty"`
+	Config  map[string]string `yaml:"config,omitempty"`
+}
+
+// scriptNode 是脚本步骤的人类友好嵌套块(对标 Jenkins sh / 云效自定义命令)。
+type scriptNode struct {
+	Image    string            `yaml:"image,omitempty"`
+	Commands []string          `yaml:"commands,omitempty"`
+	Env      map[string]string `yaml:"env,omitempty"`
+	WorkDir  string            `yaml:"workdir,omitempty"`
+}
+
+// Parse 把 `.pipewright.yml` 文档字节解析为已校验、已规范化的 pipeline.Config。
+//
+// 流程:严格 YAML 解码(未知字段报错)→ 摊平 script 块进 Job.Config → 组装 pipeline.Spec →
+// 复用 pipeline.NormalizeSpec 做全部领域校验 → 经 pipeline.RenderYAML 回填规范 YAML。
+// 任何失败都包成 ErrParse(领域校验错误经 %w 挂在链上,便于上层精确映射状态码)。
+func Parse(data []byte) (pipeline.Config, error) {
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return pipeline.Config{}, fmt.Errorf("%w: 文档为空", ErrParse)
+	}
+
+	var d doc
+	dec := yaml.NewDecoder(strings.NewReader(string(data)))
+	dec.KnownFields(true) // 拒绝未知字段,避免静默吞掉拼错的键
+	if err := dec.Decode(&d); err != nil {
+		return pipeline.Config{}, fmt.Errorf("%w: YAML 语法/结构错误: %s", ErrParse, sanitizeYAMLErr(err))
+	}
+
+	if d.Version != 0 && d.Version != SchemaVersion {
+		return pipeline.Config{}, fmt.Errorf("%w: 不支持的 version %d(当前支持 %d)", ErrParse, d.Version, SchemaVersion)
+	}
+	if len(d.Stages) == 0 {
+		return pipeline.Config{}, fmt.Errorf("%w: 至少需要一个 stage", ErrParse)
+	}
+
+	stages := make([]pipeline.Stage, 0, len(d.Stages))
+	for si, sn := range d.Stages {
+		stageLabel := stageLabel(si, sn)
+		jobs := make([]pipeline.Job, 0, len(sn.Jobs))
+		for ji, jn := range sn.Jobs {
+			cfg, err := jobConfig(jn)
+			if err != nil {
+				return pipeline.Config{}, fmt.Errorf("%w: %s 的任务 #%d(%s): %s", ErrParse, stageLabel, ji+1, jobLabel(jn), err)
+			}
+			jobs = append(jobs, pipeline.Job{
+				ID:      strings.TrimSpace(jn.ID),
+				Name:    jn.Name,
+				Type:    jn.Type,
+				Summary: jn.Summary,
+				Config:  cfg,
+			})
+		}
+
+		var when pipeline.When
+		if sn.When != nil {
+			when = pipeline.When{Branches: sn.When.Branches, Events: sn.When.Events}
+		}
+		stages = append(stages, pipeline.Stage{
+			ID:           strings.TrimSpace(sn.ID),
+			Name:         sn.Name,
+			Kind:         sn.Kind,
+			Needs:        sn.Needs,
+			AllowFailure: sn.AllowFailure,
+			When:         when,
+			Gate:         sn.Gate,
+			Jobs:         jobs,
+		})
+	}
+
+	// 复用领域校验 + 规范化(单一事实来源:与画布 PUT 走同一套规则)。
+	// 用 %w 双层挂链(ErrParse + 领域 ErrInvalidStage/ErrInvalidJob/...),便于上层精确映射状态码。
+	spec, err := pipeline.NormalizeSpec(pipeline.Spec{Stages: stages})
+	if err != nil {
+		return pipeline.Config{}, fmt.Errorf("%w: %w", ErrParse, err)
+	}
+
+	renderedYAML, err := pipeline.RenderYAML(spec)
+	if err != nil {
+		return pipeline.Config{}, fmt.Errorf("%w: 渲染 YAML 失败", ErrParse)
+	}
+	return pipeline.Config{Spec: spec, YAML: renderedYAML, Status: pipeline.StatusDraft}, nil
+}
+
+// Marshal 把 pipeline.Spec 序列化为人类友好的 `.pipewright.yml` 文档字节。
+// 与 Parse 往返一致:script 块从 Job.Config 的约定键重建;非约定键落回 config: 透传。
+func Marshal(spec pipeline.Spec) ([]byte, error) {
+	d := doc{Version: SchemaVersion, Stages: make([]stageNode, 0, len(spec.Stages))}
+	for _, st := range spec.Stages {
+		sn := stageNode{
+			ID:           strings.TrimSpace(st.ID),
+			Name:         st.Name,
+			Kind:         st.Kind,
+			Needs:        nonEmpty(st.Needs),
+			AllowFailure: st.AllowFailure,
+			Gate:         st.Gate,
+		}
+		if !st.When.IsEmpty() {
+			sn.When = &whenNode{Branches: nonEmpty(st.When.Branches), Events: nonEmpty(st.When.Events)}
+		}
+		for _, jb := range st.Jobs {
+			jn := jobNode{
+				ID:      strings.TrimSpace(jb.ID),
+				Name:    jb.Name,
+				Type:    jb.Type,
+				Summary: jb.Summary,
+			}
+			script, rest := splitConfig(jb.Config)
+			jn.Script = script
+			if len(rest) > 0 {
+				jn.Config = rest
+			}
+			sn.Jobs = append(sn.Jobs, jn)
+		}
+		d.Stages = append(d.Stages, sn)
+	}
+	out, err := yaml.Marshal(d)
+	if err != nil {
+		return nil, fmt.Errorf("pipelineyaml: marshal: %w", err)
+	}
+	return out, nil
+}
+
+// jobConfig 把一个 YAML job 节点的 script 块 + config 透传合并为 pipeline.Job.Config
+// (字符串 KV;commands/env 以 JSON 编码进单值,与画布 jobConfigSchema 对齐)。
+func jobConfig(jn jobNode) (map[string]any, error) {
+	cfg := map[string]any{}
+	// 先放 config: 原样透传(字符串 KV),再让 script 块覆盖约定键。
+	for k, v := range jn.Config {
+		k = strings.TrimSpace(k)
+		if k == "" {
+			return nil, errors.New("config 键不能为空")
+		}
+		cfg[k] = v
+	}
+	if jn.Script != nil {
+		s := jn.Script
+		if img := strings.TrimSpace(s.Image); img != "" {
+			cfg[configKeyImage] = img
+		}
+		if wd := strings.TrimSpace(s.WorkDir); wd != "" {
+			cfg[configKeyWorkDir] = wd
+		}
+		if len(s.Commands) > 0 {
+			cmds := make([]string, 0, len(s.Commands))
+			for _, c := range s.Commands {
+				if strings.TrimSpace(c) != "" {
+					cmds = append(cmds, c)
+				}
+			}
+			if len(cmds) > 0 {
+				// 画布把多行命令存为单个换行连接串(textarea);此处对齐,保序拼接。
+				cfg[configKeyCommands] = strings.Join(cmds, "\n")
+			}
+		}
+		if len(s.Env) > 0 {
+			cfg[configKeyEnv] = encodeJSON(s.Env)
+		}
+	}
+	if len(cfg) == 0 {
+		return cfg, nil
+	}
+	return cfg, nil
+}
+
+// splitConfig 从 Job.Config 里把脚本步骤的约定键重建为 scriptNode,其余键作为透传 config 返回。
+// 用于 Marshal 往返;commands/env 若为 JSON 编码则解码回结构,否则退化为透传(不丢数据)。
+func splitConfig(cfg map[string]any) (*scriptNode, map[string]string) {
+	rest := map[string]string{}
+	var script scriptNode
+	hasScript := false
+
+	for k, v := range cfg {
+		sv := asString(v)
+		switch k {
+		case configKeyImage:
+			if sv != "" {
+				script.Image = sv
+				hasScript = true
+			}
+		case configKeyWorkDir:
+			if sv != "" {
+				script.WorkDir = sv
+				hasScript = true
+			}
+		case configKeyCommands:
+			if sv != "" {
+				script.Commands = strings.Split(sv, "\n")
+				hasScript = true
+			}
+		case configKeyEnv:
+			if env, ok := decodeStringMap(sv); ok {
+				script.Env = env
+				hasScript = true
+			} else if sv != "" {
+				rest[k] = sv
+			}
+		default:
+			rest[k] = sv
+		}
+	}
+	if !hasScript {
+		return nil, rest
+	}
+	return &script, rest
+}
+
+// stageLabel / jobLabel 给错误信息提供人读定位(不含 secret)。
+func stageLabel(idx int, sn stageNode) string {
+	if name := strings.TrimSpace(sn.Name); name != "" {
+		return fmt.Sprintf("阶段「%s」", name)
+	}
+	if id := strings.TrimSpace(sn.ID); id != "" {
+		return fmt.Sprintf("阶段「%s」", id)
+	}
+	return fmt.Sprintf("阶段 #%d", idx+1)
+}
+
+func jobLabel(jn jobNode) string {
+	if name := strings.TrimSpace(jn.Name); name != "" {
+		return name
+	}
+	if id := strings.TrimSpace(jn.ID); id != "" {
+		return id
+	}
+	return "<未命名>"
+}
+
+// nonEmpty 把 nil/空切片归一为 nil(让 omitempty 生效),否则原样返回。
+func nonEmpty(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	return in
+}
+
+// asString 把 Job.Config 的 any 值尽量转字符串(画布存的恒为字符串;JSON 回读亦如此)。
+func asString(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case nil:
+		return ""
+	default:
+		return fmt.Sprintf("%v", t)
+	}
+}
+
+// encodeJSON 把 env map 编码为确定性 JSON 串(键排序,跨次稳定),供存入 Job.Config 单值。
+func encodeJSON(m map[string]string) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.Write(mustJSON(k))
+		b.WriteByte(':')
+		b.Write(mustJSON(m[k]))
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
+// mustJSON 把字符串安全编码为 JSON 字面量(转义引号/控制符)。
+func mustJSON(s string) []byte {
+	out, err := json.Marshal(s)
+	if err != nil {
+		// string 编码不会失败;兜底退化为空串字面量。
+		return []byte(`""`)
+	}
+	return out
+}
+
+// decodeStringMap 把 Job.Config 里的 JSON 对象单值解码回 map[string]string;非 JSON 对象返回 ok=false。
+func decodeStringMap(s string) (map[string]string, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" || s[0] != '{' {
+		return nil, false
+	}
+	var m map[string]string
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		return nil, false
+	}
+	return m, true
+}
+
+// sanitizeYAMLErr 收敛 yaml 解码错误为一行人读串(去多行/去内部前缀,不外泄实现细节)。
+func sanitizeYAMLErr(err error) string {
+	msg := err.Error()
+	msg = strings.TrimPrefix(msg, "yaml: ")
+	if i := strings.IndexByte(msg, '\n'); i >= 0 {
+		msg = msg[:i]
+	}
+	return strings.TrimSpace(msg)
+}

--- a/internal/pipelineyaml/pipelineyaml_test.go
+++ b/internal/pipelineyaml/pipelineyaml_test.go
@@ -1,0 +1,360 @@
+package pipelineyaml
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+)
+
+// multiStageFixture 是一份多阶段 DAG 流水线:source → build(script 步骤)→ deploy(needs + when + gate)
+// → notify(allowFailure)。覆盖 needs/when/gate/allowFailure + 脚本步骤 image/commands/env/workdir。
+const multiStageFixture = `version: 1
+stages:
+  - id: stg_src
+    name: 流水线源
+    kind: source
+    jobs:
+      - id: job_src
+        name: Gitee 源
+        type: git_source
+        summary: org/repo · main
+  - id: stg_build
+    name: 构建
+    kind: build
+    needs:
+      - stg_src
+    jobs:
+      - id: job_test
+        name: 运行测试
+        type: script
+        script:
+          image: golang:1.23
+          commands:
+            - go vet ./...
+            - go test ./...
+          env:
+            CGO_ENABLED: "0"
+            GOFLAGS: -count=1
+          workdir: src/app
+  - id: stg_deploy
+    name: 部署
+    kind: deploy
+    needs:
+      - stg_build
+    gate: true
+    when:
+      branches:
+        - main
+        - release/*
+      events:
+        - webhook
+    jobs:
+      - id: job_deploy
+        name: SSH 部署
+        type: deploy_ssh
+        config:
+          targetEnv: prod
+  - id: stg_notify
+    name: 通知
+    kind: notify
+    needs:
+      - stg_deploy
+    allowFailure: true
+    jobs:
+      - id: job_notify
+        name: 钉钉通知
+        type: notify
+`
+
+func TestParseMultiStageDAG(t *testing.T) {
+	cfg, err := Parse([]byte(multiStageFixture))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	st := cfg.Spec.Stages
+	if len(st) != 4 {
+		t.Fatalf("阶段数 = %d, want 4", len(st))
+	}
+
+	// 阶段顺序与基本字段。
+	if st[0].Kind != pipeline.KindSource || st[1].Kind != pipeline.KindBuild {
+		t.Fatalf("阶段 kind 顺序错: %+v", []string{st[0].Kind, st[1].Kind})
+	}
+
+	// needs 链。
+	if len(st[1].Needs) != 1 || st[1].Needs[0] != "stg_src" {
+		t.Fatalf("build needs = %+v, want [stg_src]", st[1].Needs)
+	}
+	if len(st[2].Needs) != 1 || st[2].Needs[0] != "stg_build" {
+		t.Fatalf("deploy needs = %+v", st[2].Needs)
+	}
+
+	// gate + when。
+	if !st[2].Gate {
+		t.Fatalf("deploy gate 应为 true")
+	}
+	if len(st[2].When.Branches) != 2 || st[2].When.Branches[0] != "main" {
+		t.Fatalf("deploy when.branches = %+v", st[2].When.Branches)
+	}
+	if len(st[2].When.Events) != 1 || st[2].When.Events[0] != "webhook" {
+		t.Fatalf("deploy when.events = %+v", st[2].When.Events)
+	}
+
+	// allowFailure。
+	if !st[3].AllowFailure {
+		t.Fatalf("notify allowFailure 应为 true")
+	}
+
+	// 脚本步骤摊平进 Job.Config(对齐画布扁平约定)。
+	build := st[1].Jobs[0]
+	if build.Config["image"] != "golang:1.23" {
+		t.Fatalf("script image = %v", build.Config["image"])
+	}
+	if build.Config["workDir"] != "src/app" {
+		t.Fatalf("script workDir = %v", build.Config["workDir"])
+	}
+	cmds, _ := build.Config["commands"].(string)
+	if cmds != "go vet ./...\ngo test ./..." {
+		t.Fatalf("script commands = %q", cmds)
+	}
+	env, _ := build.Config["env"].(string)
+	if !strings.Contains(env, `"CGO_ENABLED":"0"`) || !strings.Contains(env, `"GOFLAGS":"-count=1"`) {
+		t.Fatalf("script env JSON = %q", env)
+	}
+
+	// config: 透传。
+	if st[2].Jobs[0].Config["targetEnv"] != "prod" {
+		t.Fatalf("deploy job config 透传 = %+v", st[2].Jobs[0].Config)
+	}
+
+	// 渲染 YAML 非空(规范回填)。
+	if strings.TrimSpace(cfg.YAML) == "" {
+		t.Fatalf("回填 YAML 不应为空")
+	}
+	if cfg.Status != pipeline.StatusDraft {
+		t.Fatalf("status = %q, want draft", cfg.Status)
+	}
+}
+
+// TestRoundTrip 验证 Parse → Marshal → Parse 语义不变(往返一致)。
+func TestRoundTrip(t *testing.T) {
+	cfg1, err := Parse([]byte(multiStageFixture))
+	if err != nil {
+		t.Fatalf("first Parse: %v", err)
+	}
+	out, err := Marshal(cfg1.Spec)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	cfg2, err := Parse(out)
+	if err != nil {
+		t.Fatalf("re-Parse marshaled: %v\n---\n%s", err, out)
+	}
+
+	if len(cfg1.Spec.Stages) != len(cfg2.Spec.Stages) {
+		t.Fatalf("往返阶段数变化: %d → %d", len(cfg1.Spec.Stages), len(cfg2.Spec.Stages))
+	}
+	for i := range cfg1.Spec.Stages {
+		a, b := cfg1.Spec.Stages[i], cfg2.Spec.Stages[i]
+		if a.ID != b.ID || a.Name != b.Name || a.Kind != b.Kind || a.Gate != b.Gate || a.AllowFailure != b.AllowFailure {
+			t.Fatalf("阶段 %d 往返字段不一致:\n a=%+v\n b=%+v", i, a, b)
+		}
+		if strings.Join(a.Needs, ",") != strings.Join(b.Needs, ",") {
+			t.Fatalf("阶段 %d needs 往返不一致: %+v vs %+v", i, a.Needs, b.Needs)
+		}
+		if strings.Join(a.When.Branches, ",") != strings.Join(b.When.Branches, ",") ||
+			strings.Join(a.When.Events, ",") != strings.Join(b.When.Events, ",") {
+			t.Fatalf("阶段 %d when 往返不一致", i)
+		}
+		if len(a.Jobs) != len(b.Jobs) {
+			t.Fatalf("阶段 %d 任务数往返不一致", i)
+		}
+		for j := range a.Jobs {
+			ja, jb := a.Jobs[j], b.Jobs[j]
+			if ja.ID != jb.ID || ja.Name != jb.Name || ja.Type != jb.Type || ja.Summary != jb.Summary {
+				t.Fatalf("阶段 %d 任务 %d 往返字段不一致:\n a=%+v\n b=%+v", i, j, ja, jb)
+			}
+			// Config 关键键往返一致。
+			for _, k := range []string{"image", "commands", "workDir", "env", "targetEnv"} {
+				if asString(ja.Config[k]) != asString(jb.Config[k]) {
+					t.Fatalf("阶段 %d 任务 %d config[%q] 往返不一致: %q vs %q", i, j, k, asString(ja.Config[k]), asString(jb.Config[k]))
+				}
+			}
+		}
+	}
+}
+
+func TestParseEmpty(t *testing.T) {
+	if _, err := Parse([]byte("   \n  ")); !errors.Is(err, ErrParse) {
+		t.Fatalf("空文档应回 ErrParse, got %v", err)
+	}
+}
+
+func TestParseUnknownField(t *testing.T) {
+	doc := `stages:
+  - name: src
+    kind: source
+    bogusKey: 1
+    jobs:
+      - name: j
+        type: git_source
+`
+	if _, err := Parse([]byte(doc)); !errors.Is(err, ErrParse) {
+		t.Fatalf("未知字段应回 ErrParse, got %v", err)
+	}
+}
+
+func TestParseBadKind(t *testing.T) {
+	doc := `stages:
+  - name: src
+    kind: source
+    jobs:
+      - name: j
+        type: git_source
+  - name: weird
+    kind: nonsense
+    jobs:
+      - name: j2
+        type: script
+        script:
+          image: node:20
+          commands: [echo hi]
+`
+	_, err := Parse([]byte(doc))
+	if !errors.Is(err, ErrParse) || !errors.Is(err, pipeline.ErrInvalidStage) {
+		t.Fatalf("非法 kind 应回 ErrParse∧ErrInvalidStage, got %v", err)
+	}
+}
+
+func TestParseMultipleSourceStages(t *testing.T) {
+	doc := `stages:
+  - name: src1
+    kind: source
+    jobs: [{name: a, type: git_source}]
+  - name: src2
+    kind: source
+    jobs: [{name: b, type: git_source}]
+`
+	_, err := Parse([]byte(doc))
+	if !errors.Is(err, ErrParse) || !errors.Is(err, pipeline.ErrInvalidStage) {
+		t.Fatalf("双 source 应回 ErrParse∧ErrInvalidStage, got %v", err)
+	}
+}
+
+func TestParseUnknownNeeds(t *testing.T) {
+	doc := `stages:
+  - name: src
+    kind: source
+    jobs: [{name: a, type: git_source}]
+  - id: b
+    name: build
+    kind: build
+    needs: [nonexistent]
+    jobs: [{name: j, type: script, script: {image: node:20, commands: [echo]}}]
+`
+	_, err := Parse([]byte(doc))
+	if !errors.Is(err, ErrParse) || !errors.Is(err, pipeline.ErrInvalidStage) {
+		t.Fatalf("needs 引用不存在阶段应回 ErrParse∧ErrInvalidStage, got %v", err)
+	}
+}
+
+func TestParseCycle(t *testing.T) {
+	doc := `stages:
+  - name: src
+    kind: source
+    jobs: [{name: a, type: git_source}]
+  - id: x
+    name: x
+    kind: build
+    needs: [y]
+    jobs: [{name: j, type: script, script: {image: node:20, commands: [echo]}}]
+  - id: y
+    name: y
+    kind: custom
+    needs: [x]
+    jobs: [{name: k, type: script, script: {image: node:20, commands: [echo]}}]
+`
+	_, err := Parse([]byte(doc))
+	if !errors.Is(err, ErrParse) || !errors.Is(err, pipeline.ErrInvalidStage) {
+		t.Fatalf("成环应回 ErrParse∧ErrInvalidStage, got %v", err)
+	}
+}
+
+func TestParseEmptyJobName(t *testing.T) {
+	doc := `stages:
+  - name: src
+    kind: source
+    jobs:
+      - name: "  "
+        type: git_source
+`
+	_, err := Parse([]byte(doc))
+	if !errors.Is(err, ErrParse) || !errors.Is(err, pipeline.ErrInvalidJob) {
+		t.Fatalf("空任务名应回 ErrParse∧ErrInvalidJob, got %v", err)
+	}
+}
+
+// TestParseErrorNoSecretLeak 断言:即便 env 里写了疑似 secret 值,解析错误信息也不回显它。
+func TestParseErrorNoSecretLeak(t *testing.T) {
+	doc := `stages:
+  - name: src
+    kind: badkind
+    jobs:
+      - name: j
+        type: script
+        script:
+          image: node:20
+          commands: [echo]
+          env:
+            TOKEN: SUPERSECRET_LEAKMARKER_999
+`
+	_, err := Parse([]byte(doc))
+	if err == nil {
+		t.Fatalf("应解析失败")
+	}
+	if strings.Contains(err.Error(), "LEAKMARKER") {
+		t.Fatalf("错误信息泄漏了 env 值: %v", err)
+	}
+}
+
+// TestMarshalDeterministic 验证同一 spec 序列化两次字节一致(确定性)。
+func TestMarshalDeterministic(t *testing.T) {
+	cfg, err := Parse([]byte(multiStageFixture))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	a, err := Marshal(cfg.Spec)
+	if err != nil {
+		t.Fatalf("Marshal a: %v", err)
+	}
+	b, err := Marshal(cfg.Spec)
+	if err != nil {
+		t.Fatalf("Marshal b: %v", err)
+	}
+	if string(a) != string(b) {
+		t.Fatalf("序列化非确定性:\n--- a ---\n%s\n--- b ---\n%s", a, b)
+	}
+}
+
+// TestParseAutoFillsStageID 验证缺省 id 时由领域规范化补 uuid(不报错)。
+func TestParseAutoFillsStageID(t *testing.T) {
+	doc := `stages:
+  - name: 源
+    kind: source
+    jobs:
+      - name: src
+        type: git_source
+`
+	cfg, err := Parse([]byte(doc))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if strings.TrimSpace(cfg.Spec.Stages[0].ID) == "" {
+		t.Fatalf("缺省阶段 id 应被补全")
+	}
+	if strings.TrimSpace(cfg.Spec.Stages[0].Jobs[0].ID) == "" {
+		t.Fatalf("缺省任务 id 应被补全")
+	}
+}

--- a/web/src/api/pipeline.test.ts
+++ b/web/src/api/pipeline.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { importPipeline, type PipelineDTO } from './pipeline'
+import { HttpError } from './http'
+
+function jsonResponse(status: number, body: unknown, ok = status < 400): Response {
+  return {
+    status,
+    ok,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response
+}
+
+const dto: PipelineDTO = {
+  stages: [{ id: 's1', name: '源', kind: 'source', jobs: [] }],
+  yaml: 'version: 1\n',
+  status: 'draft',
+  updatedAt: '2026-05-31T00:00:00Z',
+}
+
+describe('importPipeline (FR-8-12)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('POSTs to /pipeline/import with save=false by default (preview)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, dto))
+    const result = await importPipeline('p1', 'version: 1\nstages: []\n')
+    expect(result).toEqual(dto)
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/projects/p1/pipeline/import')
+    expect(init.method).toBe('POST')
+    const sent = JSON.parse(init.body as string)
+    expect(sent.save).toBe(false)
+    expect(sent.yaml).toContain('stages')
+  })
+
+  it('passes save=true through to persist', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, dto))
+    await importPipeline('p1', 'yaml', true)
+    const [, init] = fetchMock.mock.calls[0]
+    expect(JSON.parse(init.body as string).save).toBe(true)
+  })
+
+  it('throws HttpError with the server code on a 422 validation failure', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(422, { error: { code: 'invalid_stage', message: '阶段配置不合法' } }),
+    )
+    await expect(importPipeline('p1', 'bad')).rejects.toBeInstanceOf(HttpError)
+    try {
+      await importPipeline('p1', 'bad')
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError)
+      expect((err as HttpError).apiError?.code).toBe('invalid_stage')
+      expect((err as HttpError).status).toBe(422)
+    }
+  })
+})

--- a/web/src/api/pipeline.ts
+++ b/web/src/api/pipeline.ts
@@ -91,3 +91,22 @@ export async function savePipeline(
 ): Promise<PipelineDTO> {
   return http.put<PipelineDTO>(`/api/projects/${projectId}/pipeline`, input)
 }
+
+// ─── Pipeline-as-code import / preview (FR-8-12) ──────────────────────────────
+
+/**
+ * Parse + validate a `.pipewright.yml` document into the pipeline model.
+ *
+ * POST /api/projects/{id}/pipeline/import  (needs CSRF)
+ * Body: { yaml, save }
+ *   - save=false (default): returns the parsed PipelineDTO as a preview, does NOT persist.
+ *   - save=true: persists the parsed spec via the same Save path as the canvas PUT.
+ * Validation failures surface as HttpError 422 with codes invalid_yaml/invalid_stage/...
+ */
+export async function importPipeline(
+  projectId: string,
+  yaml: string,
+  save = false,
+): Promise<PipelineDTO> {
+  return http.post<PipelineDTO>(`/api/projects/${projectId}/pipeline/import`, { yaml, save })
+}

--- a/web/src/components/pipeline/YamlImportModal.vue
+++ b/web/src/components/pipeline/YamlImportModal.vue
@@ -1,0 +1,394 @@
+<script setup lang="ts">
+/**
+ * YamlImportModal — import a `.pipewright.yml` document into the pipeline editor (FR-8-12).
+ *
+ * Flow:
+ *   1. Paste/edit YAML → 「预览」 calls importPipeline(save=false): server parses + validates,
+ *      returns the parsed PipelineDTO. We emit `preview` so the canvas reflects it without saving.
+ *   2. 「导入到画布」 commits the previewed stages into the editor's local state (still unsaved —
+ *      user reviews on the canvas, then clicks 保存草稿 as usual).
+ *   3. 「导入并保存」 calls importPipeline(save=true): parses, persists, reloads.
+ *
+ * Validation errors (422) are shown inline with the server's human-readable, secret-free message.
+ */
+import { ref } from 'vue'
+import { importPipeline, type PipelineDTO } from '../../api/pipeline'
+import { HttpError } from '../../api/http'
+
+const props = defineProps<{
+  projectId: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  /** A successful preview (save=false): parent applies stages to the canvas without saving. */
+  (e: 'preview', dto: PipelineDTO): void
+  /** A successful save (save=true): parent reloads pipeline + settings. */
+  (e: 'saved', dto: PipelineDTO): void
+}>()
+
+const STARTER = `version: 1
+stages:
+  - name: 流水线源
+    kind: source
+    jobs:
+      - name: 源
+        type: git_source
+  - name: 构建
+    kind: build
+    jobs:
+      - name: 运行测试
+        type: script
+        script:
+          image: golang:1.23
+          commands:
+            - go test ./...
+`
+
+const yamlText = ref('')
+const busy = ref<'preview' | 'save' | null>(null)
+const errorMsg = ref('')
+const previewedStageCount = ref<number | null>(null)
+
+/** Maps 422 codes to user-visible hints; falls back to the server's (sanitized) message. */
+function mapError(err: HttpError): string {
+  const code = err.apiError?.code
+  const msg = err.apiError?.message
+  switch (code) {
+    case 'invalid_yaml':  return msg ?? '无法解析 .pipewright.yml,请检查 YAML 语法与结构。'
+    case 'invalid_stage': return msg ?? '阶段配置不合法(名称 / kind / needs / 须恰有一个 source 阶段)。'
+    case 'invalid_job':   return msg ?? '任务名称或类型不能为空。'
+    case 'duplicate_id':  return msg ?? '阶段或任务 ID 重复。'
+    case 'project_not_found': return '项目不存在。'
+    default:              return msg ?? `导入失败(${err.status})`
+  }
+}
+
+function handleError(err: unknown): void {
+  if (err instanceof HttpError) {
+    errorMsg.value = err.status === 0
+      ? '无法连接到服务器,请检查后端是否运行后重试。'
+      : mapError(err)
+  } else {
+    errorMsg.value = '导入失败,请稍后重试。'
+  }
+}
+
+async function runPreview(): Promise<PipelineDTO | null> {
+  errorMsg.value = ''
+  busy.value = 'preview'
+  try {
+    const dto = await importPipeline(props.projectId, yamlText.value, false)
+    previewedStageCount.value = dto.stages.length
+    return dto
+  } catch (err) {
+    handleError(err)
+    previewedStageCount.value = null
+    return null
+  } finally {
+    busy.value = null
+  }
+}
+
+/** 预览:解析校验,把结果回灌画布(不落库)。 */
+async function onPreview(): Promise<void> {
+  const dto = await runPreview()
+  if (dto) emit('preview', dto)
+}
+
+/** 导入到画布:与预览同一动作语义,关闭弹窗,让用户在画布上确认后再保存草稿。 */
+async function onApplyToCanvas(): Promise<void> {
+  const dto = await runPreview()
+  if (dto) {
+    emit('preview', dto)
+    emit('close')
+  }
+}
+
+/** 导入并保存:解析 + 持久化 + 重载。 */
+async function onImportAndSave(): Promise<void> {
+  errorMsg.value = ''
+  busy.value = 'save'
+  try {
+    const dto = await importPipeline(props.projectId, yamlText.value, true)
+    emit('saved', dto)
+    emit('close')
+  } catch (err) {
+    handleError(err)
+  } finally {
+    busy.value = null
+  }
+}
+
+function loadStarter(): void {
+  yamlText.value = STARTER
+}
+
+function onBackdrop(e: MouseEvent): void {
+  if (e.target === e.currentTarget) emit('close')
+}
+</script>
+
+<template>
+  <div class="yi-backdrop" role="dialog" aria-modal="true" aria-labelledby="yi-title" @mousedown="onBackdrop">
+    <div class="yi-modal">
+      <header class="yi-head">
+        <div>
+          <h2 id="yi-title" class="yi-title">从 YAML 导入流水线</h2>
+          <p class="yi-sub">粘贴 <code>.pipewright.yml</code> 内容,先「预览」校验,再导入到画布或直接保存。</p>
+        </div>
+        <button class="yi-close" aria-label="关闭" @click="emit('close')">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12"/></svg>
+        </button>
+      </header>
+
+      <div class="yi-body">
+        <div class="yi-editor-head">
+          <label for="yi-yaml" class="yi-label">YAML 文档</label>
+          <button class="yi-starter" type="button" @click="loadStarter">填入示例模板</button>
+        </div>
+        <textarea
+          id="yi-yaml"
+          v-model="yamlText"
+          class="yi-yaml"
+          spellcheck="false"
+          autocomplete="off"
+          placeholder="version: 1&#10;stages:&#10;  - name: 流水线源&#10;    kind: source&#10;    jobs: [...]"
+          :disabled="busy !== null"
+        />
+
+        <div v-if="errorMsg" class="yi-banner yi-banner--error" role="alert">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h.01"/></svg>
+          <span>{{ errorMsg }}</span>
+        </div>
+        <div v-else-if="previewedStageCount !== null" class="yi-banner yi-banner--ok" role="status">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>
+          <span>校验通过:解析出 {{ previewedStageCount }} 个阶段,已回灌到画布预览(尚未保存)。</span>
+        </div>
+      </div>
+
+      <footer class="yi-foot">
+        <button class="yi-btn" :disabled="busy !== null || !yamlText.trim()" @click="onPreview">
+          <span v-if="busy === 'preview'" class="yi-spin" aria-hidden="true"/>
+          预览校验
+        </button>
+        <div class="yi-foot-right">
+          <button class="yi-btn" :disabled="busy !== null || !yamlText.trim()" @click="onApplyToCanvas">导入到画布</button>
+          <button class="yi-btn yi-btn--primary" :disabled="busy !== null || !yamlText.trim()" @click="onImportAndSave">
+            <span v-if="busy === 'save'" class="yi-spin" aria-hidden="true"/>
+            导入并保存
+          </button>
+        </div>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.yi-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: oklch(0% 0 0 / 0.42);
+  backdrop-filter: blur(2px);
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.yi-modal {
+  width: min(720px, 100%);
+  max-height: min(86vh, 760px);
+  display: flex;
+  flex-direction: column;
+  background: var(--color-card);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded-card);
+  box-shadow: 0 24px 64px oklch(0% 0 0 / 0.36);
+  overflow: hidden;
+}
+
+.yi-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.yi-title {
+  font-size: 1.02rem;
+  font-weight: 700;
+  color: var(--color-text);
+  letter-spacing: -0.01em;
+}
+
+.yi-sub {
+  margin-top: 4px;
+  font-size: 0.8rem;
+  color: var(--color-faint);
+  line-height: 1.5;
+}
+
+.yi-sub code {
+  font-family: var(--font-mono, monospace);
+  background: var(--color-inset);
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 0.92em;
+}
+
+.yi-close {
+  margin-left: auto;
+  flex: none;
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border: none;
+  background: none;
+  color: var(--color-faint);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: color var(--duration-fast), background-color var(--duration-fast);
+}
+
+.yi-close:hover { color: var(--color-text); background: var(--color-inset); }
+.yi-close:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
+
+.yi-body {
+  padding: 16px 20px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.yi-editor-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.yi-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-dim);
+}
+
+.yi-starter {
+  font-size: 0.76rem;
+  color: var(--color-cyan);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+.yi-starter:hover { text-decoration: underline; }
+.yi-starter:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
+
+.yi-yaml {
+  width: 100%;
+  min-height: 280px;
+  resize: vertical;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.8rem;
+  line-height: 1.6;
+  color: var(--color-text);
+  background: var(--color-canvas, var(--color-inset));
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded-md);
+  padding: 12px 14px;
+  tab-size: 2;
+}
+
+.yi-yaml:focus { outline: none; border-color: var(--color-primary); box-shadow: 0 0 0 3px var(--color-primary-soft); }
+.yi-yaml:disabled { opacity: 0.6; }
+
+.yi-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  padding: 9px 12px;
+  border-radius: var(--rounded-md);
+  border: 1px solid transparent;
+}
+
+.yi-banner--error {
+  background: var(--color-red-soft);
+  border-color: var(--color-red-line);
+  color: var(--color-red);
+}
+
+.yi-banner--ok {
+  background: var(--color-green-soft);
+  border-color: var(--color-green-line);
+  color: var(--color-green);
+}
+
+.yi-banner svg { flex: none; margin-top: 2px; }
+
+.yi-foot {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 20px;
+  border-top: 1px solid var(--color-border);
+}
+
+.yi-foot-right {
+  margin-left: auto;
+  display: flex;
+  gap: 8px;
+}
+
+.yi-btn {
+  height: 34px;
+  font-size: 0.83rem;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-card-2);
+  color: var(--color-text);
+  border-radius: var(--rounded);
+  padding: 0 14px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  transition: border-color var(--duration-fast), background-color var(--duration-fast);
+}
+
+.yi-btn:hover:not(:disabled) { border-color: var(--color-faint); }
+.yi-btn:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
+.yi-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+.yi-btn--primary {
+  background: var(--color-primary);
+  color: #fff;
+  border-color: transparent;
+  font-weight: 600;
+}
+
+.yi-btn--primary:hover:not(:disabled) { background: var(--color-primary-press); }
+
+.yi-spin {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  border-top-color: currentColor;
+  border-radius: var(--rounded-full);
+  animation: yi-spin 0.7s linear infinite;
+}
+
+@keyframes yi-spin { to { transform: rotate(360deg); } }
+
+@media (prefers-reduced-motion: reduce) {
+  .yi-spin { animation: none; }
+}
+</style>

--- a/web/src/views/ProjectPipeline.vue
+++ b/web/src/views/ProjectPipeline.vue
@@ -25,6 +25,7 @@ import EnvCredsTab from '../components/pipeline/EnvCredsTab.vue'
 import TriggersPanel from '../components/TriggersPanel.vue'
 import ValidationPanel from '../components/pipeline/ValidationPanel.vue'
 import AIGenerateWizard from '../components/pipeline/AIGenerateWizard.vue'
+import YamlImportModal from '../components/pipeline/YamlImportModal.vue'
 
 // ─── Route ────────────────────────────────────────────────────────────────────
 
@@ -254,6 +255,33 @@ function handleAI(): void {
   aiWizardOpen.value = true
 }
 
+// ─── YAML import (Pipeline-as-code, FR-8-12) ──────────────────────────────────
+
+const yamlImportOpen = ref(false)
+
+function handleImport(): void {
+  yamlImportOpen.value = true
+}
+
+/**
+ * Preview (save=false): the modal parsed + validated the YAML and returned a DTO.
+ * Reflect it on the canvas WITHOUT persisting — the user reviews, then clicks 保存草稿.
+ * We jump to the canvas tab so the change is visible.
+ */
+function handleImportPreview(dto: PipelineDTO): void {
+  pipeline.value = dto
+  editStages.value = JSON.parse(JSON.stringify(dto.stages)) as PipelineStage[]
+  if (activeTab.value !== 'canvas') setTab('canvas')
+}
+
+/** Save (save=true): the modal already persisted. Reload everything + revalidate. */
+async function handleImportSaved(): Promise<void> {
+  await Promise.all([loadPipeline(), loadSettings()])
+  if (activeTab.value !== 'canvas') setTab('canvas')
+  showSaveSuccess()
+  scheduleValidation(400)
+}
+
 /** Called by AIGenerateWizard after a successful apply. Reload all data. */
 async function handleAIApplied(): Promise<void> {
   await Promise.all([loadPipeline(), loadSettings()])
@@ -336,6 +364,13 @@ const projectName = computed(() => String(route.params.id))
             <path d="M3 12h3.5l2.2-6 3.6 12 2.4-7 1.3 1h4.5"/>
           </svg>
           AI 生成流水线
+        </button>
+
+        <button class="top-btn" :disabled="saveSubmitting" @click="handleImport">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="M7 10l5 5 5-5"/><path d="M12 15V3"/>
+          </svg>
+          从 YAML 导入
         </button>
 
         <!-- ─── Validation button + ready badge (Story 2-6) ─────────────── -->
@@ -530,6 +565,15 @@ const projectName = computed(() => String(route.params.id))
       :project-id="projectId"
       @close="aiWizardOpen = false"
       @applied="handleAIApplied"
+    />
+
+    <!-- ─── YAML Import (Pipeline-as-code, FR-8-12) ─────────────────────── -->
+    <YamlImportModal
+      v-if="yamlImportOpen"
+      :project-id="projectId"
+      @close="yamlImportOpen = false"
+      @preview="handleImportPreview"
+      @saved="handleImportSaved"
     />
 
   </div>


### PR DESCRIPTION
## 目标(FR-8-12)

让仓库以 **`.pipewright.yml`** 声明流水线(与画布完全相同的声明式模型:stages → jobs,带 `needs`/`when`/`gate`/`allowFailure` 与脚本步骤),流水线随代码一起走。本期范围安全可发:**解析/序列化 + 校验 + 导入/预览端点 + 前端导入动作**;运行时覆盖明确延后(见下)。

## YAML schema 速写

人类友好、字段顺序确定、省略空字段(像 Jenkins/云效 的流水线文件):

```yaml
version: 1                      # 可选,缺省=1
stages:
  - id: stg_src                 # 可选,缺省由领域规范化补 uuid
    name: 流水线源
    kind: source                # source | build | deploy | notify | custom
    jobs:
      - name: Gitee 源
        type: git_source
  - id: stg_build
    name: 构建
    kind: build
    needs: [stg_src]            # 阶段依赖(DAG)
    jobs:
      - name: 运行测试
        type: script
        script:                 # 脚本步骤糖:摊平进 job.config 的扁平 KV
          image: golang:1.23    #   → config.image
          commands:             #   → config.commands(多行命令拼成换行连接串,对齐画布 textarea)
            - go vet ./...
            - go test ./...
          env:                  #   → config.env(JSON 对象串;仅非 secret 明文)
            CGO_ENABLED: "0"
          workdir: src/app      #   → config.workDir(驼峰,对齐画布约定)
  - id: stg_deploy
    name: 部署
    kind: deploy
    needs: [stg_build]
    gate: true                  # 进入前人工审批
    when:                       # 条件执行:分支 glob + 触发类型(与)
      branches: [main, release/*]
      events: [webhook]
    jobs:
      - name: SSH 部署
        type: deploy_ssh
        config:                 # 任意字符串 KV 原样透传(与 script 块可并存)
          targetEnv: prod
  - id: stg_notify
    name: 通知
    kind: notify
    needs: [stg_deploy]
    allowFailure: true          # 自身失败不阻断下游
    jobs:
      - { name: 钉钉通知, type: notify }
```

## 解析器 + 校验(`internal/pipelineyaml`)

- `Parse([]byte) (pipeline.Config, error)` / `Marshal(pipeline.Spec) ([]byte, error)`,带往返测试 + 多阶段 DAG 夹具(needs/when/gate/allowFailure + 脚本步骤)。
- 严格 YAML 解码(`KnownFields(true)`,拒绝拼错的键)→ 摊平 `script` 块进 `Job.Config` → **复用 `pipeline.NormalizeSpec` 做全部领域校验**(不重造规则:阶段名/kind 枚举/任务名/type 非空、id 全局唯一、恰一个 source 阶段、needs 存在性/自指/环检测)→ `pipeline.RenderYAML` 回填规范 YAML。
- 错误信息人读、含阶段/任务定位线索,经 `%w` 双层挂链(`ErrParse` + 领域 `ErrInvalidStage/...`)便于上层精确映射状态码;**绝不回显 secret 明文**(有专门单测断言 env 值不泄漏)。
- `pipeline` 包新增 `NormalizeSpec`/`RenderYAML`/`StatusDraft` 薄导出包装(不改任何既有调用点)。

## 端点

`POST /api/projects/{id}/pipeline/import`(auth + CSRF;请求体限 256KB)

- body `{ "yaml": "...", "save": false }`
- `save=false`(默认):解析+校验,返回解析后的 `pipelineDTO` **预览,不落库**。
- `save=true`:把解析出的 spec 经 `svc.Save` 持久化(走与画布 PUT 完全一致的规范化/校验/渲染/回读)后返回。
- 失败 → 422,错误码 `invalid_yaml` / `invalid_stage` / `invalid_job` / `duplicate_id`。
- 路由在 `{id}` 组内、比 `/pipeline` 多一段不会被吞;router 仅 +1 行,diff 局部化。

## 前端

- 流水线编辑器顶栏新增「从 YAML 导入」按钮 → `YamlImportModal.vue`:粘贴 YAML →「预览校验」(`save=false`,把结果回灌画布、不保存)/「导入到画布」/「导入并保存」(`save=true`);错误码映射 + 服务端脱敏消息内联展示;附示例模板按钮。
- `api/pipeline.ts` 新增 `importPipeline(projectId, yaml, save)` + 单测。
- 预览语义符合「URL/本地状态先行、用户确认后再持久化」:导入预览只改本地 `editStages`,用户在画布确认后照常点「保存草稿」。

## 运行时覆盖(stretch)——**明确延后**

设想做法已想清:在 `dagrun` 注入一个**装饰器 `SpecLoader`**,运行时经既有 `sourceReader` 读 repo 的 `.pipewright.yml`(避免整仓克隆),命中则 `pipelineyaml.Parse` 覆盖库内 spec、未命中回退。**本期不实现**——它要碰执行路径(每次运行按项目读 repo 文件、缓存/失效、与触发分支/ref 绑定、失败语义),属有风险手术,与「安全可发」的本期范围相悖。故按需求中「entangled 则延后」处理,留作独立 story。

## 迁移

**无需迁移**。复用既有 `pipeline_configs` 存储;改动纯增量,存量库内 spec 项目不受影响。未使用 0031 前缀。

## 绿灯证据

后端(`export PATH=...go/bin`):
- `gofmt -l`(touched 文件)→ 空
- `go vet ./...` → 干净
- `go build ./...` → 干净
- `go test ./...` → 28 包 ok,0 FAIL(含新增 `internal/pipelineyaml` 往返/校验测试 + `internal/httpapi` 导入端点测试)

前端(`web/`):
- `npm run typecheck`(vue-tsc)→ 干净
- `npm run test` → 20 文件 / 173 测试 全过
- `npm run build` → 成功(已还原 `web/dist/index.html` 构建 churn,不入库)

🤖 Generated with [Claude Code](https://claude.com/claude-code)