### PR TITLE
feat(pipeline): Pipeline-as-code 运行时覆盖 — repo .pipewright.yml 驱动运行(FR-8-12)

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/mask"
 	"github.com/huangchengsir/pipewright/internal/notify"
 	"github.com/huangchengsir/pipewright/internal/oauth"
+	"github.com/huangchengsir/pipewright/internal/pacloader"
 	"github.com/huangchengsir/pipewright/internal/pipeline"
 	"github.com/huangchengsir/pipewright/internal/project"
 	"github.com/huangchengsir/pipewright/internal/promotion"
@@ -222,7 +223,21 @@ func main() {
 		} else {
 			log.Printf("[run] PIPEWRIGHT_RUNNER=dag:DAG 调度执行器已启用(阶段按 needs 编排;⚠ 未探测到容器 CLI,阶段执行体回退 stub:%v)", berr)
 		}
-		runnerOpts = []run.PoolOption{run.WithRunner(dagrun.New(pipelineSvc, dagOpts...))}
+		// 「流水线即代码」运行时覆盖(FR-8-12):PIPEWRIGHT_PAC_RUNTIME=1 时,用装饰器包住库内
+		// loader——运行时若项目仓库根含合法 `.pipewright.yml` 即用它驱动本次运行,否则一律回退库内
+		// 配置(任何 YAML/拉取问题都不中断运行)。约束:SpecLoader 只有 projectID 无运行分支,故从
+		// **项目默认分支**拉取;按运行分支覆盖需改 SpecLoader 签名,本期推迟(见 internal/pacloader)。
+		var specLoader dagrun.SpecLoader = pipelineSvc
+		if strings.EqualFold(strings.TrimSpace(os.Getenv("PIPEWRIGHT_PAC_RUNTIME")), "1") {
+			specLoader = pacloader.New(
+				pipelineSvc,
+				pacProjectLookup{projectSvc},
+				credVault, // vault.Vault 满足 TokenRevealer(Reveal)
+				pacBlobFetcher{httpapi.NewSourceReader()},
+			)
+			log.Printf("[pac] 运行时 .pipewright.yml 覆盖已启用(PIPEWRIGHT_PAC_RUNTIME=1;从项目默认分支拉取;任何问题回退库内配置)")
+		}
+		runnerOpts = []run.PoolOption{run.WithRunner(dagrun.New(specLoader, dagOpts...))}
 	} else {
 		runnerOpts = buildRunnerOption(projectSvc, pipelineSettingsSvc, credVault)
 	}
@@ -362,6 +377,35 @@ func main() {
 	cronScheduler.Stop()
 	pool.Stop(shutdownCtx)
 	log.Printf("[run] worker pool stopped")
+}
+
+// ── 「流水线即代码」运行时覆盖适配器(FR-8-12)──────────────────────────────────
+// 把既有领域服务桥接到 pacloader 的小接口,使 pacloader 不反向 import project/vault/httpapi。
+
+// pacProjectLookup 把 project.Service 适配为 pacloader.ProjectLookup(取仓库/凭据/默认分支)。
+type pacProjectLookup struct{ svc project.Service }
+
+func (p pacProjectLookup) Lookup(ctx context.Context, projectID string) (pacloader.ProjectInfo, error) {
+	proj, err := p.svc.Get(ctx, projectID)
+	if err != nil {
+		return pacloader.ProjectInfo{}, err
+	}
+	return pacloader.ProjectInfo{
+		RepoURL:       proj.RepoURL,
+		CredentialID:  proj.CredentialID,
+		DefaultBranch: proj.DefaultBranch,
+	}, nil
+}
+
+// pacBlobFetcher 把 httpapi.SourceReader 适配为 pacloader.BlobFetcher(只取所需字段;token 不外泄)。
+type pacBlobFetcher struct{ reader httpapi.SourceReader }
+
+func (b pacBlobFetcher) FetchBlob(ctx context.Context, repoURL, token, ref, file string) (string, bool, error) {
+	blob, err := b.reader.Blob(ctx, repoURL, token, ref, file)
+	if err != nil {
+		return "", false, err
+	}
+	return blob.Content, blob.Degraded, nil
 }
 
 // buildRunnerOption 按 PIPEWRIGHT_BUILDER 开关返回注入 pool 的运行执行器选项(Story 3-3/3-5)。

