### PR TITLE
feat(deploy): 部署策略 — 金丝雀 / 蓝绿(FR-8-8)

### DIFF
--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -61,6 +61,9 @@ type DeployInput struct {
 	// HealthCheck 是可选的部署后健康门控(Story 4.3 / FR-12)。
 	// nil 或 type=none → 跳过(向后兼容 4-2:部署命令成功即 success)。
 	HealthCheck *HealthCheck
+	// Strategy 是部署策略(Story 8-8 / FR-8-8):rolling(默认)| canary | blue_green。
+	// 空 / 未知 → rolling(行为与未加策略前一致)。金丝雀批量经 Config["canaryCount"|"canaryPercent"]。
+	Strategy string
 }
 
 // RetryInput 是一次「仅重试失败目标」请求(对齐 POST /api/runs/{id}/deploy/retry 请求体)。
@@ -213,9 +216,10 @@ func (s *service) Deploy(ctx context.Context, in DeployInput) ([]TargetResult, e
 		servers = append(servers, srv)
 	}
 
-	// 4) **并行扇出**执行部署命令(Story 4.5):每机独立 goroutine + recover,有界信号量(cap 4)
-	// 防同时打爆 N 台;单机 panic/失败不连累其它机;结果按输入顺序独立收集。
-	results := s.deployFanout(ctx, servers, *artifact, in.Config, in.HealthCheck)
+	// 4) 按**部署策略**执行(Story 8-8 / FR-8-8):rolling(默认,= 4-5 并行扇出)| canary | blue_green。
+	// 每机独立 goroutine + recover,有界信号量(cap 4)防同时打爆 N 台;单机 panic/失败不连累其它机;
+	// 结果按输入顺序独立收集。策略仅改机群编排(分批门控 / 统一切换),不改单机执行语义。
+	results := s.deployWithStrategy(ctx, servers, *artifact, in.Config, in.HealthCheck, NormalizeStrategy(in.Strategy))
 
 	// 5) 持久化每机结果(填 run-detail targets slot)。
 	dts := make([]run.DeployTarget, 0, len(results))

--- a/internal/deploy/release.go
+++ b/internal/deploy/release.go
@@ -90,29 +90,55 @@ func keepReleases(cfg map[string]string) int {
 	return n
 }
 
+// releaseState 是「发布目录就绪、尚未切换 current」的一机中间态(Story 8-8 蓝绿两阶段用)。
+// stageReleaseOne 产出;activateReleaseOne 消费(切换 + 健康 + 回滚)。rolling/canary 走
+// deployReleaseOne(= stage 紧接 activate,行为与拆分前字节级一致);蓝绿才分两阶段跨机编排。
+type releaseState struct {
+	releasesDir string // <base>/releases
+	current     string // <base>/current 软链路径
+	release     string // <base>/releases/<runId> 本次发布目录
+	prev        string // 上一发布绝对路径("" = 首次部署,无可回滚)
+}
+
 // deployReleaseOne 在一台目标机上执行「发布目录 + current 软链原子切换 + 健康门控 + 失败回滚」。
 // 仅在 releaseModeArtifact(a) 为真时被 deployOne 调用。执行错误**不上抛**:映射为 status=failed /
 // rolled_back + 人读 message(绝无明文密钥)。
