### PR TITLE
feat(pipeline): Pipeline-as-code 按运行分支取 .pipewright.yml(FR-8-12 补完)

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -225,9 +225,10 @@ func main() {
 		}
 		// 「流水线即代码」运行时覆盖(FR-8-12):PIPEWRIGHT_PAC_RUNTIME=1 时,用装饰器包住库内
 		// loader——运行时若项目仓库根含合法 `.pipewright.yml` 即用它驱动本次运行,否则一律回退库内
-		// 配置(任何 YAML/拉取问题都不中断运行)。约束:SpecLoader 只有 projectID 无运行分支,故从
-		// **项目默认分支**拉取;按运行分支覆盖需改 SpecLoader 签名,本期推迟(见 internal/pacloader)。
-		var specLoader dagrun.SpecLoader = pipelineSvc
+		// 配置(任何 YAML/拉取问题都不中断运行)。SpecLoader 现已带运行分支,故按**本次运行分支**
+		// 拉取(空分支退化默认分支);库内 pipeline.Service(分支无关)经 dagrun.SpecLoaderFunc
+		// 适配进 branch 感知契约,其 2 参公有签名不变(其它调用方不受影响)。
+		var specLoader dagrun.SpecLoader = dagrun.SpecLoaderFunc(pipelineSvc.Get)
 		if strings.EqualFold(strings.TrimSpace(os.Getenv("PIPEWRIGHT_PAC_RUNTIME")), "1") {
 			specLoader = pacloader.New(
 				pipelineSvc,
@@ -235,7 +236,7 @@ func main() {
 				credVault, // vault.Vault 满足 TokenRevealer(Reveal)
 				pacBlobFetcher{httpapi.NewSourceReader()},
 			)
-			log.Printf("[pac] 运行时 .pipewright.yml 覆盖已启用(PIPEWRIGHT_PAC_RUNTIME=1;从项目默认分支拉取;任何问题回退库内配置)")
+			log.Printf("[pac] 运行时 .pipewright.yml 覆盖已启用(PIPEWRIGHT_PAC_RUNTIME=1;按本次运行分支拉取,空分支退化默认分支;任何问题回退库内配置)")
 		}
 		runnerOpts = []run.PoolOption{run.WithRunner(dagrun.New(specLoader, dagOpts...))}
 	} else {

--- a/internal/dagrun/dagrun.go
+++ b/internal/dagrun/dagrun.go
@@ -25,9 +25,23 @@ import (
 	"github.com/huangchengsir/pipewright/internal/run"
 )
 
-// SpecLoader 加载某项目的流水线配置(pipeline.Service 即满足此接口)。
+// SpecLoader 加载某项目「在某运行分支上」的流水线配置。
+//
+// branch 是本次运行的目标分支(run.Trigger.Branch),供「流水线即代码」按运行分支取
+// `.pipewright.yml`(FR-8-12);库内 loader(pipeline.Service,分支无关)可经 SpecLoaderFunc
+// 包成此契约并忽略 branch。branch 为空(如无分支的手动运行)时,实现应退化为既有默认分支行为。
 type SpecLoader interface {
-	Get(ctx context.Context, projectID string) (*pipeline.Config, error)
+	Get(ctx context.Context, projectID, branch string) (*pipeline.Config, error)
+}
+
+// SpecLoaderFunc 把任意「按 projectID 取配置」的库内 loader(如 pipeline.Service.Get,分支无关)
+// 适配成 branch 感知的 SpecLoader:它忽略 branch,直接委托底层 2 参方法。用于把存量库内 loader
+// 接进 branch 感知的 dagrun 内核,而不改动其公有 2 参签名(其它调用方不受影响)。
+type SpecLoaderFunc func(ctx context.Context, projectID string) (*pipeline.Config, error)
+
+// Get 实现 SpecLoader:忽略 branch,委托底层分支无关的 loader。
+func (f SpecLoaderFunc) Get(ctx context.Context, projectID, _ string) (*pipeline.Config, error) {
+	return f(ctx, projectID)
 }
 
 // StageReporter 给 StageExecutor 上报「本阶段」的日志/产物(自动关联到该阶段的 run_steps 序号)。
@@ -115,7 +129,7 @@ func New(loader SpecLoader, opts ...Option) *Runner {
 // StepSink 非并发安全约定:本 Runner 用单一 mutex 串行化所有 sink 调用,即便阶段并行执行,
 // 对 sink 的 Plan/StepRunning/StepDone/Log/EmitArtifact 也互斥,安全复用既有持久化管道。
 func (r *Runner) Run(ctx context.Context, rn *run.Run, sink run.StepSink) error {
-	cfg, err := r.loader.Get(ctx, rn.ProjectID)
+	cfg, err := r.loader.Get(ctx, rn.ProjectID, rn.Trigger.Branch)
 	if err != nil {
 		return fmt.Errorf("dagrun: load pipeline spec: %w", err)
 	}

--- a/internal/dagrun/dagrun_test.go
+++ b/internal/dagrun/dagrun_test.go
@@ -14,9 +14,15 @@ import (
 
 // ─── 测试替身 ──────────────────────────────────────────────────────────────────
 
-type fakeLoader struct{ cfg *pipeline.Config }
+type fakeLoader struct {
+	cfg        *pipeline.Config
+	gotBranch  string
+	gotProject string
+}
 
-func (f fakeLoader) Get(_ context.Context, _ string) (*pipeline.Config, error) {
+func (f *fakeLoader) Get(_ context.Context, projectID string, branch string) (*pipeline.Config, error) {
+	f.gotProject = projectID
+	f.gotBranch = branch
 	return f.cfg, nil
 }
 
@@ -73,7 +79,7 @@ func TestRunnerWhenSkipsStageAndDownstreamWithoutFailing(t *testing.T) {
 	)
 	var ranDeploy bool
 	sink := newFakeSink()
-	r := New(fakeLoader{cfg}, WithStageExecutor(
+	r := New(&fakeLoader{cfg: cfg}, WithStageExecutor(
 		func(_ context.Context, _ *run.Run, st pipeline.Stage, _ StageReporter) error {
 			if st.ID == "deploy" {
 				ranDeploy = true
@@ -113,7 +119,7 @@ func TestRunnerGateApprovedRunsStage(t *testing.T) {
 		pipeline.Stage{ID: "deploy", Name: "部署", Needs: []string{"src"}, Gate: true},
 	)
 	var ran bool
-	r := New(fakeLoader{cfg},
+	r := New(&fakeLoader{cfg: cfg},
 		WithGate(func(_ context.Context, _ *run.Run, _ pipeline.Stage) (bool, error) {
 			return true, nil // 批准
 		}),
@@ -138,7 +144,7 @@ func TestRunnerGateRejectedFailsStage(t *testing.T) {
 		pipeline.Stage{ID: "deploy", Name: "部署", Needs: []string{"src"}, Gate: true},
 	)
 	var ran bool
-	r := New(fakeLoader{cfg},
+	r := New(&fakeLoader{cfg: cfg},
 		WithGate(func(_ context.Context, _ *run.Run, _ pipeline.Stage) (bool, error) {
 			return false, nil // 拒绝
 		}),
@@ -177,7 +183,7 @@ func TestRunnerWhenMatchedRunsStage(t *testing.T) {
 	)
 	var ranDeploy bool
 	sink := newFakeSink()
-	r := New(fakeLoader{cfg}, WithStageExecutor(
+	r := New(&fakeLoader{cfg: cfg}, WithStageExecutor(
 		func(_ context.Context, _ *run.Run, st pipeline.Stage, _ StageReporter) error {
 			if st.ID == "deploy" {
 				ranDeploy = true
@@ -230,6 +236,47 @@ func TestBuildGraphExplicitNeeds(t *testing.T) {
 	}
 }
 
+// ─── SpecLoader 分支贯穿(FR-8-12)──────────────────────────────────────────────
+
+// Runner 须把本次运行的分支(run.Trigger.Branch)透传给 SpecLoader.Get,
+// 供「流水线即代码」按运行分支取 `.pipewright.yml`。
+func TestRunnerThreadsRunBranchToLoader(t *testing.T) {
+	cfg := cfgWith(pipeline.Stage{ID: "src", Name: "源"})
+	ld := &fakeLoader{cfg: cfg}
+	r := New(ld)
+	err := r.Run(context.Background(),
+		&run.Run{ProjectID: "proj-x", Trigger: run.Trigger{Type: "push", Branch: "feature/x"}}, newFakeSink())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if ld.gotProject != "proj-x" {
+		t.Errorf("loader 应收到 projectID=proj-x,实际 %q", ld.gotProject)
+	}
+	if ld.gotBranch != "feature/x" {
+		t.Errorf("loader 应收到运行分支 feature/x,实际 %q", ld.gotBranch)
+	}
+}
+
+// SpecLoaderFunc 把分支无关的 2 参库内 loader 适配成 branch 感知契约:忽略 branch,委托底层。
+func TestSpecLoaderFuncIgnoresBranchAndDelegates(t *testing.T) {
+	cfg := cfgWith(pipeline.Stage{ID: "src", Name: "源"})
+	var gotProject string
+	var adapter SpecLoader = SpecLoaderFunc(func(_ context.Context, projectID string) (*pipeline.Config, error) {
+		gotProject = projectID
+		return cfg, nil
+	})
+	got, err := adapter.Get(context.Background(), "proj-y", "any-branch")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != cfg {
+		t.Errorf("应委托底层返回同一 cfg")
+	}
+	if gotProject != "proj-y" {
+		t.Errorf("应透传 projectID=proj-y,实际 %q", gotProject)
+	}
+}
+
 // ─── Runner.Run ────────────────────────────────────────────────────────────────
 
 func TestRunnerLinearSuccess(t *testing.T) {
@@ -239,7 +286,7 @@ func TestRunnerLinearSuccess(t *testing.T) {
 		pipeline.Stage{ID: "deploy", Name: "部署"},
 	)
 	sink := newFakeSink()
-	r := New(fakeLoader{cfg})
+	r := New(&fakeLoader{cfg: cfg})
 	err := r.Run(context.Background(), &run.Run{ProjectID: "p"}, sink)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
@@ -262,7 +309,7 @@ func TestRunnerFailBlocksDownstreamAsSkipped(t *testing.T) {
 		pipeline.Stage{ID: "deploy", Name: "部署"},
 	)
 	sink := newFakeSink()
-	r := New(fakeLoader{cfg}, WithStageExecutor(
+	r := New(&fakeLoader{cfg: cfg}, WithStageExecutor(
 		func(_ context.Context, _ *run.Run, st pipeline.Stage, _ StageReporter) error {
 			if st.ID == "build" {
 				return errors.New("build boom")
@@ -300,7 +347,7 @@ func TestRunnerParallelSiblingsContinueOnFailure(t *testing.T) {
 	)
 	var ranB atomic.Bool
 	sink := newFakeSink()
-	r := New(fakeLoader{cfg}, WithStageExecutor(
+	r := New(&fakeLoader{cfg: cfg}, WithStageExecutor(
 		func(_ context.Context, _ *run.Run, st pipeline.Stage, _ StageReporter) error {
 			if st.ID == "a" {
 				return errors.New("a boom")
@@ -344,7 +391,7 @@ func TestRunnerExecutesIndependentStagesInParallel(t *testing.T) {
 	var once sync.Once
 	const par = 3
 	sink := newFakeSink()
-	r := New(fakeLoader{cfg}, WithStageExecutor(
+	r := New(&fakeLoader{cfg: cfg}, WithStageExecutor(
 		func(_ context.Context, _ *run.Run, st pipeline.Stage, _ StageReporter) error {
 			if st.ID == "src" {
 				return nil

--- a/internal/pacloader/pacloader.go
+++ b/internal/pacloader/pacloader.go
@@ -9,12 +9,11 @@
 // 取不到)都**静默回退**到被包住的库内 loader——运行绝不因 YAML 问题而中断。仅在 debug
 // 级别记一行原因(不含任何密钥)。
 //
-// ── 已知约束:无分支(KNOWN CONSTRAINT,显式处理)──────────────────────────────
-// dagrun.SpecLoader.Get 只拿到 projectID,**没有本次运行的分支/ref**。因此本装饰器从
-// **项目的默认分支**(项目记录里的 DefaultBranch)拉取 `.pipewright.yml`。
-// 「按运行分支覆盖」(feature 分支上改 YAML 即对该分支运行生效)需要把运行分支贯穿进
-// SpecLoader 签名 / dagrun 内核——风险较大,**本期推迟(DEFERRED)**,不动 SpecLoader
-// 签名,也不碰 dagrun 执行内核。默认分支解析是本期可交付范围。
+// ── 按运行分支取 YAML(FR-8-12 补完)─────────────────────────────────────────────
+// dagrun.SpecLoader.Get 现已带本次运行的分支(run.Trigger.Branch),本装饰器据此从
+// **该运行分支**拉取 `.pipewright.yml`:在 feature 分支上改 YAML,即对该分支的运行生效。
+// 运行分支为空(如无分支的手动运行)时,退化为从项目**默认分支**(DefaultBranch)拉取,
+// 与历史行为一致;默认分支也为空时按底层拉取器语义处理(失败即回退)。
 //
 // ── 安全 ─────────────────────────────────────────────────────────────────────
 // token 仅在进程内取用即弃,绝不进日志/错误/返回值。底层拉取错误不外泄(可能含 URL 凭据)。
@@ -75,18 +74,18 @@ func New(inner SpecLoader, projects ProjectLookup, tokens TokenRevealer, blobs B
 	return &Loader{inner: inner, projects: projects, tokens: tokens, blobs: blobs}
 }
 
-// Get 实现 dagrun.SpecLoader:尝试用仓库默认分支的 `.pipewright.yml` 覆盖;
-// 任何问题都回退到 inner(库内配置)。绝不把 YAML 问题冒泡给调用方。
-func (l *Loader) Get(ctx context.Context, projectID string) (*pipeline.Config, error) {
-	if cfg, ok := l.tryOverride(ctx, projectID); ok {
+// Get 实现 dagrun.SpecLoader:尝试用**运行分支**的 `.pipewright.yml` 覆盖(分支为空时退化为
+// 默认分支);任何问题都回退到 inner(库内配置)。绝不把 YAML 问题冒泡给调用方。
+func (l *Loader) Get(ctx context.Context, projectID, branch string) (*pipeline.Config, error) {
+	if cfg, ok := l.tryOverride(ctx, projectID, branch); ok {
 		return cfg, nil
 	}
 	return l.inner.Get(ctx, projectID)
 }
 
-// tryOverride 尝试从仓库默认分支拉取并解析 `.pipewright.yml`;成功返回 (cfg,true)。
+// tryOverride 尝试从运行分支(空则默认分支)拉取并解析 `.pipewright.yml`;成功返回 (cfg,true)。
 // 任何环节失败返回 (nil,false)(调用方回退)。失败只记 debug 原因(无密钥)。
-func (l *Loader) tryOverride(ctx context.Context, projectID string) (*pipeline.Config, bool) {
+func (l *Loader) tryOverride(ctx context.Context, projectID, branch string) (*pipeline.Config, bool) {
 	if l.projects == nil || l.blobs == nil {
 		return nil, false
 	}
@@ -108,7 +107,13 @@ func (l *Loader) tryOverride(ctx context.Context, projectID string) (*pipeline.C
 		}
 	}
 
-	content, degraded, ferr := l.blobs.FetchBlob(ctx, info.RepoURL, token, info.DefaultBranch, DefaultFile)
+	// 优先用本次运行分支取 YAML(feature 分支改 YAML 即对该分支生效);分支为空退化为默认分支。
+	ref := strings.TrimSpace(branch)
+	if ref == "" {
+		ref = info.DefaultBranch
+	}
+
+	content, degraded, ferr := l.blobs.FetchBlob(ctx, info.RepoURL, token, ref, DefaultFile)
 	if ferr != nil {
 		// 文件不存在 / 克隆失败 → 回退(正常路径:多数项目没有 .pipewright.yml)。
 		debugf("项目 %s 未读到 %s(回退库内配置)", projectID, DefaultFile)
@@ -128,7 +133,7 @@ func (l *Loader) tryOverride(ctx context.Context, projectID string) (*pipeline.C
 		debugf("项目 %s 的 %s 解析/校验失败,回退库内配置", projectID, DefaultFile)
 		return nil, false
 	}
-	debugf("项目 %s 命中仓库 %s(默认分支 %s),用其驱动本次运行", projectID, DefaultFile, info.DefaultBranch)
+	debugf("项目 %s 命中仓库 %s(分支 %s),用其驱动本次运行", projectID, DefaultFile, ref)
 	return &cfg, true
 }
 

--- a/internal/pacloader/pacloader_test.go
+++ b/internal/pacloader/pacloader_test.go
@@ -115,7 +115,8 @@ func TestGet_ValidRepoYAML_UsesRepoSpec(t *testing.T) {
 	blobs := &fakeBlobs{content: validYAML}
 	l := newLoader(stored, fakeProjects{info: defaultInfo()}, tokens, blobs)
 
-	cfg, err := l.Get(context.Background(), "proj-1")
+	// 空运行分支 → 退化为默认分支 main(与历史行为一致)。
+	cfg, err := l.Get(context.Background(), "proj-1", "")
 	if err != nil {
 		t.Fatalf("意外错误: %v", err)
 	}
@@ -125,9 +126,9 @@ func TestGet_ValidRepoYAML_UsesRepoSpec(t *testing.T) {
 	if stored.called != 0 {
 		t.Fatalf("命中仓库 YAML 时不应回退库内 loader,called=%d", stored.called)
 	}
-	// 从默认分支拉取正确文件,并把凭据明文透传给拉取器。
+	// 空分支 → 默认分支拉取正确文件,并把凭据明文透传给拉取器。
 	if blobs.gotRef != "main" {
-		t.Errorf("应从默认分支 main 拉取,实际 ref=%q", blobs.gotRef)
+		t.Errorf("空运行分支应从默认分支 main 拉取,实际 ref=%q", blobs.gotRef)
 	}
 	if blobs.gotFile != DefaultFile {
 		t.Errorf("应拉取 %s,实际 file=%q", DefaultFile, blobs.gotFile)
@@ -140,6 +141,30 @@ func TestGet_ValidRepoYAML_UsesRepoSpec(t *testing.T) {
 	}
 }
 
+// ─── (a') 运行分支贯穿:按运行分支 X 取 YAML,而非默认分支(FR-8-12 补完核心)──────
+
+// 在 feature 分支上跑 → 应从 **该运行分支** 拉取 `.pipewright.yml`,而不是项目默认分支。
+func TestGet_RunBranch_FetchesFromRunBranchNotDefault(t *testing.T) {
+	stored := &storedLoader{cfg: storedCfg()}
+	blobs := &fakeBlobs{content: validYAML}
+	// 默认分支是 main;本次运行在 feature/awesome 上。
+	l := newLoader(stored, fakeProjects{info: defaultInfo()}, &fakeTokens{token: "tk"}, blobs)
+
+	cfg, err := l.Get(context.Background(), "proj-1", "feature/awesome")
+	if err != nil {
+		t.Fatalf("意外错误: %v", err)
+	}
+	if firstStage(cfg) != "from-repo" {
+		t.Fatalf("应使用运行分支 YAML 的 spec(name=from-repo),实际 name=%q", firstStage(cfg))
+	}
+	if blobs.gotRef != "feature/awesome" {
+		t.Errorf("应按运行分支 feature/awesome 拉取 %s,而非默认分支;实际 ref=%q", DefaultFile, blobs.gotRef)
+	}
+	if blobs.gotRef == "main" {
+		t.Errorf("绝不应回落到默认分支 main(运行分支非空)")
+	}
+}
+
 // ─── (b) 文件不存在 → 用库内配置 ────────────────────────────────────────────────
 
 func TestGet_FileMissing_FallsBackToStored(t *testing.T) {
@@ -148,7 +173,7 @@ func TestGet_FileMissing_FallsBackToStored(t *testing.T) {
 	blobs := &fakeBlobs{err: errors.New("source: path not found")}
 	l := newLoader(stored, fakeProjects{info: defaultInfo()}, &fakeTokens{}, blobs)
 
-	cfg, err := l.Get(context.Background(), "proj-1")
+	cfg, err := l.Get(context.Background(), "proj-1", "")
 	if err != nil {
 		t.Fatalf("文件缺失不应报错(应回退): %v", err)
 	}
@@ -167,7 +192,7 @@ func TestGet_FetchError_FallsBackNoError(t *testing.T) {
 	blobs := &fakeBlobs{err: errors.New("source: clone failed")}
 	l := newLoader(stored, fakeProjects{info: defaultInfo()}, &fakeTokens{}, blobs)
 
-	cfg, err := l.Get(context.Background(), "proj-1")
+	cfg, err := l.Get(context.Background(), "proj-1", "")
 	if err != nil {
 		t.Fatalf("拉取失败绝不应冒泡给调用方: %v", err)
 	}
@@ -182,7 +207,7 @@ func TestGet_DegradedClone_FallsBack(t *testing.T) {
 	blobs := &fakeBlobs{content: "", degraded: true}
 	l := newLoader(stored, fakeProjects{info: defaultInfo()}, &fakeTokens{}, blobs)
 
-	cfg, err := l.Get(context.Background(), "proj-1")
+	cfg, err := l.Get(context.Background(), "proj-1", "")
 	if err != nil {
 		t.Fatalf("降级不应报错: %v", err)
 	}
@@ -198,7 +223,7 @@ func TestGet_InvalidYAML_FallsBackToStored(t *testing.T) {
 	blobs := &fakeBlobs{content: "this: : is not valid pipewright yaml\n  - broken"}
 	l := newLoader(stored, fakeProjects{info: defaultInfo()}, &fakeTokens{}, blobs)
 
-	cfg, err := l.Get(context.Background(), "proj-1")
+	cfg, err := l.Get(context.Background(), "proj-1", "")
 	if err != nil {
 		t.Fatalf("非法 YAML 绝不应中断运行: %v", err)
 	}
@@ -213,7 +238,7 @@ func TestGet_ProjectLookupError_FallsBack(t *testing.T) {
 	stored := &storedLoader{cfg: storedCfg()}
 	l := newLoader(stored, fakeProjects{err: errors.New("not found")}, &fakeTokens{}, &fakeBlobs{content: validYAML})
 
-	cfg, _ := l.Get(context.Background(), "proj-1")
+	cfg, _ := l.Get(context.Background(), "proj-1", "")
 	if firstStage(cfg) != "stored-pipeline" {
 		t.Fatalf("项目查询失败应回退库内,实际 name=%q", firstStage(cfg))
 	}
@@ -225,7 +250,7 @@ func TestGet_EmptyRepoURL_FallsBack(t *testing.T) {
 	info.RepoURL = "  "
 	l := newLoader(stored, fakeProjects{info: info}, &fakeTokens{}, &fakeBlobs{content: validYAML})
 
-	cfg, _ := l.Get(context.Background(), "proj-1")
+	cfg, _ := l.Get(context.Background(), "proj-1", "")
 	if firstStage(cfg) != "stored-pipeline" {
 		t.Fatalf("空仓库地址应回退库内,实际 name=%q", firstStage(cfg))
 	}
@@ -235,7 +260,7 @@ func TestGet_EmptyContent_FallsBack(t *testing.T) {
 	stored := &storedLoader{cfg: storedCfg()}
 	l := newLoader(stored, fakeProjects{info: defaultInfo()}, &fakeTokens{}, &fakeBlobs{content: "   \n"})
 
-	cfg, _ := l.Get(context.Background(), "proj-1")
+	cfg, _ := l.Get(context.Background(), "proj-1", "")
 	if firstStage(cfg) != "stored-pipeline" {
 		t.Fatalf("空文件应回退库内,实际 name=%q", firstStage(cfg))
 	}
@@ -245,7 +270,7 @@ func TestGet_NilDeps_PurePassthrough(t *testing.T) {
 	stored := &storedLoader{cfg: storedCfg()}
 	l := New(stored, nil, nil, nil)
 
-	cfg, err := l.Get(context.Background(), "proj-1")
+	cfg, err := l.Get(context.Background(), "proj-1", "")
 	if err != nil {
 		t.Fatalf("意外错误: %v", err)
 	}
@@ -261,7 +286,7 @@ func TestGet_TokenRevealError_TriesPublicWithEmptyToken(t *testing.T) {
 	blobs := &fakeBlobs{content: validYAML}
 	l := newLoader(stored, fakeProjects{info: defaultInfo()}, tokens, blobs)
 
-	cfg, err := l.Get(context.Background(), "proj-1")
+	cfg, err := l.Get(context.Background(), "proj-1", "")
 	if err != nil {
 		t.Fatalf("意外错误: %v", err)
 	}


### PR DESCRIPTION
## 背景

PR #35/#37 落地了「流水线即代码」运行时覆盖:`PIPEWRIGHT_PAC_RUNTIME=1` 时,装饰器从项目仓库拉取 `.pipewright.yml` 驱动本次运行,任何问题优雅回退库内配置。当时遗留的已知约束(DEFERRED):`SpecLoader.Get(ctx, projectID)` 没有运行分支,只能从**项目默认分支**拉 YAML。

本 PR 补完该约束:把本次运行的分支贯穿进 `SpecLoader`,使 **feature 分支上改 `.pipewright.yml` 即对该分支的运行生效**。

## 改动

### 签名变更(唯一的接口变更)
`internal/dagrun`:
```
SpecLoader.Get(ctx, projectID)            // 旧
SpecLoader.Get(ctx, projectID, branch)    // 新
```
调用点(`Runner.Run`)透传 `rn.Trigger.Branch`。

### 适配器思路(最小爆炸半径)
新增 `dagrun.SpecLoaderFunc`:把分支无关的 2 参库内 loader(`pipeline.Service.Get`)包成 branch 感知契约并**忽略 branch**。

- `pipeline.Service.Get(ctx, projectID)` 的公有 2 参签名**保持不变** —— `pipeline.go:147/175`、`httpapi/pipelines.go` 等既有调用方零影响。
- 只有 `dagrun.SpecLoader` 这道接缝变 branch 感知。
- `main.go` 里 `var specLoader = dagrun.SpecLoaderFunc(pipelineSvc.Get)`;开启 PAC 时换成 `pacloader.New(...)`(其内部 inner loader 仍是 2 参 `pipeline.Service`,未改)。

### pacloader 按运行分支取 YAML
`Loader.Get(ctx, projectID, branch)`:优先用**运行分支**拉 `.pipewright.yml`;**运行分支为空**(如无分支的手动运行)→ 退化为项目**默认分支**(与历史行为一致)。

**优雅回退语义全部保留**:文件缺失 / 克隆失败 / 克隆降级 / 空内容 / 坏 YAML / 项目查询失败 → 一律回退库内配置,**运行绝不因 YAML 问题中断**。token / 仓库 URL 凭据绝不进日志/错误/返回值。包注释已更新、移除 DEFERRED 说明。

## 空分支回退
`ref := strings.TrimSpace(branch); if ref == "" { ref = info.DefaultBranch }` —— 空运行分支按默认分支拉取,行为与本 PR 前完全一致。

## 测试
- `dagrun`:`TestRunnerThreadsRunBranchToLoader`(Runner 把 `Trigger.Branch` 透传给 loader)、`TestSpecLoaderFuncIgnoresBranchAndDelegates`(适配器忽略 branch、委托底层);既有 fake loader 升 3 参。
- `pacloader`:**新增 `TestGet_RunBranch_FetchesFromRunBranchNotDefault`** —— 默认分支 `main`、运行分支 `feature/awesome`,断言 `BlobFetcher` 被请求的是 `feature/awesome` 而非 `main`(证明运行分支到达文件拉取);`TestGet_ValidRepoYAML_UsesRepoSpec` 改为空分支→默认分支回退场景;全部回退/边界用例升 3 参。

## 绿灯证据
```
gofmt -l (touched)  → clean(空)
go vet ./...        → clean
go build ./...      → OK
go test ./...       → exit=0,31 packages ok,NO FAILURES
```

无 migration(纯签名/贯穿变更)。未触碰 `internal/ai/*`、`internal/build/*`、`internal/target/*`、`httpapi/router.go`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)