### PR TITLE
feat(pipeline): 流水线模板 + 变量组(FR-8-13)

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/dagrun"
 	"github.com/huangchengsir/pipewright/internal/deploy"
 	"github.com/huangchengsir/pipewright/internal/httpapi"
+	"github.com/huangchengsir/pipewright/internal/library"
 	"github.com/huangchengsir/pipewright/internal/mask"
 	"github.com/huangchengsir/pipewright/internal/notify"
 	"github.com/huangchengsir/pipewright/internal/oauth"
@@ -107,6 +108,13 @@ func main() {
 	// 装配定时(cron)触发配置服务(Story 8-6):每项目一份 cron 表达式 + 分支 + 启用开关。
 	// 调度器(下方,pool 后)按启用配置分钟粒度扫描、到点经 run.Service 创建「定时」触发的运行。
 	cronSvc := cron.NewService(st.DB)
+
+	// 装配流水线模板 + 变量组复用基座(FR-8-13 · 对标 Jenkins Shared Library / 云效模板与变量组)。
+	// 模板:命名、可复用的流水线定义(与项目流水线同一套 stages 模型),跨项目共享;应用模板经
+	// pipelineSvc.Save 把 stages 落到项目流水线(复用同一套规范化/校验/渲染)。变量组:命名、可复用的
+	// 变量集合,镜像每流水线变量模型;secret 经 credVault 校验存在性、只存引用,明文绝不入库。
+	templateSvc := library.NewTemplateService(st.DB, pipelineSvc)
+	varGroupSvc := library.NewVarGroupService(st.DB, credVault)
 
 	// 装配项目级并发上限配置服务(FR-8-10 并发/队列控制):每项目一份 max_concurrent。
 	// 注入 worker pool 做准入(下方);经 /api/projects/{id}/concurrency 读写。
@@ -322,7 +330,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithServers(targetSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithChain(chainSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc), httpapi.WithPromotion(promotionStore), httpapi.WithDoraMetrics(doraMetricsSvc)),
+		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithServers(targetSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithChain(chainSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc), httpapi.WithPromotion(promotionStore), httpapi.WithDoraMetrics(doraMetricsSvc), httpapi.WithTemplates(templateSvc), httpapi.WithVariableGroups(varGroupSvc)),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		// WriteTimeout 置 0:SSE 长连接(/api/runs/{id}/events)不可被写超时切断;

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -41,6 +41,13 @@ const (
 	ActionSessionRevoke      = "session_revoke"
 	ActionServiceOp          = "service_op"
 	ActionContainerTerminal  = "container_terminal"
+	// 流水线模板 + 变量组(FR-8-13 复用基座)。
+	ActionTemplateCreate = "template_create"
+	ActionTemplateDelete = "template_delete"
+	ActionTemplateApply  = "template_apply"
+	ActionVarGroupCreate = "variable_group_create"
+	ActionVarGroupUpdate = "variable_group_update"
+	ActionVarGroupDelete = "variable_group_delete"
 )
 
 // 目标类型枚举(供 TargetType 填值;非强制白名单,便于后续 story 扩展)。
@@ -52,6 +59,8 @@ const (
 	TargetAccount    = "account"
 	TargetSession    = "session"
 	TargetServer     = "server"
+	TargetTemplate   = "template"
+	TargetVarGroup   = "variable_group"
 )
 
 // Entry 是一条审计写入入参(冻结契约)。Detail 写库前过 Masker,绝不含明文 secret。

--- a/internal/httpapi/pipelines.go
+++ b/internal/httpapi/pipelines.go
@@ -55,10 +55,11 @@ type jobDTO struct {
 	Config  map[string]any `json:"config"`
 }
 
-// toPipelineDTO 把领域 Config 转为契约 DTO(切片/map 保证非 nil,JSON 输出 [] / {})。
-func toPipelineDTO(c *pipeline.Config) pipelineDTO {
-	stages := make([]stageDTO, 0, len(c.Spec.Stages))
-	for _, st := range c.Spec.Stages {
+// toStageDTOs 把领域阶段集合转契约 stageDTO 列表(切片/map 保证非 nil,JSON 输出 [] / {})。
+// 供流水线配置与流水线模板(library)共用同一阶段形状。
+func toStageDTOs(in []pipeline.Stage) []stageDTO {
+	stages := make([]stageDTO, 0, len(in))
+	for _, st := range in {
 		jobs := make([]jobDTO, 0, len(st.Jobs))
 		for _, jb := range st.Jobs {
 			cfg := jb.Config
@@ -79,12 +80,66 @@ func toPipelineDTO(c *pipeline.Config) pipelineDTO {
 		}
 		stages = append(stages, stageDTO{ID: st.ID, Name: st.Name, Kind: st.Kind, Needs: needs, AllowFailure: st.AllowFailure, When: toWhenDTO(st.When), Gate: st.Gate, Jobs: jobs})
 	}
+	return stages
+}
+
+// toPipelineDTO 把领域 Config 转为契约 DTO(切片/map 保证非 nil,JSON 输出 [] / {})。
+func toPipelineDTO(c *pipeline.Config) pipelineDTO {
 	return pipelineDTO{
-		Stages:    stages,
+		Stages:    toStageDTOs(c.Spec.Stages),
 		Yaml:      c.YAML,
 		Status:    c.Status,
 		UpdatedAt: c.UpdatedAt.UTC().Format(time.RFC3339),
 	}
+}
+
+// reqStage 是请求里的一条阶段(供流水线 PUT 与模板 POST 共用同一解析形状)。
+type reqStage struct {
+	ID           string   `json:"id"`
+	Name         string   `json:"name"`
+	Kind         string   `json:"kind"`
+	Needs        []string `json:"needs"`
+	AllowFailure bool     `json:"allowFailure"`
+	When         struct {
+		Branches []string `json:"branches"`
+		Events   []string `json:"events"`
+	} `json:"when"`
+	Gate bool `json:"gate"`
+	Jobs []struct {
+		ID      string         `json:"id"`
+		Name    string         `json:"name"`
+		Type    string         `json:"type"`
+		Summary string         `json:"summary"`
+		Config  map[string]any `json:"config"`
+	} `json:"jobs"`
+}
+
+// reqStagesToDomain 把请求阶段转领域阶段(规范化/校验由领域层 Save / NormalizeSpec 兜)。
+func reqStagesToDomain(in []reqStage) []pipeline.Stage {
+	stages := make([]pipeline.Stage, 0, len(in))
+	for _, st := range in {
+		jobs := make([]pipeline.Job, 0, len(st.Jobs))
+		for _, jb := range st.Jobs {
+			jobs = append(jobs, pipeline.Job{
+				ID:      jb.ID,
+				Name:    jb.Name,
+				Type:    jb.Type,
+				Summary: jb.Summary,
+				Config:  jb.Config,
+			})
+		}
+		stages = append(stages, pipeline.Stage{
+			ID:           st.ID,
+			Name:         st.Name,
+			Kind:         st.Kind,
+			Needs:        st.Needs,
+			AllowFailure: st.AllowFailure,
+			When:         pipeline.When{Branches: st.When.Branches, Events: st.When.Events},
+			Gate:         st.Gate,
+			Jobs:         jobs,
+		})
+	}
+	return stages
 }
 
 // writePipelineError 把领域错误映射为契约错误码/状态码。
@@ -133,56 +188,14 @@ func makeSavePipelineHandler(svc pipeline.Service) http.HandlerFunc {
 		id := chi.URLParam(r, "id")
 		r.Body = http.MaxBytesReader(w, r.Body, 1<<18) // 256KB
 		var req struct {
-			Stages []struct {
-				ID           string   `json:"id"`
-				Name         string   `json:"name"`
-				Kind         string   `json:"kind"`
-				Needs        []string `json:"needs"`
-				AllowFailure bool     `json:"allowFailure"`
-				When         struct {
-					Branches []string `json:"branches"`
-					Events   []string `json:"events"`
-				} `json:"when"`
-				Gate bool `json:"gate"`
-				Jobs []struct {
-					ID      string         `json:"id"`
-					Name    string         `json:"name"`
-					Type    string         `json:"type"`
-					Summary string         `json:"summary"`
-					Config  map[string]any `json:"config"`
-				} `json:"jobs"`
-			} `json:"stages"`
+			Stages []reqStage `json:"stages"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
 			return
 		}
 
-		stages := make([]pipeline.Stage, 0, len(req.Stages))
-		for _, st := range req.Stages {
-			jobs := make([]pipeline.Job, 0, len(st.Jobs))
-			for _, jb := range st.Jobs {
-				jobs = append(jobs, pipeline.Job{
-					ID:      jb.ID,
-					Name:    jb.Name,
-					Type:    jb.Type,
-					Summary: jb.Summary,
-					Config:  jb.Config,
-				})
-			}
-			stages = append(stages, pipeline.Stage{
-				ID:           st.ID,
-				Name:         st.Name,
-				Kind:         st.Kind,
-				Needs:        st.Needs,
-				AllowFailure: st.AllowFailure,
-				When:         pipeline.When{Branches: st.When.Branches, Events: st.When.Events},
-				Gate:         st.Gate,
-				Jobs:         jobs,
-			})
-		}
-
-		cfg, err := svc.Save(r.Context(), id, pipeline.Spec{Stages: stages})
+		cfg, err := svc.Save(r.Context(), id, pipeline.Spec{Stages: reqStagesToDomain(req.Stages)})
 		if err != nil {
 			writePipelineError(w, err)
 			return

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -24,6 +24,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/chain"
 	"github.com/huangchengsir/pipewright/internal/cron"
 	"github.com/huangchengsir/pipewright/internal/deploy"
+	"github.com/huangchengsir/pipewright/internal/library"
 	"github.com/huangchengsir/pipewright/internal/notify"
 	"github.com/huangchengsir/pipewright/internal/oauth"
 	"github.com/huangchengsir/pipewright/internal/pipeline"
@@ -78,6 +79,8 @@ type options struct {
 	approvalStore    *approval.Store
 	promotionStore   *promotion.Store
 	doraMetrics      run.MetricsService
+	templates        library.TemplateService
+	varGroups        library.VarGroupService
 }
 
 // WithApprovals 注入审批门协调器 + 持久层(Story 8-4),挂载 /api/runs/{id}/{approve,reject,approvals} 路由。
@@ -101,6 +104,20 @@ func WithPromotion(store *promotion.Store) Option {
 // 不传则该端点返回 503(服务未初始化)。
 func WithDoraMetrics(s run.MetricsService) Option {
 	return func(o *options) { o.doraMetrics = s }
+}
+
+// WithTemplates 注入流水线模板服务(FR-8-13 复用基座),挂载 /api/templates* 与
+// POST /api/projects/{id}/pipeline/apply-template 路由。GET 过 auth;写方法过 auth + CSRF + 审计。
+// 不传则相关端点返回 503(服务未初始化)。
+func WithTemplates(s library.TemplateService) Option {
+	return func(o *options) { o.templates = s }
+}
+
+// WithVariableGroups 注入变量组服务(FR-8-13 复用基座),挂载 /api/variable-groups* 路由。
+// GET 过 auth;POST/PUT/DELETE 过 auth + CSRF + 审计。secret 变量只存/回 credentialId + 掩码,绝无明文。
+// 不传则相关端点返回 503(服务未初始化)。
+func WithVariableGroups(s library.VarGroupService) Option {
+	return func(o *options) { o.varGroups = s }
 }
 
 // WithVault 注入凭据保险库,挂载 /api/credentials* 路由。
@@ -569,6 +586,26 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		// 对既有运行数据做纯聚合(无新表、无副作用)。GET 只读 → 过 auth、豁免 CSRF。
 		// projectId 可选过滤;window 形如 30d(默认)。o.doraMetrics 为 nil → handler 返回 503。
 		ar.Get("/metrics/dora", makeDoraMetricsHandler(o.doraMetrics))
+
+		// 流水线模板(FR-8-13 复用基座):命名、可复用的流水线定义,跨项目共享。
+		// tpl 为 nil → handler 返回 503。GET(列表/详情)过 auth;POST/DELETE/apply 为写方法,
+		// 过 auth + CSRF + 审计。模板 spec 不含明文 secret。apply-template 比 /pipeline 多一段,不会被吞。
+		tpl := o.templates
+		ar.Get("/templates", makeListPipelineTemplatesHandler(tpl))
+		ar.Post("/templates", makeCreatePipelineTemplateHandler(tpl, aud))
+		ar.Get("/templates/{id}", makeGetPipelineTemplateHandler(tpl))
+		ar.Delete("/templates/{id}", makeDeletePipelineTemplateHandler(tpl, aud))
+		ar.Post("/projects/{id}/pipeline/apply-template", makeApplyTemplateHandler(tpl, aud))
+
+		// 变量组(FR-8-13 复用基座):命名、可复用的变量集合(key=value + secret 引用)。
+		// vg 为 nil → handler 返回 503。GET 过 auth;POST/PUT/DELETE 为写方法,过 auth + CSRF + 审计。
+		// secret 变量只存/回 credentialId + 掩码,绝无明文。
+		vg := o.varGroups
+		ar.Get("/variable-groups", makeListVarGroupsHandler(vg))
+		ar.Post("/variable-groups", makeCreateVarGroupHandler(vg, aud))
+		ar.Get("/variable-groups/{id}", makeGetVarGroupHandler(vg))
+		ar.Put("/variable-groups/{id}", makeUpdateVarGroupHandler(vg, aud))
+		ar.Delete("/variable-groups/{id}", makeDeleteVarGroupHandler(vg, aud))
 
 		// 后续 story 在此挂载其他 API 路由。
 	})

--- a/internal/httpapi/templates.go
+++ b/internal/httpapi/templates.go
@@ -1,0 +1,217 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/audit"
+	"github.com/huangchengsir/pipewright/internal/library"
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+)
+
+// templates.go 暴露流水线模板端点(FR-8-13 复用基座 · 对标 Jenkins Shared Library / 云效模板)。
+//
+//	GET    /api/templates                              → 列模板(画廊)
+//	POST   /api/templates                              → 建模板(name + spec;走 pipeline 校验)
+//	GET    /api/templates/{id}                         → 取单模板(含 stages)
+//	DELETE /api/templates/{id}                         → 删模板
+//	POST   /api/projects/{id}/pipeline/apply-template  → 把模板 stages 应用到项目流水线(校验后落库)
+//
+// 模板 spec 不含任何明文 secret(凭据走保险库引用)。写操作过 auth + CSRF + 审计(detail 仅元数据)。
+
+// pipelineTemplateSummaryDTO 是模板列表项 DTO(不含完整 spec,只元数据 + 阶段数,列表更轻)。
+type pipelineTemplateSummaryDTO struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	StageCount  int    `json:"stageCount"`
+	CreatedAt   string `json:"createdAt"`
+	UpdatedAt   string `json:"updatedAt"`
+}
+
+// pipelineTemplateDTO 是模板详情 DTO(含完整 stages,复用流水线 stageDTO 形状)。
+type pipelineTemplateDTO struct {
+	ID          string     `json:"id"`
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	Stages      []stageDTO `json:"stages"`
+	CreatedAt   string     `json:"createdAt"`
+	UpdatedAt   string     `json:"updatedAt"`
+}
+
+func toPipelineTemplateSummaryDTO(t library.Template) pipelineTemplateSummaryDTO {
+	return pipelineTemplateSummaryDTO{
+		ID:          t.ID,
+		Name:        t.Name,
+		Description: t.Description,
+		StageCount:  len(t.Spec.Stages),
+		CreatedAt:   t.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:   t.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+func toPipelineTemplateDTO(t *library.Template) pipelineTemplateDTO {
+	return pipelineTemplateDTO{
+		ID:          t.ID,
+		Name:        t.Name,
+		Description: t.Description,
+		Stages:      toStageDTOs(t.Spec.Stages),
+		CreatedAt:   t.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:   t.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+// writeTemplateError 把模板领域错误映射为契约错误码/状态码。
+func writeTemplateError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, library.ErrTemplateNotFound):
+		writeError(w, http.StatusNotFound, "template_not_found", "模板不存在")
+	case errors.Is(err, library.ErrProjectNotFound):
+		writeError(w, http.StatusNotFound, "project_not_found", "项目不存在")
+	case errors.Is(err, library.ErrTemplateNameTaken):
+		writeError(w, http.StatusConflict, "template_name_taken", "模板名已被占用")
+	case errors.Is(err, library.ErrInvalidTemplate):
+		writeError(w, http.StatusUnprocessableEntity, "invalid_template", err.Error())
+	// 模板应用走 pipeline.Save,可能透出 pipeline 校验错误。
+	case errors.Is(err, pipeline.ErrInvalidStage):
+		writeError(w, http.StatusUnprocessableEntity, "invalid_stage", "模板阶段非法(阶段名空 / kind 非枚举 / 须恰一个源阶段)")
+	case errors.Is(err, pipeline.ErrInvalidJob):
+		writeError(w, http.StatusUnprocessableEntity, "invalid_job", "模板任务名与类型不能为空")
+	case errors.Is(err, pipeline.ErrDuplicateID):
+		writeError(w, http.StatusUnprocessableEntity, "duplicate_id", "模板阶段或任务 id 重复")
+	default:
+		writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+	}
+}
+
+func makeListPipelineTemplatesHandler(svc library.TemplateService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "模板服务未初始化")
+			return
+		}
+		list, err := svc.List(r.Context())
+		if err != nil {
+			writeTemplateError(w, err)
+			return
+		}
+		out := make([]pipelineTemplateSummaryDTO, 0, len(list))
+		for _, t := range list {
+			out = append(out, toPipelineTemplateSummaryDTO(t))
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"templates": out})
+	}
+}
+
+func makeGetPipelineTemplateHandler(svc library.TemplateService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "模板服务未初始化")
+			return
+		}
+		t, err := svc.Get(r.Context(), chi.URLParam(r, "id"))
+		if err != nil {
+			writeTemplateError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, toPipelineTemplateDTO(t))
+	}
+}
+
+func makeCreatePipelineTemplateHandler(svc library.TemplateService, aud audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "模板服务未初始化")
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<18) // 256KB
+		var req struct {
+			Name        string     `json:"name"`
+			Description string     `json:"description"`
+			Stages      []reqStage `json:"stages"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+
+		t, err := svc.Create(r.Context(), library.TemplateInput{
+			Name:        req.Name,
+			Description: req.Description,
+			Spec:        pipeline.Spec{Stages: reqStagesToDomain(req.Stages)},
+		})
+		if err != nil {
+			writeTemplateError(w, err)
+			return
+		}
+		recordAudit(r.Context(), aud, audit.Entry{
+			Actor:      auditActor,
+			Action:     audit.ActionTemplateCreate,
+			TargetType: audit.TargetTemplate,
+			TargetID:   t.ID,
+			Detail:     map[string]any{"name": t.Name, "stageCount": len(t.Spec.Stages)},
+			IP:         clientIP(r),
+		})
+		writeJSON(w, http.StatusCreated, toPipelineTemplateDTO(t))
+	}
+}
+
+func makeDeletePipelineTemplateHandler(svc library.TemplateService, aud audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "模板服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		if err := svc.Delete(r.Context(), id); err != nil {
+			writeTemplateError(w, err)
+			return
+		}
+		recordAudit(r.Context(), aud, audit.Entry{
+			Actor:      auditActor,
+			Action:     audit.ActionTemplateDelete,
+			TargetType: audit.TargetTemplate,
+			TargetID:   id,
+			IP:         clientIP(r),
+		})
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// makeApplyTemplateHandler 返回 POST /api/projects/{id}/pipeline/apply-template handler。
+// 收 {templateId};把模板 stages 经 pipeline.Save 应用到项目流水线(再走规范化/校验/渲染)→ 回项目流水线 DTO。
+func makeApplyTemplateHandler(svc library.TemplateService, aud audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "模板服务未初始化")
+			return
+		}
+		projectID := chi.URLParam(r, "id")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<14)
+		var req struct {
+			TemplateID string `json:"templateId"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+
+		cfg, err := svc.Apply(r.Context(), req.TemplateID, projectID)
+		if err != nil {
+			writeTemplateError(w, err)
+			return
+		}
+		recordAudit(r.Context(), aud, audit.Entry{
+			Actor:      auditActor,
+			Action:     audit.ActionTemplateApply,
+			TargetType: audit.TargetProject,
+			TargetID:   projectID,
+			Detail:     map[string]any{"templateId": req.TemplateID},
+			IP:         clientIP(r),
+		})
+		writeJSON(w, http.StatusOK, toPipelineDTO(cfg))
+	}
+}

--- a/internal/httpapi/templates_vargroups_test.go
+++ b/internal/httpapi/templates_vargroups_test.go
@@ -1,0 +1,189 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/auth"
+	"github.com/huangchengsir/pipewright/internal/library"
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/project"
+	"github.com/huangchengsir/pipewright/internal/vault"
+)
+
+// setupLibraryServer 构造带 auth + vault + project + pipeline + templates + variable-groups 的测试 server。
+func setupLibraryServer(t *testing.T) (*httptest.Server, *http.Client, string, string) {
+	t.Helper()
+	st := testStoreAuth(t)
+	svc := auth.NewService(st.DB, nil)
+	if err := svc.Bootstrap("admin", "testpass"); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	v := vault.New(st.DB, testMasterKey())
+	psvc := project.New(st.DB, v, stubProber{branch: "main"})
+	pipes := pipeline.New(st.DB)
+	tplSvc := library.NewTemplateService(st.DB, pipes)
+	vgSvc := library.NewVarGroupService(st.DB, v)
+	srv := httptest.NewServer(New(testWebFSAuth(), svc,
+		WithVault(v), WithProjects(psvc), WithPipelines(pipes),
+		WithTemplates(tplSvc), WithVariableGroups(vgSvc)))
+	t.Cleanup(srv.Close)
+
+	client := newTestClient(t)
+	csrf := loginWithClient(t, client, srv.URL)
+
+	credID := newGitCred(t, client, srv.URL, csrf, "ghp_token_for_library_proj")
+	resp := doJSON(t, client, http.MethodPost, srv.URL+"/api/projects", csrf,
+		`{"name":"libproj","repoUrl":"https://gitee.com/acme/lib.git","credentialId":"`+credID+`"}`)
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	var p map[string]any
+	_ = json.Unmarshal(raw, &p)
+	projID, _ := p["id"].(string)
+	if projID == "" {
+		t.Fatalf("create project failed: %s", raw)
+	}
+	return srv, client, csrf, projID
+}
+
+func TestTemplateCreateApplyToProjectHTTP(t *testing.T) {
+	srv, client, csrf, projID := setupLibraryServer(t)
+
+	// 建模板:含一个源阶段 + 一个构建阶段。
+	tplBody := `{"name":"go-svc","description":"Go 模板","stages":[
+		{"name":"源","kind":"source","jobs":[{"name":"git","type":"git_source"}]},
+		{"name":"构建","kind":"build","jobs":[{"name":"compile","type":"build"}]}
+	]}`
+	resp := doJSON(t, client, http.MethodPost, srv.URL+"/api/templates", csrf, tplBody)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create template status = %d, body=%s", resp.StatusCode, raw)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	var tpl map[string]any
+	_ = json.Unmarshal(raw, &tpl)
+	tplID, _ := tpl["id"].(string)
+	if tplID == "" {
+		t.Fatalf("template id empty: %s", raw)
+	}
+
+	// 应用模板到项目流水线。
+	applyResp := doJSON(t, client, http.MethodPost,
+		srv.URL+"/api/projects/"+projID+"/pipeline/apply-template", csrf,
+		`{"templateId":"`+tplID+`"}`)
+	defer applyResp.Body.Close()
+	if applyResp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(applyResp.Body)
+		t.Fatalf("apply status = %d, body=%s", applyResp.StatusCode, raw)
+	}
+	rawApply, _ := io.ReadAll(applyResp.Body)
+	var applied map[string]any
+	_ = json.Unmarshal(rawApply, &applied)
+	stages, _ := applied["stages"].([]any)
+	if len(stages) != 2 {
+		t.Fatalf("applied pipeline stages = %d, want 2: %s", len(stages), rawApply)
+	}
+	if yaml, _ := applied["yaml"].(string); strings.TrimSpace(yaml) == "" {
+		t.Fatalf("applied pipeline should render YAML")
+	}
+
+	// 读回项目流水线,确认与模板一致(落库)。
+	getResp := doJSON(t, client, http.MethodGet, srv.URL+"/api/projects/"+projID+"/pipeline", csrf, "")
+	defer getResp.Body.Close()
+	rawGet, _ := io.ReadAll(getResp.Body)
+	var got map[string]any
+	_ = json.Unmarshal(rawGet, &got)
+	if gotStages, _ := got["stages"].([]any); len(gotStages) != 2 {
+		t.Fatalf("project pipeline stages = %d, want 2: %s", len(gotStages), rawGet)
+	}
+}
+
+func TestTemplateApplyMissingTemplateHTTP(t *testing.T) {
+	srv, client, csrf, projID := setupLibraryServer(t)
+	resp := doJSON(t, client, http.MethodPost,
+		srv.URL+"/api/projects/"+projID+"/pipeline/apply-template", csrf,
+		`{"templateId":"nope"}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 404, body=%s", resp.StatusCode, raw)
+	}
+}
+
+func TestVariableGroupSecretMaskedRoundTripHTTP(t *testing.T) {
+	srv, client, csrf, _ := setupLibraryServer(t)
+
+	const leak = "vg_LEAKMARKER_secret_zzz"
+	credID := newGitCred(t, client, srv.URL, csrf, leak)
+
+	body := `{"name":"shared-env","vars":[
+		{"key":"API_URL","secret":false,"value":"https://api.example.com"},
+		{"key":"TOKEN","secret":true,"credentialId":"` + credID + `","value":"should-be-dropped"}
+	]}`
+	resp := doJSON(t, client, http.MethodPost, srv.URL+"/api/variable-groups", csrf, body)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create variable group status = %d, body=%s", resp.StatusCode, raw)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	// 响应绝无明文 secret。
+	if strings.Contains(string(raw), leak) || strings.Contains(string(raw), "should-be-dropped") {
+		t.Fatalf("variable group response leaked plaintext: %s", raw)
+	}
+	var g map[string]any
+	_ = json.Unmarshal(raw, &g)
+	vars, _ := g["vars"].([]any)
+	if len(vars) != 2 {
+		t.Fatalf("vars = %d, want 2: %s", len(vars), raw)
+	}
+	for _, vAny := range vars {
+		vmap, _ := vAny.(map[string]any)
+		if vmap["key"] == "TOKEN" {
+			if vmap["secret"] != true {
+				t.Fatalf("TOKEN should be secret: %v", vmap)
+			}
+			if _, hasValue := vmap["value"]; hasValue {
+				t.Fatalf("secret var should not carry plaintext value: %v", vmap)
+			}
+			if vmap["credentialId"] != credID {
+				t.Fatalf("secret var credentialId = %v, want %s", vmap["credentialId"], credID)
+			}
+			if masked, _ := vmap["maskedValue"].(string); masked == "" {
+				t.Fatalf("secret var should carry maskedValue: %v", vmap)
+			}
+		}
+	}
+
+	gid, _ := g["id"].(string)
+	// 列表与详情同样不泄漏明文。
+	listResp := doJSON(t, client, http.MethodGet, srv.URL+"/api/variable-groups", csrf, "")
+	defer listResp.Body.Close()
+	rawList, _ := io.ReadAll(listResp.Body)
+	if strings.Contains(string(rawList), leak) {
+		t.Fatalf("variable group list leaked plaintext: %s", rawList)
+	}
+
+	// 删除。
+	delResp := doJSON(t, client, http.MethodDelete, srv.URL+"/api/variable-groups/"+gid, csrf, "")
+	defer delResp.Body.Close()
+	if delResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("delete status = %d, want 204", delResp.StatusCode)
+	}
+}
+
+func TestVariableGroupDuplicateKeysRejectedHTTP(t *testing.T) {
+	srv, client, csrf, _ := setupLibraryServer(t)
+	body := `{"name":"dup","vars":[{"key":"K","value":"1"},{"key":"K","value":"2"}]}`
+	resp := doJSON(t, client, http.MethodPost, srv.URL+"/api/variable-groups", csrf, body)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 422, body=%s", resp.StatusCode, raw)
+	}
+}

