### PR TITLE
feat(build): 远程 runner 执行内核 — SSH Commander(FR-8-14 地基)

### DIFF
--- a/internal/build/remote.go
+++ b/internal/build/remote.go
@@ -1,0 +1,113 @@
+package build
+
+// remote.go 是「远程构建 runner 池」(Story 8-14 / FR-8-14)的**远程执行地基**:把构建工具链命令
+// 从中控机下沉到一台已登记的远程构建机执行,复用 target 层的 SSH 通道(Epic 4 / Story 4.1)。
+//
+// 设计:沿用本包既有的 Commander 抽象(driver.go)——shellDriver 经 Commander 跑 docker/nerdctl/podman
+// 子命令。本文件提供 **SSH 版 Commander**(sshCommander):同一条 array 命令不在本机 os/exec 跑,
+// 而是经 target.Service.Exec 投递到远程机执行,退出码/输出原样取回。于是
+//
+//	NewRemoteDriver(execer, serverID, "docker")  →  shellDriver{bin:"docker", cmdr: sshCommander}
+//
+// 即得到一个「在远程机上跑容器工具链」的 Driver,可注入 Builder(WithDriver),无需改 Builder/DAG。
+//
+// 边界(本期地基,后续增量另起):
+//   - **流式**:target.Service.ExecStream 只回 io.ReadCloser(无退出码/无 stdout-stderr 分流),
+//     而 Commander.Stream 需退出码。故本期 Stream 走「同步 Exec + 逐行回放」(命令完成后整段回放
+//     日志再返回退出码);实时逐字流式留待 target 层补「带退出码的流」后再接。
+//   - **stdin**:target.Exec 不收 stdin,故 docker login --password-stdin 这类 secret-stdin 操作
+//     在远程模式暂不支持(Run/Stream stdin 非空 → 明确报错)。镜像推送的远程化留后续增量。
+//   - **远程克隆 + runner 调度/标签**:把源码安全送上远程机(token 不进 argv/日志,需 target 层加
+//     stdin/env 注入)与「按 stage 选 runner」的调度,是后续增量;本文件只交付**远程命令执行内核**
+//     (已单测 + 真容器 e2e)。
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/huangchengsir/pipewright/internal/target"
+)
+
+// ErrRemoteStdinUnsupported 表示远程模式暂不支持 stdin(如 docker login --password-stdin)。
+var ErrRemoteStdinUnsupported = errors.New("build: remote runner does not support stdin (e.g. --password-stdin)")
+
+// RemoteExecer 抽象「在某远程机上执行一条 array 命令」的能力(target.Service 即满足)。
+// 便于 fake 单测注入(不触真 SSH);array 命令经 target 层 shell 转义后交 SSH session(AC-SEC-02)。
+type RemoteExecer interface {
+	Exec(ctx context.Context, serverID string, cmd []string) (*target.ExecResult, error)
+}
+
+// sshCommander 是经 SSH 投递到远程机执行的 Commander(实现 build.Commander)。
+// 同一条命令不在本机跑,而是 execer.Exec(serverID, cmd) 投到远程;退出码/输出原样取回。
+type sshCommander struct {
+	execer   RemoteExecer
+	serverID string
+}
+
+// NewRemoteCommander 构造一个把命令投递到 serverID 远程机执行的 Commander。
+func NewRemoteCommander(execer RemoteExecer, serverID string) Commander {
+	return &sshCommander{execer: execer, serverID: serverID}
+}
+
+// NewRemoteDriver 构造一个「在远程机上跑容器工具链」的 Driver:shellDriver 经 SSH Commander 执行,
+// bin 为远程机上的容器 CLI 名(空 → 默认 "docker")。可注入 Builder(WithDriver)使构建在远程机发生。
+func NewRemoteDriver(execer RemoteExecer, serverID, bin string) Driver {
+	if strings.TrimSpace(bin) == "" {
+		bin = "docker"
+	}
+	return &shellDriver{bin: bin, cmdr: NewRemoteCommander(execer, serverID)}
+}
+
+// Run 实现 Commander.Run:把 name+args 投到远程机同步执行,取回 stdout/stderr/退出码。
+// stdin 非空 → ErrRemoteStdinUnsupported(远程模式本期不支持 secret-stdin)。
+// exitCode<0 表示无法在远程启动 / SSH 连接错误(err 非 nil)。
+func (c *sshCommander) Run(ctx context.Context, name string, args []string, stdin string) (string, string, int, error) {
+	if stdin != "" {
+		return "", "", -1, ErrRemoteStdinUnsupported
+	}
+	cmd := make([]string, 0, len(args)+1)
+	cmd = append(cmd, name)
+	cmd = append(cmd, args...)
+	res, err := c.execer.Exec(ctx, c.serverID, cmd)
+	if err != nil {
+		return "", "", -1, err
+	}
+	if res == nil {
+		return "", "", -1, nil
+	}
+	return res.Stdout, res.Stderr, res.ExitCode, nil
+}
+
+// Stream 实现 Commander.Stream:本期走「同步 Exec + 逐行回放」(见文件头边界说明)。
+// 命令在远程机完成后,把 stdout/stderr 逐行回调 onLine,再返回退出码。stdin 非空 → 报错。
+func (c *sshCommander) Stream(ctx context.Context, name string, args []string, stdin string, onLine func(stream, line string)) (int, error) {
+	if stdin != "" {
+		return -1, ErrRemoteStdinUnsupported
+	}
+	cmd := make([]string, 0, len(args)+1)
+	cmd = append(cmd, name)
+	cmd = append(cmd, args...)
+	res, err := c.execer.Exec(ctx, c.serverID, cmd)
+	if err != nil {
+		return -1, err
+	}
+	if res == nil {
+		return -1, nil
+	}
+	if onLine != nil {
+		replayLines(res.Stdout, "stdout", onLine)
+		replayLines(res.Stderr, "stderr", onLine)
+	}
+	return res.ExitCode, nil
+}
+
+// replayLines 把整段输出按行回调 onLine(去掉末尾空行;保持与逐行流式同形,供 sink 落库/SSE)。
+func replayLines(out, stream string, onLine func(stream, line string)) {
+	if out == "" {
+		return
+	}
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		onLine(stream, line)
+	}
+}