+//
+// 实现 = stageReleaseOne(置发布目录,不切换)紧接 activateReleaseOne(原子切换 + 健康 + 回滚);
+// 行为与未拆分前完全一致(rolling/canary 单机路径)。蓝绿策略另行跨机分两阶段调度这两个原语。
 func (s *service) deployReleaseOne(ctx context.Context, srv *target.Server, a run.Artifact, cfg map[string]string, hc *HealthCheck) TargetResult {
 	started := time.Now().UTC()
 	res := TargetResult{ServerID: srv.ID, ServerName: srv.Name, StartedAt: started}
 
+	st, failMsg, ok := s.stageReleaseOne(ctx, srv, a, cfg)
+	if !ok {
+		return finishFailed(res, failMsg)
+	}
+	return s.activateReleaseOne(ctx, srv, a, cfg, hc, st, started)
+}
+
+// stageReleaseOne 执行 release 模式的**预备阶段**:探测上一发布 + mkdir 发布目录 + 写入产物负载,
+// **不切换 current**(切换在 activateReleaseOne)。返回就绪中间态;放置失败 → (中间态, 人读 message, false)。
+// 拆出以支撑蓝绿「全机先就绪、再统一切换」(stage-all → cutover-all)。
+func (s *service) stageReleaseOne(ctx context.Context, srv *target.Server, a run.Artifact, cfg map[string]string) (releaseState, string, bool) {
 	base := releaseBase(a, cfg)
-	releasesDir := path.Join(base, "releases")
-	current := path.Join(base, "current")
-	release := path.Join(releasesDir, sanitizeRunID(a.RunID))
-	file := path.Join(release, deployFileName(a))
+	st := releaseState{
+		releasesDir: path.Join(base, "releases"),
+		current:     path.Join(base, "current"),
+		release:     path.Join(base, "releases", sanitizeRunID(a.RunID)),
+	}
+	file := path.Join(st.release, deployFileName(a))
 
 	execCtx, cancel := context.WithTimeout(ctx, execTimeout)
 	defer cancel()
 
 	// 1) 探测上一发布(readlink current);失败 / 无软链 → prev 为空(首次部署,无可回滚)。
-	prev := s.readCurrentRelease(execCtx, srv.ID, current)
+	st.prev = s.readCurrentRelease(execCtx, srv.ID, st.current)
 
 	// 2) mkdir 发布目录 → 写入产物负载(base64 经 array 命令落地,不拼 shell)。
 	payload := base64.StdEncoding.EncodeToString([]byte(a.Reference + "\n"))
 	placeCmds := [][]string{
-		{"mkdir", "-p", release},
+		{"mkdir", "-p", st.release},
 		{"sh", "-c", `printf '%s' "$1" | base64 -d > "$0"`, file, payload},
 	}
 	if a.Type == run.ArtifactJar {
@@ -120,33 +146,43 @@ func (s *service) deployReleaseOne(ctx context.Context, srv *target.Server, a ru
 		placeCmds = append(placeCmds, []string{"java", "-jar", file, "--version"})
 	}
 	if failMsg, ok := s.runStep(execCtx, srv.ID, placeCmds); !ok {
-		return finishFailed(res, failMsg)
+		return st, failMsg, false
 	}
+	return st, "", true
+}
+
+// activateReleaseOne 执行 release 模式的**切换阶段**:原子切换 current → 本次发布 + 切后健康门控 +
+// 失败回滚 + 旧发布清理。消费 stageReleaseOne 产出的就绪中间态。started 透传以保留单机起始时刻。
+func (s *service) activateReleaseOne(ctx context.Context, srv *target.Server, a run.Artifact, cfg map[string]string, hc *HealthCheck, st releaseState, started time.Time) TargetResult {
+	res := TargetResult{ServerID: srv.ID, ServerName: srv.Name, StartedAt: started}
+
+	execCtx, cancel := context.WithTimeout(ctx, execTimeout)
+	defer cancel()
 
 	// 3) **真·原子**切换 current 软链 → 本次发布(code-review P2)。
 	// `ln -sfn` 在 current 已存在时是 unlink+symlink 两步,中间有 current 不存在的窗口(并发请求 404),
 	// 破坏「零停机」。改为「ln 到临时名 + `mv -T` 原子 rename」:rename(2) 是 POSIX 原子,无窗口。
-	if failMsg, ok := s.runStep(execCtx, srv.ID, atomicSymlinkCmds(release, current)); !ok {
+	if failMsg, ok := s.runStep(execCtx, srv.ID, atomicSymlinkCmds(st.release, st.current)); !ok {
 		return finishFailed(res, failMsg)
 	}
 
 	// 4) 切换之后跑健康门控(4-3);失败触发回滚。
 	if hc.enabled() {
 		if herr := s.runHealthCheck(execCtx, srv.ID, hc); herr != nil {
-			return s.rollback(execCtx, srv, res, current, prev, release, herr.Error())
+			return s.rollback(execCtx, srv, res, st.current, st.prev, st.release, herr.Error())
 		}
 	}
 
 	// 5) 成功(健康通过或未配置健康检查)→ 清理超 keepReleases 的旧发布(尽力;失败不影响成功态)。
 	keep := keepReleases(cfg)
-	s.pruneReleases(execCtx, srv.ID, releasesDir, sanitizeRunID(a.RunID), prev, keep)
+	s.pruneReleases(execCtx, srv.ID, st.releasesDir, sanitizeRunID(a.RunID), st.prev, keep)
 
 	finish := time.Now().UTC()
 	res.Status = run.TargetSuccess
 	if hc.enabled() {
-		res.Message = fmt.Sprintf("%s 零停机部署完成 → current → %s(健康检查通过)", a.Type, release)
+		res.Message = fmt.Sprintf("%s 零停机部署完成 → current → %s(健康检查通过)", a.Type, st.release)
 	} else {
-		res.Message = fmt.Sprintf("%s 零停机部署完成 → current → %s", a.Type, release)
+		res.Message = fmt.Sprintf("%s 零停机部署完成 → current → %s", a.Type, st.release)
 	}
 	res.FinishedAt = &finish
 	return res

--- a/internal/deploy/strategy.go
+++ b/internal/deploy/strategy.go
@@ -1,0 +1,260 @@
+package deploy
+
+// strategy.go 实现「部署策略」(Story 8-8 / FR-8-8):在既有多机扇出之上叠加 **金丝雀(canary)**
+// 与 **蓝绿(blue-green)** 两种发布编排,默认 **滚动(rolling)** = 原有 deployFanout 行为不变。
+//
+// 策略是**机群级编排**关注点(如何在 N 台之间排序 / 门控 / 统一切换),不改单机执行语义:
+//   - rolling   : 全机有界并行,各机独立成败,失败机自行回滚(deployFanout,原状)。
+//   - canary    : 先发**金丝雀子集**(默认 1 台)→ 全过才铺其余;金丝雀任一失败 → 中止其余
+//                 (其余标 failed 人读「未部署,仍运行旧版本」)。复用 deployOne,任意产物类型。
+//   - blue_green: **stage-all → cutover-all**(release 类产物 dist/jar):全机先就绪发布目录(不切换),
+//                 全部就绪才统一原子切换 + 健康;切换阶段任一失败 → 把**已切换成功**的机一并回滚到上一发布
+//                 (机群级原子性)。非 release 产物(image/archive)无 stage/cutover 之分 → 退化 rolling。
+//
+// 安全不变量沿用:命令 array 化(不拼 shell)、单机 panic recover、有界并发(maxParallelDeploys)、
+// message 无明文密钥、错误不上抛(映射 status + 人读)。
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/huangchengsir/pipewright/internal/run"
+	"github.com/huangchengsir/pipewright/internal/target"
+)
+
+// 部署策略枚举(DeployInput.Strategy / Config["strategy"];空 / 未知 → rolling)。
+const (
+	// StrategyRolling 滚动发布(默认):全机有界并行,各机独立成败。
+	StrategyRolling = "rolling"
+	// StrategyCanary 金丝雀:先发小批,健康门控通过才铺其余,否则中止。
+	StrategyCanary = "canary"
+	// StrategyBlueGreen 蓝绿:全机先就绪、统一切换、机群级失败回滚(release 类产物)。
+	StrategyBlueGreen = "blue_green"
+)
+
+// NormalizeStrategy 归一策略串(大小写 / 连字符容错;空 / 未知 → rolling)。
+func NormalizeStrategy(s string) string {
+	switch strings.TrimSpace(strings.ToLower(s)) {
+	case StrategyCanary:
+		return StrategyCanary
+	case StrategyBlueGreen, "blue-green", "bluegreen", "blue green":
+		return StrategyBlueGreen
+	default:
+		return StrategyRolling
+	}
+}
+
+// deployWithStrategy 按策略调度多机部署。结果按 servers 输入顺序对齐(稳定可断言)。
+func (s *service) deployWithStrategy(ctx context.Context, servers []*target.Server, a run.Artifact, cfg map[string]string, hc *HealthCheck, strategy string) []TargetResult {
+	switch strategy {
+	case StrategyCanary:
+		return s.deployCanary(ctx, servers, a, cfg, hc)
+	case StrategyBlueGreen:
+		// 蓝绿需要 stage/cutover 两阶段,仅 release 类产物(dist/jar)成立;其余退化滚动。
+		if releaseModeArtifact(a) {
+			return s.deployBlueGreen(ctx, servers, a, cfg, hc)
+		}
+		return s.deployFanout(ctx, servers, a, cfg, hc)
+	default:
+		return s.deployFanout(ctx, servers, a, cfg, hc)
+	}
+}
+
+// canaryCount 解析金丝雀批量(Config["canaryCount"] 优先;否则 Config["canaryPercent"] 向上取整)。
+// 默认 1 台。夹紧:总数 1 → 1(整体即金丝雀);否则 [1, total-1](至少留 1 台在「其余」)。
+func canaryCount(cfg map[string]string, total int) int {
+	if total <= 1 {
+		return total
+	}
+	n := 1
+	if raw := strings.TrimSpace(cfg["canaryCount"]); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v > 0 {
+			n = v
+		}
+	} else if raw := strings.TrimSpace(cfg["canaryPercent"]); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v > 0 {
+			n = (total*v + 99) / 100 // 向上取整
+		}
+	}
+	if n >= total {
+		n = total - 1
+	}
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+// allSuccess 报告一批结果是否全为 success(canary 门控 / 蓝绿 cutover 判定)。
+func allSuccess(results []TargetResult) bool {
+	for i := range results {
+		if results[i].Status != run.TargetSuccess {
+			return false
+		}
+	}
+	return len(results) > 0
+}
+
+// abortedResult 合成「因门控中止、本机未部署」的结果(canary 中止其余 / 蓝绿预备中止)。
+func abortedResult(srv *target.Server, msg string) TargetResult {
+	now := time.Now().UTC()
+	return TargetResult{
+		ServerID:   srv.ID,
+		ServerName: srv.Name,
+		Status:     run.TargetFailed,
+		Message:    msg,
+		StartedAt:  now,
+		FinishedAt: &now,
+	}
+}
+
+// deployCanary 金丝雀发布:先发金丝雀子集,健康门控通过才铺其余;否则中止其余。
+func (s *service) deployCanary(ctx context.Context, servers []*target.Server, a run.Artifact, cfg map[string]string, hc *HealthCheck) []TargetResult {
+	total := len(servers)
+	if total == 0 {
+		return nil
+	}
+	n := canaryCount(cfg, total)
+	results := make([]TargetResult, total)
+
+	// 1) 金丝雀批次(servers[:n])。
+	canaryRes := s.deployFanout(ctx, servers[:n], a, cfg, hc)
+	copy(results[:n], canaryRes)
+
+	rest := servers[n:]
+	if len(rest) == 0 {
+		return results // 单机或全是金丝雀:无「其余」可铺。
+	}
+
+	// 2) 金丝雀全过 → 铺其余;否则中止其余(标 failed 人读,本机未部署)。
+	if allSuccess(canaryRes) {
+		restRes := s.deployFanout(ctx, rest, a, cfg, hc)
+		copy(results[n:], restRes)
+	} else {
+		for i, srv := range rest {
+			results[n+i] = abortedResult(srv, fmt.Sprintf("金丝雀批次(%d 台)未全部通过,已中止后续 %d 台部署(本机未部署,仍运行旧版本)", n, len(rest)))
+		}
+	}
+	return results
+}
+
+// deployBlueGreen 蓝绿发布(release 类产物):stage-all → cutover-all → 失败机群回滚。
+//
+//  1. **预备(stage-all)**:全机并行就绪发布目录(写产物,不切换 current)。任一就绪失败 →
+//     中止:已就绪的机不切换(仍运行旧版本),标 failed 人读;整体无任何切换(安全)。
+//  2. **切换(cutover-all)**:全机并行原子切换 current + 切后健康门控(activateReleaseOne)。
+//  3. **机群回滚**:cutover 阶段任一非 success(failed / 自身已 rolled_back)→ 把**本阶段切换成功**
+//     且有上一发布的机一并回滚到上一发布(标 rolled_back 人读),实现机群级「要么全切要么全退」。
+func (s *service) deployBlueGreen(ctx context.Context, servers []*target.Server, a run.Artifact, cfg map[string]string, hc *HealthCheck) []TargetResult {
+	n := len(servers)
+	if n == 0 {
+		return nil
+	}
+	results := make([]TargetResult, n)
+	states := make([]releaseState, n)
+	staged := make([]bool, n)
+	started := make([]time.Time, n)
+
+	// ── 阶段 1:全机就绪(不切换)──────────────────────────────────────────────
+	s.forEachServer(servers, func(idx int, srv *target.Server) {
+		started[idx] = time.Now().UTC()
+		st, failMsg, ok := s.stageReleaseOne(ctx, srv, a, cfg)
+		states[idx] = st
+		if !ok {
+			results[idx] = finishFailed(TargetResult{ServerID: srv.ID, ServerName: srv.Name, StartedAt: started[idx]}, failMsg)
+			return
+		}
+		staged[idx] = true
+	}, func(idx int, srv *target.Server) {
+		results[idx] = abortedResult(srv, "蓝绿预备阶段执行异常中断(本机未切换)")
+	})
+
+	// 任一就绪失败 → 中止:已就绪机不切换(仍运行旧版本),标 failed 人读。
+	allStaged := true
+	for i := range staged {
+		if !staged[i] {
+			allStaged = false
+			break
+		}
+	}
+	if !allStaged {
+		for i, srv := range servers {
+			if staged[i] {
+				results[i] = abortedResult(srv, "蓝绿:预备阶段其它机失败,已中止本机切换(仍运行旧版本)")
+			}
+		}
+		return results
+	}
+
+	// ── 阶段 2:全机统一切换 + 健康 ───────────────────────────────────────────
+	s.forEachServer(servers, func(idx int, srv *target.Server) {
+		results[idx] = s.activateReleaseOne(ctx, srv, a, cfg, hc, states[idx], started[idx])
+	}, func(idx int, srv *target.Server) {
+		results[idx] = abortedResult(srv, "蓝绿切换阶段执行异常中断")
+	})
+
+	// ── 阶段 3:切换阶段任一失败 → 已成功切换的机群回滚到上一发布 ──────────────
+	if !allSuccess(results) {
+		s.forEachServer(servers, func(idx int, srv *target.Server) {
+			if results[idx].Status != run.TargetSuccess {
+				return // 失败 / 已自行回滚的机不动。
+			}
+			if states[idx].prev == "" {
+				return // 首次部署无上一发布可回滚:保留(无更好选择;切换阶段它本机是健康的)。
+			}
+			s.fleetRollbackOne(ctx, srv, states[idx], &results[idx])
+		}, func(idx int, srv *target.Server) {
+			// 回滚异常:保留原成功结果,不致命(尽力回滚)。
+		})
+	}
+	return results
+}
+
+// fleetRollbackOne 把一台「本机切换成功、但机群中其它机失败」的目标回滚到上一发布(蓝绿阶段 3)。
+// 原子切回 current → prev;就地改写该机结果为 rolled_back + 人读。回滚命令失败仍记 rolled_back(意图)。
+func (s *service) fleetRollbackOne(ctx context.Context, srv *target.Server, st releaseState, res *TargetResult) {
+	execCtx, cancel := context.WithTimeout(ctx, execTimeout)
+	defer cancel()
+
+	var rbErr error
+	for _, cmd := range atomicSymlinkCmds(st.prev, st.current) {
+		if _, e := s.targets.Exec(execCtx, srv.ID, cmd); e != nil {
+			rbErr = e
+			break
+		}
+	}
+	finish := time.Now().UTC()
+	res.Status = run.TargetRolledBack
+	res.FinishedAt = &finish
+	if rbErr != nil {
+		res.Message = "蓝绿:其它机切换失败,本机尝试回滚到上一发布但回滚命令执行失败:" + humanExecError(rbErr)
+		return
+	}
+	res.Message = "蓝绿:其它机切换失败,本机已回滚到上一发布(机群级原子性:要么全切要么全退)"
+}
+
+// forEachServer 以有界并发(maxParallelDeploys)对每台 server 跑 work;每 goroutine recover 兜底,
+// panic → 调用 onPanic(由其写入该机失败结果)。work / onPanic 各自写入自己的索引槽,不共享可变状态外的竞争。
+func (s *service) forEachServer(servers []*target.Server, work func(idx int, srv *target.Server), onPanic func(idx int, srv *target.Server)) {
+	sem := make(chan struct{}, maxParallelDeploys)
+	var wg sync.WaitGroup
+	for i := range servers {
+		wg.Add(1)
+		go func(idx int, srv *target.Server) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			defer func() {
+				if rec := recover(); rec != nil {
+					onPanic(idx, srv)
+				}
+			}()
+			work(idx, srv)
+		}(i, servers[i])
+	}
+	wg.Wait()
+}