--- a/internal/pacloader/pacloader.go
+++ b/internal/pacloader/pacloader.go
@@ -1,0 +1,138 @@
+// Package pacloader 实现「流水线即代码」(Pipeline-as-code)运行时覆盖(FR-8-12)。
+//
+// 背景:项目的流水线配置原本只来自库内 pipeline.Service(UI 编辑、落库)。本包提供一个
+// **装饰器** dagrun.SpecLoader(Loader),包住库内 loader:运行时若项目仓库根含合法的
+// `.pipewright.yml`,就用它驱动本次运行;否则一律回退库内配置。
+//
+// ── 不破坏运行的铁律 ─────────────────────────────────────────────────────────
+// 任何环节出问题(项目查不到、克隆/拉取失败、文件不存在、YAML 解析/校验失败、token
+// 取不到)都**静默回退**到被包住的库内 loader——运行绝不因 YAML 问题而中断。仅在 debug
+// 级别记一行原因(不含任何密钥)。
+//
+// ── 已知约束:无分支(KNOWN CONSTRAINT,显式处理)──────────────────────────────
+// dagrun.SpecLoader.Get 只拿到 projectID,**没有本次运行的分支/ref**。因此本装饰器从
+// **项目的默认分支**(项目记录里的 DefaultBranch)拉取 `.pipewright.yml`。
+// 「按运行分支覆盖」(feature 分支上改 YAML 即对该分支运行生效)需要把运行分支贯穿进
+// SpecLoader 签名 / dagrun 内核——风险较大,**本期推迟(DEFERRED)**,不动 SpecLoader
+// 签名,也不碰 dagrun 执行内核。默认分支解析是本期可交付范围。
+//
+// ── 安全 ─────────────────────────────────────────────────────────────────────
+// token 仅在进程内取用即弃,绝不进日志/错误/返回值。底层拉取错误不外泄(可能含 URL 凭据)。
+package pacloader
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/pipelineyaml"
+)
+
+// DefaultFile 是仓库根「流水线即代码」文件名。
+const DefaultFile = ".pipewright.yml"
+
+// SpecLoader 是被装饰的库内加载器契约(与 dagrun.SpecLoader 同形,避免反向 import dagrun)。
+type SpecLoader interface {
+	Get(ctx context.Context, projectID string) (*pipeline.Config, error)
+}
+
+// ProjectInfo 是覆盖装饰器拉取 `.pipewright.yml` 所需的项目最小视图。
+type ProjectInfo struct {
+	RepoURL       string
+	CredentialID  string
+	DefaultBranch string
+}
+
+// ProjectLookup 按 projectID 取仓库地址/凭据/默认分支(由 project.Service 适配)。
+type ProjectLookup interface {
+	Lookup(ctx context.Context, projectID string) (ProjectInfo, error)
+}
+
+// TokenRevealer 解密并返回凭据明文(由 vault.Vault.Reveal 适配)。
+// 取不到时返回错误,装饰器据此回退(空 token 也可继续尝试公开仓库)。
+type TokenRevealer interface {
+	Reveal(credentialID string) (string, error)
+}
+
+// BlobFetcher 按 ref 读仓库单文件内容(由 httpapi.SourceReader 适配)。
+// degraded=true 表示克隆失败的降级响应(非「真实空文件」),装饰器据此回退。
+type BlobFetcher interface {
+	FetchBlob(ctx context.Context, repoURL, token, ref, file string) (content string, degraded bool, err error)
+}
+
+// Loader 是 PAC 运行时覆盖装饰器:实现 dagrun.SpecLoader。
+type Loader struct {
+	inner    SpecLoader
+	projects ProjectLookup
+	tokens   TokenRevealer
+	blobs    BlobFetcher
+}
+
+// New 构造装饰器。inner 必填(回退目标);projects/blobs 任一为 nil 时退化为纯透传(仅回退)。
+// tokens 可为 nil(无保险库时按公开仓库以空 token 尝试)。
+func New(inner SpecLoader, projects ProjectLookup, tokens TokenRevealer, blobs BlobFetcher) *Loader {
+	return &Loader{inner: inner, projects: projects, tokens: tokens, blobs: blobs}
+}
+
+// Get 实现 dagrun.SpecLoader:尝试用仓库默认分支的 `.pipewright.yml` 覆盖;
+// 任何问题都回退到 inner(库内配置)。绝不把 YAML 问题冒泡给调用方。
+func (l *Loader) Get(ctx context.Context, projectID string) (*pipeline.Config, error) {
+	if cfg, ok := l.tryOverride(ctx, projectID); ok {
+		return cfg, nil
+	}
+	return l.inner.Get(ctx, projectID)
+}
+
+// tryOverride 尝试从仓库默认分支拉取并解析 `.pipewright.yml`;成功返回 (cfg,true)。
+// 任何环节失败返回 (nil,false)(调用方回退)。失败只记 debug 原因(无密钥)。
+func (l *Loader) tryOverride(ctx context.Context, projectID string) (*pipeline.Config, bool) {
+	if l.projects == nil || l.blobs == nil {
+		return nil, false
+	}
+
+	info, err := l.projects.Lookup(ctx, projectID)
+	if err != nil {
+		debugf("项目 %s 查询失败,回退库内配置", projectID)
+		return nil, false
+	}
+	if strings.TrimSpace(info.RepoURL) == "" {
+		return nil, false
+	}
+
+	// 取仓库凭据明文(进程内取用即弃;取不到不致命 → 空 token 尝试公开仓库)。
+	token := ""
+	if l.tokens != nil && strings.TrimSpace(info.CredentialID) != "" {
+		if t, terr := l.tokens.Reveal(info.CredentialID); terr == nil {
+			token = t
+		}
+	}
+
+	content, degraded, ferr := l.blobs.FetchBlob(ctx, info.RepoURL, token, info.DefaultBranch, DefaultFile)
+	if ferr != nil {
+		// 文件不存在 / 克隆失败 → 回退(正常路径:多数项目没有 .pipewright.yml)。
+		debugf("项目 %s 未读到 %s(回退库内配置)", projectID, DefaultFile)
+		return nil, false
+	}
+	if degraded {
+		debugf("项目 %s 仓库克隆降级,无法读 %s(回退库内配置)", projectID, DefaultFile)
+		return nil, false
+	}
+	if strings.TrimSpace(content) == "" {
+		return nil, false
+	}
+
+	cfg, perr := pipelineyaml.Parse([]byte(content))
+	if perr != nil {
+		// YAML 非法 → 回退(绝不让坏 YAML 中断运行)。错误不含密钥但仍只记 debug。
+		debugf("项目 %s 的 %s 解析/校验失败,回退库内配置", projectID, DefaultFile)
+		return nil, false
+	}
+	debugf("项目 %s 命中仓库 %s(默认分支 %s),用其驱动本次运行", projectID, DefaultFile, info.DefaultBranch)
+	return &cfg, true
+}
+
+// debugf 记录回退原因(诊断用)。绝不打印 token / 仓库 URL 凭据。
+func debugf(format string, args ...any) {
+	log.Printf("[pac] "+format, args...)
+}