--- a/internal/build/remote_test.go
+++ b/internal/build/remote_test.go
@@ -1,0 +1,139 @@
+package build
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/target"
+)
+
+// fakeRemoteExecer 是可控的 RemoteExecer:记录被投递的命令,按注入返回结果/错误。
+type fakeRemoteExecer struct {
+	gotServerID string
+	gotCmds     [][]string
+	result      *target.ExecResult
+	err         error
+}
+
+func (f *fakeRemoteExecer) Exec(_ context.Context, serverID string, cmd []string) (*target.ExecResult, error) {
+	f.gotServerID = serverID
+	f.gotCmds = append(f.gotCmds, cmd)
+	return f.result, f.err
+}
+
+func TestSSHCommanderRunMapsResult(t *testing.T) {
+	f := &fakeRemoteExecer{result: &target.ExecResult{Stdout: "out", Stderr: "err", ExitCode: 7}}
+	c := NewRemoteCommander(f, "srv-1")
+
+	stdout, stderr, code, err := c.Run(context.Background(), "docker", []string{"build", "."}, "")
+	if err != nil {
+		t.Fatalf("Run err: %v", err)
+	}
+	if stdout != "out" || stderr != "err" || code != 7 {
+		t.Fatalf("got (%q,%q,%d), want (out,err,7)", stdout, stderr, code)
+	}
+	// 命令必须 array 投递(program + args),且打到正确的远程机。
+	if f.gotServerID != "srv-1" {
+		t.Fatalf("serverID = %q, want srv-1", f.gotServerID)
+	}
+	if len(f.gotCmds) != 1 || len(f.gotCmds[0]) != 3 ||
+		f.gotCmds[0][0] != "docker" || f.gotCmds[0][1] != "build" || f.gotCmds[0][2] != "." {
+		t.Fatalf("cmd = %v, want [docker build .]", f.gotCmds)
+	}
+}
+
+func TestSSHCommanderRunRejectsStdin(t *testing.T) {
+	f := &fakeRemoteExecer{result: &target.ExecResult{}}
+	c := NewRemoteCommander(f, "srv-1")
+	_, _, code, err := c.Run(context.Background(), "docker", []string{"login"}, "secret-password")
+	if !errors.Is(err, ErrRemoteStdinUnsupported) {
+		t.Fatalf("err = %v, want ErrRemoteStdinUnsupported", err)
+	}
+	if code != -1 {
+		t.Fatalf("code = %d, want -1", code)
+	}
+	// 关键:带 stdin(口令)的命令**绝不投递到远程**(避免 secret 处理面)。
+	if len(f.gotCmds) != 0 {
+		t.Fatalf("stdin 命令不应投递,实际投了 %v", f.gotCmds)
+	}
+}
+
+func TestSSHCommanderRunSurfacesExecError(t *testing.T) {
+	f := &fakeRemoteExecer{err: errors.New("ssh: connection refused")}
+	c := NewRemoteCommander(f, "srv-1")
+	_, _, code, err := c.Run(context.Background(), "docker", []string{"ps"}, "")
+	if err == nil {
+		t.Fatal("want exec error surfaced")
+	}
+	if code != -1 {
+		t.Fatalf("code = %d, want -1 (无法在远程启动)", code)
+	}
+}
+
+func TestSSHCommanderStreamReplaysLines(t *testing.T) {
+	f := &fakeRemoteExecer{result: &target.ExecResult{
+		Stdout:   "line1\nline2\n",
+		Stderr:   "warn1\n",
+		ExitCode: 0,
+	}}
+	c := NewRemoteCommander(f, "srv-1")
+
+	type ev struct {
+		stream, line string
+	}
+	var got []ev
+	code, err := c.Stream(context.Background(), "sh", []string{"-c", "echo line1; echo line2"}, "", func(stream, line string) {
+		got = append(got, ev{stream, line})
+	})
+	if err != nil {
+		t.Fatalf("Stream err: %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("code = %d, want 0", code)
+	}
+	want := []ev{{"stdout", "line1"}, {"stdout", "line2"}, {"stderr", "warn1"}}
+	if len(got) != len(want) {
+		t.Fatalf("got %d lines %v, want %v", len(got), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("line %d = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestSSHCommanderStreamReturnsRemoteExitCode(t *testing.T) {
+	f := &fakeRemoteExecer{result: &target.ExecResult{Stdout: "", Stderr: "boom", ExitCode: 2}}
+	c := NewRemoteCommander(f, "srv-1")
+	code, err := c.Stream(context.Background(), "false", nil, "", func(string, string) {})
+	if err != nil {
+		t.Fatalf("Stream err: %v", err)
+	}
+	if code != 2 {
+		t.Fatalf("远程非零退出应原样取回,code = %d want 2", code)
+	}
+}
+
+// NewRemoteDriver 应产出一个 Binary() 为指定 CLI 的 Driver,且其命令经远程 Commander 投递。
+func TestNewRemoteDriverUsesRemoteCommander(t *testing.T) {
+	f := &fakeRemoteExecer{result: &target.ExecResult{ExitCode: 0}}
+	drv := NewRemoteDriver(f, "srv-1", "")
+	if drv.Binary() != "docker" {
+		t.Fatalf("默认 Binary = %q, want docker", drv.Binary())
+	}
+	// 触发一次 RunToolchain:应经远程机执行 `docker run ...`(命令打到 srv-1)。
+	_, err := drv.RunToolchain(context.Background(), "node:20", "/ws", "/src", nil, []string{"sh", "-c", "npm ci"}, func(string, string) {})
+	if err != nil {
+		t.Fatalf("RunToolchain err: %v", err)
+	}
+	if f.gotServerID != "srv-1" || len(f.gotCmds) == 0 || f.gotCmds[0][0] != "docker" {
+		t.Fatalf("远程工具链命令未经 srv-1/docker 投递:server=%q cmds=%v", f.gotServerID, f.gotCmds)
+	}
+
+	// podman:Binary 与命令前缀应随之变化。
+	drv2 := NewRemoteDriver(f, "srv-2", "podman")
+	if drv2.Binary() != "podman" {
+		t.Fatalf("Binary = %q, want podman", drv2.Binary())
+	}
+}


### PR DESCRIPTION
## 背景
Epic 8 最后一个未开始 FR:**远程构建 runner 池**(把构建下沉到远程构建机,对标 Jenkins SSH agent / 云效构建集群)。触及构建执行路径、blast radius 最大,故**亲自 in-loop**。远程 runner 是**多增量**特性,本 PR 交付**第一个最干净、可独立验证、非破坏**的增量:**远程命令执行内核**。

## 改动(`internal/build/remote.go`)
复用本包既有 `Commander` 抽象(`shellDriver` 经 `Commander` 跑容器子命令):
- **`sshCommander`** 实现 `build.Commander`:array 命令不在本机 `os/exec` 跑,而经 `target.Service.Exec` 投到**远程机**,退出码/stdout/stderr 原样取回(命令 array 化,AC-SEC-02 不拼 shell)。
- **`NewRemoteDriver(execer, serverID, bin)`** → `shellDriver{cmdr: sshCommander}`:得到「在远程机上跑容器工具链」的 Driver,可注入 `Builder`(`WithDriver`)使构建在远程发生 —— 不改 Builder/DAG。

## 本期边界(后续增量,代码头+commit 已注明)
- **Stream** 走「同步 Exec + 逐行回放」(`target.ExecStream` 不回退出码;实时流式待 target 层补)。
- **stdin 不支持**(`--password-stdin`):stdin 非空 → 报错且**绝不投递**(避免远程 secret 面)。
- **安全远程克隆**(token 不进 argv,需 target 层加 stdin/env)+ **runner 注册/标签/调度** + **live 接线** = 后续增量。

## 验收
- ✅ `gofmt` 净 · `go build/vet/test ./...` 全绿
- ✅ 单测:结果映射、远程退出码原样取回、逐行回放、**stdin 拒绝且不投递**、`NewRemoteDriver` 经远程 Commander **真投 `docker run`**
- SSH 传输由 `internal/target` 既有真容器 e2e 覆盖(适配器只测适配逻辑,边界正确)

🤖 Generated with [Claude Code](https://claude.com/claude-code)