--- a/internal/deploy/strategy_centos_e2e_test.go
+++ b/internal/deploy/strategy_centos_e2e_test.go
@@ -1,0 +1,160 @@
+package deploy
+
+// strategy_centos_e2e_test.go 是部署策略(Story 8-8 / FR-8-8:金丝雀 / 蓝绿)的**真多机 e2e**:
+// 复用 multi_target_centos_e2e 的 CentOS+sshd 容器集群 + 真 SSH,验 fake 证不到的真实策略语义:
+//   - 金丝雀:金丝雀台不可达 → 其余台**绝不被部署**(真容器内断言无发布目录,仍运行旧版本)。
+//   - 蓝绿成功:全机先就绪、统一切换 → 每台真落地 + current 软链。
+//   - 蓝绿机群回滚:已有 v1 上一发布,蓝绿发 v2 + 健康检查仅一台失败 → **整个机群回滚到 v1**
+//     (真容器内断言每台 current 都切回 v1,机群级「要么全切要么全退」)。
+//
+// 默认 SKIP(PIPEWRIGHT_E2E_DEPLOY=1 启用)。跑法:
+//   PIPEWRIGHT_E2E_DEPLOY=1 go test ./internal/deploy/ -run E2EStrategy -v
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// TestE2EStrategyCanaryAbort:3 台,金丝雀(第 1 台)不可达 → 金丝雀 failed、其余 2 台**未被部署**。
+func TestE2EStrategyCanaryAbort(t *testing.T) {
+	fleet, key := startCentOSFleet(t, 3)
+	h := newMultiHarness(t, fleet, key)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	base := "/opt/pw-canary-" + uuid.NewString()[:8]
+	runID, artID := seedSuccessRunWithArtifact(t, h.db, h.rsvc, run.ArtifactDist, "dist/shop-v1.tar.gz")
+
+	// 金丝雀(第 1 台,serverIDs[0])部署前宕机 → SSH 不可达 → 金丝雀失败。
+	canary := fleet[0]
+	if out, err := exec.Command(canary.dockerBin, "stop", "-t", "1", canary.Name).CombinedOutput(); err != nil {
+		t.Fatalf("停金丝雀台失败: %v\n%s", err, out)
+	}
+
+	res, err := h.dsvc.Deploy(ctx, DeployInput{
+		RunID: runID, ArtifactID: artID, ServerIDs: h.serverIDs,
+		Strategy: "canary",
+		Config:   map[string]string{"releaseBase": base},
+	})
+	if err != nil {
+		t.Fatalf("金丝雀 Deploy: %v", err)
+	}
+	// 金丝雀台 failed;其余 2 台被中止 → 也 failed(含「未部署」)。
+	if res[0].Status != run.TargetFailed {
+		t.Fatalf("金丝雀台应 failed,实际 %s", res[0].Status)
+	}
+	for i := 1; i < 3; i++ {
+		if res[i].Status != run.TargetFailed || !strings.Contains(res[i].Message, "未部署") {
+			t.Fatalf("其余台 %d 应 failed+未部署,实际 %s / %q", i, res[i].Status, res[i].Message)
+		}
+	}
+	// 关键:其余 2 台真容器内**绝无发布目录**(金丝雀门控拦住了,仍运行旧版本)。
+	releaseDir := base + "/releases/" + runID
+	for _, idx := range []int{1, 2} {
+		if _, err := fleet[idx].Exec(t, "test", "-e", releaseDir); err == nil {
+			t.Fatalf("金丝雀失败后第 %d 台仍被部署(发布目录存在),金丝雀门控失效", idx+1)
+		}
+	}
+	rn, _ := h.rsvc.Get(ctx, runID)
+	if rn.Status != run.StatusFailed {
+		t.Fatalf("金丝雀中止 run 终态应 failed,实际 %s", rn.Status)
+	}
+	t.Logf("✅ 金丝雀台不可达 → 其余 2 台真容器内零发布目录(门控拦截,未部署)")
+}
+
+// TestE2EStrategyBlueGreenSuccess:2 台蓝绿,全机就绪 → 统一切换 → 每台真落地 + current 软链。
+func TestE2EStrategyBlueGreenSuccess(t *testing.T) {
+	fleet, key := startCentOSFleet(t, 2)
+	h := newMultiHarness(t, fleet, key)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	base := "/opt/pw-bg-" + uuid.NewString()[:8]
+	runID, artID := seedSuccessRunWithArtifact(t, h.db, h.rsvc, run.ArtifactDist, "dist/shop-v1.tar.gz")
+
+	res, err := h.dsvc.Deploy(ctx, DeployInput{
+		RunID: runID, ArtifactID: artID, ServerIDs: h.serverIDs,
+		Strategy: "blue_green",
+		Config:   map[string]string{"releaseBase": base},
+	})
+	if err != nil {
+		t.Fatalf("蓝绿 Deploy: %v", err)
+	}
+	for i, r := range res {
+		if r.Status != run.TargetSuccess {
+			t.Fatalf("蓝绿目标 %d 应 success,实际 %s / %q", i, r.Status, r.Message)
+		}
+	}
+	releaseDir := base + "/releases/" + runID
+	for i, c := range fleet {
+		out, _ := c.Exec(t, "readlink", base+"/current")
+		if strings.TrimSpace(out) != releaseDir {
+			t.Fatalf("第 %d 台蓝绿后 current 应 → %s,实际 %q", i+1, releaseDir, strings.TrimSpace(out))
+		}
+	}
+	t.Logf("✅ 蓝绿:2 台先就绪、统一切换,每台真落地 + current 软链")
+}
+
+// TestE2EStrategyBlueGreenFleetRollback:已有 v1,蓝绿发 v2 + 健康检查仅 1 台失败 → 整个机群回滚到 v1。
+func TestE2EStrategyBlueGreenFleetRollback(t *testing.T) {
+	fleet, key := startCentOSFleet(t, 2)
+	h := newMultiHarness(t, fleet, key)
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	base := "/opt/pw-bgrb-" + uuid.NewString()[:8]
+
+	// 1) 先滚动部署 v1 到两台,建立 current → v1(作为回滚目标)。
+	runV1, artV1 := seedSuccessRunWithArtifact(t, h.db, h.rsvc, run.ArtifactDist, "dist/shop-v1.tar.gz")
+	if _, err := h.dsvc.Deploy(ctx, DeployInput{
+		RunID: runV1, ArtifactID: artV1, ServerIDs: h.serverIDs,
+		Config: map[string]string{"releaseBase": base},
+	}); err != nil {
+		t.Fatalf("v1 预部署: %v", err)
+	}
+	v1Dir := base + "/releases/" + runV1
+	for i, c := range fleet {
+		out, _ := c.Exec(t, "readlink", base+"/current")
+		if strings.TrimSpace(out) != v1Dir {
+			t.Fatalf("v1 预部署后第 %d 台 current 应 → v1,实际 %q", i+1, strings.TrimSpace(out))
+		}
+	}
+
+	// 2) 健康检查:test -f /tmp/pw-healthy。仅第 1 台(good)创建该文件 → 第 2 台(bad)健康必失败。
+	if _, err := fleet[0].Exec(t, "touch", "/tmp/pw-healthy"); err != nil {
+		t.Fatalf("good 台创建健康标记失败: %v", err)
+	}
+
+	// 3) 蓝绿发 v2 + 命令健康检查。bad 台健康失败 → 自身回滚;机群级 → good 台也回滚 → 两台都回 v1。
+	runV2, artV2 := seedSuccessRunWithArtifact(t, h.db, h.rsvc, run.ArtifactDist, "dist/shop-v2.tar.gz")
+	hc := &HealthCheck{Type: HealthCheckCommand, Command: []string{"test", "-f", "/tmp/pw-healthy"}, Retries: 1}
+	res, err := h.dsvc.Deploy(ctx, DeployInput{
+		RunID: runV2, ArtifactID: artV2, ServerIDs: h.serverIDs,
+		Strategy:    "blue_green",
+		HealthCheck: hc,
+		Config:      map[string]string{"releaseBase": base},
+	})
+	if err != nil {
+		t.Fatalf("v2 蓝绿 Deploy: %v", err)
+	}
+	// 两台都应 rolled_back(bad 健康失败自回滚;good 机群级回滚)。
+	for i, r := range res {
+		if r.Status != run.TargetRolledBack {
+			t.Fatalf("蓝绿机群回滚:目标 %d 应 rolled_back,实际 %s / %q", i, r.Status, r.Message)
+		}
+	}
+	// 关键:两台真容器内 current 都切回 v1(机群级原子性:要么全切要么全退)。
+	for i, c := range fleet {
+		out, _ := c.Exec(t, "readlink", base+"/current")
+		if strings.TrimSpace(out) != v1Dir {
+			t.Fatalf("机群回滚后第 %d 台 current 应切回 v1(%s),实际 %q", i+1, v1Dir, strings.TrimSpace(out))
+		}
+	}
+	t.Logf("✅ 蓝绿机群回滚:1 台健康失败 → 两台真容器 current 全切回 v1(机群级原子性)")
+}