--- a/internal/pacloader/pacloader_test.go
+++ b/internal/pacloader/pacloader_test.go
@@ -1,0 +1,274 @@
+package pacloader
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+)
+
+// ─── 测试替身 ──────────────────────────────────────────────────────────────────
+
+// storedLoader 是被装饰的「库内」loader 替身:返回一份可辨识的 stored 配置。
+type storedLoader struct {
+	cfg    *pipeline.Config
+	err    error
+	called int
+}
+
+func (s *storedLoader) Get(_ context.Context, _ string) (*pipeline.Config, error) {
+	s.called++
+	return s.cfg, s.err
+}
+
+type fakeProjects struct {
+	info ProjectInfo
+	err  error
+}
+
+func (f fakeProjects) Lookup(_ context.Context, _ string) (ProjectInfo, error) {
+	return f.info, f.err
+}
+
+type fakeTokens struct {
+	token string
+	err   error
+	gotID string
+}
+
+func (f *fakeTokens) Reveal(id string) (string, error) {
+	f.gotID = id
+	return f.token, f.err
+}
+
+type fakeBlobs struct {
+	content  string
+	degraded bool
+	err      error
+	gotRef   string
+	gotFile  string
+	gotToken string
+}
+
+func (f *fakeBlobs) FetchBlob(_ context.Context, _, token, ref, file string) (string, bool, error) {
+	f.gotToken = token
+	f.gotRef = ref
+	f.gotFile = file
+	return f.content, f.degraded, f.err
+}
+
+// ─── 夹具 ──────────────────────────────────────────────────────────────────────
+
+func storedCfg() *pipeline.Config {
+	return &pipeline.Config{Spec: pipeline.Spec{Stages: []pipeline.Stage{
+		{ID: "stg_stored", Name: "stored-pipeline", Kind: pipeline.KindBuild},
+	}}}
+}
+
+// firstStage 取配置首个阶段名(测试用「stored」/「from-repo」辨识来源)。
+func firstStage(cfg *pipeline.Config) string {
+	if cfg == nil || len(cfg.Spec.Stages) == 0 {
+		return ""
+	}
+	return cfg.Spec.Stages[0].Name
+}
+
+// validYAML 是一份最小合法 `.pipewright.yml`(经 pipelineyaml.Parse 校验通过:须恰好一个 source 阶段)。
+// 首阶段名「from-repo」用于在测试中辨识「来自仓库 YAML」。
+const validYAML = `version: 1
+stages:
+  - id: stg_src
+    name: from-repo
+    kind: source
+    jobs:
+      - id: job_src
+        name: 源
+        type: git_source
+  - id: stg_build
+    name: 构建
+    kind: build
+    needs:
+      - stg_src
+    jobs:
+      - id: job_compile
+        name: compile
+        type: script
+        script:
+          commands:
+            - echo hi
+`
+
+func newLoader(stored *storedLoader, p ProjectLookup, t TokenRevealer, b BlobFetcher) *Loader {
+	return New(stored, p, t, b)
+}
+
+func defaultInfo() ProjectInfo {
+	return ProjectInfo{RepoURL: "https://git.example.com/acme/app.git", CredentialID: "cred-1", DefaultBranch: "main"}
+}
+
+// ─── (a) 合法 .pipewright.yml → 用其 spec ───────────────────────────────────────
+
+func TestGet_ValidRepoYAML_UsesRepoSpec(t *testing.T) {
+	stored := &storedLoader{cfg: storedCfg()}
+	tokens := &fakeTokens{token: "secret-token"}
+	blobs := &fakeBlobs{content: validYAML}
+	l := newLoader(stored, fakeProjects{info: defaultInfo()}, tokens, blobs)
+
+	cfg, err := l.Get(context.Background(), "proj-1")
+	if err != nil {
+		t.Fatalf("意外错误: %v", err)
+	}
+	if cfg == nil || firstStage(cfg) != "from-repo" {
+		t.Fatalf("应使用仓库 YAML 的 spec(name=from-repo),实际: %+v", cfg)
+	}
+	if stored.called != 0 {
+		t.Fatalf("命中仓库 YAML 时不应回退库内 loader,called=%d", stored.called)
+	}
+	// 从默认分支拉取正确文件,并把凭据明文透传给拉取器。
+	if blobs.gotRef != "main" {
+		t.Errorf("应从默认分支 main 拉取,实际 ref=%q", blobs.gotRef)
+	}
+	if blobs.gotFile != DefaultFile {
+		t.Errorf("应拉取 %s,实际 file=%q", DefaultFile, blobs.gotFile)
+	}
+	if blobs.gotToken != "secret-token" {
+		t.Errorf("应把凭据明文透传给拉取器")
+	}
+	if tokens.gotID != "cred-1" {
+		t.Errorf("应按项目 CredentialID 解密,实际 id=%q", tokens.gotID)
+	}
+}
+
+// ─── (b) 文件不存在 → 用库内配置 ────────────────────────────────────────────────
+
+func TestGet_FileMissing_FallsBackToStored(t *testing.T) {
+	stored := &storedLoader{cfg: storedCfg()}
+	// 拉取器对「文件不存在」返回错误(SourceReader 语义:path not found)。
+	blobs := &fakeBlobs{err: errors.New("source: path not found")}
+	l := newLoader(stored, fakeProjects{info: defaultInfo()}, &fakeTokens{}, blobs)
+
+	cfg, err := l.Get(context.Background(), "proj-1")
+	if err != nil {
+		t.Fatalf("文件缺失不应报错(应回退): %v", err)
+	}
+	if cfg == nil || firstStage(cfg) != "stored-pipeline" {
+		t.Fatalf("应回退库内配置,实际: %+v", cfg)
+	}
+	if stored.called != 1 {
+		t.Fatalf("应恰好回退一次库内 loader,called=%d", stored.called)
+	}
+}
+
+// ─── (c) 拉取/克隆失败 → 用库内配置(不冒泡错误)─────────────────────────────────
+
+func TestGet_FetchError_FallsBackNoError(t *testing.T) {
+	stored := &storedLoader{cfg: storedCfg()}
+	blobs := &fakeBlobs{err: errors.New("source: clone failed")}
+	l := newLoader(stored, fakeProjects{info: defaultInfo()}, &fakeTokens{}, blobs)
+
+	cfg, err := l.Get(context.Background(), "proj-1")
+	if err != nil {
+		t.Fatalf("拉取失败绝不应冒泡给调用方: %v", err)
+	}
+	if firstStage(cfg) != "stored-pipeline" {
+		t.Fatalf("应回退库内配置,实际 name=%q", firstStage(cfg))
+	}
+}
+
+// degraded 克隆降级(SourceReader 对 tree/blob 的优雅降级)同样回退。
+func TestGet_DegradedClone_FallsBack(t *testing.T) {
+	stored := &storedLoader{cfg: storedCfg()}
+	blobs := &fakeBlobs{content: "", degraded: true}
+	l := newLoader(stored, fakeProjects{info: defaultInfo()}, &fakeTokens{}, blobs)
+
+	cfg, err := l.Get(context.Background(), "proj-1")
+	if err != nil {
+		t.Fatalf("降级不应报错: %v", err)
+	}
+	if firstStage(cfg) != "stored-pipeline" {
+		t.Fatalf("降级应回退库内配置,实际 name=%q", firstStage(cfg))
+	}
+}
+
+// ─── (d) 非法 YAML → 用库内配置 ─────────────────────────────────────────────────
+
+func TestGet_InvalidYAML_FallsBackToStored(t *testing.T) {
+	stored := &storedLoader{cfg: storedCfg()}
+	blobs := &fakeBlobs{content: "this: : is not valid pipewright yaml\n  - broken"}
+	l := newLoader(stored, fakeProjects{info: defaultInfo()}, &fakeTokens{}, blobs)
+
+	cfg, err := l.Get(context.Background(), "proj-1")
+	if err != nil {
+		t.Fatalf("非法 YAML 绝不应中断运行: %v", err)
+	}
+	if firstStage(cfg) != "stored-pipeline" {
+		t.Fatalf("非法 YAML 应回退库内配置,实际 name=%q", firstStage(cfg))
+	}
+}
+
+// ─── 边界:项目查询失败 / 空仓库 / 空内容 / 缺依赖 → 回退 ────────────────────────
+
+func TestGet_ProjectLookupError_FallsBack(t *testing.T) {
+	stored := &storedLoader{cfg: storedCfg()}
+	l := newLoader(stored, fakeProjects{err: errors.New("not found")}, &fakeTokens{}, &fakeBlobs{content: validYAML})
+
+	cfg, _ := l.Get(context.Background(), "proj-1")
+	if firstStage(cfg) != "stored-pipeline" {
+		t.Fatalf("项目查询失败应回退库内,实际 name=%q", firstStage(cfg))
+	}
+}
+
+func TestGet_EmptyRepoURL_FallsBack(t *testing.T) {
+	stored := &storedLoader{cfg: storedCfg()}
+	info := defaultInfo()
+	info.RepoURL = "  "
+	l := newLoader(stored, fakeProjects{info: info}, &fakeTokens{}, &fakeBlobs{content: validYAML})
+
+	cfg, _ := l.Get(context.Background(), "proj-1")
+	if firstStage(cfg) != "stored-pipeline" {
+		t.Fatalf("空仓库地址应回退库内,实际 name=%q", firstStage(cfg))
+	}
+}
+
+func TestGet_EmptyContent_FallsBack(t *testing.T) {
+	stored := &storedLoader{cfg: storedCfg()}
+	l := newLoader(stored, fakeProjects{info: defaultInfo()}, &fakeTokens{}, &fakeBlobs{content: "   \n"})
+
+	cfg, _ := l.Get(context.Background(), "proj-1")
+	if firstStage(cfg) != "stored-pipeline" {
+		t.Fatalf("空文件应回退库内,实际 name=%q", firstStage(cfg))
+	}
+}
+
+func TestGet_NilDeps_PurePassthrough(t *testing.T) {
+	stored := &storedLoader{cfg: storedCfg()}
+	l := New(stored, nil, nil, nil)
+
+	cfg, err := l.Get(context.Background(), "proj-1")
+	if err != nil {
+		t.Fatalf("意外错误: %v", err)
+	}
+	if firstStage(cfg) != "stored-pipeline" || stored.called != 1 {
+		t.Fatalf("缺依赖应纯透传库内 loader,name=%q called=%d", firstStage(cfg), stored.called)
+	}
+}
+
+// 凭据取不到(Reveal 失败)→ 以空 token 继续尝试公开仓库(不直接回退)。
+func TestGet_TokenRevealError_TriesPublicWithEmptyToken(t *testing.T) {
+	stored := &storedLoader{cfg: storedCfg()}
+	tokens := &fakeTokens{err: errors.New("vault: not found")}
+	blobs := &fakeBlobs{content: validYAML}
+	l := newLoader(stored, fakeProjects{info: defaultInfo()}, tokens, blobs)
+
+	cfg, err := l.Get(context.Background(), "proj-1")
+	if err != nil {
+		t.Fatalf("意外错误: %v", err)
+	}
+	if firstStage(cfg) != "from-repo" {
+		t.Fatalf("凭据取不到应以空 token 尝试公开仓库,实际 name=%q", firstStage(cfg))
+	}
+	if blobs.gotToken != "" {
+		t.Errorf("Reveal 失败时应以空 token 拉取,实际 token=%q", blobs.gotToken)
+	}
+}


