### PR TITLE
feat(metrics): DORA 四指标 — 部署频率/前置时长/变更失败率/MTTR(FR-8-15)

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -120,6 +120,8 @@ func main() {
 	// 装配运行服务(Story 3.1):本期桩 runner 跑占位步骤打通状态机;真实构建/部署=3-3/4-x。
 	// worker pool 在 aiSvc 装配后创建(以便注入 best-effort 自动诊断钩子,Story 7.2)。
 	runSvc := run.New(st.DB)
+	// DORA 指标只读聚合(FR-8-15):同一 *service 实现暴露为 MetricsService,无新连接/新表。
+	doraMetricsSvc := run.NewMetricsService(runSvc)
 
 	// 装配人工审批门协调器 + 持久层(Story 8-4):DAG 调度到 Gate 阶段时阻塞等待批准/拒绝。
 	// 协调器为进程内(零持久状态);记录落 run_approvals 供 UI/审计/重启清理。
@@ -320,7 +322,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithServers(targetSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithChain(chainSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc), httpapi.WithPromotion(promotionStore)),
+		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithServers(targetSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithChain(chainSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc), httpapi.WithPromotion(promotionStore), httpapi.WithDoraMetrics(doraMetricsSvc)),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		// WriteTimeout 置 0:SSE 长连接(/api/runs/{id}/events)不可被写超时切断;

--- a/internal/dora/bands.go
+++ b/internal/dora/bands.go
@@ -1,0 +1,99 @@
+package dora
+
+import "time"
+
+// 绩效分档阈值(对齐 DORA / Accelerate State of DevOps 报告的经典四档口径)。
+//
+// 这些阈值是行业惯例的近似刻度,用于把原始数值翻译成「Elite/High/Medium/Low」直觉标签;
+// 在 CI 运行数据上是参考性的(口径已在 dora.go 顶部声明),不作 SLA 依据。
+//
+// 常量集中于此,便于审阅 / 调参,且让分档函数保持纯粹的「数值 → 标签」映射。
+const (
+	// 部署频率(按日均成功部署数,折算「按需 / 每周 / 每月」直觉)。
+	deployFreqElitePerDay  = 1.0      // ≥ 每天一次(按需多次)→ Elite
+	deployFreqHighPerDay   = 1.0 / 7  // ≥ 每周一次 → High
+	deployFreqMediumPerDay = 1.0 / 30 // ≥ 每月一次 → Medium;低于则 Low
+
+	// 变更前置时长(秒)。
+	leadTimeEliteSeconds  = float64(24 * time.Hour / time.Second)      // < 1 天 → Elite
+	leadTimeHighSeconds   = float64(7 * 24 * time.Hour / time.Second)  // < 1 周 → High
+	leadTimeMediumSeconds = float64(30 * 24 * time.Hour / time.Second) // < 1 月 → Medium;否则 Low
+
+	// 变更失败率(比例 [0,1])。
+	cfrEliteMax  = 0.15 // ≤ 15% → Elite
+	cfrHighMax   = 0.30 // ≤ 30% → High
+	cfrMediumMax = 0.45 // ≤ 45% → Medium;高于则 Low
+
+	// 故障恢复时长(秒)。
+	mttrEliteSeconds  = float64(1 * time.Hour / time.Second)      // < 1 小时 → Elite
+	mttrHighSeconds   = float64(24 * time.Hour / time.Second)     // < 1 天 → High
+	mttrMediumSeconds = float64(7 * 24 * time.Hour / time.Second) // < 1 周 → Medium;否则 Low
+)
+
+// deployFrequencyBand 据日均成功部署数分档。无成功样本 → None(样本不足,不强行分档)。
+func deployFrequencyBand(perDay float64, successCount int) string {
+	if successCount == 0 {
+		return BandNone
+	}
+	switch {
+	case perDay >= deployFreqElitePerDay:
+		return BandElite
+	case perDay >= deployFreqHighPerDay:
+		return BandHigh
+	case perDay >= deployFreqMediumPerDay:
+		return BandMedium
+	default:
+		return BandLow
+	}
+}
+
+// leadTimeBand 据前置时长中位数(秒)分档。无样本 → None。
+func leadTimeBand(seconds float64, sampleCount int) string {
+	if sampleCount == 0 {
+		return BandNone
+	}
+	switch {
+	case seconds < leadTimeEliteSeconds:
+		return BandElite
+	case seconds < leadTimeHighSeconds:
+		return BandHigh
+	case seconds < leadTimeMediumSeconds:
+		return BandMedium
+	default:
+		return BandLow
+	}
+}
+
+// changeFailureRateBand 据变更失败率分档。无部署 → None。
+func changeFailureRateBand(rate float64, totalDeployments int) string {
+	if totalDeployments == 0 {
+		return BandNone
+	}
+	switch {
+	case rate <= cfrEliteMax:
+		return BandElite
+	case rate <= cfrHighMax:
+		return BandHigh
+	case rate <= cfrMediumMax:
+		return BandMedium
+	default:
+		return BandLow
+	}
+}
+
+// mttrBand 据恢复时长中位数(秒)分档。无「失败→恢复」配对 → None。
+func mttrBand(seconds float64, sampleCount int) string {
+	if sampleCount == 0 {
+		return BandNone
+	}
+	switch {
+	case seconds < mttrEliteSeconds:
+		return BandElite
+	case seconds < mttrHighSeconds:
+		return BandHigh
+	case seconds < mttrMediumSeconds:
+		return BandMedium
+	default:
+		return BandLow
+	}
+}

--- a/internal/dora/bands_test.go
+++ b/internal/dora/bands_test.go
@@ -1,0 +1,98 @@
+package dora
+
+import (
+	"testing"
+	"time"
+)
+
+func sec(d time.Duration) float64 { return d.Seconds() }
+
+func TestDeployFrequencyBand(t *testing.T) {
+	tests := []struct {
+		name    string
+		perDay  float64
+		success int
+		want    string
+	}{
+		{"no samples", 0, 0, BandNone},
+		{"elite daily", 2, 60, BandElite},
+		{"elite exactly one per day", 1, 30, BandElite},
+		{"high weekly", 1.0 / 5, 6, BandHigh},
+		{"medium monthly", 1.0 / 20, 1, BandMedium},
+		{"low below monthly", 1.0 / 90, 1, BandLow},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deployFrequencyBand(tt.perDay, tt.success); got != tt.want {
+				t.Fatalf("deployFrequencyBand(%v,%d) = %q, want %q", tt.perDay, tt.success, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLeadTimeBand(t *testing.T) {
+	tests := []struct {
+		name    string
+		seconds float64
+		samples int
+		want    string
+	}{
+		{"no samples", 0, 0, BandNone},
+		{"elite under a day", sec(2 * time.Hour), 3, BandElite},
+		{"high under a week", sec(3 * 24 * time.Hour), 3, BandHigh},
+		{"medium under a month", sec(15 * 24 * time.Hour), 3, BandMedium},
+		{"low over a month", sec(60 * 24 * time.Hour), 3, BandLow},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := leadTimeBand(tt.seconds, tt.samples); got != tt.want {
+				t.Fatalf("leadTimeBand(%v,%d) = %q, want %q", tt.seconds, tt.samples, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestChangeFailureRateBand(t *testing.T) {
+	tests := []struct {
+		name  string
+		rate  float64
+		total int
+		want  string
+	}{
+		{"no deployments", 0, 0, BandNone},
+		{"elite low failure", 0.10, 10, BandElite},
+		{"elite boundary 15pct", 0.15, 10, BandElite},
+		{"high", 0.25, 10, BandHigh},
+		{"medium", 0.40, 10, BandMedium},
+		{"low high failure", 0.80, 10, BandLow},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := changeFailureRateBand(tt.rate, tt.total); got != tt.want {
+				t.Fatalf("changeFailureRateBand(%v,%d) = %q, want %q", tt.rate, tt.total, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMTTRBand(t *testing.T) {
+	tests := []struct {
+		name    string
+		seconds float64
+		samples int
+		want    string
+	}{
+		{"no pairs", 0, 0, BandNone},
+		{"elite under an hour", sec(30 * time.Minute), 2, BandElite},
+		{"high under a day", sec(6 * time.Hour), 2, BandHigh},
+		{"medium under a week", sec(3 * 24 * time.Hour), 2, BandMedium},
+		{"low over a week", sec(10 * 24 * time.Hour), 2, BandLow},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mttrBand(tt.seconds, tt.samples); got != tt.want {
+				t.Fatalf("mttrBand(%v,%d) = %q, want %q", tt.seconds, tt.samples, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/dora/dora.go
+++ b/internal/dora/dora.go
@@ -1,0 +1,243 @@
+// Package dora 计算 DORA 四指标(FR-8-15),对既有运行数据做**只读聚合**(不新增事件采集)。
+//
+// 四指标(DevOps Research and Assessment):
+//   - 部署频率(Deployment Frequency):单位时间内的成功部署次数 / 节奏。
+//   - 变更前置时长(Lead Time for Changes):提交到投产的时长(从可用时间戳近似)。
+//   - 变更失败率(Change Failure Rate):失败部署 / 总部署。
+//   - 故障恢复时长(MTTR / Time to Restore):一次失败到下一次成功之间的时长。
+//
+// 在 CI 运行数据上算 DORA 必然是**近似**的。本包把所有派生口径显式写在常量/注释里,
+// 并把数学下沉为可单测的纯函数(对合成运行集断言),边界(空集 / 除零 / 单条)优雅降级。
+//
+// 派生口径(冻结,前后端 / 文档一致):
+//
+//	一次「部署(deployment)」    = 一条进入**终态**的运行(success|failed|partial_failed|rolled_back)。
+//	                              即把每条结束的运行视作一次投产尝试(平台无独立部署事件流,运行即投产单元)。
+//	一次「成功部署」              = status == success 的终态运行。
+//	一次「失败部署」              = status ∈ {failed, partial_failed, rolled_back} 的终态运行。
+//	                              partial_failed / rolled_back 均计为失败(投产未达预期)。
+//	部署频率(perDay/perWeek)    = 成功部署数 / 窗口天数(再换算到周)。
+//	变更前置时长(LeadTime)      = 每条**成功**部署的 (finished_at − commitTime);
+//	                              commitTime 不可得时回退用 created_at(入队时刻)作提交时间代理。
+//	                              取所有成功部署的**中位数**(抗离群,DORA 惯例)。
+//	变更失败率(CFR)             = 失败部署数 / 终态部署总数;总数为 0 → 0。
+//	故障恢复时长(MTTR)          = 按时间排序的运行序列里,每段「失败 → 下一次成功」的
+//	                              (恢复成功 finished_at − 失败 finished_at) 的**中位数**;
+//	                              无任何「失败后恢复」配对 → 0(未定义,优雅降级)。
+//
+// 本包不依赖 internal/run(避免循环 / 抬高耦合):调用方把运行投影成本包的 Record 切片。
+package dora
+
+import (
+	"sort"
+	"time"
+)
+
+// 终态运行状态(与 internal/run 的枚举字面值一致;本包不 import run 以保持纯净)。
+const (
+	statusSuccess       = "success"
+	statusFailed        = "failed"
+	statusPartialFailed = "partial_failed"
+	statusRolledBack    = "rolled_back"
+)
+
+// Record 是计算 DORA 所需的单条运行投影(由调用方从运行模型映射而来)。
+//
+// 只取计算必需的字段:终态判定靠 Status + FinishedAt;前置时长靠 CommitTime/CreatedAt + FinishedAt。
+// 非终态运行(queued/running/...)由 FinishedAt==nil 自然排除,无需调用方预过滤。
+type Record struct {
+	// Status 是运行状态(success|failed|partial_failed|rolled_back|其它非终态)。
+	Status string
+	// CreatedAt 是入队时刻(必有);CommitTime 不可得时作提交时间代理。
+	CreatedAt time.Time
+	// CommitTime 是提交时刻(可空)。本平台运行模型当前不持久化提交时间,故通常为 nil;
+	// 一旦上游补齐(如 webhook 带 commit 时间),前置时长口径自动更精确,无需改本包。
+	CommitTime *time.Time
+	// FinishedAt 是终态时刻(非终态为 nil — 据此判定「是否一次部署」)。
+	FinishedAt *time.Time
+}
+
+// 部署绩效分档(DORA 四档:Elite / High / Medium / Low)。
+// 字面值稳定(前端据此着色 / 文案),勿改。
+const (
+	// BandElite 表示精英级。
+	BandElite = "elite"
+	// BandHigh 表示高效级。
+	BandHigh = "high"
+	// BandMedium 表示中等级。
+	BandMedium = "medium"
+	// BandLow 表示低效级。
+	BandLow = "low"
+	// BandNone 表示样本不足、无法分档(空窗口)。
+	BandNone = "none"
+)
+
+// Metrics 是一个窗口内聚合出的 DORA 四指标 + 派生分档 + 计数。
+//
+// 时长类指标以秒(float64)表达;无样本时为 0(调用方据 *Count==0 区分「真 0」与「无数据」)。
+type Metrics struct {
+	// WindowDays 是统计窗口天数(>0)。
+	WindowDays float64
+	// TotalDeployments 是窗口内终态运行(部署)总数。
+	TotalDeployments int
+	// SuccessfulDeployments 是成功部署数。
+	SuccessfulDeployments int
+	// FailedDeployments 是失败部署数(failed|partial_failed|rolled_back)。
+	FailedDeployments int
+
+	// DeploymentFrequencyPerDay 是日均成功部署数(SuccessfulDeployments / WindowDays)。
+	DeploymentFrequencyPerDay float64
+	// DeploymentFrequencyPerWeek 是周均成功部署数(便于「每周 N 次」直觉)。
+	DeploymentFrequencyPerWeek float64
+	// LeadTimeSeconds 是变更前置时长中位数(秒);无成功样本 → 0。
+	LeadTimeSeconds float64
+	// LeadTimeSampleCount 是参与前置时长统计的成功部署数。
+	LeadTimeSampleCount int
+	// ChangeFailureRate 是变更失败率 [0,1];无部署 → 0。
+	ChangeFailureRate float64
+	// MTTRSeconds 是故障恢复时长中位数(秒);无「失败→恢复」配对 → 0。
+	MTTRSeconds float64
+	// MTTRSampleCount 是参与 MTTR 统计的「失败→恢复」配对数。
+	MTTRSampleCount int
+
+	// DeploymentFrequencyBand / LeadTimeBand / ChangeFailureRateBand / MTTRBand
+	// 是四指标各自的 DORA 绩效分档(Elite/High/Medium/Low / None)。
+	DeploymentFrequencyBand string
+	LeadTimeBand            string
+	ChangeFailureRateBand   string
+	MTTRBand                string
+}
+
+// isFailure 报告状态是否为「失败部署」(failed | partial_failed | rolled_back)。
+func isFailure(status string) bool {
+	switch status {
+	case statusFailed, statusPartialFailed, statusRolledBack:
+		return true
+	default:
+		return false
+	}
+}
+
+// isTerminalDeployment 报告一条运行是否计作一次「部署」(已进入终态 = 有 FinishedAt 且状态为四终态之一)。
+func isTerminalDeployment(r Record) bool {
+	if r.FinishedAt == nil {
+		return false
+	}
+	return r.Status == statusSuccess || isFailure(r.Status)
+}
+
+// Compute 对一组运行投影计算窗口内的 DORA 四指标。
+//
+// windowDays 是统计窗口天数(<=0 时钳为 1,避免除零并给出合理日频)。records 顺序无所谓
+// (内部按 FinishedAt 排序算 MTTR)。非终态运行被自动忽略(FinishedAt==nil)。
+//
+// 纯函数:无 I/O、无副作用,可对合成集直接断言。
+func Compute(records []Record, windowDays float64) Metrics {
+	if windowDays <= 0 {
+		windowDays = 1
+	}
+	m := Metrics{WindowDays: windowDays}
+
+	// 仅保留终态部署。
+	deploys := make([]Record, 0, len(records))
+	for _, r := range records {
+		if isTerminalDeployment(r) {
+			deploys = append(deploys, r)
+		}
+	}
+
+	leadTimes := make([]float64, 0, len(deploys))
+	for _, r := range deploys {
+		m.TotalDeployments++
+		if r.Status == statusSuccess {
+			m.SuccessfulDeployments++
+			// 前置时长:finished − commit(commit 不可得 → created 代理)。负值丢弃(脏数据防御)。
+			commit := r.CreatedAt
+			if r.CommitTime != nil {
+				commit = *r.CommitTime
+			}
+			if lt := r.FinishedAt.Sub(commit).Seconds(); lt >= 0 {
+				leadTimes = append(leadTimes, lt)
+			}
+		} else {
+			m.FailedDeployments++
+		}
+	}
+
+	// 部署频率:成功部署 / 窗口。
+	m.DeploymentFrequencyPerDay = float64(m.SuccessfulDeployments) / windowDays
+	m.DeploymentFrequencyPerWeek = m.DeploymentFrequencyPerDay * 7
+
+	// 前置时长:成功样本中位数。
+	m.LeadTimeSampleCount = len(leadTimes)
+	m.LeadTimeSeconds = median(leadTimes)
+
+	// 变更失败率:失败 / 总部署(总数 0 → 0,避免 NaN)。
+	if m.TotalDeployments > 0 {
+		m.ChangeFailureRate = float64(m.FailedDeployments) / float64(m.TotalDeployments)
+	}
+
+	// MTTR:按完成时间排序,逐段「失败 → 下一次成功」配对。
+	restoreTimes := mttrRestoreSeconds(deploys)
+	m.MTTRSampleCount = len(restoreTimes)
+	m.MTTRSeconds = median(restoreTimes)
+
+	// 分档。
+	m.DeploymentFrequencyBand = deployFrequencyBand(m.DeploymentFrequencyPerDay, m.SuccessfulDeployments)
+	m.LeadTimeBand = leadTimeBand(m.LeadTimeSeconds, m.LeadTimeSampleCount)
+	m.ChangeFailureRateBand = changeFailureRateBand(m.ChangeFailureRate, m.TotalDeployments)
+	m.MTTRBand = mttrBand(m.MTTRSeconds, m.MTTRSampleCount)
+
+	return m
+}
+
+// mttrRestoreSeconds 按完成时间升序扫描部署序列,对每个「失败段 → 下一次成功」产出恢复时长(秒)。
+//
+// 语义:进入失败态后,记录该段最早一次失败的完成时刻 failStart;遇到下一次成功时,
+// 产出 (success.finished − failStart),并清空失败段(等待下一次失败开启新段)。
+// 连续多次失败只按**该段最早**一次失败起算(故障从首次失败算起,到恢复为止)。
+// 末尾悬空的失败段(尚未恢复)不产出配对(未恢复,不纳入恢复时长统计)。
+func mttrRestoreSeconds(deploys []Record) []float64 {
+	ordered := make([]Record, len(deploys))
+	copy(ordered, deploys)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].FinishedAt.Before(*ordered[j].FinishedAt)
+	})
+
+	out := []float64{}
+	var failStart *time.Time
+	for i := range ordered {
+		r := ordered[i]
+		if isFailure(r.Status) {
+			if failStart == nil {
+				ft := *r.FinishedAt
+				failStart = &ft
+			}
+			continue
+		}
+		// 成功:若处于失败段中,结算恢复时长。
+		if r.Status == statusSuccess && failStart != nil {
+			if d := r.FinishedAt.Sub(*failStart).Seconds(); d >= 0 {
+				out = append(out, d)
+			}
+			failStart = nil
+		}
+	}
+	return out
+}
+
+// median 返回切片中位数(升序后取中;偶数个取中间两者均值)。空切片 → 0。
+func median(values []float64) float64 {
+	n := len(values)
+	if n == 0 {
+		return 0
+	}
+	sorted := make([]float64, n)
+	copy(sorted, values)
+	sort.Float64s(sorted)
+	mid := n / 2
+	if n%2 == 1 {
+		return sorted[mid]
+	}
+	return (sorted[mid-1] + sorted[mid]) / 2
+}

--- a/internal/dora/dora_test.go
+++ b/internal/dora/dora_test.go
@@ -1,0 +1,251 @@
+package dora
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// base 是测试用的固定参照时刻(UTC)。
+var base = time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+// at 返回 base + d 的指针(便于构造 FinishedAt/CommitTime)。
+func at(d time.Duration) *time.Time {
+	t := base.Add(d)
+	return &t
+}
+
+// success 构造一条成功终态运行:created 在 commitOffset,finished 在 finishOffset。
+func success(createdOffset, finishOffset time.Duration) Record {
+	return Record{Status: statusSuccess, CreatedAt: base.Add(createdOffset), FinishedAt: at(finishOffset)}
+}
+
+// failed 构造一条失败终态运行。
+func failed(status string, createdOffset, finishOffset time.Duration) Record {
+	return Record{Status: status, CreatedAt: base.Add(createdOffset), FinishedAt: at(finishOffset)}
+}
+
+const eps = 1e-9
+
+func almostEqual(a, b float64) bool { return math.Abs(a-b) < eps }
+
+func TestCompute_Empty(t *testing.T) {
+	m := Compute(nil, 30)
+	if m.TotalDeployments != 0 || m.SuccessfulDeployments != 0 || m.FailedDeployments != 0 {
+		t.Fatalf("empty: counts not zero: %+v", m)
+	}
+	if m.DeploymentFrequencyPerDay != 0 || m.LeadTimeSeconds != 0 || m.ChangeFailureRate != 0 || m.MTTRSeconds != 0 {
+		t.Fatalf("empty: metrics not zero: %+v", m)
+	}
+	// 空窗口各指标分档应为 None(样本不足)。
+	if m.DeploymentFrequencyBand != BandNone || m.LeadTimeBand != BandNone ||
+		m.ChangeFailureRateBand != BandNone || m.MTTRBand != BandNone {
+		t.Fatalf("empty: bands not None: %+v", m)
+	}
+}
+
+func TestCompute_IgnoresNonTerminal(t *testing.T) {
+	recs := []Record{
+		{Status: "queued", CreatedAt: base},           // FinishedAt nil → 忽略
+		{Status: "running", CreatedAt: base},          // 忽略
+		{Status: "waiting_approval", CreatedAt: base}, // 忽略
+		{Status: statusSuccess, CreatedAt: base},      // FinishedAt nil → 即便 success 也忽略(未结束)
+		success(0, time.Hour),                         // 唯一计入的部署
+	}
+	m := Compute(recs, 30)
+	if m.TotalDeployments != 1 || m.SuccessfulDeployments != 1 {
+		t.Fatalf("expected 1 terminal deployment, got %+v", m)
+	}
+}
+
+func TestCompute_DeploymentFrequency(t *testing.T) {
+	// 30 天窗口内 15 次成功部署 → 0.5/天 → 3.5/周。
+	recs := make([]Record, 0, 15)
+	for i := 0; i < 15; i++ {
+		recs = append(recs, success(time.Duration(i)*time.Hour, time.Duration(i)*time.Hour+time.Hour))
+	}
+	m := Compute(recs, 30)
+	if !almostEqual(m.DeploymentFrequencyPerDay, 0.5) {
+		t.Fatalf("perDay = %v, want 0.5", m.DeploymentFrequencyPerDay)
+	}
+	if !almostEqual(m.DeploymentFrequencyPerWeek, 3.5) {
+		t.Fatalf("perWeek = %v, want 3.5", m.DeploymentFrequencyPerWeek)
+	}
+}
+
+func TestCompute_WindowDaysClampedToOne(t *testing.T) {
+	m := Compute([]Record{success(0, time.Hour)}, 0)
+	if m.WindowDays != 1 {
+		t.Fatalf("windowDays clamp = %v, want 1", m.WindowDays)
+	}
+	if !almostEqual(m.DeploymentFrequencyPerDay, 1) {
+		t.Fatalf("perDay = %v, want 1", m.DeploymentFrequencyPerDay)
+	}
+}
+
+func TestCompute_LeadTimeMedian_UsesCommitWhenPresent(t *testing.T) {
+	// 三条成功:lead = 1h, 2h, 4h → 中位数 2h。
+	r1 := Record{Status: statusSuccess, CreatedAt: base, CommitTime: at(0), FinishedAt: at(time.Hour)}
+	r2 := Record{Status: statusSuccess, CreatedAt: base, CommitTime: at(0), FinishedAt: at(2 * time.Hour)}
+	r3 := Record{Status: statusSuccess, CreatedAt: base, CommitTime: at(0), FinishedAt: at(4 * time.Hour)}
+	m := Compute([]Record{r1, r2, r3}, 30)
+	if m.LeadTimeSampleCount != 3 {
+		t.Fatalf("leadTime sample = %d, want 3", m.LeadTimeSampleCount)
+	}
+	if !almostEqual(m.LeadTimeSeconds, (2 * time.Hour).Seconds()) {
+		t.Fatalf("leadTime = %v, want %v", m.LeadTimeSeconds, (2 * time.Hour).Seconds())
+	}
+}
+
+func TestCompute_LeadTimeFallsBackToCreatedAt(t *testing.T) {
+	// 无 CommitTime → 用 CreatedAt 当提交代理:created=base, finished=base+3h → lead 3h。
+	r := success(0, 3*time.Hour) // createdOffset 0 → CreatedAt = base
+	m := Compute([]Record{r}, 30)
+	if !almostEqual(m.LeadTimeSeconds, (3 * time.Hour).Seconds()) {
+		t.Fatalf("leadTime fallback = %v, want %v", m.LeadTimeSeconds, (3 * time.Hour).Seconds())
+	}
+}
+
+func TestCompute_LeadTimeEvenMedian(t *testing.T) {
+	// 偶数个样本 lead = 1h, 3h → 中位数 (1+3)/2 = 2h。
+	r1 := success(0, time.Hour)
+	r2 := success(0, 3*time.Hour)
+	m := Compute([]Record{r1, r2}, 30)
+	if !almostEqual(m.LeadTimeSeconds, (2 * time.Hour).Seconds()) {
+		t.Fatalf("even median = %v, want %v", m.LeadTimeSeconds, (2 * time.Hour).Seconds())
+	}
+}
+
+func TestCompute_LeadTimeNegativeDiscarded(t *testing.T) {
+	// finished 早于 commit(脏数据)→ 该样本丢弃;只剩一条有效 lead=2h。
+	dirty := Record{Status: statusSuccess, CreatedAt: base, CommitTime: at(5 * time.Hour), FinishedAt: at(time.Hour)}
+	good := Record{Status: statusSuccess, CreatedAt: base, CommitTime: at(0), FinishedAt: at(2 * time.Hour)}
+	m := Compute([]Record{dirty, good}, 30)
+	if m.LeadTimeSampleCount != 1 {
+		t.Fatalf("expected 1 valid lead sample, got %d", m.LeadTimeSampleCount)
+	}
+	if !almostEqual(m.LeadTimeSeconds, (2 * time.Hour).Seconds()) {
+		t.Fatalf("leadTime = %v, want 2h", m.LeadTimeSeconds)
+	}
+	// 但 dirty 仍计入成功部署数(它确实成功了,只是 lead 不可信)。
+	if m.SuccessfulDeployments != 2 {
+		t.Fatalf("successful deployments = %d, want 2", m.SuccessfulDeployments)
+	}
+}
+
+func TestCompute_ChangeFailureRate(t *testing.T) {
+	// 2 成功 + 1 failed + 1 partial_failed + 1 rolled_back → 失败 3 / 总 5 = 0.6。
+	recs := []Record{
+		success(0, time.Hour),
+		success(0, time.Hour),
+		failed(statusFailed, 0, time.Hour),
+		failed(statusPartialFailed, 0, time.Hour),
+		failed(statusRolledBack, 0, time.Hour),
+	}
+	m := Compute(recs, 30)
+	if m.TotalDeployments != 5 || m.FailedDeployments != 3 || m.SuccessfulDeployments != 2 {
+		t.Fatalf("counts = %+v", m)
+	}
+	if !almostEqual(m.ChangeFailureRate, 0.6) {
+		t.Fatalf("CFR = %v, want 0.6", m.ChangeFailureRate)
+	}
+}
+
+func TestCompute_ChangeFailureRate_DivisionByZeroSafe(t *testing.T) {
+	// 只有非终态运行 → 0 部署 → CFR 0(非 NaN)。
+	m := Compute([]Record{{Status: "running", CreatedAt: base}}, 30)
+	if m.ChangeFailureRate != 0 || math.IsNaN(m.ChangeFailureRate) {
+		t.Fatalf("CFR = %v, want 0", m.ChangeFailureRate)
+	}
+}
+
+func TestCompute_MTTR_SinglePair(t *testing.T) {
+	// 失败@1h → 成功@4h → 恢复 3h。
+	recs := []Record{
+		failed(statusFailed, 0, time.Hour),
+		success(0, 4*time.Hour),
+	}
+	m := Compute(recs, 30)
+	if m.MTTRSampleCount != 1 {
+		t.Fatalf("MTTR sample = %d, want 1", m.MTTRSampleCount)
+	}
+	if !almostEqual(m.MTTRSeconds, (3 * time.Hour).Seconds()) {
+		t.Fatalf("MTTR = %v, want 3h", m.MTTRSeconds)
+	}
+}
+
+func TestCompute_MTTR_ConsecutiveFailuresUseEarliest(t *testing.T) {
+	// 失败@1h, 失败@2h, 成功@5h → 故障从首次失败(1h)算起 → 恢复 4h(只一对)。
+	recs := []Record{
+		failed(statusFailed, 0, time.Hour),
+		failed(statusFailed, 0, 2*time.Hour),
+		success(0, 5*time.Hour),
+	}
+	m := Compute(recs, 30)
+	if m.MTTRSampleCount != 1 {
+		t.Fatalf("MTTR sample = %d, want 1 (consecutive failures collapse)", m.MTTRSampleCount)
+	}
+	if !almostEqual(m.MTTRSeconds, (4 * time.Hour).Seconds()) {
+		t.Fatalf("MTTR = %v, want 4h", m.MTTRSeconds)
+	}
+}
+
+func TestCompute_MTTR_MultiplePairsMedian(t *testing.T) {
+	// 段1: 失败@1h → 成功@3h(2h);段2: 失败@5h → 成功@9h(4h)。中位数(2 样本)=(2+4)/2=3h。
+	recs := []Record{
+		failed(statusFailed, 0, time.Hour),
+		success(0, 3*time.Hour),
+		failed(statusRolledBack, 0, 5*time.Hour),
+		success(0, 9*time.Hour),
+	}
+	m := Compute(recs, 30)
+	if m.MTTRSampleCount != 2 {
+		t.Fatalf("MTTR sample = %d, want 2", m.MTTRSampleCount)
+	}
+	if !almostEqual(m.MTTRSeconds, (3 * time.Hour).Seconds()) {
+		t.Fatalf("MTTR median = %v, want 3h", m.MTTRSeconds)
+	}
+}
+
+func TestCompute_MTTR_DanglingFailureNoPair(t *testing.T) {
+	// 成功@1h → 失败@3h(末尾未恢复)→ 无配对。
+	recs := []Record{
+		success(0, time.Hour),
+		failed(statusFailed, 0, 3*time.Hour),
+	}
+	m := Compute(recs, 30)
+	if m.MTTRSampleCount != 0 || m.MTTRSeconds != 0 {
+		t.Fatalf("dangling failure should yield no MTTR pair: %+v", m)
+	}
+	if m.MTTRBand != BandNone {
+		t.Fatalf("MTTR band = %q, want none", m.MTTRBand)
+	}
+}
+
+func TestCompute_MTTR_UnorderedInputSorted(t *testing.T) {
+	// 乱序输入仍按完成时间排序:失败@1h → 成功@2h → 恢复 1h。
+	recs := []Record{
+		success(0, 2*time.Hour),
+		failed(statusFailed, 0, time.Hour),
+	}
+	m := Compute(recs, 30)
+	if !almostEqual(m.MTTRSeconds, time.Hour.Seconds()) {
+		t.Fatalf("MTTR (unordered) = %v, want 1h", m.MTTRSeconds)
+	}
+}
+
+func TestCompute_LeadingSuccessDoesNotCountAsRecovery(t *testing.T) {
+	// 成功@1h(无前序失败)→ 失败@2h → 成功@4h:只有第二段配对(2h)。
+	recs := []Record{
+		success(0, time.Hour),
+		failed(statusFailed, 0, 2*time.Hour),
+		success(0, 4*time.Hour),
+	}
+	m := Compute(recs, 30)
+	if m.MTTRSampleCount != 1 {
+		t.Fatalf("MTTR sample = %d, want 1 (leading success ignored)", m.MTTRSampleCount)
+	}
+	if !almostEqual(m.MTTRSeconds, (2 * time.Hour).Seconds()) {
+		t.Fatalf("MTTR = %v, want 2h", m.MTTRSeconds)
+	}
+}

--- a/internal/dora/trend.go
+++ b/internal/dora/trend.go
@@ -1,0 +1,95 @@
+package dora
+
+import (
+	"sort"
+	"time"
+)
+
+// TrendPoint 是趋势序列里的一个时间桶(默认按天)的聚合,供前端画 sparkline / 迷你折线。
+//
+// 每个桶独立按「该桶内的终态部署」算频率 / 失败率(轻量,不含 lead/MTTR 跨桶配对,
+// 避免桶边界把一段故障切碎)。BucketStart 是桶起始时刻(UTC,RFC3339 由 HTTP 层格式化)。
+type TrendPoint struct {
+	// BucketStart 是该桶起始时刻(UTC,按天对齐到 00:00:00)。
+	BucketStart time.Time
+	// Deployments 是该桶内终态部署总数。
+	Deployments int
+	// Successes 是该桶内成功部署数。
+	Successes int
+	// Failures 是该桶内失败部署数。
+	Failures int
+	// ChangeFailureRate 是该桶变更失败率 [0,1];桶内无部署 → 0。
+	ChangeFailureRate float64
+}
+
+// ComputeTrend 把 [windowStart, now] 切成 bucketCount 个等宽桶(按天对齐),逐桶聚合部署计数。
+//
+// windowStart 是窗口起点(UTC),now 是窗口终点;bucketCount<=0 时退化为不产出趋势(返回空切片)。
+// 每条 record 按 FinishedAt 落桶;落在窗口外或非终态的运行被忽略。
+// 桶按天对齐:bucketDays = ceil(windowDays / bucketCount),保证整天边界,前端 x 轴可读。
+//
+// 纯函数:可对合成集断言桶计数。
+func ComputeTrend(records []Record, windowStart, now time.Time, bucketCount int) []TrendPoint {
+	if bucketCount <= 0 || !now.After(windowStart) {
+		return []TrendPoint{}
+	}
+
+	windowStart = windowStart.UTC()
+	now = now.UTC()
+
+	// 桶宽(整天):至少 1 天。
+	totalDays := int(now.Sub(windowStart).Hours()/24) + 1
+	bucketDays := (totalDays + bucketCount - 1) / bucketCount
+	if bucketDays < 1 {
+		bucketDays = 1
+	}
+
+	// 把窗口起点对齐到当天 00:00 UTC,使桶边界落在整天。
+	origin := time.Date(windowStart.Year(), windowStart.Month(), windowStart.Day(), 0, 0, 0, 0, time.UTC)
+	bucketDur := time.Duration(bucketDays) * 24 * time.Hour
+
+	// 桶数:覆盖到 now。
+	span := now.Sub(origin)
+	nBuckets := int(span/bucketDur) + 1
+	if nBuckets < 1 {
+		nBuckets = 1
+	}
+
+	points := make([]TrendPoint, nBuckets)
+	for i := range points {
+		points[i] = TrendPoint{BucketStart: origin.Add(time.Duration(i) * bucketDur)}
+	}
+
+	for _, r := range records {
+		if !isTerminalDeployment(r) {
+			continue
+		}
+		ft := r.FinishedAt.UTC()
+		if ft.Before(origin) || ft.After(now) {
+			continue
+		}
+		idx := int(ft.Sub(origin) / bucketDur)
+		if idx < 0 || idx >= nBuckets {
+			continue
+		}
+		p := &points[idx]
+		p.Deployments++
+		if r.Status == statusSuccess {
+			p.Successes++
+		} else {
+			p.Failures++
+		}
+	}
+
+	for i := range points {
+		if points[i].Deployments > 0 {
+			points[i].ChangeFailureRate = float64(points[i].Failures) / float64(points[i].Deployments)
+		}
+	}
+
+	// 已天然按 BucketStart 升序(origin + i*dur),但稳妥起见显式排序。
+	sort.SliceStable(points, func(i, j int) bool {
+		return points[i].BucketStart.Before(points[j].BucketStart)
+	})
+	return points
+}

--- a/internal/dora/trend_test.go
+++ b/internal/dora/trend_test.go
@@ -1,0 +1,93 @@
+package dora
+
+import (
+	"testing"
+	"time"
+)
+
+func TestComputeTrend_Empty(t *testing.T) {
+	start := base
+	now := base.Add(7 * 24 * time.Hour)
+	pts := ComputeTrend(nil, start, now, 7)
+	if len(pts) == 0 {
+		t.Fatalf("expected non-empty bucket skeleton, got 0")
+	}
+	for _, p := range pts {
+		if p.Deployments != 0 || p.ChangeFailureRate != 0 {
+			t.Fatalf("empty trend bucket not zero: %+v", p)
+		}
+	}
+}
+
+func TestComputeTrend_ZeroBucketsOrBadWindow(t *testing.T) {
+	if got := ComputeTrend(nil, base, base.Add(time.Hour), 0); len(got) != 0 {
+		t.Fatalf("bucketCount 0 should yield empty, got %d", len(got))
+	}
+	if got := ComputeTrend(nil, base, base, 7); len(got) != 0 {
+		t.Fatalf("now==start should yield empty, got %d", len(got))
+	}
+	if got := ComputeTrend(nil, base.Add(time.Hour), base, 7); len(got) != 0 {
+		t.Fatalf("now<start should yield empty, got %d", len(got))
+	}
+}
+
+func TestComputeTrend_BucketsByDay(t *testing.T) {
+	// 7 天窗口、7 桶 → 每桶 1 天。在第 0 天放 2 成功 1 失败,第 3 天放 1 成功。
+	start := base
+	now := base.Add(6*24*time.Hour + 23*time.Hour)
+	recs := []Record{
+		success(0, 1*time.Hour),                // day 0
+		success(0, 2*time.Hour),                // day 0
+		failed(statusFailed, 0, 3*time.Hour),   // day 0
+		success(0, 3*24*time.Hour+1*time.Hour), // day 3
+	}
+	pts := ComputeTrend(recs, start, now, 7)
+	if len(pts) != 7 {
+		t.Fatalf("expected 7 daily buckets, got %d", len(pts))
+	}
+	if pts[0].Deployments != 3 || pts[0].Successes != 2 || pts[0].Failures != 1 {
+		t.Fatalf("day 0 bucket = %+v", pts[0])
+	}
+	if !almostEqual(pts[0].ChangeFailureRate, 1.0/3) {
+		t.Fatalf("day 0 CFR = %v, want 1/3", pts[0].ChangeFailureRate)
+	}
+	if pts[3].Deployments != 1 || pts[3].Successes != 1 {
+		t.Fatalf("day 3 bucket = %+v", pts[3])
+	}
+	// 其余桶应为空。
+	for i, p := range pts {
+		if i == 0 || i == 3 {
+			continue
+		}
+		if p.Deployments != 0 {
+			t.Fatalf("bucket %d expected empty, got %+v", i, p)
+		}
+	}
+}
+
+func TestComputeTrend_IgnoresNonTerminalAndOutOfWindow(t *testing.T) {
+	start := base
+	now := base.Add(3 * 24 * time.Hour)
+	recs := []Record{
+		{Status: "running", CreatedAt: base}, // 非终态 → 忽略
+		{Status: statusSuccess, CreatedAt: base.Add(-48 * time.Hour), FinishedAt: at(-24 * time.Hour)}, // 窗口前 → 忽略
+		success(0, 1*time.Hour), // 计入
+	}
+	pts := ComputeTrend(recs, start, now, 3)
+	total := 0
+	for _, p := range pts {
+		total += p.Deployments
+	}
+	if total != 1 {
+		t.Fatalf("expected 1 in-window terminal deployment, got %d", total)
+	}
+}
+
+func TestComputeTrend_Ascending(t *testing.T) {
+	pts := ComputeTrend([]Record{success(0, time.Hour)}, base, base.Add(5*24*time.Hour), 5)
+	for i := 1; i < len(pts); i++ {
+		if !pts[i].BucketStart.After(pts[i-1].BucketStart) {
+			t.Fatalf("buckets not strictly ascending at %d: %v <= %v", i, pts[i].BucketStart, pts[i-1].BucketStart)
+		}
+	}
+}

--- a/internal/httpapi/dora.go
+++ b/internal/httpapi/dora.go
@@ -1,0 +1,200 @@
+package httpapi
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/huangchengsir/pipewright/internal/dora"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// dora.go 挂载 DORA 四指标只读端点(FR-8-15):
+//
+//	GET /api/metrics/dora?projectId=&window=30d
+//	  → { deploymentFrequency, leadTimeSeconds, changeFailureRate, mttrSeconds, window, trend, ... }
+//
+// 纯只读聚合:取窗口内运行投影(run.MetricsService)→ dora.Compute / dora.ComputeTrend → DTO。
+// 无副作用、无新表。认证由路由组的 requireAuth 统一兜底(GET 豁免 CSRF)。
+//
+// 派生口径见 internal/dora 包顶部注释(部署=终态运行;成功部署=success;失败=failed/partial/rolled_back;
+// 前置时长=finished−commit,commit 不可得回退 created;MTTR=失败→恢复成功配对中位数)。
+
+const (
+	// doraDefaultWindowDays 是默认统计窗口(天)。
+	doraDefaultWindowDays = 30
+	// doraMaxWindowDays 是窗口上界(防超长扫描;约两年)。
+	doraMaxWindowDays = 730
+	// doraTrendBuckets 是趋势序列的目标桶数(前端 sparkline 点数;实际按天对齐取整)。
+	doraTrendBuckets = 12
+)
+
+// doraMetricDTO 是单个指标的统一表达:数值 + DORA 绩效分档 + 样本数(供前端判「无数据」)。
+type doraMetricDTO struct {
+	// Value 是指标数值(频率为日均成功部署数;时长为秒;失败率为 [0,1] 比例)。
+	Value float64 `json:"value"`
+	// Band 是 DORA 绩效分档(elite|high|medium|low|none)。
+	Band string `json:"band"`
+	// SampleCount 是参与该指标统计的样本数(0 = 无数据,前端显「—」而非「0」)。
+	SampleCount int `json:"sampleCount"`
+}
+
+// doraTrendPointDTO 是趋势序列的一个时间桶(冻结形状;前端画迷你折线)。
+type doraTrendPointDTO struct {
+	BucketStart       string  `json:"bucketStart"`
+	Deployments       int     `json:"deployments"`
+	Successes         int     `json:"successes"`
+	Failures          int     `json:"failures"`
+	ChangeFailureRate float64 `json:"changeFailureRate"`
+}
+
+// doraResponseDTO 是 GET /api/metrics/dora 响应体。
+//
+// 四个核心指标既给「裸值」字段(deploymentFrequency/leadTimeSeconds/changeFailureRate/mttrSeconds,
+// 便于直接消费),又在 metrics 块给「值+分档+样本数」的完整形态(前端卡片)。
+type doraResponseDTO struct {
+	// 窗口与计数。
+	Window                string `json:"window"`
+	WindowDays            int    `json:"windowDays"`
+	ProjectID             string `json:"projectId"`
+	TotalDeployments      int    `json:"totalDeployments"`
+	SuccessfulDeployments int    `json:"successfulDeployments"`
+	FailedDeployments     int    `json:"failedDeployments"`
+
+	// 裸值(便捷消费)。
+	DeploymentFrequency        float64 `json:"deploymentFrequency"`        // 日均成功部署数
+	DeploymentFrequencyPerWeek float64 `json:"deploymentFrequencyPerWeek"` // 周均
+	LeadTimeSeconds            float64 `json:"leadTimeSeconds"`
+	ChangeFailureRate          float64 `json:"changeFailureRate"`
+	MTTRSeconds                float64 `json:"mttrSeconds"`
+
+	// 完整形态(值+分档+样本)。
+	Metrics doraMetricsBlockDTO `json:"metrics"`
+
+	// 趋势(按天对齐的时间桶;前端 sparkline)。
+	Trend []doraTrendPointDTO `json:"trend"`
+
+	// GeneratedAt 是聚合时刻(RFC3339;前端显「数据截至」)。
+	GeneratedAt string `json:"generatedAt"`
+}
+
+type doraMetricsBlockDTO struct {
+	DeploymentFrequency doraMetricDTO `json:"deploymentFrequency"`
+	LeadTime            doraMetricDTO `json:"leadTime"`
+	ChangeFailureRate   doraMetricDTO `json:"changeFailureRate"`
+	MTTR                doraMetricDTO `json:"mttr"`
+}
+
+// makeDoraMetricsHandler 返回 GET /api/metrics/dora handler(只读 + 认证)。
+// ms 为 nil → 503(服务未初始化)。projectId 可选(空 = 全部项目);window 形如 30d / 7d(默认 30d)。
+func makeDoraMetricsHandler(ms run.MetricsService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if ms == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "运行服务未初始化")
+			return
+		}
+		q := r.URL.Query()
+		projectID := strings.TrimSpace(q.Get("projectId"))
+
+		windowDays, windowLabel, ok := parseWindowDays(q.Get("window"))
+		if !ok {
+			writeError(w, http.StatusBadRequest, "invalid_window", "window 必须形如 30d / 7d / 90d,且不超过 730 天")
+			return
+		}
+
+		now := time.Now().UTC()
+		since := now.Add(-time.Duration(windowDays) * 24 * time.Hour)
+
+		records, err := ms.MetricsRecords(r.Context(), projectID, since)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+			return
+		}
+
+		doraRecords := make([]dora.Record, 0, len(records))
+		for _, rec := range records {
+			doraRecords = append(doraRecords, dora.Record{
+				Status:     rec.Status,
+				CreatedAt:  rec.CreatedAt,
+				FinishedAt: rec.FinishedAt,
+				// CommitTime 暂不可得(运行模型未持久化提交时间);dora 层回退用 CreatedAt 作代理。
+			})
+		}
+
+		m := dora.Compute(doraRecords, float64(windowDays))
+		trend := dora.ComputeTrend(doraRecords, since, now, doraTrendBuckets)
+
+		writeJSON(w, http.StatusOK, toDoraResponse(m, trend, windowLabel, windowDays, projectID, now))
+	}
+}
+
+// toDoraResponse 把 dora 计算结果映射为响应 DTO。
+func toDoraResponse(m dora.Metrics, trend []dora.TrendPoint, windowLabel string, windowDays int, projectID string, now time.Time) doraResponseDTO {
+	points := make([]doraTrendPointDTO, 0, len(trend))
+	for _, p := range trend {
+		points = append(points, doraTrendPointDTO{
+			BucketStart:       p.BucketStart.UTC().Format(time.RFC3339),
+			Deployments:       p.Deployments,
+			Successes:         p.Successes,
+			Failures:          p.Failures,
+			ChangeFailureRate: p.ChangeFailureRate,
+		})
+	}
+
+	return doraResponseDTO{
+		Window:                     windowLabel,
+		WindowDays:                 windowDays,
+		ProjectID:                  projectID,
+		TotalDeployments:           m.TotalDeployments,
+		SuccessfulDeployments:      m.SuccessfulDeployments,
+		FailedDeployments:          m.FailedDeployments,
+		DeploymentFrequency:        m.DeploymentFrequencyPerDay,
+		DeploymentFrequencyPerWeek: m.DeploymentFrequencyPerWeek,
+		LeadTimeSeconds:            m.LeadTimeSeconds,
+		ChangeFailureRate:          m.ChangeFailureRate,
+		MTTRSeconds:                m.MTTRSeconds,
+		Metrics: doraMetricsBlockDTO{
+			DeploymentFrequency: doraMetricDTO{
+				Value:       m.DeploymentFrequencyPerDay,
+				Band:        m.DeploymentFrequencyBand,
+				SampleCount: m.SuccessfulDeployments,
+			},
+			LeadTime: doraMetricDTO{
+				Value:       m.LeadTimeSeconds,
+				Band:        m.LeadTimeBand,
+				SampleCount: m.LeadTimeSampleCount,
+			},
+			ChangeFailureRate: doraMetricDTO{
+				Value:       m.ChangeFailureRate,
+				Band:        m.ChangeFailureRateBand,
+				SampleCount: m.TotalDeployments,
+			},
+			MTTR: doraMetricDTO{
+				Value:       m.MTTRSeconds,
+				Band:        m.MTTRBand,
+				SampleCount: m.MTTRSampleCount,
+			},
+		},
+		Trend:       points,
+		GeneratedAt: now.UTC().Format(time.RFC3339),
+	}
+}
+
+// parseWindowDays 解析 window 参数(形如 "30d" / "7d" / "90d";也接受纯数字当天数)。
+// 空 → 默认 30d。返回 (天数, 规范化标签, 是否合法)。超界/非法 → ok=false。
+func parseWindowDays(raw string) (days int, label string, ok bool) {
+	raw = strings.TrimSpace(strings.ToLower(raw))
+	if raw == "" {
+		return doraDefaultWindowDays, strconv.Itoa(doraDefaultWindowDays) + "d", true
+	}
+	numStr := raw
+	if strings.HasSuffix(raw, "d") {
+		numStr = strings.TrimSuffix(raw, "d")
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(numStr))
+	if err != nil || n < 1 || n > doraMaxWindowDays {
+		return 0, "", false
+	}
+	return n, strconv.Itoa(n) + "d", true
+}

--- a/internal/httpapi/dora_test.go
+++ b/internal/httpapi/dora_test.go
@@ -1,0 +1,203 @@
+package httpapi
+
+import (
+	"database/sql"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/huangchengsir/pipewright/internal/auth"
+	"github.com/huangchengsir/pipewright/internal/run"
+	"github.com/huangchengsir/pipewright/internal/vault"
+)
+
+// setupDoraServer 构造带 auth + DORA 指标端点的测试 server。返回 server / client / csrf / DB。
+func setupDoraServer(t *testing.T) (*httptest.Server, *http.Client, string, *sql.DB) {
+	t.Helper()
+	st := testStoreAuth(t)
+	svc := auth.NewService(st.DB, nil)
+	if err := svc.Bootstrap("admin", "testpass"); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	v := vault.New(st.DB, testMasterKey())
+	rsvc := run.New(st.DB)
+	ms := run.NewMetricsService(rsvc)
+
+	srv := httptest.NewServer(New(testWebFSAuth(), svc, WithVault(v), WithDoraMetrics(ms)))
+	t.Cleanup(srv.Close)
+
+	client := newTestClient(t)
+	csrf := loginWithClient(t, client, srv.URL)
+	return srv, client, csrf, st.DB
+}
+
+func TestDoraMetrics_RequiresAuth(t *testing.T) {
+	st := testStoreAuth(t)
+	svc := auth.NewService(st.DB, nil)
+	if err := svc.Bootstrap("admin", "testpass"); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	ms := run.NewMetricsService(run.New(st.DB))
+	srv := httptest.NewServer(New(testWebFSAuth(), svc, WithDoraMetrics(ms)))
+	t.Cleanup(srv.Close)
+
+	// 无会话 cookie → 401。
+	resp, err := http.Get(srv.URL + "/api/metrics/dora")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestDoraMetrics_Unconfigured503(t *testing.T) {
+	st := testStoreAuth(t)
+	svc := auth.NewService(st.DB, nil)
+	if err := svc.Bootstrap("admin", "testpass"); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	// 不注入 WithDoraMetrics → 503。
+	srv := httptest.NewServer(New(testWebFSAuth(), svc))
+	t.Cleanup(srv.Close)
+	client := newTestClient(t)
+	csrf := loginWithClient(t, client, srv.URL)
+
+	resp := doJSON(t, client, http.MethodGet, srv.URL+"/api/metrics/dora", csrf, "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestDoraMetrics_EmptyOk(t *testing.T) {
+	srv, client, csrf, _ := setupDoraServer(t)
+	resp := doJSON(t, client, http.MethodGet, srv.URL+"/api/metrics/dora", csrf, "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var body doraResponseDTO
+	raw, _ := io.ReadAll(resp.Body)
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal: %v (%s)", err, raw)
+	}
+	if body.Window != "30d" || body.WindowDays != 30 {
+		t.Fatalf("default window = %q/%d, want 30d/30", body.Window, body.WindowDays)
+	}
+	if body.TotalDeployments != 0 {
+		t.Fatalf("empty totalDeployments = %d, want 0", body.TotalDeployments)
+	}
+	if body.Metrics.DeploymentFrequency.Band != "none" {
+		t.Fatalf("empty band = %q, want none", body.Metrics.DeploymentFrequency.Band)
+	}
+}
+
+func TestDoraMetrics_AggregatesAndFilters(t *testing.T) {
+	srv, client, csrf, db := setupDoraServer(t)
+
+	projA := seedDoraProject(t, db, "acme")
+	projB := seedDoraProject(t, db, "globex")
+
+	base := time.Now().UTC().Add(-5 * 24 * time.Hour)
+	fin := func(d time.Duration) *time.Time { tt := base.Add(d); return &tt }
+
+	// projA: 2 成功 + 1 失败(终态)+ 1 running(忽略)。
+	seedDoraRun(t, db, projA, run.StatusSuccess, base, fin(time.Hour))
+	seedDoraRun(t, db, projA, run.StatusSuccess, base.Add(time.Hour), fin(2*time.Hour))
+	seedDoraRun(t, db, projA, run.StatusFailed, base.Add(2*time.Hour), fin(3*time.Hour))
+	seedDoraRun(t, db, projA, run.StatusRunning, base.Add(3*time.Hour), nil)
+	// projB: 1 成功。
+	seedDoraRun(t, db, projB, run.StatusSuccess, base, fin(time.Hour))
+
+	// 全项目:3 成功 + 1 失败 = 4 部署。
+	resp := doJSON(t, client, http.MethodGet, srv.URL+"/api/metrics/dora?window=30d", csrf, "")
+	var all doraResponseDTO
+	raw, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err := json.Unmarshal(raw, &all); err != nil {
+		t.Fatalf("unmarshal: %v (%s)", err, raw)
+	}
+	if all.TotalDeployments != 4 || all.SuccessfulDeployments != 3 || all.FailedDeployments != 1 {
+		t.Fatalf("all counts = %+v", all)
+	}
+	if all.ChangeFailureRate <= 0.24 || all.ChangeFailureRate >= 0.26 {
+		t.Fatalf("CFR = %v, want ~0.25", all.ChangeFailureRate)
+	}
+
+	// 仅 projA:2 成功 + 1 失败 = 3 部署。
+	resp2 := doJSON(t, client, http.MethodGet, srv.URL+"/api/metrics/dora?projectId="+projA, csrf, "")
+	var a doraResponseDTO
+	raw2, _ := io.ReadAll(resp2.Body)
+	_ = resp2.Body.Close()
+	if err := json.Unmarshal(raw2, &a); err != nil {
+		t.Fatalf("unmarshal A: %v (%s)", err, raw2)
+	}
+	if a.TotalDeployments != 3 || a.SuccessfulDeployments != 2 || a.FailedDeployments != 1 {
+		t.Fatalf("projA counts = %+v", a)
+	}
+	if a.ProjectID != projA {
+		t.Fatalf("projectId echo = %q, want %q", a.ProjectID, projA)
+	}
+	if len(a.Trend) == 0 {
+		t.Fatalf("expected non-empty trend")
+	}
+}
+
+func TestDoraMetrics_InvalidWindow(t *testing.T) {
+	srv, client, csrf, _ := setupDoraServer(t)
+	for _, bad := range []string{"abc", "0d", "-5d", "9999d", "10x"} {
+		resp := doJSON(t, client, http.MethodGet, srv.URL+"/api/metrics/dora?window="+bad, csrf, "")
+		got := resp.StatusCode
+		_ = resp.Body.Close()
+		if got != http.StatusBadRequest {
+			t.Fatalf("window=%q status = %d, want 400", bad, got)
+		}
+	}
+}
+
+// seedDoraProject 直接插一个项目(满足运行外键),返回 project id。
+func seedDoraProject(t *testing.T, db *sql.DB, name string) string {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	credID := uuid.NewString()
+	if _, err := db.Exec(
+		`INSERT INTO credentials (id, name, type, scope, ciphertext, masked_value, created_at, updated_at)
+		 VALUES (?, ?, 'git_token', '', X'00', 'm', ?, ?)`,
+		credID, name+"-cred", now, now,
+	); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+	projID := uuid.NewString()
+	if _, err := db.Exec(
+		`INSERT INTO projects (id, name, repo_url, default_branch, credential_id, created_at, updated_at)
+		 VALUES (?, ?, 'https://example.com/p.git', 'main', ?, ?, ?)`,
+		projID, name, credID, now, now,
+	); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	return projID
+}
+
+// seedDoraRun 直接插一条 pipeline_runs(绕过状态机),便于构造 DORA 测试数据。
+func seedDoraRun(t *testing.T, db *sql.DB, projID, status string, created time.Time, finished *time.Time) {
+	t.Helper()
+	var finishedVal any
+	if finished != nil {
+		finishedVal = finished.UTC().Format(time.RFC3339)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO pipeline_runs
+		   (id, project_id, status, trigger_type, trigger_branch, trigger_commit, trigger_actor,
+		    created_at, started_at, finished_at)
+		 VALUES (?, ?, ?, 'manual', 'main', '', 'admin', ?, NULL, ?)`,
+		uuid.NewString(), projID, status, created.UTC().Format(time.RFC3339), finishedVal,
+	); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -77,6 +77,7 @@ type options struct {
 	approvalCoord    *approval.Coordinator
 	approvalStore    *approval.Store
 	promotionStore   *promotion.Store
+	doraMetrics      run.MetricsService
 }
 
 // WithApprovals 注入审批门协调器 + 持久层(Story 8-4),挂载 /api/runs/{id}/{approve,reject,approvals} 路由。
@@ -93,6 +94,13 @@ func WithApprovals(coord *approval.Coordinator, store *approval.Store) Option {
 // 不传则晋级端点返回 503。
 func WithPromotion(store *promotion.Store) Option {
 	return func(o *options) { o.promotionStore = store }
+}
+
+// WithDoraMetrics 注入 DORA 指标只读聚合服务(FR-8-15),挂载 GET /api/metrics/dora 路由
+// (认证 + 只读;projectId 可选过滤 + window 时间窗口)。对既有运行数据做纯聚合,无新表、无副作用。
+// 不传则该端点返回 503(服务未初始化)。
+func WithDoraMetrics(s run.MetricsService) Option {
+	return func(o *options) { o.doraMetrics = s }
 }
 
 // WithVault 注入凭据保险库,挂载 /api/credentials* 路由。
@@ -556,6 +564,11 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		ar.Put("/oauth/apps/{provider}", makeSaveOAuthAppHandler(oa))
 		ar.Get("/oauth/{provider}/authorize", makeOAuthAuthorizeHandler(oa))
 		ar.Get("/oauth/{provider}/callback", makeOAuthCallbackHandler(oa, v))
+
+		// DORA 四指标只读聚合(FR-8-15):部署频率 / 变更前置时长 / 变更失败率 / MTTR。
+		// 对既有运行数据做纯聚合(无新表、无副作用)。GET 只读 → 过 auth、豁免 CSRF。
+		// projectId 可选过滤;window 形如 30d(默认)。o.doraMetrics 为 nil → handler 返回 503。
+		ar.Get("/metrics/dora", makeDoraMetricsHandler(o.doraMetrics))
 
 		// 后续 story 在此挂载其他 API 路由。
 	})

--- a/internal/run/metrics.go
+++ b/internal/run/metrics.go
@@ -1,0 +1,97 @@
+package run
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// metrics.go 暴露 DORA 四指标(FR-8-15)所需的**只读**运行投影查询。
+//
+// 不新增表、不改既有 service.go:只新增一个轻量查询服务,从 pipeline_runs 拉取窗口内
+// 的运行(精简列:status / created_at / finished_at),供 internal/dora 做纯聚合。
+// commit 时间本平台运行模型当前不持久化,故投影只回 created_at(dora 层据此回退作提交代理)。
+
+// MetricsRecord 是计算 DORA 所需的单条运行投影(精简,只取聚合必需列)。
+// 与 dora.Record 字段对齐但解耦(run 包不 import dora;httpapi 层做映射)。
+type MetricsRecord struct {
+	// Status 是运行状态(success|failed|partial_failed|rolled_back|其它非终态)。
+	Status string
+	// CreatedAt 是入队时刻(必有;dora 层在无 commit 时间时作前置时长的提交代理)。
+	CreatedAt time.Time
+	// FinishedAt 是终态时刻(非终态为 nil;dora 层据此判定「是否一次部署」)。
+	FinishedAt *time.Time
+}
+
+// MetricsService 暴露 DORA 聚合所需的只读查询。
+type MetricsService interface {
+	// MetricsRecords 返回窗口 [since, now] 内、按指定项目(projectID 为空 = 全部项目)的运行投影,
+	// 按 created_at 升序。只取计算必需列;非终态运行 finished_at 为 nil(dora 层自然忽略)。
+	// since 为零值时不设下界(取全部历史)。
+	MetricsRecords(ctx context.Context, projectID string, since time.Time) ([]MetricsRecord, error)
+}
+
+// MetricsRecords 实现 MetricsService:参数化 SQL 拉窗口内运行投影。
+//
+// created_at 以 RFC3339 文本存储,字典序与时间序一致(同一 UTC 格式),故 since 下界可直接文本比较。
+func (s *service) MetricsRecords(ctx context.Context, projectID string, since time.Time) ([]MetricsRecord, error) {
+	where := []string{}
+	args := []any{}
+	if pid := strings.TrimSpace(projectID); pid != "" {
+		where = append(where, "project_id = ?")
+		args = append(args, pid)
+	}
+	if !since.IsZero() {
+		where = append(where, "created_at >= ?")
+		args = append(args, since.UTC().Format(time.RFC3339))
+	}
+	clause := ""
+	if len(where) > 0 {
+		clause = " WHERE " + strings.Join(where, " AND ")
+	}
+
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT status, created_at, finished_at
+		 FROM pipeline_runs`+clause+`
+		 ORDER BY created_at ASC, id ASC`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("run: query metrics records: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := []MetricsRecord{}
+	for rows.Next() {
+		var (
+			rec        MetricsRecord
+			createdStr string
+			finishStr  sql.NullString
+		)
+		if err := rows.Scan(&rec.Status, &createdStr, &finishStr); err != nil {
+			return nil, fmt.Errorf("run: scan metrics record: %w", err)
+		}
+		t, perr := time.Parse(time.RFC3339, createdStr)
+		if perr != nil {
+			return nil, fmt.Errorf("run: parse metrics created_at: %w", perr)
+		}
+		rec.CreatedAt = t.UTC()
+		if rec.FinishedAt, err = parseNullTime(finishStr); err != nil {
+			return nil, err
+		}
+		out = append(out, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("run: iterate metrics records: %w", err)
+	}
+	return out, nil
+}
+
+// NewMetricsService 把既有运行 Service 暴露为 MetricsService(同一 *service 实现)。
+// 供 httpapi 层装配 DORA 端点用;不引入新依赖、不开新连接。
+func NewMetricsService(s Service) MetricsService {
+	if impl, ok := s.(*service); ok {
+		return impl
+	}
+	return nil
+}

--- a/internal/run/metrics_test.go
+++ b/internal/run/metrics_test.go
@@ -1,0 +1,126 @@
+package run
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// seedRun 直接插一条 pipeline_runs(绕过状态机/worker),便于构造 DORA 测试数据。
+// finished 为 nil 时存 NULL(非终态)。
+func seedRun(t *testing.T, db *sql.DB, projID, status string, created time.Time, finished *time.Time) {
+	t.Helper()
+	var finishedVal any
+	if finished != nil {
+		finishedVal = finished.UTC().Format(time.RFC3339)
+	}
+	_, err := db.Exec(
+		`INSERT INTO pipeline_runs
+		   (id, project_id, status, trigger_type, trigger_branch, trigger_commit, trigger_actor,
+		    created_at, started_at, finished_at)
+		 VALUES (?, ?, ?, 'manual', 'main', '', 'admin', ?, NULL, ?)`,
+		uuid.NewString(), projID, status, created.UTC().Format(time.RFC3339), finishedVal,
+	)
+	if err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+}
+
+func TestMetricsRecords_FilterAndProjection(t *testing.T) {
+	db := testDB(t)
+	svc := newService(db)
+	ms := NewMetricsService(svc)
+	if ms == nil {
+		t.Fatal("NewMetricsService returned nil")
+	}
+
+	projA := seedProject(t, db)
+	projB := seedProject(t, db)
+
+	base := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	fin := base.Add(time.Hour)
+
+	// projA: 1 成功(终态)+ 1 running(非终态)。
+	seedRun(t, db, projA, StatusSuccess, base, &fin)
+	seedRun(t, db, projA, StatusRunning, base.Add(2*time.Hour), nil)
+	// projB: 1 failed(终态)。
+	seedRun(t, db, projB, StatusFailed, base.Add(time.Hour), &fin)
+
+	ctx := context.Background()
+
+	// 全项目:3 条。
+	all, err := ms.MetricsRecords(ctx, "", time.Time{})
+	if err != nil {
+		t.Fatalf("MetricsRecords all: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("all records = %d, want 3", len(all))
+	}
+
+	// 仅 projA:2 条,且 running 的 FinishedAt 为 nil。
+	a, err := ms.MetricsRecords(ctx, projA, time.Time{})
+	if err != nil {
+		t.Fatalf("MetricsRecords projA: %v", err)
+	}
+	if len(a) != 2 {
+		t.Fatalf("projA records = %d, want 2", len(a))
+	}
+	var sawRunningNil, sawSuccessFin bool
+	for _, r := range a {
+		switch r.Status {
+		case StatusRunning:
+			if r.FinishedAt != nil {
+				t.Fatalf("running record should have nil FinishedAt")
+			}
+			sawRunningNil = true
+		case StatusSuccess:
+			if r.FinishedAt == nil {
+				t.Fatalf("success record should have FinishedAt")
+			}
+			sawSuccessFin = true
+		}
+	}
+	if !sawRunningNil || !sawSuccessFin {
+		t.Fatalf("projection missing expected rows: running=%v success=%v", sawRunningNil, sawSuccessFin)
+	}
+}
+
+func TestMetricsRecords_SinceWindow(t *testing.T) {
+	db := testDB(t)
+	svc := newService(db)
+	ms := NewMetricsService(svc)
+
+	proj := seedProject(t, db)
+	base := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	fin := base.Add(time.Hour)
+
+	old := base.Add(-10 * 24 * time.Hour) // 窗口前
+	seedRun(t, db, proj, StatusSuccess, old, &fin)
+	seedRun(t, db, proj, StatusSuccess, base, &fin)
+
+	since := base.Add(-1 * time.Hour)
+	recs, err := ms.MetricsRecords(context.Background(), "", since)
+	if err != nil {
+		t.Fatalf("MetricsRecords: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("windowed records = %d, want 1 (old excluded)", len(recs))
+	}
+}
+
+func TestMetricsRecords_Empty(t *testing.T) {
+	db := testDB(t)
+	svc := newService(db)
+	ms := NewMetricsService(svc)
+
+	recs, err := ms.MetricsRecords(context.Background(), "", time.Time{})
+	if err != nil {
+		t.Fatalf("MetricsRecords: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("expected empty, got %d", len(recs))
+	}
+}

--- a/web/src/api/metrics.test.ts
+++ b/web/src/api/metrics.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { bandLabel, formatDuration, formatFrequency, formatPercent } from './metrics'
+
+describe('bandLabel', () => {
+  it('maps each band to Chinese copy', () => {
+    expect(bandLabel('elite')).toBe('精英')
+    expect(bandLabel('high')).toBe('高效')
+    expect(bandLabel('medium')).toBe('中等')
+    expect(bandLabel('low')).toBe('待改进')
+    expect(bandLabel('none')).toBe('暂无数据')
+  })
+})
+
+describe('formatDuration', () => {
+  it('returns dash for invalid input', () => {
+    expect(formatDuration(-1)).toBe('—')
+    expect(formatDuration(NaN)).toBe('—')
+  })
+  it('formats seconds / minutes / hours / days', () => {
+    expect(formatDuration(30)).toBe('30 秒')
+    expect(formatDuration(90)).toBe('1.5 分钟')
+    expect(formatDuration(3600)).toBe('1 小时')
+    expect(formatDuration(5400)).toBe('1.5 小时')
+    expect(formatDuration(86400)).toBe('1 天')
+    expect(formatDuration(129600)).toBe('1.5 天')
+  })
+})
+
+describe('formatFrequency', () => {
+  it('returns dash for non-positive input', () => {
+    expect(formatFrequency(0)).toBe('—')
+    expect(formatFrequency(-2)).toBe('—')
+  })
+  it('formats per-day / per-week / per-month cadence', () => {
+    expect(formatFrequency(2)).toBe('2 次/天')
+    expect(formatFrequency(0.5)).toBe('3.5 次/周') // 0.5/day → 3.5/week
+    expect(formatFrequency(1 / 30)).toBe('1 次/月') // 1/30 day → 1/month
+  })
+})
+
+describe('formatPercent', () => {
+  it('returns dash for invalid input', () => {
+    expect(formatPercent(-0.1)).toBe('—')
+    expect(formatPercent(NaN)).toBe('—')
+  })
+  it('formats ratio as percentage', () => {
+    expect(formatPercent(0)).toBe('0%')
+    expect(formatPercent(0.25)).toBe('25%')
+    expect(formatPercent(0.333)).toBe('33.3%')
+    expect(formatPercent(1)).toBe('100%')
+  })
+})

--- a/web/src/api/metrics.ts
+++ b/web/src/api/metrics.ts
@@ -1,0 +1,140 @@
+/**
+ * DORA metrics API — Story FR-8-15.
+ *
+ * GET /api/metrics/dora?projectId=&window=30d → DoraMetrics
+ *
+ * Read-only aggregation over existing pipeline-run data (no new event capture).
+ * Derivation口径(与后端 internal/dora 一致):
+ *   - 一次「部署」  = 一条进入终态(success|failed|partial_failed|rolled_back)的运行。
+ *   - 部署频率      = 成功部署数 / 窗口天数(日均;另给周均)。
+ *   - 变更前置时长  = 每条成功部署 finished−commit 的中位数(秒);commit 不可得时用 created 代理。
+ *   - 变更失败率    = 失败部署 / 终态部署总数 ∈ [0,1]。
+ *   - MTTR          = 「失败 → 下一次成功」配对恢复时长的中位数(秒)。
+ *
+ * Errors follow the canonical envelope; callers inspect `err.apiError?.code` /
+ * `.message` / `err.status` on HttpError.
+ */
+
+import { http } from './http'
+
+/** DORA performance band (Elite/High/Medium/Low; `none` when sample is too small). */
+export type DoraBand = 'elite' | 'high' | 'medium' | 'low' | 'none'
+
+/** One metric: raw value + DORA band + sample size (0 ⇒ no data, render "—"). */
+export interface DoraMetric {
+  /** Frequency = deploys/day; lead/MTTR = seconds; CFR = ratio [0,1]. */
+  value: number
+  band: DoraBand
+  /** Number of samples backing this metric. 0 ⇒ no data. */
+  sampleCount: number
+}
+
+/** One time bucket of the trend series (day-aligned). */
+export interface DoraTrendPoint {
+  /** RFC3339 bucket start (UTC, aligned to 00:00). */
+  bucketStart: string
+  deployments: number
+  successes: number
+  failures: number
+  /** Change failure rate within this bucket [0,1]; 0 when no deployments. */
+  changeFailureRate: number
+}
+
+export interface DoraMetricsBlock {
+  deploymentFrequency: DoraMetric
+  leadTime: DoraMetric
+  changeFailureRate: DoraMetric
+  mttr: DoraMetric
+}
+
+export interface DoraMetrics {
+  /** Normalized window label, e.g. "30d". */
+  window: string
+  windowDays: number
+  /** Echoed project filter ("" = all projects). */
+  projectId: string
+  totalDeployments: number
+  successfulDeployments: number
+  failedDeployments: number
+
+  /** Bare convenience values (also present, with bands, under `metrics`). */
+  deploymentFrequency: number
+  deploymentFrequencyPerWeek: number
+  leadTimeSeconds: number
+  changeFailureRate: number
+  mttrSeconds: number
+
+  metrics: DoraMetricsBlock
+  trend: DoraTrendPoint[]
+  /** RFC3339 aggregation timestamp ("data as of"). */
+  generatedAt: string
+}
+
+export interface GetDoraMetricsParams {
+  /** Optional project filter; omit / empty = all projects. */
+  projectId?: string
+  /** Window like "30d" / "7d" / "90d". Defaults server-side to "30d". */
+  window?: string
+}
+
+/** Fetch the four DORA metrics for a window (read-only aggregation). */
+export async function getDoraMetrics(params: GetDoraMetricsParams = {}): Promise<DoraMetrics> {
+  const qs = new URLSearchParams()
+  if (params.projectId) qs.set('projectId', params.projectId)
+  if (params.window) qs.set('window', params.window)
+  const suffix = qs.toString() ? `?${qs.toString()}` : ''
+  return http.get<DoraMetrics>(`/api/metrics/dora${suffix}`)
+}
+
+// ─── Presentation helpers (pure; unit-tested) ────────────────────────────────
+
+/** Human-readable label for a DORA band (Chinese, matches product copy). */
+export function bandLabel(band: DoraBand): string {
+  switch (band) {
+    case 'elite':
+      return '精英'
+    case 'high':
+      return '高效'
+    case 'medium':
+      return '中等'
+    case 'low':
+      return '待改进'
+    default:
+      return '暂无数据'
+  }
+}
+
+/**
+ * Format a duration in seconds to a compact human string (秒/分/时/天).
+ * Returns "—" for non-finite / negative inputs (callers also gate on sampleCount).
+ */
+export function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '—'
+  if (seconds < 60) return `${Math.round(seconds)} 秒`
+  const mins = seconds / 60
+  if (mins < 60) return `${round1(mins)} 分钟`
+  const hours = mins / 60
+  if (hours < 24) return `${round1(hours)} 小时`
+  const days = hours / 24
+  return `${round1(days)} 天`
+}
+
+/** Format deployment frequency (deploys/day) to an intuitive cadence string. */
+export function formatFrequency(perDay: number): string {
+  if (!Number.isFinite(perDay) || perDay <= 0) return '—'
+  if (perDay >= 1) return `${round1(perDay)} 次/天`
+  const perWeek = perDay * 7
+  if (perWeek >= 1) return `${round1(perWeek)} 次/周`
+  const perMonth = perDay * 30
+  return `${round1(perMonth)} 次/月`
+}
+
+/** Format a [0,1] ratio as a percentage string. */
+export function formatPercent(ratio: number): string {
+  if (!Number.isFinite(ratio) || ratio < 0) return '—'
+  return `${round1(ratio * 100)}%`
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10
+}

--- a/web/src/components/metrics/DoraMetricCard.vue
+++ b/web/src/components/metrics/DoraMetricCard.vue
@@ -1,0 +1,210 @@
+<!--
+  DoraMetricCard.vue — 单个 DORA 指标卡(部署频率 / 前置时长 / 变更失败率 / MTTR)。
+
+  设计意图(避开「dashboard-by-numbers」):
+    · 强层级:大号主值(tabular-nums)+ 弱化的单位/口径行 + 顶部细绩效色条(语义色,非装饰)。
+    · 绩效分档徽标(精英/高效/中等/待改进)按 band 着色 —— 颜色承载语义。
+    · 底部 sparkline 把「趋势」纳入设计系统,而非事后堆图。
+    · 无数据(sampleCount 0)→ 主值显「—」+ 「暂无数据」徽标,口径行解释为何为空。
+    · hover 抬升 + 边框增强,聚焦态可见(键盘可达,卡片是 article 语义)。
+-->
+<script setup lang="ts">
+import { computed } from 'vue'
+import { type DoraBand, bandLabel } from '../../api/metrics'
+import DoraSparkline from './DoraSparkline.vue'
+
+const props = defineProps<{
+  /** 指标标题(中文,如「部署频率」)。 */
+  title: string
+  /** 英文副标(如 "Deployment Frequency",编排排版的次要层级)。 */
+  subtitle: string
+  /** 主值显示串(已格式化;无数据时传 "—")。 */
+  display: string
+  /** 口径/解释行(如「30 天内 12 次成功部署」)。 */
+  caption: string
+  band: DoraBand
+  /** 该指标样本数;0 ⇒ 无数据态。 */
+  sampleCount: number
+  /** sparkline 数值序列(可空)。 */
+  trend: number[]
+}>()
+
+const hasData = computed(() => props.sampleCount > 0)
+
+/** band → 语义色变量(用于色条 / 徽标 / sparkline)。 */
+const bandColor = computed(() => {
+  switch (props.band) {
+    case 'elite':
+      return 'var(--color-green)'
+    case 'high':
+      return 'var(--color-cyan)'
+    case 'medium':
+      return 'var(--color-amber)'
+    case 'low':
+      return 'var(--color-red)'
+    default:
+      return 'var(--color-faint)'
+  }
+})
+
+const bandSoft = computed(() => {
+  switch (props.band) {
+    case 'elite':
+      return 'var(--color-green-soft)'
+    case 'high':
+      return 'var(--color-cyan-soft)'
+    case 'medium':
+      return 'var(--color-amber-soft)'
+    case 'low':
+      return 'var(--color-red-soft)'
+    default:
+      return 'transparent'
+  }
+})
+
+const label = computed(() => bandLabel(props.band))
+</script>
+
+<template>
+  <article
+    class="dora-card"
+    :class="{ 'dora-card--empty': !hasData }"
+    :style="{ '--band-color': bandColor, '--band-soft': bandSoft }"
+    tabindex="0"
+  >
+    <!-- semantic performance bar (top) -->
+    <span class="dora-card__bar" aria-hidden="true" />
+
+    <header class="dora-card__head">
+      <div class="dora-card__titles">
+        <h2 class="dora-card__title">{{ title }}</h2>
+        <p class="dora-card__subtitle">{{ subtitle }}</p>
+      </div>
+      <span class="dora-card__band" :data-band="band">{{ label }}</span>
+    </header>
+
+    <div class="dora-card__value-row">
+      <span class="dora-card__value">{{ hasData ? display : '—' }}</span>
+    </div>
+
+    <p class="dora-card__caption">{{ caption }}</p>
+
+    <div class="dora-card__spark" v-if="hasData && trend.length >= 2">
+      <DoraSparkline :values="trend" :stroke="bandColor" :fill="bandSoft" :width="240" :height="40" />
+    </div>
+    <div class="dora-card__spark dora-card__spark--placeholder" v-else aria-hidden="true" />
+  </article>
+</template>
+
+<style scoped>
+.dora-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-5) var(--space-5) var(--space-4);
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-card);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  transition:
+    transform var(--duration-fast) var(--ease-out-expo),
+    border-color var(--duration-fast) var(--ease-out-expo),
+    box-shadow var(--duration-fast) var(--ease-out-expo);
+}
+.dora-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--color-border-strong);
+}
+.dora-card:focus-visible {
+  outline: 2px solid var(--band-color);
+  outline-offset: 2px;
+}
+.dora-card--empty {
+  box-shadow: none;
+}
+
+/* Top semantic bar — colour carries the band meaning. */
+.dora-card__bar {
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--band-color), transparent 85%);
+}
+
+.dora-card__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+.dora-card__titles {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.dora-card__title {
+  margin: 0;
+  font-size: var(--text-section);
+  font-weight: 650;
+  color: var(--color-text);
+  letter-spacing: 0.01em;
+}
+.dora-card__subtitle {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-faint);
+}
+
+.dora-card__band {
+  flex-shrink: 0;
+  padding: 2px 9px;
+  font-size: var(--text-caps);
+  font-weight: 600;
+  border-radius: var(--rounded-full);
+  color: var(--band-color);
+  background: var(--band-soft);
+  border: 1px solid color-mix(in oklch, var(--band-color) 35%, transparent);
+  white-space: nowrap;
+}
+.dora-card--empty .dora-card__band {
+  color: var(--color-faint);
+  border-color: var(--color-border);
+}
+
+.dora-card__value-row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+.dora-card__value {
+  font-size: var(--text-kpi);
+  font-weight: 700;
+  line-height: 1;
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+}
+.dora-card--empty .dora-card__value {
+  color: var(--color-faint);
+}
+
+.dora-card__caption {
+  margin: 0;
+  font-size: var(--text-micro);
+  color: var(--color-dim);
+  min-height: 1.1em;
+}
+
+.dora-card__spark {
+  margin-top: auto;
+  padding-top: var(--space-2);
+}
+.dora-card__spark--placeholder {
+  height: 40px;
+}
+</style>

--- a/web/src/components/metrics/DoraSparkline.vue
+++ b/web/src/components/metrics/DoraSparkline.vue
@@ -1,0 +1,130 @@
+<!--
+  DoraSparkline.vue — 趋势迷你折线(纯 SVG,无第三方图表库)。
+
+  把一组数值画成紧凑折线 + 末点强调,供 DORA 卡片底部展示节奏走向。
+  · 纯展示、无交互(图表作为设计系统的一部分,非事后堆叠)。
+  · compositor-friendly:仅静态 SVG path,无逐帧布局动画。
+  · 无数据(<2 点)→ 渲染一条基线占位,不报错。
+-->
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    /** 等间距数值序列(如每桶部署数 / 失败率)。 */
+    values: number[]
+    /** 折线描边色(CSS 颜色或 var())。 */
+    stroke?: string
+    /** 区域填充色(渐变顶色;底部透明)。 */
+    fill?: string
+    width?: number
+    height?: number
+  }>(),
+  {
+    stroke: 'var(--color-primary)',
+    fill: 'var(--color-primary-soft)',
+    width: 220,
+    height: 44,
+  },
+)
+
+const pad = 3
+
+/** 归一化后的折线点(x 等间距,y 翻转使大值在上)。 */
+const points = computed(() => {
+  const vs = props.values
+  if (vs.length < 2) return []
+  const max = Math.max(...vs)
+  const min = Math.min(...vs)
+  const span = max - min || 1
+  const innerW = props.width - pad * 2
+  const innerH = props.height - pad * 2
+  return vs.map((v, i) => {
+    const x = pad + (i / (vs.length - 1)) * innerW
+    const y = pad + innerH - ((v - min) / span) * innerH
+    return { x, y }
+  })
+})
+
+const linePath = computed(() => {
+  if (points.value.length === 0) return ''
+  return points.value.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ')
+})
+
+const areaPath = computed(() => {
+  if (points.value.length === 0) return ''
+  const first = points.value[0]
+  const last = points.value[points.value.length - 1]
+  const baseY = props.height - pad
+  return `${linePath.value} L${last.x.toFixed(1)},${baseY} L${first.x.toFixed(1)},${baseY} Z`
+})
+
+const lastPoint = computed(() =>
+  points.value.length > 0 ? points.value[points.value.length - 1] : null,
+)
+
+const gradId = `spark-grad-${Math.random().toString(36).slice(2, 8)}`
+</script>
+
+<template>
+  <svg
+    class="sparkline"
+    :viewBox="`0 0 ${width} ${height}`"
+    :width="width"
+    :height="height"
+    role="img"
+    aria-label="趋势走向"
+    preserveAspectRatio="none"
+  >
+    <defs>
+      <linearGradient :id="gradId" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0%" :stop-color="fill" />
+        <stop offset="100%" stop-color="transparent" />
+      </linearGradient>
+    </defs>
+
+    <!-- baseline when too few points -->
+    <line
+      v-if="points.length < 2"
+      :x1="pad"
+      :y1="height / 2"
+      :x2="width - pad"
+      :y2="height / 2"
+      class="sparkline__baseline"
+    />
+
+    <template v-else>
+      <path :d="areaPath" :fill="`url(#${gradId})`" stroke="none" />
+      <path :d="linePath" :stroke="stroke" fill="none" class="sparkline__line" />
+      <circle
+        v-if="lastPoint"
+        :cx="lastPoint.x"
+        :cy="lastPoint.y"
+        r="2.6"
+        :fill="stroke"
+        class="sparkline__dot"
+      />
+    </template>
+  </svg>
+</template>
+
+<style scoped>
+.sparkline {
+  display: block;
+  overflow: visible;
+}
+.sparkline__line {
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+}
+.sparkline__baseline {
+  stroke: var(--color-border-strong);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+}
+.sparkline__dot {
+  filter: drop-shadow(0 0 3px var(--color-primary-soft));
+}
+</style>

--- a/web/src/layouts/AppShell.vue
+++ b/web/src/layouts/AppShell.vue
@@ -4,6 +4,7 @@ import { useRoute } from 'vue-router'
 import {
   GitBranch,
   GitFork,
+  ChartBar,
   Server,
   AlertTriangle,
   Bell,
@@ -25,6 +26,8 @@ interface NavItem {
 const navItems: NavItem[] = [
   { name: 'projects',      to: '/projects',      icon: GitBranch,  label: '项目',  ariaLabel: '项目' },
   { name: 'runs',          to: '/runs',          icon: GitFork,    label: '运行',  ariaLabel: '运行' },
+  // FR-8-15: DORA 四指标仪表盘(交付效能;只读聚合)。
+  { name: 'dora',          to: '/metrics/dora',  icon: ChartBar,   label: 'DORA 指标', ariaLabel: 'DORA 指标' },
   // Story 6-1: 多机状态总览(服务器层指标 FR-15);登记在 设置 → 服务器。
   { name: 'server-status', to: '/server-status', icon: Server,     label: '服务器', ariaLabel: '服务器' },
   // Story 6-5: configurable anomaly detection & alerts (FR-23)

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -8,6 +8,8 @@ const AppShell    = () => import('../layouts/AppShell.vue')
 const Onboarding  = () => import('../views/Onboarding.vue')
 const Projects    = () => import('../views/Projects.vue')
 const Runs        = () => import('../views/Runs.vue')
+// FR-8-15: DORA 四指标仪表盘(部署频率 / 前置时长 / 变更失败率 / MTTR;只读聚合)
+const DoraDashboard = () => import('../views/DoraDashboard.vue')
 // Story 6-1: multi-host status overview (server-layer CPU/memory/disk metrics, FR-15)
 const ServerStatus = () => import('../views/ServerStatus.vue')
 // Story 6-5: configurable anomaly detection & alerts (FR-23)
@@ -70,6 +72,8 @@ const router = createRouter({
         { path: 'projects/:id/code', name: 'project-code', component: ProjectCode },
         { path: 'runs', name: 'runs', component: Runs },
         { path: 'runs/:id', name: 'run-detail', component: RunDetail },
+        // FR-8-15: DORA 指标仪表盘(只读聚合;projectId / window 经 query 即状态)
+        { path: 'metrics/dora', name: 'dora', component: DoraDashboard },
         // 顶层「服务器」占位页 → 重定向到真实的多机状态页(登记在 /settings/servers)。
         { path: 'servers', name: 'servers', redirect: { name: 'server-status' } },
         // Story 6-1: multi-host status overview (server-layer metrics, FR-15)

--- a/web/src/views/DoraDashboard.vue
+++ b/web/src/views/DoraDashboard.vue
@@ -1,0 +1,448 @@
+<!--
+  DoraDashboard.vue — FR-8-15: DORA 四指标仪表盘。
+
+  对既有运行数据做**只读聚合**的交付效能视图:
+    · 部署频率 / 变更前置时长 / 变更失败率 / 故障恢复时长(MTTR)。
+    · 每指标一张卡(值 + DORA 绩效分档 Elite/High/Medium/Low + 趋势 sparkline)。
+    · 顶部汇总条:窗口内部署总数 / 成功 / 失败 + 项目筛选 + 时间窗口切换 + 刷新。
+    · URL 即状态:projectId / window 落 query,可分享、可前进后退(web-patterns「URL as state」)。
+
+  口径(与后端 internal/dora 一致):部署=终态运行;成功部署=success;失败=failed/partial/rolled_back;
+  前置时长=finished−commit(commit 不可得回退 created 代理);MTTR=失败→恢复成功配对中位数。
+  这些是 CI 运行数据上的**近似**口径,卡片 caption 已显式说明样本。
+-->
+<script setup lang="ts">
+import { computed, ref, watch, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import {
+  getDoraMetrics,
+  formatDuration,
+  formatFrequency,
+  formatPercent,
+  type DoraMetrics,
+} from '../api/metrics'
+import { listProjects, type Project } from '../api/projects'
+import { HttpError } from '../api/http'
+import DoraMetricCard from '../components/metrics/DoraMetricCard.vue'
+import AppButton from '../components/ui/AppButton.vue'
+import ErrorState from '../components/ui/ErrorState.vue'
+import SkeletonBlock from '../components/ui/SkeletonBlock.vue'
+
+type LoadState = 'idle' | 'loading' | 'error'
+
+const route = useRoute()
+const router = useRouter()
+
+const loadState = ref<LoadState>('idle')
+const loadError = ref('')
+const data = ref<DoraMetrics | null>(null)
+const projects = ref<Project[]>([])
+
+/** 窗口选项(label 即发给后端的 window 值)。 */
+const windowOptions = [
+  { value: '7d', label: '近 7 天' },
+  { value: '30d', label: '近 30 天' },
+  { value: '90d', label: '近 90 天' },
+] as const
+
+// ─── URL as state ───────────────────────────────────────────────────────────
+
+const projectId = computed<string>(() => {
+  const p = route.query.projectId
+  return typeof p === 'string' ? p : ''
+})
+const windowSel = computed<string>(() => {
+  const w = route.query.window
+  return typeof w === 'string' && windowOptions.some((o) => o.value === w) ? w : '30d'
+})
+
+function setQuery(patch: Record<string, string | undefined>): void {
+  const next: Record<string, string> = {}
+  for (const [k, v] of Object.entries({ ...route.query, ...patch })) {
+    if (typeof v === 'string' && v !== '') next[k] = v
+  }
+  void router.replace({ query: next })
+}
+
+function onProjectChange(e: Event): void {
+  setQuery({ projectId: (e.target as HTMLSelectElement).value || undefined })
+}
+function onWindowChange(value: string): void {
+  setQuery({ window: value })
+}
+
+// ─── derived display ──────────────────────────────────────────────────────────
+
+const generatedAtLabel = computed(() => {
+  if (!data.value?.generatedAt) return ''
+  const d = new Date(data.value.generatedAt)
+  return Number.isNaN(d.getTime()) ? '' : d.toLocaleString()
+})
+
+const deployTrend = computed(() => (data.value?.trend ?? []).map((t) => t.deployments))
+const successTrend = computed(() => (data.value?.trend ?? []).map((t) => t.successes))
+const cfrTrend = computed(() => (data.value?.trend ?? []).map((t) => t.changeFailureRate))
+
+const windowDaysLabel = computed(() => data.value?.windowDays ?? 30)
+
+// ─── load ─────────────────────────────────────────────────────────────────────
+
+async function load(): Promise<void> {
+  loadState.value = 'loading'
+  loadError.value = ''
+  try {
+    const res = await getDoraMetrics({ projectId: projectId.value, window: windowSel.value })
+    data.value = res
+    loadState.value = 'idle'
+  } catch (err) {
+    if (err instanceof HttpError) {
+      loadError.value =
+        err.status === 0
+          ? '无法连接到服务器,请检查后端是否运行后重试'
+          : (err.apiError?.message ?? `加载 DORA 指标失败(${err.status})`)
+    } else {
+      loadError.value = '加载 DORA 指标失败,请稍后重试'
+    }
+    loadState.value = 'error'
+  }
+}
+
+async function loadProjects(): Promise<void> {
+  try {
+    projects.value = await listProjects()
+  } catch {
+    // 项目下拉失败不阻断主指标:留空(只能看全部项目)。
+    projects.value = []
+  }
+}
+
+// query 变化 → 重新拉取(URL 即状态的单一数据流)。
+watch([projectId, windowSel], () => void load())
+
+onMounted(() => {
+  void loadProjects()
+  void load()
+})
+</script>
+
+<template>
+  <div class="dora-view">
+    <header class="view-header">
+      <div class="view-header__text">
+        <h1 class="view-title">DORA 指标</h1>
+        <p class="view-sub">
+          基于既有运行数据聚合的交付效能视图 · 部署频率 / 前置时长 / 变更失败率 / 故障恢复
+          <span v-if="generatedAtLabel" class="view-sub__count">· 数据截至 {{ generatedAtLabel }}</span>
+        </p>
+      </div>
+      <AppButton variant="default" :loading="loadState === 'loading'" @click="load">刷新</AppButton>
+    </header>
+
+    <!-- Controls: project filter + window segmented -->
+    <div class="dora-controls">
+      <label class="dora-controls__field">
+        <span class="dora-controls__label">项目</span>
+        <select class="select" :value="projectId" @change="onProjectChange" aria-label="按项目筛选">
+          <option value="">全部项目</option>
+          <option v-for="p in projects" :key="p.id" :value="p.id">{{ p.name }}</option>
+        </select>
+      </label>
+
+      <div class="dora-segmented" role="group" aria-label="时间窗口">
+        <button
+          v-for="opt in windowOptions"
+          :key="opt.value"
+          type="button"
+          class="dora-segmented__btn"
+          :class="{ 'dora-segmented__btn--active': windowSel === opt.value }"
+          :aria-pressed="windowSel === opt.value"
+          @click="onWindowChange(opt.value)"
+        >
+          {{ opt.label }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Error -->
+    <ErrorState
+      v-if="loadState === 'error'"
+      title="加载 DORA 指标失败"
+      :description="loadError"
+      @retry="load"
+    />
+
+    <!-- Loading skeleton (first load) -->
+    <div v-else-if="loadState === 'loading' && !data" class="dora-grid" aria-busy="true">
+      <div v-for="n in 4" :key="n" class="skeleton-card">
+        <SkeletonBlock :height="14" width="40%" />
+        <SkeletonBlock :height="32" width="60%" />
+        <SkeletonBlock :height="14" width="80%" />
+      </div>
+    </div>
+
+    <!-- Content -->
+    <template v-else-if="data">
+      <!-- Summary strip -->
+      <div class="dora-summary">
+        <div class="dora-summary__stat">
+          <span class="dora-summary__num">{{ data.totalDeployments }}</span>
+          <span class="dora-summary__lbl">{{ windowDaysLabel }} 天内部署</span>
+        </div>
+        <div class="dora-summary__divider" aria-hidden="true" />
+        <div class="dora-summary__stat">
+          <span class="dora-summary__num dora-summary__num--ok">{{ data.successfulDeployments }}</span>
+          <span class="dora-summary__lbl">成功</span>
+        </div>
+        <div class="dora-summary__stat">
+          <span class="dora-summary__num dora-summary__num--bad">{{ data.failedDeployments }}</span>
+          <span class="dora-summary__lbl">失败</span>
+        </div>
+      </div>
+
+      <!-- 4 metric cards (bento-ish 2×2; wide screens 4-up) -->
+      <div class="dora-grid">
+        <DoraMetricCard
+          title="部署频率"
+          subtitle="Deployment Frequency"
+          :display="formatFrequency(data.metrics.deploymentFrequency.value)"
+          :caption="`${windowDaysLabel} 天内 ${data.successfulDeployments} 次成功部署`"
+          :band="data.metrics.deploymentFrequency.band"
+          :sample-count="data.metrics.deploymentFrequency.sampleCount"
+          :trend="successTrend"
+        />
+        <DoraMetricCard
+          title="变更前置时长"
+          subtitle="Lead Time for Changes"
+          :display="formatDuration(data.metrics.leadTime.value)"
+          :caption="
+            data.metrics.leadTime.sampleCount > 0
+              ? `${data.metrics.leadTime.sampleCount} 次成功部署的中位提交→投产时长`
+              : '尚无成功部署可统计前置时长'
+          "
+          :band="data.metrics.leadTime.band"
+          :sample-count="data.metrics.leadTime.sampleCount"
+          :trend="deployTrend"
+        />
+        <DoraMetricCard
+          title="变更失败率"
+          subtitle="Change Failure Rate"
+          :display="formatPercent(data.metrics.changeFailureRate.value)"
+          :caption="`${data.failedDeployments} / ${data.totalDeployments} 次部署失败`"
+          :band="data.metrics.changeFailureRate.band"
+          :sample-count="data.metrics.changeFailureRate.sampleCount"
+          :trend="cfrTrend"
+        />
+        <DoraMetricCard
+          title="故障恢复时长"
+          subtitle="Time to Restore (MTTR)"
+          :display="formatDuration(data.metrics.mttr.value)"
+          :caption="
+            data.metrics.mttr.sampleCount > 0
+              ? `${data.metrics.mttr.sampleCount} 段「失败→恢复」的中位时长`
+              : '窗口内无「失败后恢复」配对'
+          "
+          :band="data.metrics.mttr.band"
+          :sample-count="data.metrics.mttr.sampleCount"
+          :trend="cfrTrend"
+        />
+      </div>
+
+      <p class="dora-note">
+        口径说明:一次「部署」= 一条进入终态的运行;前置时长在缺少提交时间时以入队时刻近似。
+        DORA 指标基于 CI 运行数据为<strong>近似</strong>参考,不作 SLA 依据。
+      </p>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.dora-view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.view-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+.view-header__text {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.view-title {
+  margin: 0;
+  font-size: var(--text-display);
+  font-weight: 700;
+  color: var(--color-text);
+  letter-spacing: -0.01em;
+}
+.view-sub {
+  margin: 0;
+  font-size: var(--text-label);
+  color: var(--color-dim);
+}
+.view-sub__count {
+  color: var(--color-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Controls */
+.dora-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--space-4);
+}
+.dora-controls__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.dora-controls__label {
+  font-size: var(--text-micro);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--color-faint);
+}
+.select {
+  appearance: none;
+  padding: 7px 30px 7px 11px;
+  font-size: var(--text-body);
+  color: var(--color-text);
+  background: var(--color-card);
+  background-image: linear-gradient(45deg, transparent 50%, var(--color-dim) 50%),
+    linear-gradient(135deg, var(--color-dim) 50%, transparent 50%);
+  background-position:
+    calc(100% - 16px) center,
+    calc(100% - 11px) center;
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded-md);
+  min-width: 180px;
+  cursor: pointer;
+  transition: border-color var(--duration-fast) var(--ease-out-expo);
+}
+.select:hover {
+  border-color: var(--color-primary);
+}
+.select:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+
+/* Segmented window switch */
+.dora-segmented {
+  display: inline-flex;
+  padding: 3px;
+  gap: 2px;
+  background: var(--color-inset);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded);
+}
+.dora-segmented__btn {
+  padding: 5px 13px;
+  font-size: var(--text-label);
+  color: var(--color-dim);
+  background: transparent;
+  border: none;
+  border-radius: var(--rounded-sm);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) var(--ease-out-expo),
+    color var(--duration-fast) var(--ease-out-expo);
+}
+.dora-segmented__btn:hover {
+  color: var(--color-text);
+}
+.dora-segmented__btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+.dora-segmented__btn--active {
+  color: var(--color-text);
+  background: var(--color-card);
+  box-shadow: var(--shadow);
+  font-weight: 600;
+}
+
+/* Summary strip */
+.dora-summary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-6);
+  padding: var(--space-4) var(--space-5);
+  background: linear-gradient(135deg, var(--color-card-2), var(--color-card));
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-card);
+}
+.dora-summary__stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.dora-summary__num {
+  font-size: var(--text-kpi);
+  font-weight: 700;
+  line-height: 1;
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+.dora-summary__num--ok {
+  color: var(--color-green);
+}
+.dora-summary__num--bad {
+  color: var(--color-red);
+}
+.dora-summary__lbl {
+  font-size: var(--text-micro);
+  color: var(--color-dim);
+}
+.dora-summary__divider {
+  width: 1px;
+  align-self: stretch;
+  background: var(--color-border);
+}
+
+/* Cards grid: 2×2 on medium, 4-up on wide */
+.dora-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-4);
+}
+@media (min-width: 1180px) {
+  .dora-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+@media (max-width: 640px) {
+  .dora-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.skeleton-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-5);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-card);
+  background: var(--color-card);
+}
+
+.dora-note {
+  margin: 0;
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  line-height: 1.5;
+}
+.dora-note strong {
+  color: var(--color-dim);
+  font-weight: 600;
+}
+</style>


### PR DESCRIPTION
## 概述

实现 **FR-8-15 DORA 指标**:对既有运行数据(`pipeline_runs`)做**只读聚合**,在仪表盘展示交付效能四指标。无新事件采集、无新表、无副作用。

## 各指标派生口径(显式声明 · CI 运行数据上必为近似)

口径冻结在 `internal/dora/dora.go` 顶部,并在前端卡片 caption / 底部说明同步呈现:

- **一次「部署」** = 一条进入**终态**的运行(`success | failed | partial_failed | rolled_back`)。平台无独立部署事件流,运行即投产单元。
- **部署频率(Deployment Frequency)** = 成功部署数 ÷ 窗口天数(日均;另给周/月折算)。`band` 按「每天/每周/每月一次」分档。
- **变更前置时长(Lead Time for Changes)** = 每条**成功**部署的 `finished_at − commitTime` 的**中位数**(抗离群)。运行模型当前未持久化提交时间,故 `commitTime` 通常不可得 → **回退用 `created_at`(入队时刻)作提交代理**;一旦上游补齐提交时间,口径自动更精确,无需改本包。负值(脏数据)丢弃。
- **变更失败率(Change Failure Rate)** = 失败部署 ÷ 终态部署总数 ∈ [0,1]。`partial_failed`/`rolled_back` 均计失败;总数为 0 → 0(除零安全)。
- **故障恢复时长(MTTR / Time to Restore)** = 按完成时间排序后,每段「失败 → 下一次成功」的恢复时长(`recover.finished − 该段最早失败.finished`)的**中位数**。连续多次失败按该段**最早一次**起算;末尾未恢复的失败段不计;无配对 → 0(未定义,优雅降级)。

绩效分档(Elite/High/Medium/Low/None)阈值集中在 `internal/dora/bands.go`,对齐 Accelerate State of DevOps 经典四档,仅作参考、不作 SLA。

## 端点

`GET /api/metrics/dora?projectId=&window=30d`(认证 + 只读;GET 豁免 CSRF)

- `projectId` 可选(空 = 全部项目);`window` 形如 `7d`/`30d`/`90d`(默认 `30d`,上界 730d,非法 → 400 `invalid_window`)。
- 未注入服务 → 503。响应含四指标裸值 + `metrics`(值+分档+样本数)块 + `trend`(按天对齐分桶)+ 计数 + `generatedAt`。

## 仪表盘

- 视图:`web/src/views/DoraDashboard.vue`;路由 `/metrics/dora`(name `dora`);左侧导航新增「DORA 指标」入口(ChartBar 图标)。
- 4 张指标卡(`DoraMetricCard.vue`):大号主值 + 顶部语义绩效色条 + 分档徽标(语义色)+ SVG sparkline 趋势(`DoraSparkline.vue`,无第三方图表库)。汇总条(部署总数/成功/失败)+ 项目筛选 + 时间窗口分段切换。`projectId`/`window` 经 **URL query 即状态**(可分享、前进后退)。
- 无数据态:主值显「—」+「暂无数据」徽标,caption 解释为何为空。设计避开「dashboard-by-numbers」:强层级、语义着色、designed hover/focus、bento 2×2(宽屏 4-up)、浅色默认 + 双主题。
- 客户端:`web/src/api/metrics.ts`(类型化 + 展示纯函数,`HttpError` 形状 `err.apiError?.code/.message/.status`)。

## 迁移

**无**。纯只读聚合,不新增/不改表。(未使用预留前缀 0032。)

## 绿灯证据

后端(`go` 工具链):
- `gofmt -l`(改动文件)→ **空**
- `go vet ./...` → 通过
- `go build ./...` → 通过
- `go test ./...` → **全绿**(含新增 `internal/dora` Compute/Trend/Bands 单测、`internal/run` MetricsService 查询测、`internal/httpapi` 端点测:auth/503/空/聚合过滤/非法 window)

前端(`web/`):
- `npm run typecheck`(vue-tsc) → 通过
- `npm run test`(vitest) → **177 passed**(含新增 `metrics.test.ts` 7 项格式化助手测)
- `npm run build`(vite) → 通过(DoraDashboard 已独立 code-split;唯一 chunk-size 告警来自既有 Monaco editor,与本 PR 无关)

未提交 `web/dist/index.html` churn(go:embed 占位);`web/dist/assets` 已 gitignore。

## 协作边界

仅对共享文件做最小**新增式**编辑:`cmd/pipewright/main.go`(一处 option)、`internal/httpapi/router.go`(一条 option + 一条 GET 路由)、前端 `router/index.ts` + `AppShell.vue`(各一条 route/nav,本地化)。未触碰 `pool.go`/`dagrun.go`/`promotion`/`chain`/`trigger`/`pipeline`/`TriggersPanel.vue`/流水线编辑器。

🤖 Generated with [Claude Code](https://claude.com/claude-code)