--- a/internal/deploy/strategy_test.go
+++ b/internal/deploy/strategy_test.go
@@ -1,0 +1,275 @@
+package deploy
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/run"
+	"github.com/huangchengsir/pipewright/internal/target"
+)
+
+// ---- 纯函数单元 ------------------------------------------------------------
+
+func TestNormalizeStrategy(t *testing.T) {
+	cases := map[string]string{
+		"":            StrategyRolling,
+		"rolling":     StrategyRolling,
+		"unknown":     StrategyRolling,
+		"canary":      StrategyCanary,
+		"CANARY":      StrategyCanary,
+		"blue_green":  StrategyBlueGreen,
+		"blue-green":  StrategyBlueGreen,
+		"BlueGreen":   StrategyBlueGreen,
+		" blue green": StrategyBlueGreen,
+	}
+	for in, want := range cases {
+		if got := NormalizeStrategy(in); got != want {
+			t.Errorf("NormalizeStrategy(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCanaryCount(t *testing.T) {
+	cases := []struct {
+		cfg   map[string]string
+		total int
+		want  int
+	}{
+		{nil, 1, 1}, // 单机:整体即金丝雀
+		{nil, 3, 1}, // 默认 1 台
+		{map[string]string{"canaryCount": "2"}, 5, 2},
+		{map[string]string{"canaryCount": "9"}, 3, 2}, // 夹紧:至少留 1 台在其余
+		{map[string]string{"canaryPercent": "50"}, 4, 2},
+		{map[string]string{"canaryPercent": "10"}, 5, 1}, // ceil(0.5)=1
+		{map[string]string{"canaryCount": "0"}, 3, 1},    // 非法 → 默认 1
+	}
+	for _, c := range cases {
+		if got := canaryCount(c.cfg, c.total); got != c.want {
+			t.Errorf("canaryCount(%v, %d) = %d, want %d", c.cfg, c.total, got, c.want)
+		}
+	}
+}
+
+// ---- 测试用可控 stub:按 serverID 注入失败,记录每机被执行的命令 -----------------
+
+// recordingTarget 包装 stubTarget 语义:execFn 据 (serverID, cmd) 决定结果,并记录触达的 serverID。
+type touchRecorder struct {
+	mu       sync.Mutex
+	touched  map[string]bool // 被 Exec 过的 serverID
+	sawMv    bool            // 是否出现过 cutover 切换(mv -T → current)
+	failOn   func(serverID string, cmd []string) bool
+	prevLink string // 非空 → readlink current 返回该路径(模拟已有上一发布)
+}
+
+func (r *touchRecorder) exec(serverID string, cmd []string) (*target.ExecResult, error) {
+	r.mu.Lock()
+	if r.touched == nil {
+		r.touched = map[string]bool{}
+	}
+	r.touched[serverID] = true
+	if cmd[0] == "mv" {
+		r.sawMv = true
+	}
+	r.mu.Unlock()
+	// 模拟 readlink current → 上一发布(供机群回滚有 prev 可回)。
+	if cmd[0] == "readlink" {
+		if r.prevLink != "" {
+			return &target.ExecResult{ExitCode: 0, Stdout: r.prevLink}, nil
+		}
+		return &target.ExecResult{ExitCode: 0}, nil
+	}
+	if r.failOn != nil && r.failOn(serverID, cmd) {
+		return &target.ExecResult{ExitCode: 1, Stderr: "injected failure"}, nil
+	}
+	return &target.ExecResult{ExitCode: 0}, nil
+}
+
+// ---- canary -----------------------------------------------------------------
+
+func TestDeployCanaryProceeds(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	rec := &touchRecorder{}
+	tgt := &stubTarget{execFn: rec.exec}
+	s1 := seedServer(t, tgt, "web-1")
+	s2 := seedServer(t, tgt, "web-2")
+	s3 := seedServer(t, tgt, "web-3")
+	runID, artID := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactDist, "dist/shop.tar.gz")
+
+	svc := New(tgt, rsvc)
+	res, err := svc.Deploy(context.Background(), DeployInput{
+		RunID: runID, ArtifactID: artID,
+		ServerIDs: []string{s1.ID, s2.ID, s3.ID},
+		Strategy:  "canary",
+	})
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if len(res) != 3 {
+		t.Fatalf("want 3 results, got %d", len(res))
+	}
+	for i, r := range res {
+		if r.Status != run.TargetSuccess {
+			t.Fatalf("target %d status = %s (msg %q), want success", i, r.Status, r.Message)
+		}
+	}
+	// 金丝雀全过 → 其余机也应被部署(全 3 台触达)。
+	if !rec.touched[s2.ID] || !rec.touched[s3.ID] {
+		t.Fatalf("金丝雀通过后其余机应被部署;touched=%v", rec.touched)
+	}
+}
+
+func TestDeployCanaryAbortsOnFailure(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	s1ID, s2ID, s3ID := "", "", ""
+	rec := &touchRecorder{
+		failOn: func(serverID string, cmd []string) bool {
+			// 金丝雀(第一台)放置命令失败。
+			return serverID == s1ID && cmd[0] == "mkdir"
+		},
+	}
+	tgt := &stubTarget{execFn: rec.exec}
+	s1 := seedServer(t, tgt, "web-1")
+	s2 := seedServer(t, tgt, "web-2")
+	s3 := seedServer(t, tgt, "web-3")
+	s1ID, s2ID, s3ID = s1.ID, s2.ID, s3.ID
+	_ = s2ID
+	_ = s3ID
+	runID, artID := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactDist, "dist/shop.tar.gz")
+
+	svc := New(tgt, rsvc)
+	res, err := svc.Deploy(context.Background(), DeployInput{
+		RunID: runID, ArtifactID: artID,
+		ServerIDs: []string{s1.ID, s2.ID, s3.ID},
+		Strategy:  "canary",
+	})
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	// 金丝雀(s1)失败,其余(s2/s3)应被中止 → 全 failed。
+	if res[0].Status != run.TargetFailed {
+		t.Fatalf("canary status = %s, want failed", res[0].Status)
+	}
+	for i := 1; i < 3; i++ {
+		if res[i].Status != run.TargetFailed {
+			t.Fatalf("rest target %d status = %s, want failed(aborted)", i, res[i].Status)
+		}
+		if !strings.Contains(res[i].Message, "未部署") {
+			t.Fatalf("rest target %d message = %q, want 含「未部署」", i, res[i].Message)
+		}
+	}
+	// 关键:被中止的其余机**绝不应被执行任何部署命令**(仍运行旧版本)。
+	if rec.touched[s2.ID] || rec.touched[s3.ID] {
+		t.Fatalf("金丝雀失败后其余机不应被部署;touched=%v", rec.touched)
+	}
+}
+
+// ---- blue-green -------------------------------------------------------------
+
+func TestDeployBlueGreenSuccess(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	rec := &touchRecorder{}
+	tgt := &stubTarget{execFn: rec.exec}
+	s1 := seedServer(t, tgt, "web-1")
+	s2 := seedServer(t, tgt, "web-2")
+	runID, artID := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactDist, "dist/shop.tar.gz")
+
+	svc := New(tgt, rsvc)
+	res, err := svc.Deploy(context.Background(), DeployInput{
+		RunID: runID, ArtifactID: artID,
+		ServerIDs: []string{s1.ID, s2.ID},
+		Strategy:  "blue_green",
+	})
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	for i, r := range res {
+		if r.Status != run.TargetSuccess {
+			t.Fatalf("target %d status = %s (msg %q), want success", i, r.Status, r.Message)
+		}
+	}
+	if !rec.sawMv {
+		t.Fatalf("蓝绿成功应发生 current 原子切换(mv -T)")
+	}
+}
+
+// 蓝绿安全不变量:预备阶段任一机失败 → 绝不切换任何机(无 mv → current),已就绪机标 failed 未切换。
+func TestDeployBlueGreenStageFailAbortsAllCutover(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	s2ID := ""
+	rec := &touchRecorder{
+		failOn: func(serverID string, cmd []string) bool {
+			return serverID == s2ID && cmd[0] == "mkdir" // 第二台就绪失败
+		},
+	}
+	tgt := &stubTarget{execFn: rec.exec}
+	s1 := seedServer(t, tgt, "web-1")
+	s2 := seedServer(t, tgt, "web-2")
+	s2ID = s2.ID
+	runID, artID := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactDist, "dist/shop.tar.gz")
+
+	svc := New(tgt, rsvc)
+	res, err := svc.Deploy(context.Background(), DeployInput{
+		RunID: runID, ArtifactID: artID,
+		ServerIDs: []string{s1.ID, s2.ID},
+		Strategy:  "blue_green",
+	})
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	// 任一就绪失败 → 整体不切换;两机均非 success。
+	for i, r := range res {
+		if r.Status == run.TargetSuccess {
+			t.Fatalf("target %d 不应 success(预备失败应中止全部切换);msg=%q", i, r.Message)
+		}
+	}
+	if rec.sawMv {
+		t.Fatalf("蓝绿预备阶段失败后绝不应发生任何 current 切换(mv),但出现了 cutover")
+	}
+}
+
+// 蓝绿机群级原子性:切换阶段一机健康失败 → 已切换成功且有上一发布的机一并回滚(rolled_back)。
+func TestDeployBlueGreenFleetRollbackOnPartialFailure(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	badID := ""
+	rec := &touchRecorder{
+		prevLink: "/srv/app/releases/old", // 模拟已有上一发布 → 可回滚
+		failOn: func(serverID string, cmd []string) bool {
+			// 仅 bad 机健康探测(command=["true"])失败;放置/切换均成功。
+			return serverID == badID && cmd[0] == "true"
+		},
+	}
+	tgt := &stubTarget{execFn: rec.exec}
+	good := seedServer(t, tgt, "web-good")
+	bad := seedServer(t, tgt, "web-bad")
+	badID = bad.ID
+	runID, artID := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactDist, "dist/shop.tar.gz")
+
+	svc := New(tgt, rsvc)
+	hc := &HealthCheck{Type: HealthCheckCommand, Command: []string{"true"}, Retries: 1}
+	res, err := svc.Deploy(context.Background(), DeployInput{
+		RunID: runID, ArtifactID: artID,
+		ServerIDs:   []string{good.ID, bad.ID},
+		Strategy:    "blue_green",
+		HealthCheck: hc,
+	})
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	// 两机都应为 rolled_back:bad 机健康失败自身回滚;good 机因机群失败被一并回滚。
+	for i, r := range res {
+		if r.Status != run.TargetRolledBack {
+			t.Fatalf("target %d (%s) status = %s (msg %q), want rolled_back", i, r.ServerName, r.Status, r.Message)
+		}
+	}
+	// good 机回滚 message 应点明机群级回滚。
+	if !strings.Contains(res[0].Message, "机群") && !strings.Contains(res[0].Message, "其它机") {
+		t.Fatalf("good 机 message = %q, want 含机群级回滚说明", res[0].Message)
+	}
+}