### PR DESCRIPTION
## 背景

PR #35 已落地解析层(`internal/pipelineyaml.Parse` + `POST /api/projects/{id}/pipeline/import`)。
本 PR 让仓库里的 `.pipewright.yml` **真正驱动运行**:运行时若项目仓库根含合法 `.pipewright.yml`,
就用它而非库内存储的流水线配置。(FR-8-12,Pipeline-as-code 收口)

## 装饰器设计

新增 `internal/pacloader`,提供装饰器 `Loader`(实现 `dagrun.SpecLoader`),包住库内
`pipeline.Service`。为不让 pacloader 反向 import project/vault/httpapi,定义三个小接口、
在 `cmd/pipewright/main.go` 用适配器桥接:

- `ProjectLookup` ← `project.Service.Get`(取 RepoURL / CredentialID / DefaultBranch)
- `TokenRevealer` ← `vault.Vault.Reveal`(解密凭据明文)
- `BlobFetcher` ← `httpapi.SourceReader.Blob`(按 ref 读单文件;已 SSRF 收口)

`Get(ctx, projectID)` 流程:查项目 → Reveal 凭据明文 → 用**默认分支**读 `.pipewright.yml`
→ `pipelineyaml.Parse` → 命中即返回该 spec。

## 回退保证(运行绝不因 YAML 中断)