--- a/internal/httpapi/variable_groups.go
+++ b/internal/httpapi/variable_groups.go
@@ -1,0 +1,203 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/audit"
+	"github.com/huangchengsir/pipewright/internal/library"
+)
+
+// variable_groups.go 暴露变量组端点(FR-8-13 复用基座 · 对标云效变量组 / GitLab CI variable groups)。
+//
+//	GET    /api/variable-groups       → 列变量组(secret 项仅掩码)
+//	POST   /api/variable-groups       → 建变量组(name + vars;secret 只传 credentialId)
+//	GET    /api/variable-groups/{id}  → 取单变量组
+//	PUT    /api/variable-groups/{id}  → 覆盖变量组
+//	DELETE /api/variable-groups/{id}  → 删变量组
+//
+// secret 变量绝无明文:只存/回 credentialId + maskedValue(复用 buildVarDTO + reqVar)。
+// 写操作过 auth + CSRF + 审计(detail 仅元数据:名称 + 变量 key,绝无明文/凭据值)。
+
+// variableGroupDTO 是变量组对外 DTO(冻结契约;camelCase;secret 仅 credentialId + maskedValue)。
+type variableGroupDTO struct {
+	ID          string        `json:"id"`
+	Name        string        `json:"name"`
+	Description string        `json:"description"`
+	Vars        []buildVarDTO `json:"vars"`
+	CreatedAt   string        `json:"createdAt"`
+	UpdatedAt   string        `json:"updatedAt"`
+}
+
+func toVariableGroupDTO(g *library.VarGroup) variableGroupDTO {
+	return variableGroupDTO{
+		ID:          g.ID,
+		Name:        g.Name,
+		Description: g.Description,
+		Vars:        toBuildVarDTOs(g.Vars),
+		CreatedAt:   g.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:   g.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+// writeVarGroupError 把变量组领域错误映射为契约错误码/状态码。
+func writeVarGroupError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, library.ErrVarGroupNotFound):
+		writeError(w, http.StatusNotFound, "variable_group_not_found", "变量组不存在")
+	case errors.Is(err, library.ErrVarGroupNameTaken):
+		writeError(w, http.StatusConflict, "variable_group_name_taken", "变量组名已被占用")
+	case errors.Is(err, library.ErrInvalidVarGroup):
+		writeError(w, http.StatusUnprocessableEntity, "invalid_variable_group", err.Error())
+	case errors.Is(err, library.ErrInvalidVar):
+		writeError(w, http.StatusUnprocessableEntity, "invalid_variable", "变量 key 不能为空且组内不可重复;secret 变量须指定 credentialId")
+	case errors.Is(err, library.ErrCredentialNotFound):
+		writeError(w, http.StatusUnprocessableEntity, "credential_not_found", "引用的保险库凭据不存在")
+	case errors.Is(err, library.ErrVaultUnconfigured):
+		writeError(w, http.StatusUnprocessableEntity, "vault_unconfigured", "保险库未配置 master key,无法校验 secret 变量引用")
+	default:
+		writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+	}
+}
+
+func makeListVarGroupsHandler(svc library.VarGroupService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "变量组服务未初始化")
+			return
+		}
+		list, err := svc.List(r.Context())
+		if err != nil {
+			writeVarGroupError(w, err)
+			return
+		}
+		out := make([]variableGroupDTO, 0, len(list))
+		for i := range list {
+			out = append(out, toVariableGroupDTO(&list[i]))
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"variableGroups": out})
+	}
+}
+
+func makeGetVarGroupHandler(svc library.VarGroupService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "变量组服务未初始化")
+			return
+		}
+		g, err := svc.Get(r.Context(), chi.URLParam(r, "id"))
+		if err != nil {
+			writeVarGroupError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, toVariableGroupDTO(g))
+	}
+}
+
+// varGroupReqBody 是建/改变量组的请求体(secret 项只传 credentialId,不传明文/掩码)。
+type varGroupReqBody struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Vars        []reqVar `json:"vars"`
+}
+
+func (b varGroupReqBody) toInput() library.VarGroupInput {
+	return library.VarGroupInput{
+		Name:        b.Name,
+		Description: b.Description,
+		Vars:        toDomainVars(b.Vars),
+	}
+}
+
+// auditVarKeys 取请求变量 key 列表(审计 detail;绝无明文/凭据值)。
+func auditVarKeys(vars []reqVar) []string {
+	keys := make([]string, 0, len(vars))
+	for _, v := range vars {
+		keys = append(keys, v.Key)
+	}
+	return keys
+}
+
+func makeCreateVarGroupHandler(svc library.VarGroupService, aud audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "变量组服务未初始化")
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+		var req varGroupReqBody
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		g, err := svc.Create(r.Context(), req.toInput())
+		if err != nil {
+			writeVarGroupError(w, err)
+			return
+		}
+		recordAudit(r.Context(), aud, audit.Entry{
+			Actor:      auditActor,
+			Action:     audit.ActionVarGroupCreate,
+			TargetType: audit.TargetVarGroup,
+			TargetID:   g.ID,
+			Detail:     map[string]any{"name": g.Name, "keys": auditVarKeys(req.Vars)},
+			IP:         clientIP(r),
+		})
+		writeJSON(w, http.StatusCreated, toVariableGroupDTO(g))
+	}
+}
+
+func makeUpdateVarGroupHandler(svc library.VarGroupService, aud audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "变量组服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+		var req varGroupReqBody
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		g, err := svc.Update(r.Context(), id, req.toInput())
+		if err != nil {
+			writeVarGroupError(w, err)
+			return
+		}
+		recordAudit(r.Context(), aud, audit.Entry{
+			Actor:      auditActor,
+			Action:     audit.ActionVarGroupUpdate,
+			TargetType: audit.TargetVarGroup,
+			TargetID:   g.ID,
+			Detail:     map[string]any{"name": g.Name, "keys": auditVarKeys(req.Vars)},
+			IP:         clientIP(r),
+		})
+		writeJSON(w, http.StatusOK, toVariableGroupDTO(g))
+	}
+}
+
+func makeDeleteVarGroupHandler(svc library.VarGroupService, aud audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "变量组服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		if err := svc.Delete(r.Context(), id); err != nil {
+			writeVarGroupError(w, err)
+			return
+		}
+		recordAudit(r.Context(), aud, audit.Entry{
+			Actor:      auditActor,
+			Action:     audit.ActionVarGroupDelete,
+			TargetType: audit.TargetVarGroup,
+			TargetID:   id,
+			IP:         clientIP(r),
+		})
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/internal/library/library_test.go
+++ b/internal/library/library_test.go
@@ -1,0 +1,349 @@
+package library
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/store"
+	"github.com/huangchengsir/pipewright/internal/vault"
+)
+
+// testMasterKey 返回确定性测试用 master key。
+func testMasterKey() *[32]byte {
+	var k [32]byte
+	for i := range k {
+		k[i] = byte(i + 7)
+	}
+	return &k
+}
+
+// testDB 打开临时 SQLite(含全部迁移)。
+func testDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st.DB
+}
+
+// seedProject 插入一个最小凭据 + 项目,返回 project id(供应用模板/项目存在性)。
+func seedProject(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	credID := uuid.NewString()
+	if _, err := db.Exec(
+		`INSERT INTO credentials (id, name, type, scope, ciphertext, masked_value, created_at, updated_at)
+		 VALUES (?, 'c', 'git_token', '', X'00', 'm', ?, ?)`,
+		credID, now, now,
+	); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+	projID := uuid.NewString()
+	if _, err := db.Exec(
+		`INSERT INTO projects (id, name, repo_url, default_branch, credential_id, created_at, updated_at)
+		 VALUES (?, 'p', 'https://example.com/p.git', 'main', ?, ?, ?)`,
+		projID, credID, now, now,
+	); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	return projID
+}
+
+// sampleSpec 返回一个最小合法 spec(恰一个源阶段 + 一个构建阶段)。
+func sampleSpec() pipeline.Spec {
+	return pipeline.Spec{Stages: []pipeline.Stage{
+		{ID: "src", Name: "源", Kind: pipeline.KindSource, Jobs: []pipeline.Job{
+			{ID: "j1", Name: "git", Type: "git_source"},
+		}},
+		{ID: "build", Name: "构建", Kind: pipeline.KindBuild, Jobs: []pipeline.Job{
+			{ID: "j2", Name: "compile", Type: "build"},
+		}},
+	}}
+}
+
+// ---- 模板 ----
+
+func TestTemplateCreateApplyProducesValidPipeline(t *testing.T) {
+	db := testDB(t)
+	projID := seedProject(t, db)
+	pipes := pipeline.New(db)
+	svc := NewTemplateService(db, pipes)
+	ctx := context.Background()
+
+	tpl, err := svc.Create(ctx, TemplateInput{Name: "go-service", Description: "Go 服务模板", Spec: sampleSpec()})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if tpl.ID == "" || len(tpl.Spec.Stages) != 2 {
+		t.Fatalf("unexpected template: %+v", tpl)
+	}
+
+	// 应用模板到项目:产出合法流水线(经 pipeline.Save 再校验/渲染)。
+	cfg, err := svc.Apply(ctx, tpl.ID, projID)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(cfg.Spec.Stages) != 2 {
+		t.Fatalf("applied pipeline stages = %d, want 2", len(cfg.Spec.Stages))
+	}
+	if strings.TrimSpace(cfg.YAML) == "" {
+		t.Fatalf("applied pipeline should render YAML")
+	}
+	// 应用后,项目流水线读回与模板一致。
+	got, err := pipes.Get(ctx, projID)
+	if err != nil {
+		t.Fatalf("pipeline Get after apply: %v", err)
+	}
+	if len(got.Spec.Stages) != 2 {
+		t.Fatalf("project pipeline stages = %d, want 2", len(got.Spec.Stages))
+	}
+}
+
+func TestTemplateCreateRejectsInvalidSpec(t *testing.T) {
+	db := testDB(t)
+	svc := NewTemplateService(db, pipeline.New(db))
+	// 无源阶段 → pipeline.NormalizeSpec 拒绝 → ErrInvalidTemplate。
+	_, err := svc.Create(context.Background(), TemplateInput{
+		Name: "bad",
+		Spec: pipeline.Spec{Stages: []pipeline.Stage{
+			{Name: "构建", Kind: pipeline.KindBuild},
+		}},
+	})
+	if err == nil {
+		t.Fatalf("expected error for spec without source stage")
+	}
+	if want := ErrInvalidTemplate; !isWrapped(err, want) {
+		t.Fatalf("err = %v, want wrapped %v", err, want)
+	}
+}
+
+func TestTemplateCreateRejectsEmptyName(t *testing.T) {
+	db := testDB(t)
+	svc := NewTemplateService(db, pipeline.New(db))
+	_, err := svc.Create(context.Background(), TemplateInput{Name: "  ", Spec: sampleSpec()})
+	if !isWrapped(err, ErrInvalidTemplate) {
+		t.Fatalf("err = %v, want ErrInvalidTemplate", err)
+	}
+}
+
+func TestTemplateDuplicateName(t *testing.T) {
+	db := testDB(t)
+	svc := NewTemplateService(db, pipeline.New(db))
+	ctx := context.Background()
+	if _, err := svc.Create(ctx, TemplateInput{Name: "dup", Spec: sampleSpec()}); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+	_, err := svc.Create(ctx, TemplateInput{Name: "dup", Spec: sampleSpec()})
+	if err != ErrTemplateNameTaken {
+		t.Fatalf("err = %v, want ErrTemplateNameTaken", err)
+	}
+}
+
+func TestTemplateGetDeleteNotFound(t *testing.T) {
+	db := testDB(t)
+	svc := NewTemplateService(db, pipeline.New(db))
+	ctx := context.Background()
+	if _, err := svc.Get(ctx, "missing"); err != ErrTemplateNotFound {
+		t.Fatalf("Get err = %v, want ErrTemplateNotFound", err)
+	}
+	if err := svc.Delete(ctx, "missing"); err != ErrTemplateNotFound {
+		t.Fatalf("Delete err = %v, want ErrTemplateNotFound", err)
+	}
+}
+
+func TestTemplateListAndDelete(t *testing.T) {
+	db := testDB(t)
+	svc := NewTemplateService(db, pipeline.New(db))
+	ctx := context.Background()
+	a, _ := svc.Create(ctx, TemplateInput{Name: "a", Spec: sampleSpec()})
+	svc.Create(ctx, TemplateInput{Name: "b", Spec: sampleSpec()})
+	list, err := svc.List(ctx)
+	if err != nil || len(list) != 2 {
+		t.Fatalf("List = %v (n=%d), err=%v", list, len(list), err)
+	}
+	// 升序按名称。
+	if list[0].Name != "a" || list[1].Name != "b" {
+		t.Fatalf("List order = %q,%q want a,b", list[0].Name, list[1].Name)
+	}
+	if err := svc.Delete(ctx, a.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if list, _ := svc.List(ctx); len(list) != 1 {
+		t.Fatalf("after delete len = %d, want 1", len(list))
+	}
+}
+
+func TestTemplateApplyProjectNotFound(t *testing.T) {
+	db := testDB(t)
+	svc := NewTemplateService(db, pipeline.New(db))
+	ctx := context.Background()
+	tpl, _ := svc.Create(ctx, TemplateInput{Name: "t", Spec: sampleSpec()})
+	if _, err := svc.Apply(ctx, tpl.ID, "no-such-project"); err != ErrProjectNotFound {
+		t.Fatalf("Apply err = %v, want ErrProjectNotFound", err)
+	}
+}
+
+// ---- 变量组 ----
+
+func TestVarGroupNormalizationAndSecretRefs(t *testing.T) {
+	db := testDB(t)
+	v := vault.New(db, testMasterKey())
+	cred, err := v.Create(vault.CreateInput{Name: "tok", Type: vault.TypeGitToken, Secret: "super-secret-plaintext"})
+	if err != nil {
+		t.Fatalf("vault.Create: %v", err)
+	}
+	svc := NewVarGroupService(db, v)
+	ctx := context.Background()
+
+	g, err := svc.Create(ctx, VarGroupInput{
+		Name: "shared",
+		Vars: []pipeline.BuildVar{
+			{Key: "API_URL", Value: "https://api"},
+			{Key: "TOKEN", Secret: true, CredentialID: cred.ID, Value: "leak-me"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// 非 secret 保留明文;secret 只留引用 + 掩码,绝无明文。
+	var apiVar, tokVar *pipeline.BuildVar
+	for i := range g.Vars {
+		switch g.Vars[i].Key {
+		case "API_URL":
+			apiVar = &g.Vars[i]
+		case "TOKEN":
+			tokVar = &g.Vars[i]
+		}
+	}
+	if apiVar == nil || apiVar.Value != "https://api" {
+		t.Fatalf("API_URL not preserved: %+v", apiVar)
+	}
+	if tokVar == nil {
+		t.Fatalf("TOKEN missing")
+	}
+	if tokVar.Value != "" {
+		t.Fatalf("secret var leaked plaintext value %q", tokVar.Value)
+	}
+	if tokVar.CredentialID != cred.ID {
+		t.Fatalf("secret var credentialId = %q, want %q", tokVar.CredentialID, cred.ID)
+	}
+	if tokVar.MaskedValue == "" {
+		t.Fatalf("secret var should carry masked value")
+	}
+
+	// 落库的 vars_json 绝不含明文 secret。
+	var varsJSON string
+	if err := db.QueryRowContext(ctx, `SELECT vars_json FROM variable_groups WHERE id = ?`, g.ID).Scan(&varsJSON); err != nil {
+		t.Fatalf("read vars_json: %v", err)
+	}
+	if strings.Contains(varsJSON, "super-secret-plaintext") || strings.Contains(varsJSON, "leak-me") {
+		t.Fatalf("plaintext secret leaked into DB: %s", varsJSON)
+	}
+}
+
+func TestVarGroupRejectsDuplicateKeys(t *testing.T) {
+	db := testDB(t)
+	svc := NewVarGroupService(db, vault.New(db, testMasterKey()))
+	_, err := svc.Create(context.Background(), VarGroupInput{
+		Name: "dupkeys",
+		Vars: []pipeline.BuildVar{
+			{Key: "K", Value: "1"},
+			{Key: "K", Value: "2"},
+		},
+	})
+	if !isWrapped(err, ErrInvalidVar) {
+		t.Fatalf("err = %v, want ErrInvalidVar", err)
+	}
+}
+
+func TestVarGroupRejectsEmptyName(t *testing.T) {
+	db := testDB(t)
+	svc := NewVarGroupService(db, vault.New(db, testMasterKey()))
+	_, err := svc.Create(context.Background(), VarGroupInput{Name: " "})
+	if !isWrapped(err, ErrInvalidVarGroup) {
+		t.Fatalf("err = %v, want ErrInvalidVarGroup", err)
+	}
+}
+
+func TestVarGroupSecretRefMissingCredential(t *testing.T) {
+	db := testDB(t)
+	svc := NewVarGroupService(db, vault.New(db, testMasterKey()))
+	_, err := svc.Create(context.Background(), VarGroupInput{
+		Name: "g",
+		Vars: []pipeline.BuildVar{{Key: "T", Secret: true, CredentialID: "does-not-exist"}},
+	})
+	if !isWrapped(err, ErrCredentialNotFound) {
+		t.Fatalf("err = %v, want ErrCredentialNotFound", err)
+	}
+}
+
+func TestVarGroupVaultUnconfigured(t *testing.T) {
+	db := testDB(t)
+	svc := NewVarGroupService(db, vault.New(db, nil)) // 未配置 master key
+	_, err := svc.Create(context.Background(), VarGroupInput{
+		Name: "g",
+		Vars: []pipeline.BuildVar{{Key: "T", Secret: true, CredentialID: "x"}},
+	})
+	if !isWrapped(err, ErrVaultUnconfigured) {
+		t.Fatalf("err = %v, want ErrVaultUnconfigured", err)
+	}
+}
+
+func TestVarGroupUpdateAndDelete(t *testing.T) {
+	db := testDB(t)
+	svc := NewVarGroupService(db, vault.New(db, testMasterKey()))
+	ctx := context.Background()
+	g, err := svc.Create(ctx, VarGroupInput{Name: "g", Vars: []pipeline.BuildVar{{Key: "A", Value: "1"}}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	upd, err := svc.Update(ctx, g.ID, VarGroupInput{Name: "g2", Vars: []pipeline.BuildVar{{Key: "B", Value: "2"}}})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if upd.Name != "g2" || len(upd.Vars) != 1 || upd.Vars[0].Key != "B" {
+		t.Fatalf("unexpected updated group: %+v", upd)
+	}
+	if err := svc.Delete(ctx, g.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := svc.Get(ctx, g.ID); err != ErrVarGroupNotFound {
+		t.Fatalf("Get after delete err = %v, want ErrVarGroupNotFound", err)
+	}
+}
+
+func TestVarGroupUpdateNotFound(t *testing.T) {
+	db := testDB(t)
+	svc := NewVarGroupService(db, vault.New(db, testMasterKey()))
+	_, err := svc.Update(context.Background(), "missing", VarGroupInput{Name: "x"})
+	if err != ErrVarGroupNotFound {
+		t.Fatalf("err = %v, want ErrVarGroupNotFound", err)
+	}
+}
+
+func TestVarGroupDuplicateName(t *testing.T) {
+	db := testDB(t)
+	svc := NewVarGroupService(db, vault.New(db, testMasterKey()))
+	ctx := context.Background()
+	if _, err := svc.Create(ctx, VarGroupInput{Name: "dup"}); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+	if _, err := svc.Create(ctx, VarGroupInput{Name: "dup"}); err != ErrVarGroupNameTaken {
+		t.Fatalf("err = %v, want ErrVarGroupNameTaken", err)
+	}
+}
+
+// isWrapped 判定 err 链上是否含 target(errors.Is 包装链)。
+func isWrapped(err, target error) bool {
+	return errors.Is(err, target)
+}

--- a/internal/library/template.go
+++ b/internal/library/template.go
@@ -1,0 +1,236 @@
+// Package library 是「流水线模板 + 变量组」复用基座的领域层(FR-8-13 · 对标
+// Jenkins Shared Library / 云效模板与变量组)。
+//
+// 两类可复用资产,跨项目共享、与具体项目解耦:
+//   - 流水线模板(Template):命名、可复用的流水线定义(与项目流水线同一套 stages 模型)。
+//     创建/列出/获取/删除模板 + 「应用模板到项目」(把模板 stages 拷进项目流水线,
+//     经 pipeline.Service.Save 同一套规范化/校验/渲染落库)。校验复用 pipeline.NormalizeSpec。
+//   - 变量组(VarGroup,见 vargroup.go):命名、可复用的变量集合,镜像每流水线变量模型;
+//     secret 只存 vault 凭据引用,明文绝不入库。
+//
+// AC-SEC:模板 spec 不含任何明文 secret(凭据走保险库引用,2-4 settings 才落引用字段);
+// 变量组的 secret 同 settings.normalizeVars 语义——只存 credentialId 引用、经保险库校验存在性。
+// 领域包无 init() 副作用、无包级重对象,避免抬高空载内存。
+package library
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+)
+
+// 领域错误。错误体不含任何明文 secret。
+var (
+	// ErrTemplateNotFound 表示引用的模板不存在。
+	ErrTemplateNotFound = errors.New("library: template not found")
+	// ErrInvalidTemplate 表示模板校验失败(名称空 / spec 非法)。
+	ErrInvalidTemplate = errors.New("library: invalid template")
+	// ErrTemplateNameTaken 表示模板名已被占用(唯一约束)。
+	ErrTemplateNameTaken = errors.New("library: template name already in use")
+	// ErrProjectNotFound 表示应用模板的目标项目不存在。
+	ErrProjectNotFound = errors.New("library: project not found")
+)
+
+// Template 是一份命名、可复用的流水线定义(spec = 阶段集合,与项目流水线同形状)。
+type Template struct {
+	ID          string
+	Name        string
+	Description string
+	Spec        pipeline.Spec
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// TemplateInput 是创建模板的入参。
+type TemplateInput struct {
+	Name        string
+	Description string
+	Spec        pipeline.Spec
+}
+
+// TemplateService 定义流水线模板领域对外接口。
+type TemplateService interface {
+	// List 返回所有模板(按名称升序),供挑选画廊。
+	List(ctx context.Context) ([]Template, error)
+	// Get 返回单个模板;不存在 → ErrTemplateNotFound。
+	Get(ctx context.Context, id string) (*Template, error)
+	// Create 校验(名称非空 + spec 经 pipeline.NormalizeSpec 规范化/校验)→ 持久化 → 回读。
+	// 名称重复 → ErrTemplateNameTaken;spec 非法 → ErrInvalidTemplate(包裹底层 pipeline 错误)。
+	Create(ctx context.Context, in TemplateInput) (*Template, error)
+	// Delete 删除模板;不存在 → ErrTemplateNotFound。
+	Delete(ctx context.Context, id string) error
+	// Apply 把模板的 stages 应用到目标项目流水线(经注入的 pipeline.Service.Save 同一套规范化/
+	// 校验/渲染落库,产出合法流水线)。模板不存在 → ErrTemplateNotFound;项目不存在 → ErrProjectNotFound;
+	// 模板 spec 经再校验仍非法 → 透传 pipeline 校验错误。返回应用后的项目流水线配置。
+	Apply(ctx context.Context, templateID, projectID string) (*pipeline.Config, error)
+}
+
+type templateService struct {
+	db    *sql.DB
+	pipes pipeline.Service
+}
+
+// NewTemplateService 构造 TemplateService。
+//   - db:经参数化 SQL 触库。
+//   - pipes:应用模板时经其 Save 把 stages 落到项目流水线(复用同一套校验/渲染)。
+//
+// 不在此做任何重活(无 init() 副作用,避免抬高空载内存)。
+func NewTemplateService(db *sql.DB, pipes pipeline.Service) TemplateService {
+	return &templateService{db: db, pipes: pipes}
+}
+
+func (s *templateService) List(ctx context.Context) ([]Template, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, name, description, stages_json, created_at, updated_at
+		 FROM pipeline_templates ORDER BY name ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("library: list templates: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]Template, 0)
+	for rows.Next() {
+		t, err := scanTemplate(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("library: iterate templates: %w", err)
+	}
+	return out, nil
+}
+
+func (s *templateService) Get(ctx context.Context, id string) (*Template, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT id, name, description, stages_json, created_at, updated_at
+		 FROM pipeline_templates WHERE id = ?`, strings.TrimSpace(id))
+	t, err := scanTemplate(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrTemplateNotFound
+	}
+	return t, err
+}
+
+func (s *templateService) Create(ctx context.Context, in TemplateInput) (*Template, error) {
+	name := strings.TrimSpace(in.Name)
+	if name == "" {
+		return nil, fmt.Errorf("%w: name must not be empty", ErrInvalidTemplate)
+	}
+
+	// spec 经 pipeline 同一套规范化/校验(补 id、trim、kind 枚举、恰一个 source、needs DAG)。
+	normalized, err := pipeline.NormalizeSpec(in.Spec)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidTemplate, err.Error())
+	}
+	stagesJSON, err := json.Marshal(normalized.Stages)
+	if err != nil {
+		return nil, fmt.Errorf("library: marshal template stages: %w", err)
+	}
+
+	id := uuid.NewString()
+	now := time.Now().UTC()
+	nowStr := now.Format(time.RFC3339)
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO pipeline_templates (id, name, description, stages_json, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		id, name, strings.TrimSpace(in.Description), string(stagesJSON), nowStr, nowStr,
+	)
+	if err != nil {
+		if isUniqueErr(err) {
+			return nil, ErrTemplateNameTaken
+		}
+		return nil, fmt.Errorf("library: insert template: %w", err)
+	}
+	return s.Get(ctx, id)
+}
+
+func (s *templateService) Delete(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM pipeline_templates WHERE id = ?`, strings.TrimSpace(id))
+	if err != nil {
+		return fmt.Errorf("library: delete template: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("library: delete template rows: %w", err)
+	}
+	if n == 0 {
+		return ErrTemplateNotFound
+	}
+	return nil
+}
+
+func (s *templateService) Apply(ctx context.Context, templateID, projectID string) (*pipeline.Config, error) {
+	t, err := s.Get(ctx, templateID)
+	if err != nil {
+		return nil, err
+	}
+	if s.pipes == nil {
+		return nil, fmt.Errorf("library: pipeline service unavailable")
+	}
+	// 把模板 stages 经项目流水线 Save 落库(再走一遍规范化/校验/渲染;项目存在性由 Save 校验)。
+	cfg, err := s.pipes.Save(ctx, strings.TrimSpace(projectID), t.Spec)
+	if err != nil {
+		if errors.Is(err, pipeline.ErrProjectNotFound) {
+			return nil, ErrProjectNotFound
+		}
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// rowScanner 抽象 *sql.Row / *sql.Rows 的 Scan,供 Get/List 共用扫描逻辑。
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanTemplate(row rowScanner) (*Template, error) {
+	var (
+		id, name, desc, stagesJSON string
+		createdStr, updatedStr     string
+	)
+	if err := row.Scan(&id, &name, &desc, &stagesJSON, &createdStr, &updatedStr); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, sql.ErrNoRows
+		}
+		return nil, fmt.Errorf("library: scan template: %w", err)
+	}
+
+	var stages []pipeline.Stage
+	if strings.TrimSpace(stagesJSON) != "" {
+		if err := json.Unmarshal([]byte(stagesJSON), &stages); err != nil {
+			return nil, fmt.Errorf("library: parse template stages: %w", err)
+		}
+	}
+	if stages == nil {
+		stages = []pipeline.Stage{}
+	}
+
+	created, _ := time.Parse(time.RFC3339, createdStr)
+	updated, _ := time.Parse(time.RFC3339, updatedStr)
+	return &Template{
+		ID:          id,
+		Name:        name,
+		Description: desc,
+		Spec:        pipeline.Spec{Stages: stages},
+		CreatedAt:   created,
+		UpdatedAt:   updated,
+	}, nil
+}
+
+// isUniqueErr 判定是否为唯一约束冲突(modernc sqlite 文本含 UNIQUE)。
+func isUniqueErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToUpper(err.Error()), "UNIQUE")
+}

--- a/internal/library/vargroup.go
+++ b/internal/library/vargroup.go
@@ -1,0 +1,249 @@
+package library
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/vault"
+)
+
+// 变量组领域错误。错误体不含任何明文 secret。
+var (
+	// ErrVarGroupNotFound 表示引用的变量组不存在。
+	ErrVarGroupNotFound = errors.New("library: variable group not found")
+	// ErrInvalidVarGroup 表示变量组校验失败(名称空)。
+	ErrInvalidVarGroup = errors.New("library: invalid variable group")
+	// ErrVarGroupNameTaken 表示变量组名已被占用(唯一约束)。
+	ErrVarGroupNameTaken = errors.New("library: variable group name already in use")
+)
+
+// 透传 pipeline 的变量校验错误(供 handler 统一映射;变量组复用 settings.normalizeVars 语义)。
+var (
+	// ErrInvalidVar 表示变量校验失败(key 空 / 组内重复 / secret 缺 credentialId)。
+	ErrInvalidVar = pipeline.ErrInvalidVar
+	// ErrCredentialNotFound 表示 secret 引用的 credentialId 不存在于保险库。
+	ErrCredentialNotFound = pipeline.ErrCredentialNotFound
+	// ErrVaultUnconfigured 表示保险库未配置但存在 secret 引用,无法校验/掩码。
+	ErrVaultUnconfigured = pipeline.ErrSettingsVaultUnconfigured
+)
+
+// VarGroup 是一份命名、可复用的变量集合(镜像每流水线变量模型)。Vars 复用 pipeline.BuildVar:
+// 非 secret 存明文 Value;secret 只存 CredentialID 引用(明文绝不入库),MaskedValue 仅响应里回算。
+type VarGroup struct {
+	ID          string
+	Name        string
+	Description string
+	Vars        []pipeline.BuildVar
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// VarGroupInput 是创建/更新变量组的入参(secret 项只传 credentialId,不传明文/掩码)。
+type VarGroupInput struct {
+	Name        string
+	Description string
+	Vars        []pipeline.BuildVar
+}
+
+// VarGroupService 定义变量组领域对外接口。
+type VarGroupService interface {
+	// List 返回所有变量组(按名称升序;secret 项回掩码)。
+	List(ctx context.Context) ([]VarGroup, error)
+	// Get 返回单个变量组(secret 项回掩码);不存在 → ErrVarGroupNotFound。
+	Get(ctx context.Context, id string) (*VarGroup, error)
+	// Create 校验(名称非空 + 变量经 pipeline.NormalizeVars:key 非空不重复、secret 引用存在性)→
+	// 持久化(只存引用,绝无明文 secret)→ 回读(回掩码)。名称重复 → ErrVarGroupNameTaken。
+	Create(ctx context.Context, in VarGroupInput) (*VarGroup, error)
+	// Update 同 Create 的校验/持久化,按 id 覆盖;不存在 → ErrVarGroupNotFound。
+	Update(ctx context.Context, id string, in VarGroupInput) (*VarGroup, error)
+	// Delete 删除变量组;不存在 → ErrVarGroupNotFound。
+	Delete(ctx context.Context, id string) error
+}
+
+type varGroupService struct {
+	db    *sql.DB
+	vault vault.Vault
+}
+
+// NewVarGroupService 构造 VarGroupService。
+//   - db:经参数化 SQL 触库 + 回算掩码。
+//   - v:凭据保险库,校验 secret 引用存在性;nil/未配置且存在 secret 引用 → ErrVaultUnconfigured。
+//
+// 不在此做任何重活(无 init() 副作用,避免抬高空载内存)。
+func NewVarGroupService(db *sql.DB, v vault.Vault) VarGroupService {
+	return &varGroupService{db: db, vault: v}
+}
+
+func (s *varGroupService) List(ctx context.Context) ([]VarGroup, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, name, description, vars_json, created_at, updated_at
+		 FROM variable_groups ORDER BY name ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("library: list variable groups: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	// 先把所有行扫完(不在持有 rows 的同时再查库:单连接 SQLite 会自死锁)。
+	out := make([]VarGroup, 0)
+	for rows.Next() {
+		g, err := scanGroupRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("library: iterate variable groups: %w", err)
+	}
+	_ = rows.Close()
+
+	// rows 关闭后再回算掩码(每个 secret 引用单独查 credentials.masked_value)。
+	for i := range out {
+		if err := pipeline.ApplyVarMasks(ctx, s.db, out[i].Vars); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func (s *varGroupService) Get(ctx context.Context, id string) (*VarGroup, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT id, name, description, vars_json, created_at, updated_at
+		 FROM variable_groups WHERE id = ?`, strings.TrimSpace(id))
+	g, err := scanGroupRow(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrVarGroupNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := pipeline.ApplyVarMasks(ctx, s.db, g.Vars); err != nil {
+		return nil, err
+	}
+	return g, nil
+}
+
+func (s *varGroupService) Create(ctx context.Context, in VarGroupInput) (*VarGroup, error) {
+	name, varsJSON, err := s.validate(in)
+	if err != nil {
+		return nil, err
+	}
+
+	id := uuid.NewString()
+	nowStr := time.Now().UTC().Format(time.RFC3339)
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO variable_groups (id, name, description, vars_json, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		id, name, strings.TrimSpace(in.Description), varsJSON, nowStr, nowStr,
+	)
+	if err != nil {
+		if isUniqueErr(err) {
+			return nil, ErrVarGroupNameTaken
+		}
+		return nil, fmt.Errorf("library: insert variable group: %w", err)
+	}
+	return s.Get(ctx, id)
+}
+
+func (s *varGroupService) Update(ctx context.Context, id string, in VarGroupInput) (*VarGroup, error) {
+	id = strings.TrimSpace(id)
+	// 先确认存在(给明确 404,而非静默 0 行)。
+	if _, err := s.Get(ctx, id); err != nil {
+		return nil, err
+	}
+	name, varsJSON, err := s.validate(in)
+	if err != nil {
+		return nil, err
+	}
+
+	nowStr := time.Now().UTC().Format(time.RFC3339)
+	_, err = s.db.ExecContext(ctx,
+		`UPDATE variable_groups SET name = ?, description = ?, vars_json = ?, updated_at = ?
+		 WHERE id = ?`,
+		name, strings.TrimSpace(in.Description), varsJSON, nowStr, id,
+	)
+	if err != nil {
+		if isUniqueErr(err) {
+			return nil, ErrVarGroupNameTaken
+		}
+		return nil, fmt.Errorf("library: update variable group: %w", err)
+	}
+	return s.Get(ctx, id)
+}
+
+func (s *varGroupService) Delete(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM variable_groups WHERE id = ?`, strings.TrimSpace(id))
+	if err != nil {
+		return fmt.Errorf("library: delete variable group: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("library: delete variable group rows: %w", err)
+	}
+	if n == 0 {
+		return ErrVarGroupNotFound
+	}
+	return nil
+}
+
+// validate 校验名称 + 经 pipeline.NormalizeVars 规范化变量(key 非空不重复;secret 引用存在性),
+// 返回 trim 后名称 + 持久化形状 JSON(剥离掩码;明文 secret 从不入库)。
+func (s *varGroupService) validate(in VarGroupInput) (string, string, error) {
+	name := strings.TrimSpace(in.Name)
+	if name == "" {
+		return "", "", fmt.Errorf("%w: name must not be empty", ErrInvalidVarGroup)
+	}
+	vars, err := pipeline.NormalizeVars(s.vault, in.Vars)
+	if err != nil {
+		return "", "", err
+	}
+	varsJSON, err := pipeline.ToStoredVarsJSON(vars)
+	if err != nil {
+		return "", "", fmt.Errorf("library: marshal variable group vars: %w", err)
+	}
+	return name, string(varsJSON), nil
+}
+
+// scanGroupRow 把一行扫成 VarGroup(纯扫描,不回算掩码——掩码须在 rows 关闭后做,
+// 否则单连接 SQLite 会因「持有游标时再查库」自死锁)。
+func scanGroupRow(row rowScanner) (*VarGroup, error) {
+	var (
+		id, name, desc, varsJSON string
+		createdStr, updatedStr   string
+	)
+	if err := row.Scan(&id, &name, &desc, &varsJSON, &createdStr, &updatedStr); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, sql.ErrNoRows
+		}
+		return nil, fmt.Errorf("library: scan variable group: %w", err)
+	}
+
+	var vars []pipeline.BuildVar
+	if strings.TrimSpace(varsJSON) != "" {
+		if err := json.Unmarshal([]byte(varsJSON), &vars); err != nil {
+			return nil, fmt.Errorf("library: parse variable group vars: %w", err)
+		}
+	}
+	if vars == nil {
+		vars = []pipeline.BuildVar{}
+	}
+
+	created, _ := time.Parse(time.RFC3339, createdStr)
+	updated, _ := time.Parse(time.RFC3339, updatedStr)
+	return &VarGroup{
+		ID:          id,
+		Name:        name,
+		Description: desc,
+		Vars:        vars,
+		CreatedAt:   created,
+		UpdatedAt:   updated,
+	}, nil
+}

--- a/internal/pipeline/settings.go
+++ b/internal/pipeline/settings.go
@@ -190,6 +190,36 @@ func NewSettingsService(db *sql.DB, v vault.Vault) SettingsService {
 	return &settingsService{db: db, vault: v}
 }
 
+// NormalizeVars 校验并规范化一组变量(key 非空且组内不重复;secret 只保留 credentialId 引用
+// 并经保险库校验存在性,明文绝不留存;非 secret 保留明文 value),供域外复用同一套语义
+// (如 library 的变量组——FR-8-13)。v 为 nil/未配置且存在 secret 引用 → ErrSettingsVaultUnconfigured。
+// 返回的 secret 项不含 MaskedValue(掩码回算请用 MaskedVarsFor)。
+func NormalizeVars(v vault.Vault, in []BuildVar) ([]BuildVar, error) {
+	return (&settingsService{vault: v}).normalizeVars(in)
+}
+
+// ApplyVarMasks 为一组变量的 secret 引用回算掩码(读 credentials.masked_value;明文从不入库),
+// 供域外复用(如 library 的变量组读路径)。凭据已删 → 退化为通用点掩码(不报错)。
+func ApplyVarMasks(ctx context.Context, db *sql.DB, vars []BuildVar) error {
+	s := &settingsService{db: db}
+	for i := range vars {
+		if vars[i].Secret {
+			masked, err := s.maskedFor(ctx, vars[i].CredentialID)
+			if err != nil {
+				return err
+			}
+			vars[i].MaskedValue = masked
+		}
+	}
+	return nil
+}
+
+// ToStoredVarsJSON 把一组变量转持久化形状并序列化(剥离掩码;明文 secret 从不存在于此结构),
+// 供域外复用(如 library 变量组落库)。
+func ToStoredVarsJSON(vars []BuildVar) ([]byte, error) {
+	return json.Marshal(toStoredVars(vars))
+}
+
 func (s *settingsService) Get(ctx context.Context, projectID string) (*Settings, error) {
 	st, err := s.load(ctx, projectID)
 	if err == nil {

--- a/internal/store/migrations/0031_templates_variable_groups.sql
+++ b/internal/store/migrations/0031_templates_variable_groups.sql
@@ -1,0 +1,39 @@
+-- 0031 流水线模板 + 变量组(FR-8-13 复用基座 · 对标 Jenkins Shared Library / 云效模板与变量组)。
+--
+-- pipeline_templates:命名、可复用的流水线定义(与项目流水线同一套 stages 模型)。
+-- 一个模板存一份 spec(stages_json,与 pipeline_configs.spec_json 同形状),项目可「应用模板」
+-- 把模板的 stages 拷进自己的流水线(经 pipeline.Service.Save 同一套规范化/校验/渲染落库)。
+-- 模板与项目解耦(不挂 project_id 外键):跨项目共享。绝不存任何明文 secret(spec 不含 secret)。
+--   id          : 模板主键(uuid)
+--   name        : 模板名(去空白后非空;库内唯一,便于挑选)
+--   description : 模板说明(可空)
+--   stages_json : 流水线 spec 的阶段集合 JSON(与 pipeline spec 同形状)
+CREATE TABLE IF NOT EXISTS pipeline_templates (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    stages_json TEXT NOT NULL DEFAULT '[]',
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+
+-- 名称唯一(挑选模板时人读、避免重名歧义)。
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pipeline_templates_name ON pipeline_templates (name);
+
+-- variable_groups:命名、可复用的变量集合(key=value + secret 引用),镜像每流水线变量模型。
+-- 一个变量组存一份 vars_json(与 pipeline_settings 的 BuildVar 同语义):非 secret 存明文 value;
+-- secret 只存 vault 凭据引用(credentialId),明文绝不入库。供多流水线引用/复用同一套变量。
+--   id        : 变量组主键(uuid)
+--   name      : 变量组名(去空白后非空;库内唯一)
+--   description: 说明(可空)
+--   vars_json : 变量列表 JSON(BuildVar 持久化形状:非 secret 明文 value / secret 仅 credentialId 引用)
+CREATE TABLE IF NOT EXISTS variable_groups (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    vars_json   TEXT NOT NULL DEFAULT '[]',
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_variable_groups_name ON variable_groups (name);

--- a/web/src/api/templates.ts
+++ b/web/src/api/templates.ts
@@ -1,0 +1,69 @@
+/**
+ * Pipeline templates API — FR-8-13 (reuse base · à la Jenkins Shared Library / 云效模板).
+ *
+ * Named, reusable pipeline definitions (same stages model as a project pipeline),
+ * shared across projects. A project can instantiate a template into its own pipeline.
+ *
+ *   GET    /api/templates                              → { templates: TemplateSummary[] }
+ *   POST   /api/templates                              → Template      (needs CSRF)
+ *   GET    /api/templates/{id}                         → Template
+ *   DELETE /api/templates/{id}                         → 204           (needs CSRF)
+ *   POST   /api/projects/{id}/pipeline/apply-template  → PipelineDTO   (needs CSRF)
+ *
+ * Templates carry no plaintext secret (credentials stay vault references in 2-4 settings).
+ */
+
+import { http } from './http'
+import type { PipelineStage, PipelineDTO, SavePipelineInput } from './pipeline'
+
+/** List item — metadata + stage count only (lighter than the full spec). */
+export interface TemplateSummary {
+  id: string
+  name: string
+  description: string
+  stageCount: number
+  createdAt: string
+  updatedAt: string
+}
+
+/** Full template — includes the complete stage spec. */
+export interface Template {
+  id: string
+  name: string
+  description: string
+  stages: PipelineStage[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CreateTemplateInput {
+  name: string
+  description?: string
+  stages: SavePipelineInput['stages']
+}
+
+interface ListTemplatesResponse {
+  templates: TemplateSummary[]
+}
+
+export async function listTemplates(): Promise<TemplateSummary[]> {
+  const res = await http.get<ListTemplatesResponse>('/api/templates')
+  return res.templates ?? []
+}
+
+export async function getTemplate(id: string): Promise<Template> {
+  return http.get<Template>(`/api/templates/${id}`)
+}
+
+export async function createTemplate(input: CreateTemplateInput): Promise<Template> {
+  return http.post<Template>('/api/templates', input)
+}
+
+export async function deleteTemplate(id: string): Promise<void> {
+  await http.delete<void>(`/api/templates/${id}`)
+}
+
+/** Apply a template's stages onto a project's pipeline; returns the resulting pipeline. */
+export async function applyTemplate(projectId: string, templateId: string): Promise<PipelineDTO> {
+  return http.post<PipelineDTO>(`/api/projects/${projectId}/pipeline/apply-template`, { templateId })
+}

--- a/web/src/api/variableGroups.ts
+++ b/web/src/api/variableGroups.ts
@@ -1,0 +1,71 @@
+/**
+ * Variable groups API — FR-8-13 (reuse base · à la 云效变量组 / GitLab CI variable groups).
+ *
+ * Named, reusable sets of variables (key=value with vault secret refs), shared across
+ * pipelines. Mirrors the per-pipeline variable model (BuildVar).
+ *
+ *   GET    /api/variable-groups       → { variableGroups: VariableGroup[] }
+ *   POST   /api/variable-groups       → VariableGroup   (needs CSRF)
+ *   GET    /api/variable-groups/{id}  → VariableGroup
+ *   PUT    /api/variable-groups/{id}  → VariableGroup   (needs CSRF)
+ *   DELETE /api/variable-groups/{id}  → 204             (needs CSRF)
+ *
+ * Secret variables are stored as credentialId references only — the server never returns
+ * plaintext, only a server-computed maskedValue. On save, secret items send
+ * {key, secret:true, credentialId}; the plaintext value is dropped server-side.
+ */
+
+import { http } from './http'
+import type { BuildVar } from './pipelineSettings'
+
+export interface VariableGroup {
+  id: string
+  name: string
+  description: string
+  vars: BuildVar[]
+  createdAt: string
+  updatedAt: string
+}
+
+/** Save payload var (secret items omit plaintext value; send credentialId instead). */
+export interface VariableGroupVarInput {
+  id?: string
+  key: string
+  secret: boolean
+  value?: string
+  credentialId?: string
+}
+
+export interface SaveVariableGroupInput {
+  name: string
+  description?: string
+  vars: VariableGroupVarInput[]
+}
+
+interface ListVariableGroupsResponse {
+  variableGroups: VariableGroup[]
+}
+
+export async function listVariableGroups(): Promise<VariableGroup[]> {
+  const res = await http.get<ListVariableGroupsResponse>('/api/variable-groups')
+  return res.variableGroups ?? []
+}
+
+export async function getVariableGroup(id: string): Promise<VariableGroup> {
+  return http.get<VariableGroup>(`/api/variable-groups/${id}`)
+}
+
+export async function createVariableGroup(input: SaveVariableGroupInput): Promise<VariableGroup> {
+  return http.post<VariableGroup>('/api/variable-groups', input)
+}
+
+export async function updateVariableGroup(
+  id: string,
+  input: SaveVariableGroupInput,
+): Promise<VariableGroup> {
+  return http.put<VariableGroup>(`/api/variable-groups/${id}`, input)
+}
+
+export async function deleteVariableGroup(id: string): Promise<void> {
+  await http.delete<void>(`/api/variable-groups/${id}`)
+}

--- a/web/src/components/pipeline/TemplatePickerModal.vue
+++ b/web/src/components/pipeline/TemplatePickerModal.vue
@@ -1,0 +1,382 @@
+<script setup lang="ts">
+/**
+ * TemplatePickerModal — apply a reusable pipeline template to this project, or save the
+ * current pipeline as a new template (FR-8-13).
+ *
+ * Two modes (segmented):
+ *   - 应用模板:pick a template → applyTemplate() copies its stages into this project's pipeline.
+ *   - 另存为模板:name + describe → createTemplate() snapshots the current canvas stages.
+ *
+ * Templates carry no plaintext secret (credentials remain vault references in 2-4 settings).
+ */
+import { ref, onMounted } from 'vue'
+import {
+  listTemplates,
+  applyTemplate,
+  createTemplate,
+  type TemplateSummary,
+} from '../../api/templates'
+import type { PipelineDTO, PipelineStage } from '../../api/pipeline'
+import { HttpError } from '../../api/http'
+
+const props = defineProps<{
+  projectId: string
+  /** Current canvas stages — snapshotted when saving as a template. */
+  stages: PipelineStage[]
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  /** A successful apply: parent reloads pipeline + settings. */
+  (e: 'applied', dto: PipelineDTO): void
+}>()
+
+type Mode = 'apply' | 'save'
+const mode = ref<Mode>('apply')
+
+// ─── apply ──────────────────────────────────────────────────────────────────
+const templates = ref<TemplateSummary[]>([])
+const loading = ref(false)
+const selectedId = ref('')
+const applying = ref(false)
+const errorMsg = ref('')
+
+async function loadTemplates(): Promise<void> {
+  loading.value = true
+  errorMsg.value = ''
+  try {
+    templates.value = await listTemplates()
+    if (templates.value.length > 0) selectedId.value = templates.value[0].id
+  } catch (err: unknown) {
+    errorMsg.value = err instanceof HttpError ? err.apiError?.message ?? '加载模板失败' : '加载模板失败'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function doApply(): Promise<void> {
+  if (!selectedId.value) {
+    errorMsg.value = '请先选择一个模板'
+    return
+  }
+  if (
+    !window.confirm('应用模板会用模板的阶段覆盖当前项目流水线。确认继续?')
+  ) {
+    return
+  }
+  applying.value = true
+  errorMsg.value = ''
+  try {
+    const dto = await applyTemplate(props.projectId, selectedId.value)
+    emit('applied', dto)
+    emit('close')
+  } catch (err: unknown) {
+    errorMsg.value = err instanceof HttpError ? err.apiError?.message ?? '应用模板失败' : '应用模板失败'
+  } finally {
+    applying.value = false
+  }
+}
+
+// ─── save as template ─────────────────────────────────────────────────────────
+const saveName = ref('')
+const saveDesc = ref('')
+const saving = ref(false)
+const saveDone = ref(false)
+
+async function doSave(): Promise<void> {
+  const name = saveName.value.trim()
+  if (!name) {
+    errorMsg.value = '请填写模板名称'
+    return
+  }
+  saving.value = true
+  errorMsg.value = ''
+  try {
+    await createTemplate({
+      name,
+      description: saveDesc.value.trim(),
+      stages: props.stages.map((s) => ({
+        id: undefined,
+        name: s.name,
+        kind: s.kind,
+        needs: s.needs,
+        allowFailure: s.allowFailure,
+        when: s.when,
+        gate: s.gate,
+        jobs: s.jobs.map((j) => ({
+          id: undefined,
+          name: j.name,
+          type: j.type,
+          summary: j.summary,
+          config: j.config,
+        })),
+      })),
+    })
+    saveDone.value = true
+    // Refresh the apply list so the new template is pickable immediately.
+    await loadTemplates()
+  } catch (err: unknown) {
+    errorMsg.value = err instanceof HttpError ? err.apiError?.message ?? '保存模板失败' : '保存模板失败'
+  } finally {
+    saving.value = false
+  }
+}
+
+function switchMode(m: Mode): void {
+  mode.value = m
+  errorMsg.value = ''
+  saveDone.value = false
+}
+
+onMounted(loadTemplates)
+</script>
+
+<template>
+  <div class="scrim" @click.self="emit('close')">
+    <div class="modal" role="dialog" aria-modal="true" aria-label="流水线模板">
+      <header class="head">
+        <h2 class="title">流水线模板</h2>
+        <button class="close" aria-label="关闭" @click="emit('close')">✕</button>
+      </header>
+
+      <div class="seg" role="tablist">
+        <button
+          class="seg-item"
+          role="tab"
+          :aria-selected="mode === 'apply'"
+          :class="{ active: mode === 'apply' }"
+          @click="switchMode('apply')"
+        >
+          应用模板
+        </button>
+        <button
+          class="seg-item"
+          role="tab"
+          :aria-selected="mode === 'save'"
+          :class="{ active: mode === 'save' }"
+          @click="switchMode('save')"
+        >
+          另存为模板
+        </button>
+      </div>
+
+      <p v-if="errorMsg" class="err">{{ errorMsg }}</p>
+
+      <!-- Apply -->
+      <div v-if="mode === 'apply'" class="body">
+        <p v-if="loading" class="hint">加载模板中…</p>
+        <p v-else-if="templates.length === 0" class="hint">
+          还没有任何模板。切到「另存为模板」把当前流水线沉淀为可复用模板。
+        </p>
+        <ul v-else class="tpl-list" role="list">
+          <li v-for="t in templates" :key="t.id">
+            <label class="tpl-opt" :class="{ sel: selectedId === t.id }">
+              <input
+                type="radio"
+                name="tpl"
+                :value="t.id"
+                v-model="selectedId"
+                class="tpl-radio"
+              />
+              <span class="tpl-info">
+                <span class="tpl-name">{{ t.name }}</span>
+                <span class="tpl-meta">{{ t.stageCount }} 阶段 · {{ t.description || '无说明' }}</span>
+              </span>
+            </label>
+          </li>
+        </ul>
+        <footer class="foot">
+          <button class="btn-secondary" @click="emit('close')">取消</button>
+          <button
+            class="btn-primary"
+            :disabled="applying || templates.length === 0"
+            @click="doApply"
+          >
+            {{ applying ? '应用中…' : '应用到当前流水线' }}
+          </button>
+        </footer>
+      </div>
+
+      <!-- Save as template -->
+      <div v-else class="body">
+        <p v-if="saveDone" class="ok">已保存为模板,可在「复用库」或上方「应用模板」中复用。</p>
+        <div class="field">
+          <label class="label" for="tpl-name">模板名称</label>
+          <input
+            id="tpl-name"
+            v-model="saveName"
+            class="input"
+            placeholder="如 go-service-standard"
+            autocomplete="off"
+          />
+        </div>
+        <div class="field">
+          <label class="label" for="tpl-desc">说明(可选)</label>
+          <input
+            id="tpl-desc"
+            v-model="saveDesc"
+            class="input"
+            placeholder="这个模板的用途"
+            autocomplete="off"
+          />
+        </div>
+        <p class="hint">
+          将快照当前画布的 {{ props.stages.length }} 个阶段。模板不含明文 secret(凭据保持保险库引用)。
+        </p>
+        <footer class="foot">
+          <button class="btn-secondary" @click="emit('close')">关闭</button>
+          <button class="btn-primary" :disabled="saving" @click="doSave">
+            {{ saving ? '保存中…' : '保存为模板' }}
+          </button>
+        </footer>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.scrim {
+  position: fixed;
+  inset: 0;
+  background: oklch(0% 0 0 / 0.55);
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  z-index: 60;
+}
+.modal {
+  width: min(560px, 100%);
+  max-height: 86vh;
+  overflow-y: auto;
+  background: var(--color-card);
+  border: 1px solid var(--color-border-strong);
+  border-radius: 18px;
+  box-shadow: var(--shadow-modal);
+  padding: 1.4rem;
+}
+.head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+.title { margin: 0; font-size: 1.15rem; font-weight: 640; color: var(--color-text); }
+.close {
+  border: none;
+  background: none;
+  color: var(--color-dim);
+  font-size: 1rem;
+  cursor: pointer;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 8px;
+}
+.close:hover { background: var(--color-inset); color: var(--color-text); }
+
+.seg {
+  display: inline-flex;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  background: var(--color-inset);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  margin-bottom: 1rem;
+}
+.seg-item {
+  padding: 0.45rem 1rem;
+  border: none;
+  background: transparent;
+  color: var(--color-dim);
+  font-size: 0.88rem;
+  font-weight: 560;
+  border-radius: 8px;
+  cursor: pointer;
+}
+.seg-item.active {
+  background: var(--color-card);
+  color: var(--color-text);
+  box-shadow: var(--shadow);
+}
+
+.err {
+  margin: 0 0 0.9rem;
+  padding: 0.6rem 0.85rem;
+  border-radius: 9px;
+  font-size: 0.85rem;
+  color: var(--color-red);
+  background: var(--color-red-soft);
+  border: 1px solid var(--color-red-line);
+}
+.ok {
+  margin: 0 0 0.9rem;
+  padding: 0.6rem 0.85rem;
+  border-radius: 9px;
+  font-size: 0.85rem;
+  color: var(--color-green);
+  background: var(--color-green-soft);
+  border: 1px solid var(--color-green-line);
+}
+.hint { margin: 0.6rem 0 0; color: var(--color-dim); font-size: 0.85rem; line-height: 1.5; }
+
+.tpl-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.5rem; }
+.tpl-opt {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.7rem 0.85rem;
+  border: 1px solid var(--color-border);
+  border-radius: 11px;
+  cursor: pointer;
+  transition: border-color var(--duration-fast, 150ms), background var(--duration-fast, 150ms);
+}
+.tpl-opt:hover { border-color: var(--color-border-strong); }
+.tpl-opt.sel { border-color: var(--color-primary); background: var(--color-primary-soft); }
+.tpl-radio { accent-color: var(--color-primary); }
+.tpl-info { display: flex; flex-direction: column; gap: 0.15rem; min-width: 0; }
+.tpl-name { font-weight: 600; color: var(--color-text); }
+.tpl-meta {
+  font-size: 0.8rem;
+  color: var(--color-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.field { margin-bottom: 0.9rem; }
+.label { display: block; margin-bottom: 0.35rem; font-size: 0.83rem; font-weight: 560; color: var(--color-dim); }
+.input {
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  background: var(--color-inset);
+  border: 1px solid var(--color-border);
+  border-radius: 9px;
+  color: var(--color-text);
+  font-size: 0.9rem;
+}
+.input:focus { outline: none; border-color: var(--color-primary); }
+
+.foot { display: flex; justify-content: flex-end; gap: 0.6rem; margin-top: 1.2rem; }
+.btn-primary {
+  padding: 0.55rem 1.1rem;
+  background: var(--color-primary);
+  color: oklch(100% 0 0);
+  border: none;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+.btn-primary:hover:not(:disabled) { background: var(--color-primary-press); }
+.btn-primary:disabled { opacity: 0.55; cursor: not-allowed; }
+.btn-secondary {
+  padding: 0.55rem 1.1rem;
+  background: var(--color-card-2);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+  border-radius: 10px;
+  font-weight: 560;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+.btn-secondary:hover { border-color: var(--color-primary); }
+</style>

--- a/web/src/layouts/AppShell.vue
+++ b/web/src/layouts/AppShell.vue
@@ -9,6 +9,7 @@ import {
   AlertTriangle,
   Bell,
   Settings,
+  Stack2,
 } from '@vicons/tabler'
 import { NIcon } from 'naive-ui'
 import ThemeToggle from '../components/ThemeToggle.vue'
@@ -26,6 +27,8 @@ interface NavItem {
 const navItems: NavItem[] = [
   { name: 'projects',      to: '/projects',      icon: GitBranch,  label: '项目',  ariaLabel: '项目' },
   { name: 'runs',          to: '/runs',          icon: GitFork,    label: '运行',  ariaLabel: '运行' },
+  // FR-8-13: 复用库(流水线模板 + 变量组)。
+  { name: 'library',       to: '/library',       icon: Stack2,     label: '复用库', ariaLabel: '复用库' },
   // FR-8-15: DORA 四指标仪表盘(交付效能;只读聚合)。
   { name: 'dora',          to: '/metrics/dora',  icon: ChartBar,   label: 'DORA 指标', ariaLabel: 'DORA 指标' },
   // Story 6-1: 多机状态总览(服务器层指标 FR-15);登记在 设置 → 服务器。

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -8,6 +8,8 @@ const AppShell    = () => import('../layouts/AppShell.vue')
 const Onboarding  = () => import('../views/Onboarding.vue')
 const Projects    = () => import('../views/Projects.vue')
 const Runs        = () => import('../views/Runs.vue')
+// FR-8-13: 复用库(流水线模板 + 变量组)
+const Library     = () => import('../views/Library.vue')
 // FR-8-15: DORA 四指标仪表盘(部署频率 / 前置时长 / 变更失败率 / MTTR;只读聚合)
 const DoraDashboard = () => import('../views/DoraDashboard.vue')
 // Story 6-1: multi-host status overview (server-layer CPU/memory/disk metrics, FR-15)
@@ -71,6 +73,8 @@ const router = createRouter({
         // Story 7-4: read-only code browsing (FR-4)
         { path: 'projects/:id/code', name: 'project-code', component: ProjectCode },
         { path: 'runs', name: 'runs', component: Runs },
+        // FR-8-13: 复用库(流水线模板 + 变量组)
+        { path: 'library', name: 'library', component: Library },
         { path: 'runs/:id', name: 'run-detail', component: RunDetail },
         // FR-8-15: DORA 指标仪表盘(只读聚合;projectId / window 经 query 即状态)
         { path: 'metrics/dora', name: 'dora', component: DoraDashboard },

--- a/web/src/views/Library.vue
+++ b/web/src/views/Library.vue
@@ -1,0 +1,839 @@
+<script setup lang="ts">
+/**
+ * 复用库(Library)— FR-8-13:流水线模板 + 变量组。
+ *
+ * 两类跨项目可复用资产,合并在一个带分段切换的管理界面:
+ *   - 模板(Templates):命名、可复用的流水线定义;在流水线编辑器内「应用到项目」。
+ *   - 变量组(Variable Groups):命名、可复用的变量集合(key=value + secret 引用)。
+ *
+ * secret 变量绝无明文:仅存/回 credentialId + maskedValue。HttpError 形状 err.apiError?.code/.message/.status。
+ */
+import { ref, computed, onMounted } from 'vue'
+import { useMessage } from 'naive-ui'
+import { HttpError } from '../api/http'
+import {
+  listTemplates,
+  deleteTemplate,
+  type TemplateSummary,
+} from '../api/templates'
+import {
+  listVariableGroups,
+  createVariableGroup,
+  updateVariableGroup,
+  deleteVariableGroup,
+  type VariableGroup,
+  type VariableGroupVarInput,
+} from '../api/variableGroups'
+import { listCredentials, type Credential } from '../api/credentials'
+
+type Tab = 'templates' | 'variableGroups'
+type LoadState = 'idle' | 'loading' | 'error'
+
+const message = useMessage()
+const tab = ref<Tab>('templates')
+
+// ─── templates ────────────────────────────────────────────────────────────────
+const tplState = ref<LoadState>('idle')
+const tplError = ref('')
+const templates = ref<TemplateSummary[]>([])
+
+async function loadTemplates(): Promise<void> {
+  tplState.value = 'loading'
+  tplError.value = ''
+  try {
+    templates.value = await listTemplates()
+    tplState.value = 'idle'
+  } catch (err: unknown) {
+    tplState.value = 'error'
+    tplError.value = err instanceof HttpError
+      ? err.apiError?.message ?? `加载模板失败(${err.status})`
+      : '加载模板失败'
+  }
+}
+
+async function removeTemplate(t: TemplateSummary): Promise<void> {
+  if (!window.confirm(`删除模板「${t.name}」?此操作不可撤销。`)) return
+  try {
+    await deleteTemplate(t.id)
+    message.success(`已删除模板「${t.name}」`)
+    await loadTemplates()
+  } catch (err: unknown) {
+    message.error(err instanceof HttpError ? err.apiError?.message ?? '删除失败' : '删除失败')
+  }
+}
+
+// ─── variable groups ───────────────────────────────────────────────────────────
+const vgState = ref<LoadState>('idle')
+const vgError = ref('')
+const variableGroups = ref<VariableGroup[]>([])
+const credentials = ref<Credential[]>([])
+
+async function loadVariableGroups(): Promise<void> {
+  vgState.value = 'loading'
+  vgError.value = ''
+  try {
+    const [groups, creds] = await Promise.all([listVariableGroups(), loadCredentialsSafe()])
+    variableGroups.value = groups
+    credentials.value = creds
+    vgState.value = 'idle'
+  } catch (err: unknown) {
+    vgState.value = 'error'
+    vgError.value = err instanceof HttpError
+      ? err.apiError?.message ?? `加载变量组失败(${err.status})`
+      : '加载变量组失败'
+  }
+}
+
+/** 凭据列表用于 secret 变量挑选;保险库未配置不阻断变量组加载。 */
+async function loadCredentialsSafe(): Promise<Credential[]> {
+  try {
+    return await listCredentials()
+  } catch {
+    return []
+  }
+}
+
+// ─── variable-group editor modal ────────────────────────────────────────────────
+interface EditorVar {
+  id?: string
+  key: string
+  secret: boolean
+  value: string
+  credentialId: string
+  maskedValue: string
+}
+
+const editorOpen = ref(false)
+const editorMode = ref<'create' | 'edit'>('create')
+const editingId = ref<string | null>(null)
+const editorName = ref('')
+const editorDescription = ref('')
+const editorVars = ref<EditorVar[]>([])
+const editorBanner = ref('')
+const editorSaving = ref(false)
+
+function openCreateGroup(): void {
+  editorMode.value = 'create'
+  editingId.value = null
+  editorName.value = ''
+  editorDescription.value = ''
+  editorVars.value = [{ key: '', secret: false, value: '', credentialId: '', maskedValue: '' }]
+  editorBanner.value = ''
+  editorOpen.value = true
+}
+
+function openEditGroup(g: VariableGroup): void {
+  editorMode.value = 'edit'
+  editingId.value = g.id
+  editorName.value = g.name
+  editorDescription.value = g.description
+  editorVars.value = g.vars.map((v) => ({
+    id: v.id,
+    key: v.key,
+    secret: v.secret,
+    value: v.value ?? '',
+    credentialId: v.credentialId ?? '',
+    maskedValue: v.maskedValue ?? '',
+  }))
+  if (editorVars.value.length === 0) {
+    editorVars.value = [{ key: '', secret: false, value: '', credentialId: '', maskedValue: '' }]
+  }
+  editorBanner.value = ''
+  editorOpen.value = true
+}
+
+function addEditorVar(): void {
+  editorVars.value.push({ key: '', secret: false, value: '', credentialId: '', maskedValue: '' })
+}
+
+function removeEditorVar(idx: number): void {
+  editorVars.value.splice(idx, 1)
+}
+
+function toggleSecret(v: EditorVar): void {
+  v.secret = !v.secret
+  // 切到 secret 时清明文;切回明文时清引用(避免泄漏/悬挂)。
+  if (v.secret) v.value = ''
+  else {
+    v.credentialId = ''
+    v.maskedValue = ''
+  }
+}
+
+const editorTitle = computed(() => (editorMode.value === 'create' ? '新建变量组' : '编辑变量组'))
+
+async function saveGroup(): Promise<void> {
+  editorBanner.value = ''
+  const name = editorName.value.trim()
+  if (!name) {
+    editorBanner.value = '变量组名称不能为空'
+    return
+  }
+  // 仅提交 key 非空的变量;secret 项只传 credentialId(不传明文)。
+  const vars: VariableGroupVarInput[] = editorVars.value
+    .filter((v) => v.key.trim() !== '')
+    .map((v) =>
+      v.secret
+        ? { id: v.id, key: v.key.trim(), secret: true, credentialId: v.credentialId }
+        : { id: v.id, key: v.key.trim(), secret: false, value: v.value },
+    )
+
+  editorSaving.value = true
+  try {
+    const payload = { name, description: editorDescription.value.trim(), vars }
+    if (editorMode.value === 'create') {
+      await createVariableGroup(payload)
+      message.success(`已创建变量组「${name}」`)
+    } else if (editingId.value) {
+      await updateVariableGroup(editingId.value, payload)
+      message.success(`已更新变量组「${name}」`)
+    }
+    editorOpen.value = false
+    await loadVariableGroups()
+  } catch (err: unknown) {
+    editorBanner.value = err instanceof HttpError
+      ? err.apiError?.message ?? `保存失败(${err.status})`
+      : '保存失败'
+  } finally {
+    editorSaving.value = false
+  }
+}
+
+async function removeGroup(g: VariableGroup): Promise<void> {
+  if (!window.confirm(`删除变量组「${g.name}」?此操作不可撤销。`)) return
+  try {
+    await deleteVariableGroup(g.id)
+    message.success(`已删除变量组「${g.name}」`)
+    await loadVariableGroups()
+  } catch (err: unknown) {
+    message.error(err instanceof HttpError ? err.apiError?.message ?? '删除失败' : '删除失败')
+  }
+}
+
+function switchTab(t: Tab): void {
+  tab.value = t
+  if (t === 'templates' && templates.value.length === 0 && tplState.value !== 'error') loadTemplates()
+  if (t === 'variableGroups' && variableGroups.value.length === 0 && vgState.value !== 'error') loadVariableGroups()
+}
+
+onMounted(() => {
+  loadTemplates()
+  loadVariableGroups()
+})
+</script>
+
+<template>
+  <section class="library">
+    <header class="page-header">
+      <div>
+        <h1 class="page-title">复用库</h1>
+        <p class="page-sub">跨项目共享的流水线模板与变量组 · 一处定义,处处复用</p>
+      </div>
+      <button
+        v-if="tab === 'variableGroups'"
+        class="btn-primary"
+        @click="openCreateGroup"
+      >
+        + 新建变量组
+      </button>
+    </header>
+
+    <!-- Segmented tab switch -->
+    <div class="seg" role="tablist" aria-label="复用库分类">
+      <button
+        class="seg-item"
+        role="tab"
+        :aria-selected="tab === 'templates'"
+        :class="{ 'seg-item--active': tab === 'templates' }"
+        @click="switchTab('templates')"
+      >
+        流水线模板
+        <span class="seg-count">{{ templates.length }}</span>
+      </button>
+      <button
+        class="seg-item"
+        role="tab"
+        :aria-selected="tab === 'variableGroups'"
+        :class="{ 'seg-item--active': tab === 'variableGroups' }"
+        @click="switchTab('variableGroups')"
+      >
+        变量组
+        <span class="seg-count">{{ variableGroups.length }}</span>
+      </button>
+    </div>
+
+    <!-- ─── Templates ─── -->
+    <div v-show="tab === 'templates'" class="panel">
+      <div v-if="tplState === 'error'" class="banner banner--error">
+        <span>{{ tplError }}</span>
+        <button class="banner-retry" @click="loadTemplates">↻ 重试</button>
+      </div>
+
+      <div v-if="tplState === 'loading'" class="skeleton-grid">
+        <div v-for="i in 3" :key="i" class="skeleton-card" />
+      </div>
+
+      <div
+        v-else-if="tplState === 'idle' && templates.length === 0"
+        class="empty-state"
+      >
+        <div class="empty-icon">▦</div>
+        <p class="empty-label">还没有流水线模板</p>
+        <p class="empty-hint">
+          模板让你把一份流水线定义沉淀下来,在任意项目的流水线编辑器里一键应用。
+          在项目流水线编辑器中可把当前流水线另存为模板。
+        </p>
+      </div>
+
+      <ul v-else class="card-grid" role="list">
+        <li v-for="t in templates" :key="t.id" class="tpl-card">
+          <div class="tpl-card-head">
+            <h3 class="tpl-name">{{ t.name }}</h3>
+            <span class="tpl-stage-pill">{{ t.stageCount }} 阶段</span>
+          </div>
+          <p class="tpl-desc">{{ t.description || '无说明' }}</p>
+          <div class="tpl-card-foot">
+            <span class="tpl-time">更新于 {{ new Date(t.updatedAt).toLocaleDateString() }}</span>
+            <button class="link-danger" @click="removeTemplate(t)">删除</button>
+          </div>
+        </li>
+      </ul>
+    </div>
+
+    <!-- ─── Variable Groups ─── -->
+    <div v-show="tab === 'variableGroups'" class="panel">
+      <div v-if="vgState === 'error'" class="banner banner--error">
+        <span>{{ vgError }}</span>
+        <button class="banner-retry" @click="loadVariableGroups">↻ 重试</button>
+      </div>
+
+      <div v-if="vgState === 'loading'" class="skeleton-grid">
+        <div v-for="i in 3" :key="i" class="skeleton-card" />
+      </div>
+
+      <div
+        v-else-if="vgState === 'idle' && variableGroups.length === 0"
+        class="empty-state"
+      >
+        <div class="empty-icon">{ }</div>
+        <p class="empty-label">还没有变量组</p>
+        <p class="empty-hint">
+          把一组共享变量(如同一套环境地址、令牌引用)定义为变量组,在多条流水线间复用。
+          secret 变量只保存保险库引用,绝不存明文。
+        </p>
+        <button class="btn-primary" @click="openCreateGroup">+ 新建变量组</button>
+      </div>
+
+      <ul v-else class="card-grid" role="list">
+        <li v-for="g in variableGroups" :key="g.id" class="vg-card">
+          <div class="vg-card-head">
+            <h3 class="vg-name">{{ g.name }}</h3>
+            <span class="vg-count-pill">{{ g.vars.length }} 变量</span>
+          </div>
+          <p class="vg-desc">{{ g.description || '无说明' }}</p>
+          <ul class="vg-var-list" role="list">
+            <li v-for="v in g.vars.slice(0, 5)" :key="v.id" class="vg-var">
+              <code class="vg-var-key">{{ v.key }}</code>
+              <span v-if="v.secret" class="vg-var-secret" title="保险库引用,明文不可见">
+                🔒 {{ v.maskedValue || '••••' }}
+              </span>
+              <span v-else class="vg-var-value">{{ v.value || '空' }}</span>
+            </li>
+            <li v-if="g.vars.length > 5" class="vg-var vg-var--more">
+              +{{ g.vars.length - 5 }} 个变量…
+            </li>
+            <li v-if="g.vars.length === 0" class="vg-var vg-var--more">无变量</li>
+          </ul>
+          <div class="vg-card-foot">
+            <button class="btn-secondary btn-sm" @click="openEditGroup(g)">编辑</button>
+            <button class="link-danger" @click="removeGroup(g)">删除</button>
+          </div>
+        </li>
+      </ul>
+    </div>
+
+    <!-- ─── Variable-group editor modal ─── -->
+    <div v-if="editorOpen" class="modal-scrim" @click.self="editorOpen = false">
+      <div class="modal" role="dialog" aria-modal="true" :aria-label="editorTitle">
+        <header class="modal-head">
+          <h2 class="modal-title">{{ editorTitle }}</h2>
+          <button class="modal-close" aria-label="关闭" @click="editorOpen = false">✕</button>
+        </header>
+
+        <div v-if="editorBanner" class="banner banner--error">{{ editorBanner }}</div>
+
+        <div class="field">
+          <label class="field-label" for="vg-name">名称</label>
+          <input
+            id="vg-name"
+            v-model="editorName"
+            class="input"
+            placeholder="如 prod-shared-env"
+            autocomplete="off"
+          />
+        </div>
+        <div class="field">
+          <label class="field-label" for="vg-desc">说明(可选)</label>
+          <input
+            id="vg-desc"
+            v-model="editorDescription"
+            class="input"
+            placeholder="这组变量的用途"
+            autocomplete="off"
+          />
+        </div>
+
+        <div class="field">
+          <div class="field-label-row">
+            <span class="field-label">变量</span>
+            <button class="link-add" @click="addEditorVar">+ 添加变量</button>
+          </div>
+          <div class="var-rows">
+            <div v-for="(v, idx) in editorVars" :key="idx" class="var-row">
+              <input
+                v-model="v.key"
+                class="input input--key"
+                placeholder="KEY"
+                autocomplete="off"
+              />
+              <template v-if="v.secret">
+                <select v-model="v.credentialId" class="input input--cred">
+                  <option value="">选择凭据…</option>
+                  <option v-for="c in credentials" :key="c.id" :value="c.id">
+                    {{ c.name }} ({{ c.maskedValue }})
+                  </option>
+                </select>
+              </template>
+              <template v-else>
+                <input
+                  v-model="v.value"
+                  class="input input--val"
+                  placeholder="value"
+                  autocomplete="off"
+                />
+              </template>
+              <button
+                class="var-secret-toggle"
+                :class="{ 'var-secret-toggle--on': v.secret }"
+                :title="v.secret ? '保险库 secret(点击切回明文)' : '明文(点击切为 secret)'"
+                @click="toggleSecret(v)"
+              >
+                {{ v.secret ? '🔒' : '🔓' }}
+              </button>
+              <button class="var-remove" title="移除" @click="removeEditorVar(idx)">✕</button>
+            </div>
+          </div>
+        </div>
+
+        <footer class="modal-foot">
+          <button class="btn-secondary" :disabled="editorSaving" @click="editorOpen = false">
+            取消
+          </button>
+          <button class="btn-primary" :disabled="editorSaving" @click="saveGroup">
+            {{ editorSaving ? '保存中…' : '保存' }}
+          </button>
+        </footer>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.library {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: clamp(1.5rem, 1rem + 2vw, 3rem) clamp(1rem, 0.5rem + 2vw, 2.5rem);
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+.page-title {
+  font-size: clamp(1.5rem, 1.2rem + 1.4vw, 2.1rem);
+  font-weight: 680;
+  letter-spacing: -0.02em;
+  margin: 0;
+  color: var(--color-text);
+}
+.page-sub {
+  margin: 0.35rem 0 0;
+  color: var(--color-dim);
+  font-size: 0.92rem;
+}
+
+/* Segmented control — intentional active state with sliding underline feel */
+.seg {
+  display: inline-flex;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  background: var(--color-inset);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  margin-bottom: 1.75rem;
+}
+.seg-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border: none;
+  background: transparent;
+  color: var(--color-dim);
+  font-size: 0.9rem;
+  font-weight: 560;
+  border-radius: 9px;
+  cursor: pointer;
+  transition: color var(--duration-fast, 150ms), background var(--duration-fast, 150ms);
+}
+.seg-item:hover {
+  color: var(--color-text);
+}
+.seg-item--active {
+  background: var(--color-card);
+  color: var(--color-text);
+  box-shadow: var(--shadow);
+}
+.seg-count {
+  display: inline-grid;
+  place-items: center;
+  min-width: 1.4rem;
+  height: 1.4rem;
+  padding: 0 0.4rem;
+  font-size: 0.72rem;
+  font-weight: 640;
+  color: var(--color-faint);
+  background: var(--color-border);
+  border-radius: 999px;
+}
+.seg-item--active .seg-count {
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+}
+
+.panel { min-height: 240px; }
+
+/* Card grid — bento-ish, depth via surface + shadow + hover lift */
+.card-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
+  gap: 1rem;
+}
+
+.tpl-card,
+.vg-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  padding: 1.15rem 1.25rem;
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+  transition: transform var(--duration-fast, 150ms), border-color var(--duration-fast, 150ms);
+}
+.tpl-card:hover,
+.vg-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--color-border-strong);
+}
+
+.tpl-card-head,
+.vg-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+.tpl-name,
+.vg-name {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 640;
+  letter-spacing: -0.01em;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tpl-stage-pill,
+.vg-count-pill {
+  flex-shrink: 0;
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 0.18rem 0.55rem;
+  border-radius: 999px;
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+}
+.tpl-desc,
+.vg-desc {
+  margin: 0;
+  font-size: 0.86rem;
+  color: var(--color-dim);
+  line-height: 1.45;
+  min-height: 1.2em;
+}
+
+.vg-var-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.6rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  border-top: 1px solid var(--color-border);
+}
+.vg-var {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.82rem;
+}
+.vg-var-key {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  color: var(--color-text);
+  background: var(--color-inset);
+  padding: 0.1rem 0.4rem;
+  border-radius: 6px;
+}
+.vg-var-value {
+  color: var(--color-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.vg-var-secret {
+  color: var(--color-amber);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.78rem;
+}
+.vg-var--more {
+  color: var(--color-faint);
+  font-style: italic;
+}
+
+.tpl-card-foot,
+.vg-card-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: auto;
+  padding-top: 0.4rem;
+}
+.tpl-time {
+  font-size: 0.76rem;
+  color: var(--color-faint);
+}
+
+/* Buttons */
+.btn-primary {
+  padding: 0.55rem 1.1rem;
+  background: var(--color-primary);
+  color: oklch(100% 0 0);
+  border: none;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background var(--duration-fast, 150ms), transform var(--duration-fast, 150ms);
+}
+.btn-primary:hover:not(:disabled) { background: var(--color-primary-press); transform: translateY(-1px); }
+.btn-primary:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
+.btn-primary:disabled { opacity: 0.55; cursor: not-allowed; }
+
+.btn-secondary {
+  padding: 0.55rem 1.1rem;
+  background: var(--color-card-2);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+  border-radius: 10px;
+  font-weight: 560;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: border-color var(--duration-fast, 150ms), background var(--duration-fast, 150ms);
+}
+.btn-secondary:hover:not(:disabled) { border-color: var(--color-primary); }
+.btn-secondary:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
+.btn-secondary:disabled { opacity: 0.55; cursor: not-allowed; }
+.btn-sm { padding: 0.4rem 0.85rem; font-size: 0.84rem; }
+
+.link-danger {
+  border: none;
+  background: none;
+  color: var(--color-red);
+  font-size: 0.82rem;
+  font-weight: 560;
+  cursor: pointer;
+  padding: 0.2rem 0.3rem;
+  border-radius: 6px;
+}
+.link-danger:hover { background: var(--color-red-soft); }
+.link-danger:focus-visible { outline: 2px solid var(--color-red); outline-offset: 1px; }
+
+.link-add {
+  border: none;
+  background: none;
+  color: var(--color-primary);
+  font-size: 0.82rem;
+  font-weight: 580;
+  cursor: pointer;
+}
+.link-add:hover { text-decoration: underline; }
+
+/* Banner */
+.banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  font-size: 0.88rem;
+  margin-bottom: 1rem;
+}
+.banner--error {
+  color: var(--color-red);
+  background: var(--color-red-soft);
+  border: 1px solid var(--color-red-line);
+}
+.banner-retry {
+  border: none;
+  background: none;
+  color: var(--color-red);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+/* Empty state */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.5rem;
+  padding: 3.5rem 1rem;
+}
+.empty-icon {
+  font-size: 2rem;
+  color: var(--color-faint);
+  opacity: 0.6;
+}
+.empty-label { margin: 0.3rem 0 0; font-size: 1.1rem; font-weight: 600; color: var(--color-text); }
+.empty-hint { margin: 0; max-width: 30rem; color: var(--color-dim); font-size: 0.88rem; line-height: 1.55; }
+.empty-state .btn-primary { margin-top: 0.8rem; }
+
+/* Skeleton */
+.skeleton-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
+  gap: 1rem;
+}
+.skeleton-card {
+  height: 150px;
+  border-radius: 16px;
+  background: linear-gradient(100deg, var(--color-card) 30%, var(--color-card-2) 50%, var(--color-card) 70%);
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* Modal */
+.modal-scrim {
+  position: fixed;
+  inset: 0;
+  background: oklch(0% 0 0 / 0.55);
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  z-index: 50;
+}
+.modal {
+  width: min(620px, 100%);
+  max-height: 88vh;
+  overflow-y: auto;
+  background: var(--color-card);
+  border: 1px solid var(--color-border-strong);
+  border-radius: 18px;
+  box-shadow: var(--shadow-modal);
+  padding: 1.5rem;
+}
+.modal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+.modal-title { margin: 0; font-size: 1.2rem; font-weight: 640; color: var(--color-text); }
+.modal-close {
+  border: none;
+  background: none;
+  color: var(--color-dim);
+  font-size: 1rem;
+  cursor: pointer;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 8px;
+}
+.modal-close:hover { background: var(--color-inset); color: var(--color-text); }
+.modal-foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+  margin-top: 1.25rem;
+}
+
+/* Fields */
+.field { margin-bottom: 1rem; }
+.field-label-row { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.4rem; }
+.field-label { display: block; margin-bottom: 0.4rem; font-size: 0.84rem; font-weight: 560; color: var(--color-dim); }
+.input {
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  background: var(--color-inset);
+  border: 1px solid var(--color-border);
+  border-radius: 9px;
+  color: var(--color-text);
+  font-size: 0.9rem;
+  transition: border-color var(--duration-fast, 150ms);
+}
+.input:focus { outline: none; border-color: var(--color-primary); }
+
+.var-rows { display: flex; flex-direction: column; gap: 0.5rem; }
+.var-row { display: flex; align-items: center; gap: 0.5rem; }
+.input--key { flex: 0 0 32%; font-family: var(--font-mono, ui-monospace, monospace); }
+.input--val,
+.input--cred { flex: 1 1 auto; }
+.var-secret-toggle {
+  flex-shrink: 0;
+  width: 2.2rem;
+  height: 2.2rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-inset);
+  border-radius: 9px;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+.var-secret-toggle--on { border-color: var(--color-amber-line); background: var(--color-amber-soft); }
+.var-remove {
+  flex-shrink: 0;
+  width: 2.2rem;
+  height: 2.2rem;
+  border: 1px solid var(--color-border);
+  background: transparent;
+  border-radius: 9px;
+  color: var(--color-faint);
+  cursor: pointer;
+}
+.var-remove:hover { color: var(--color-red); border-color: var(--color-red-line); }
+</style>

--- a/web/src/views/ProjectPipeline.vue
+++ b/web/src/views/ProjectPipeline.vue
@@ -26,6 +26,7 @@ import TriggersPanel from '../components/TriggersPanel.vue'
 import ValidationPanel from '../components/pipeline/ValidationPanel.vue'
 import AIGenerateWizard from '../components/pipeline/AIGenerateWizard.vue'
 import YamlImportModal from '../components/pipeline/YamlImportModal.vue'
+import TemplatePickerModal from '../components/pipeline/TemplatePickerModal.vue'
 
 // ─── Route ────────────────────────────────────────────────────────────────────
 
@@ -263,6 +264,22 @@ function handleImport(): void {
   yamlImportOpen.value = true
 }
 
+// ─── Pipeline templates (FR-8-13) ─────────────────────────────────────────────
+
+const templateModalOpen = ref(false)
+
+function handleTemplates(): void {
+  templateModalOpen.value = true
+}
+
+/** Apply-template succeeded: server already persisted; reload pipeline + settings + revalidate. */
+async function handleTemplateApplied(): Promise<void> {
+  await Promise.all([loadPipeline(), loadSettings()])
+  if (activeTab.value !== 'canvas') setTab('canvas')
+  showSaveSuccess()
+  scheduleValidation(400)
+}
+
 /**
  * Preview (save=false): the modal parsed + validated the YAML and returned a DTO.
  * Reflect it on the canvas WITHOUT persisting — the user reviews, then clicks 保存草稿.
@@ -371,6 +388,13 @@ const projectName = computed(() => String(route.params.id))
             <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="M7 10l5 5 5-5"/><path d="M12 15V3"/>
           </svg>
           从 YAML 导入
+        </button>
+
+        <button class="top-btn" :disabled="saveSubmitting" @click="handleTemplates">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 3l9 4.5-9 4.5-9-4.5z"/><path d="M3 12l9 4.5 9-4.5"/><path d="M3 16.5l9 4.5 9-4.5"/>
+          </svg>
+          模板
         </button>
 
         <!-- ─── Validation button + ready badge (Story 2-6) ─────────────── -->
@@ -574,6 +598,15 @@ const projectName = computed(() => String(route.params.id))
       @close="yamlImportOpen = false"
       @preview="handleImportPreview"
       @saved="handleImportSaved"
+    />
+
+    <!-- ─── Pipeline templates (FR-8-13) ────────────────────────────────── -->
+    <TemplatePickerModal
+      v-if="templateModalOpen"
+      :project-id="projectId"
+      :stages="editStages"
+      @close="templateModalOpen = false"
+      @applied="handleTemplateApplied"
     />
 
   </div>


### PR DESCRIPTION
## 概述

为 Pipewright 实现 **FR-8-13 流水线模板 + 变量组** 复用基座(对标 Jenkins Shared Library / 云效模板与变量组)。两类跨项目可复用资产,新增 `internal/library/` 领域包,additive 且向后兼容。

## 领域模型

- **流水线模板(`library.Template`)**:命名、可复用的流水线定义,与项目流水线**同一套 `[]pipeline.Stage` 模型**,跨项目共享(不挂 project_id,解耦)。
- **变量组(`library.VarGroup`)**:命名、可复用的变量集合,镜像每流水线变量模型(`pipeline.BuildVar`)。

校验全部**复用现有 pipeline 包**,不另起规则:
- 模板 spec 经 `pipeline.NormalizeSpec`(恰一个源阶段 / kind 枚举 / needs DAG 环检测 / id 全局唯一)。
- 变量组变量经新增导出的 `pipeline.NormalizeVars`(key 非空且组内不重复;secret 经保险库校验存在性)。

## 端点(认证;写方法 + CSRF + 审计)

| 方法 | 路径 | 说明 |
|---|---|---|
| GET / POST | `/api/templates` | 列模板(画廊)/ 建模板 |
| GET / DELETE | `/api/templates/{id}` | 取 / 删模板 |
| POST | `/api/projects/{id}/pipeline/apply-template` | 应用模板到项目流水线 |
| GET / POST | `/api/variable-groups` | 列 / 建变量组 |
| GET / PUT / DELETE | `/api/variable-groups/{id}` | 取 / 改 / 删变量组 |

写操作审计(`audit` 新增 template_*/variable_group_* action;detail 仅元数据 + 变量 key,绝无明文/凭据值)。

## 应用模板流程

`apply-template` 收 `{templateId}` → 取模板 spec → 经 `pipeline.Service.Save` 把 stages 落到项目流水线(**走与画布 PUT 完全一致的规范化 / 再校验 / YAML 渲染 / 回读**),产出合法流水线。模板不存在 → 404;项目不存在 → 404(透出 `pipeline.ErrProjectNotFound` 归一)。

## Secret 处理(铁律:始终是引用)

- 变量组 secret 变量**只存 vault `credentialId` 引用**,落库 `vars_json` 绝无明文(测试断言 DB 内无明文标记);响应 / 列表仅回服务端回算的 `maskedValue`,从不回显明文;保险库未配置且有 secret 引用 → 明确错误(不 panic)。
- 模板 spec 不含任何 secret(凭据保持保险库引用,在 2-4 settings 才落引用字段)。
- 读路径回算掩码在 `rows` 关闭**之后**做(避免单连接 SQLite「持游标时再查库」自死锁)。

## 迁移

`internal/store/migrations/0031_templates_variable_groups.sql`:`pipeline_templates`(id, name 唯一, description, stages_json, …)+ `variable_groups`(id, name 唯一, description, vars_json, …)。

## 前端

- **复用库视图** `views/Library.vue`(顶部导航「复用库」):模板画廊 + 变量组管理,分段切换;变量组编辑器内 secret 变量经凭据下拉绑定、明文/secret 互斥切换;设计走项目既有 OKLCH 双主题 token,卡片有层次/悬停态/骨架屏/空态。
- **流水线编辑器** `ProjectPipeline.vue` 新增「模板」工具栏按钮 → `TemplatePickerModal`(应用模板 / 另存为模板)。
- api 模块 `api/templates.ts` + `api/variableGroups.ts`。

## 测试

- `internal/library`:模板创建+应用产出合法流水线、应用项目不存在、重名冲突、增删查;变量组规范化(拒重复 key、secret 引用不泄漏明文且落库无明文、缺凭据、保险库未配置、改名/删除)。
- `internal/httpapi`:端到端 —— 建模板→应用到项目落库读回一致、应用缺失模板 404、变量组 secret 掩码往返(响应/列表均不含明文标记)、重复 key 422。

## 绿灯证据

后端(`gofmt -l` 空 · `go vet ./...` · `go build ./...` · `go test ./...`):
```
gofmt -l (touched): <空>
go vet ./...: <无输出>
BUILD_OK
ok  internal/audit     3.532s
ok  internal/httpapi   15.608s
ok  internal/library   3.886s
ok  internal/pipeline  4.128s
go test ./... 全包通过(FAIL 计数 = 0)
```

前端(`web/`):
```
npm run typecheck → exit 0(vue-tsc --noEmit)
npm run test      → Test Files 22 passed (22) · Tests 191 passed (191)
npm run build     → ✓ built in 22.07s(Library 独立 lazy chunk)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)