--- a/internal/httpapi/deploy.go
+++ b/internal/httpapi/deploy.go
@@ -70,6 +70,9 @@ type deployRequest struct {
 	ServerIDs    []string          `json:"serverIds"`
 	DeployConfig map[string]string `json:"deployConfig"`
 	HealthCheck  *healthCheckDTO   `json:"healthCheck"`
+	// Strategy 是部署策略(Story 8-8 / FR-8-8):rolling(默认)| canary | blue_green。
+	// 空 / 未知 → rolling。金丝雀批量经 deployConfig["canaryCount"|"canaryPercent"] 透传。
+	Strategy string `json:"strategy"`
 }
 
 // toHealthCheck 把请求 DTO 映射为领域 HealthCheck(nil / type=none → nil,跳过健康检查)。
@@ -120,6 +123,7 @@ func makeDeployRunHandler(svc deploy.Service, runSvc run.Service) http.HandlerFu
 			ServerIDs:   req.ServerIDs,
 			Config:      req.DeployConfig,
 			HealthCheck: toHealthCheck(req.HealthCheck),
+			Strategy:    req.Strategy,
 		})
 		if err != nil {
 			writeDeployError(w, err)

--- a/web/src/api/runs.ts
+++ b/web/src/api/runs.ts
@@ -417,12 +417,22 @@ export interface HealthCheckInput {
   timeoutSeconds?: number   // default 5, cap 60
 }
 
+// Deploy strategy (Story 8-8 / FR-8-8). 'rolling' (default) = fan out to all
+// targets in parallel, each self-heals. 'canary' = deploy a small batch first,
+// gate on its health, then the rest (abort the rest if the canary fails).
+// 'blue_green' = stage every target, then cut over all at once; if any cutover
+// fails, roll back the whole fleet (release-mode artifacts: dist/jar).
+export type DeployStrategy = 'rolling' | 'canary' | 'blue_green'
+
 export interface DeployRunInput {
   artifactId: string
   serverIds: string[]
   deployConfig?: Record<string, string>
   // Optional health gate (Story 4-3). Omit ⇒ identical to 4-2 behavior.
   healthCheck?: HealthCheckInput
+  // Optional rollout strategy (Story 8-8). Omit/'rolling' ⇒ identical to prior
+  // behavior. Canary batch size flows via deployConfig.canaryCount/canaryPercent.
+  strategy?: DeployStrategy
 }
 
 export interface DeployRunResponse {

--- a/web/src/views/RunDetail.vue
+++ b/web/src/views/RunDetail.vue
@@ -31,6 +31,7 @@ import {
   type DiagnosisDTO,
   type HealthCheckType,
   type HealthCheckInput,
+  type DeployStrategy,
   type ApprovalRecord,
 } from '../api/runs'
 import { listServers, type Server } from '../api/servers'
@@ -148,6 +149,19 @@ const showAdvanced = ref(false)
 const releaseBase = ref('')
 const keepReleases = ref(1)
 
+// ─── 部署策略(Story 8-8 / FR-8-8)──────────────────────────────────────────
+// rolling(默认)= 全机并行各自成败;canary = 先发金丝雀批次、健康通过才铺其余;
+// blue_green = 全机先就绪、统一切换、失败机群回滚(release 类产物 dist/jar)。
+// 金丝雀批量经 deployConfig.canaryCount 透传。
+const deployStrategy = ref<DeployStrategy>('rolling')
+const canaryCount = ref(1)
+
+const deployStrategyOptions: ReadonlyArray<{ value: DeployStrategy; label: string; desc: string }> = [
+  { value: 'rolling', label: '滚动', desc: '全机并行,各自成败' },
+  { value: 'canary', label: '金丝雀', desc: '先发小批,通过再铺' },
+  { value: 'blue_green', label: '蓝绿', desc: '统一切换,失败全退' },
+]
+
 // buildDeployConfig 据高级选项收敛 deployConfig;空字段不传(后端取默认)。
 function buildDeployConfig(): Record<string, string> | undefined {
   const cfg: Record<string, string> = {}
@@ -156,6 +170,11 @@ function buildDeployConfig(): Record<string, string> | undefined {
   const keep = clampInt(keepReleases.value, 1, 50, 1)
   // 仅在非默认(1)时下发,避免无谓字段。
   if (keep !== 1) cfg.keepReleases = String(keep)
+  // 金丝雀批量:仅 canary 策略且 >1 时下发(默认 1 台)。
+  if (deployStrategy.value === 'canary') {
+    const n = clampInt(canaryCount.value, 1, 100, 1)
+    if (n > 1) cfg.canaryCount = String(n)
+  }
   return Object.keys(cfg).length > 0 ? cfg : undefined
 }
 
@@ -236,6 +255,7 @@ async function handleDeploy(): Promise<void> {
       serverIds: [...selectedServerIds.value],
       deployConfig: buildDeployConfig(),
       healthCheck: buildHealthCheck(),
+      strategy: deployStrategy.value,
     })
     // 同步执行:用返回的 targets 直接填 slot(与 run-detail 同源形状)。
     run.value = { ...run.value, targets: res.targets, status: deriveStatus(res.targets) }
@@ -876,6 +896,34 @@ function nodeClass(status: StepStatus): string {
                   </div>
                   <p v-if="hcType !== 'none' && !healthCheckValid" class="deploy-empty">
                     {{ hcType === 'http' ? '请填写探测 URL。' : '请填写探测命令。' }}
+                  </p>
+                </div>
+
+                <!-- 部署策略(Story 8-8 / FR-8-8):rolling | canary | blue_green -->
+                <div class="deploy-field">
+                  <span class="deploy-label">发布策略</span>
+                  <div class="strat-seg" role="radiogroup" aria-label="发布策略">
+                    <button
+                      v-for="opt in deployStrategyOptions"
+                      :key="opt.value"
+                      type="button"
+                      class="strat-opt"
+                      :class="{ 'strat-opt--active': deployStrategy === opt.value }"
+                      role="radio"
+                      :aria-checked="deployStrategy === opt.value"
+                      @click="deployStrategy = opt.value"
+                    >
+                      <span class="strat-opt-name">{{ opt.label }}</span>
+                      <span class="strat-opt-desc">{{ opt.desc }}</span>
+                    </button>
+                  </div>
+                  <label v-if="deployStrategy === 'canary'" class="adv-row strat-canary">
+                    <span class="adv-key">金丝雀台数</span>
+                    <input v-model.number="canaryCount" class="hc-num" type="number" min="1" max="100" aria-label="金丝雀台数" />
+                    <span class="adv-hint strat-canary-hint">先发这么多台并健康门控,通过后再铺其余</span>
+                  </label>
+                  <p v-else-if="deployStrategy === 'blue_green'" class="adv-hint">
+                    全机先就绪发布目录、再统一原子切换;任一机切换失败则整个机群回滚到上一发布(dist / jar)。
                   </p>
                 </div>
 
@@ -2238,4 +2286,35 @@ function nodeClass(status: StepStatus): string {
   line-height: 1.5;
   color: var(--color-faint);
 }
+
+/* ─── 部署策略选择器(Story 8-8)──────────────────────────────────────────── */
+.strat-seg {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin-top: 6px;
+}
+.strat-opt {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 9px 10px;
+  text-align: left;
+  background: var(--color-bg-subtle, var(--color-card));
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded-md);
+  cursor: pointer;
+  transition: border-color var(--duration-fast), background-color var(--duration-fast);
+}
+.strat-opt:hover { border-color: var(--color-primary); }
+.strat-opt--active {
+  border-color: var(--color-primary);
+  background: var(--color-primary-soft);
+}
+.strat-opt:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 1px; }
+.strat-opt-name { font-size: 0.82rem; font-weight: 650; color: var(--color-text); }
+.strat-opt--active .strat-opt-name { color: var(--color-primary); }
+.strat-opt-desc { font-size: 0.68rem; color: var(--color-faint); line-height: 1.35; }
+.strat-canary { margin-top: 10px; }
+.strat-canary-hint { margin-left: 8px; }
 </style>


### PR DESCRIPTION
## 背景

Epic 8 最后一块 P1:在零停机/回滚之上加**金丝雀(canary)/ 蓝绿(blue-green)**部署策略。这是最贴近真实部署执行编排(Epic 4/5)的一块,故未丢后台 agent,**亲自 in-loop 实现 + 真容器 e2e 验收**。

## 设计

策略是**机群级编排**关注点,叠加在既有 `deployFanout` 之上,**不改单机执行语义**(原子软链切换/健康/回滚原封不动)。`DeployInput.Strategy`(默认 `rolling`):

- **rolling**(默认)— 全机有界并行,各机独立成败、失败机自行回滚。**行为与加策略前字节级一致**。
- **canary** — 先发金丝雀子集(默认 1 台,`deployConfig.canaryCount`/`canaryPercent` 可配)→ 健康门控通过才铺其余;金丝雀任一失败 → **中止其余**(标 failed「未部署,仍运行旧版本」)。复用 `deployOne`,任意产物类型。
- **blue_green** — release 类产物(dist/jar)**stage-all → cutover-all**:全机先就绪发布目录(不切换)→ 全部就绪才统一原子切换 + 健康 → 切换阶段任一失败则把**已成功切换的机一并回滚到上一发布**(机群级「要么全切要么全退」)。非 release 产物退化 rolling。

实现:`release.go` 把 `deployReleaseOne` 拆 `stageReleaseOne` + `activateReleaseOne`(组合后对 rolling/canary 字节级不变);新 `strategy.go` 做机群编排;`HTTP deployRequest.strategy` 透传;前端 `RunDetail` 部署面板加策略三选 + 金丝雀台数。

## 验收

- ✅ `gofmt` 净 · `go build/vet/test ./...` 全过 · 前端 `typecheck`/**191 测试**/`build` 绿
- ✅ 策略单测:canary 推进 / canary 中止(断言其余机**零 Exec 触达**)/ blue_green 预备失败中止全切(无 cutover)/ blue_green 机群回滚 / NormalizeStrategy / canaryCount
- ✅ **真 3 台 CentOS Stream 9 容器 e2e 全过**(`PIPEWRIGHT_E2E_DEPLOY=1`):
  - 金丝雀台不可达 → 其余 2 台真容器内**零发布目录**(门控拦截)
  - 蓝绿:2 台先就绪、统一切换,每台真落地 + current 软链
  - 蓝绿机群回滚:1 台健康失败 → **两台真容器 current 全切回 v1**(机群级原子性,真 SSH 验证)
  - 既有多机/release e2e 全过(重构零回归)

## 安全不变量沿用
命令 array 化(不拼 shell)· 单机 panic recover · 有界并发 · message 无明文密钥 · 执行错误不上抛。

🤖 Generated with [Claude Code](https://claude.com/claude-code)