任何环节出问题都**静默回退**到被包住的库内 loader,绝不把错误冒泡给调用方:

- 项目查不到 / 仓库地址空 → 回退
- 凭据 Reveal 失败 → 以空 token 尝试公开仓库(仍失败再回退)
- 拉取/克隆失败、文件不存在、克隆降级(degraded)→ 回退
- 文件为空 → 回退
- YAML 解析/领域校验失败 → 回退

失败仅记一行 `[pac]` debug 原因(**不含 token / 仓库 URL 凭据**)。

测试(fakes,`internal/pacloader/pacloader_test.go`)证明四条核心路径 + 多个边界:
(a) 合法 YAML → 用仓库 spec(且不触库内 loader);(b) 文件缺失 → 库内;(c) 拉取错误 → 库内
(不冒泡);(d) 非法 YAML → 库内。另含 degraded / 项目查询失败 / 空仓库 / 空内容 / 缺依赖纯透传 /
凭据取不到走空 token。

## opt-in 机制

环境开关 **`PIPEWRIGHT_PAC_RUNTIME=1`**:仅在 `PIPEWRIGHT_RUNNER=dag` 路径(`dagrun.New`
消费 SpecLoader 处)包上装饰器,boot 打印 `[pac] 运行时 .pipewright.yml 覆盖已启用`。
**关闭时(缺省)行为与今日完全一致**——直接把 `pipelineSvc` 传给 `dagrun.New`,不新增任何
拉取/克隆开销。改动最小、局部,未触碰 `SpecLoader` 接口签名与 dagrun 执行内核。

## 默认分支约束 + 推迟项(DEFERRED)

`dagrun.SpecLoader.Get` 只拿到 `projectID`,**没有本次运行的分支/ref**。故本装饰器从
**项目默认分支**(项目记录的 `DefaultBranch`)拉取 `.pipewright.yml`。
「按运行分支覆盖」(feature 分支改 YAML 即对该分支运行生效)需把运行分支贯穿进 SpecLoader
签名 / dagrun 内核——风险较大,**本期推迟**,不动签名也不碰执行内核。默认分支解析为本期可交付范围。
(已在 `internal/pacloader` 包注释 + 代码注释明确标注。)

## 迁移

**无**。纯环境开关 opt-in,不加表/列,无 schema 变更。

## 绿门证据

```
gofmt -l internal/pacloader/ cmd/pipewright/main.go   # 空
go vet ./...                                           # exit 0
go build ./...                                         # 无输出(成功)
go test ./...                                          # 全 ok(含 internal/pacloader)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)