### PR TITLE
feat(artifact): 制品库 — jar/dist 真字节可部署 + 镜像缓存自动清理(FR-8-16/8-17)

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/ai"
 	"github.com/huangchengsir/pipewright/internal/anomaly"
 	"github.com/huangchengsir/pipewright/internal/approval"
+	"github.com/huangchengsir/pipewright/internal/artifactstore"
 	"github.com/huangchengsir/pipewright/internal/audit"
 	"github.com/huangchengsir/pipewright/internal/auth"
 	"github.com/huangchengsir/pipewright/internal/build"
@@ -208,6 +209,23 @@ func main() {
 	// 缺省/其它值仍走 PIPEWRIGHT_BUILDER 选出的真实 Builder / 桩 runner。
 	// ⚠ 当前阶段执行体为占位 stub(仅打日志即成功);真实「阶段内并行 job → job 内有序 step
 	// 在隔离容器构建/部署」= Story 8-2 尚未接入,故 dag 模式现仅用于验证编排,不做真实构建。
+	// 制品库(Story 8-16 / FR-8-16):构建后把 jar/dist 真字节归档,部署时取真字节上传目标机
+	// (否则只有占位 reference,jar/dist 无法真正部署)。默认落 DB 同级 artifacts/,可经
+	// PIPEWRIGHT_ARTIFACT_DIR 改。构造失败 → 降级 nil(保持旧占位行为,不中断启动)。
+	var artStore *artifactstore.Store
+	{
+		artDir := strings.TrimSpace(os.Getenv("PIPEWRIGHT_ARTIFACT_DIR"))
+		if artDir == "" {
+			artDir = filepath.Join(filepath.Dir(cfg.DBPath), "artifacts")
+		}
+		if as, aerr := artifactstore.New(artDir); aerr == nil {
+			artStore = as
+			log.Printf("[artifact] 制品库已启用(归档 jar/dist 真字节供部署):%s", artDir)
+		} else {
+			log.Printf("[artifact] 警告:制品库不可用(%v),jar/dist 部署退回占位引用", aerr)
+		}
+	}
+
 	var runnerOpts []run.PoolOption
 	if strings.EqualFold(strings.TrimSpace(os.Getenv("PIPEWRIGHT_RUNNER")), "dag") {
 		// 阶段执行体(Story 8-2):探测到容器 CLI → 注入真实阶段执行器(script 类型 job 在隔离
@@ -215,7 +233,7 @@ func main() {
 		var dagOpts []dagrun.Option
 		// 审批门 hook(Story 8-4):Gate 阶段阻塞等待人工批准/拒绝。
 		dagOpts = append(dagOpts, dagrun.WithGate(httpapi.NewApprovalGate(runSvc, approvalCoord, approvalStore)))
-		if b, berr := build.NewBuilder(projectSvc, pipelineSettingsSvc, credVault); berr == nil {
+		if b, berr := build.NewBuilder(projectSvc, pipelineSettingsSvc, credVault, build.WithArtifactStore(artStore), build.WithImageGC(os.Getenv("PIPEWRIGHT_NO_IMAGE_GC") != "1")); berr == nil {
 			// runSvc 作测试报告持久层注入(Story 8-6 / FR-8-6):script 步骤产报告 → 解析 →
 			// 落库 → 质量门禁裁决(不过则阶段失败,阻断下游部署)。
 			dagOpts = append(dagOpts, dagrun.WithStageExecutor(build.NewStageExecutor(b, runSvc)))
@@ -240,7 +258,7 @@ func main() {
 		}
 		runnerOpts = []run.PoolOption{run.WithRunner(dagrun.New(specLoader, dagOpts...))}
 	} else {
-		runnerOpts = buildRunnerOption(projectSvc, pipelineSettingsSvc, credVault)
+		runnerOpts = buildRunnerOption(projectSvc, pipelineSettingsSvc, credVault, artStore)
 	}
 
 	// 终态钩子:通知(Story 5.2);PIPEWRIGHT_PR_STATUS=1 时再叠加「PR 状态回写」(Story 8-9 / FR-8-9):
@@ -331,7 +349,7 @@ func main() {
 	// (notifySvc 已在 pool 装配前声明〔Story 5.2 注入 NotifyHook〕,此处不重复。)
 	// Story 4.6(FR-22 种子):注入诊断钩子 → 部署失败(failed/partial_failed)合成失败日志 +
 	// best-effort 触发 7-2 AI 诊断,让诊断飞轮覆盖部署失败(而非只覆盖构建失败)。复用 7-2 NewDiagnoseHook。
-	deploySvc := deploy.New(targetSvc, runSvc, deploy.WithDiagnoseHook(httpapi.NewDiagnoseHook(runSvc, aiSvc, secretSrc)))
+	deploySvc := deploy.New(targetSvc, runSvc, deploy.WithDiagnoseHook(httpapi.NewDiagnoseHook(runSvc, aiSvc, secretSrc)), deploy.WithArtifactStore(artStore))
 
 	// 装配可配置异常检测服务(Story 6.5;FR-23):按阈值规则对服务器指标做检测,命中产告警入库。
 	// 检测复用 6-1 指标采集(NewAnomalyCollector 适配 collectServerMetrics);不可达/指标 null 的
@@ -416,21 +434,21 @@ func (b pacBlobFetcher) FetchBlob(ctx context.Context, repoURL, token, ref, file
 //   - 其它/缺省 auto:尝试构造真实 Builder,探测不到容器 CLI 时回退桩(优雅降级,NFR-10)。
 //
 // 返回 []run.PoolOption(可能为空):空 ⇒ 用 pool 默认 StubRunner。
-func buildRunnerOption(projectSvc project.Service, settingsSvc pipeline.SettingsService, v vault.Vault) []run.PoolOption {
+func buildRunnerOption(projectSvc project.Service, settingsSvc pipeline.SettingsService, v vault.Vault, artStore *artifactstore.Store) []run.PoolOption {
 	mode := strings.ToLower(strings.TrimSpace(os.Getenv("PIPEWRIGHT_BUILDER")))
 	switch mode {
 	case "stub":
 		log.Printf("[build] PIPEWRIGHT_BUILDER=stub:使用桩 runner(合成日志,不碰容器)")
 		return nil
 	case "real":
-		b, err := build.NewBuilder(projectSvc, settingsSvc, v)
+		b, err := build.NewBuilder(projectSvc, settingsSvc, v, build.WithArtifactStore(artStore), build.WithImageGC(os.Getenv("PIPEWRIGHT_NO_IMAGE_GC") != "1"))
 		if err != nil {
 			log.Fatalf("[build] PIPEWRIGHT_BUILDER=real 但构建器不可用:%v", err)
 		}
 		log.Printf("[build] 真实隔离构建器已启用(容器 CLI=%s)", b.DriverBinary())
 		return []run.PoolOption{run.WithRunner(b)}
 	default:
-		b, err := build.NewBuilder(projectSvc, settingsSvc, v)
+		b, err := build.NewBuilder(projectSvc, settingsSvc, v, build.WithArtifactStore(artStore), build.WithImageGC(os.Getenv("PIPEWRIGHT_NO_IMAGE_GC") != "1"))
 		if err != nil {
 			log.Printf("[build] 未探测到容器 CLI(docker/nerdctl/podman),回退桩 runner(PIPEWRIGHT_BUILDER=real 可强制要求真实):%v", err)
 			return nil

--- a/internal/artifactstore/store.go
+++ b/internal/artifactstore/store.go
@@ -1,0 +1,141 @@
+// Package artifactstore 是「构建产物物理存储」(制品库 · Story 8-16 / FR-8-16)。
+//
+// 背景:Epic 3 的构建把 jar/dist **定位**出来并记元数据(run_artifacts:type/name/reference/size),
+// 但产物**字节**随临时工作区一起删了 —— Epic 4 部署只能拿到 reference 串(占位),无法真正部署。
+// 本包补这一层:构建后把 jar 文件 / dist 打包的字节**拷出工作区存盘**,产物 reference 改存「存储句柄」,
+// 部署时按句柄取**真字节**写到目标机。
+//
+// 设计:**内容寻址**(content-addressed)磁盘库 —— 字节经 SHA-256 落到 <root>/<2 位前缀>/<全 hash>,
+// 相同内容天然去重(同一产物多次构建不重复占盘)。无外部依赖、无 init 副作用;root 由 main 注入
+// (默认 DB 同级 artifacts/,env PIPEWRIGHT_ARTIFACT_DIR 可改)。句柄即 hash 串,Open 前严校(防路径穿越)。
+package artifactstore
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// 领域错误。错误体不含字节内容 / 绝对路径外的敏感信息。
+var (
+	// ErrInvalidKey 表示存储句柄非法(非 64 位小写 hex;防路径穿越)。
+	ErrInvalidKey = errors.New("artifactstore: invalid key")
+	// ErrNotFound 表示该句柄无对应产物。
+	ErrNotFound = errors.New("artifactstore: artifact not found")
+)
+
+// Store 是内容寻址磁盘制品库。零依赖;并发安全(Put 经临时文件 + 原子 rename;Open 只读)。
+type Store struct {
+	root string
+}
+
+// New 构造制品库,root 不存在则创建(0700:产物可能含敏感构建输出,限本用户)。
+func New(root string) (*Store, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return nil, errors.New("artifactstore: empty root")
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return nil, fmt.Errorf("artifactstore: mkdir root: %w", err)
+	}
+	return &Store{root: root}, nil
+}
+
+// Put 把 r 的字节流式落库,返回内容寻址句柄(sha256 hex)与字节数。
+// 经临时文件 + 原子 rename 落盘:并发/中断不产生半截文件;内容相同 → 同句柄(去重)。
+func (s *Store) Put(r io.Reader) (key string, size int64, err error) {
+	tmp, err := os.CreateTemp(s.root, ".put-*")
+	if err != nil {
+		return "", 0, fmt.Errorf("artifactstore: temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	// 失败路径清理临时文件(成功路径已 rename 走,Remove 无害)。
+	defer func() { _ = os.Remove(tmpName) }()
+
+	h := sha256.New()
+	size, err = io.Copy(io.MultiWriter(tmp, h), r)
+	if err != nil {
+		_ = tmp.Close()
+		return "", 0, fmt.Errorf("artifactstore: copy: %w", err)
+	}
+	if err = tmp.Close(); err != nil {
+		return "", 0, fmt.Errorf("artifactstore: close temp: %w", err)
+	}
+
+	key = hex.EncodeToString(h.Sum(nil))
+	dest := s.pathFor(key)
+	if err = os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+		return "", 0, fmt.Errorf("artifactstore: mkdir shard: %w", err)
+	}
+	// 已存在(同内容)→ 直接复用,不重复写(去重)。
+	if _, statErr := os.Stat(dest); statErr == nil {
+		return key, size, nil
+	}
+	if err = os.Rename(tmpName, dest); err != nil {
+		return "", 0, fmt.Errorf("artifactstore: commit: %w", err)
+	}
+	return key, size, nil
+}
+
+// Open 按句柄打开产物只读流(调用方负责 Close)。句柄非法 → ErrInvalidKey;不存在 → ErrNotFound。
+func (s *Store) Open(key string) (io.ReadCloser, error) {
+	if !validKey(key) {
+		return nil, ErrInvalidKey
+	}
+	f, err := os.Open(s.pathFor(key))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return f, nil
+}
+
+// Stat 返回产物字节数(用于校验 / 展示)。句柄非法 → ErrInvalidKey;不存在 → ErrNotFound。
+func (s *Store) Stat(key string) (int64, error) {
+	if !validKey(key) {
+		return 0, ErrInvalidKey
+	}
+	fi, err := os.Stat(s.pathFor(key))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, ErrNotFound
+		}
+		return 0, err
+	}
+	return fi.Size(), nil
+}
+
+// Has 报告句柄是否已存在(非法句柄视为不存在,不报错)。
+func (s *Store) Has(key string) bool {
+	if !validKey(key) {
+		return false
+	}
+	_, err := os.Stat(s.pathFor(key))
+	return err == nil
+}
+
+// pathFor 把句柄映射为分片磁盘路径:<root>/<前 2 位>/<全 hash>(防单目录文件过多)。
+func (s *Store) pathFor(key string) string {
+	return filepath.Join(s.root, key[:2], key)
+}
+
+// validKey 校验句柄为 64 位小写 hex(sha256);杜绝 ../ 等路径穿越。
+func validKey(key string) bool {
+	if len(key) != 64 {
+		return false
+	}
+	for i := 0; i < len(key); i++ {
+		c := key[i]
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/artifactstore/store_test.go
+++ b/internal/artifactstore/store_test.go
@@ -1,0 +1,90 @@
+package artifactstore
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func newStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return s
+}
+
+func TestPutOpenRoundTrip(t *testing.T) {
+	s := newStore(t)
+	payload := []byte("hello artifact bytes\n\x00\x01binary")
+	key, size, err := s.Put(bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if size != int64(len(payload)) {
+		t.Fatalf("size = %d, want %d", size, len(payload))
+	}
+	if !validKey(key) {
+		t.Fatalf("key 非法: %q", key)
+	}
+	rc, err := s.Open(key)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer rc.Close()
+	got, _ := io.ReadAll(rc)
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("取回字节与存入不一致")
+	}
+	if st, _ := s.Stat(key); st != int64(len(payload)) {
+		t.Fatalf("Stat = %d, want %d", st, len(payload))
+	}
+	if !s.Has(key) {
+		t.Fatal("Has 应为 true")
+	}
+}
+
+func TestContentAddressedDedup(t *testing.T) {
+	s := newStore(t)
+	k1, _, _ := s.Put(strings.NewReader("same content"))
+	k2, _, _ := s.Put(strings.NewReader("same content"))
+	if k1 != k2 {
+		t.Fatalf("相同内容应同句柄(去重):%q vs %q", k1, k2)
+	}
+	k3, _, _ := s.Put(strings.NewReader("different"))
+	if k3 == k1 {
+		t.Fatal("不同内容不应同句柄")
+	}
+}
+
+func TestOpenRejectsBadKey(t *testing.T) {
+	s := newStore(t)
+	for _, bad := range []string{"", "xyz", "../etc/passwd", strings.Repeat("g", 64), strings.Repeat("A", 64)} {
+		if _, err := s.Open(bad); !errors.Is(err, ErrInvalidKey) {
+			t.Fatalf("Open(%q) err = %v, want ErrInvalidKey", bad, err)
+		}
+	}
+}
+
+func TestOpenMissingIsNotFound(t *testing.T) {
+	s := newStore(t)
+	missing := strings.Repeat("a", 64) // 合法 hex 但未存
+	if _, err := s.Open(missing); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Open(missing) err = %v, want ErrNotFound", err)
+	}
+	if _, err := s.Stat(missing); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Stat(missing) err = %v, want ErrNotFound", err)
+	}
+	if s.Has(missing) {
+		t.Fatal("Has(missing) 应 false")
+	}
+}
+
+func TestNewEmptyRootFails(t *testing.T) {
+	if _, err := New("  "); err == nil {
+		t.Fatal("空 root 应报错")
+	}
+}

--- a/internal/build/artifact_persist.go
+++ b/internal/build/artifact_persist.go
@@ -1,0 +1,134 @@
+package build
+
+// artifact_persist.go 把构建产出的 jar 文件 / dist 目录的**真字节**拷进制品库(Story 8-16 / FR-8-16),
+// 使产物在临时工作区销毁后仍可被部署取用。无制品库注入(b.artStore==nil)时保持旧行为(reference=文件名,
+// 占位),向后兼容。
+//
+//   - jar : 文件原样字节 → store.Put → reference=storeKey;metadata 记 filename(部署落盘名)、format=file。
+//   - dist: 目录打成 tar.gz 字节流 → store.Put → reference=storeKey;metadata 记 format=tar.gz(部署远端解包)。
+//
+// 制品库句柄(sha256)落入 run_artifacts.reference;部署侧据 metadata.stored 判定走「取真字节上传」而非占位。
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// storeJarBytes 把 jar 文件字节存入制品库,改写 art.Reference 为存储句柄并补 metadata。
+// store 为 nil 或存储失败 → 不改 art(保持旧占位行为),返回是否已存。
+func (b *Builder) storeJarBytes(art *run.Artifact, jarPath string, onLine func(stream, line string)) bool {
+	if b.artStore == nil {
+		return false
+	}
+	f, err := os.Open(jarPath)
+	if err != nil {
+		onLine(streamStderr, "制品库:打开 jar 失败(降级占位):"+err.Error())
+		return false
+	}
+	defer func() { _ = f.Close() }()
+
+	key, size, err := b.artStore.Put(f)
+	if err != nil {
+		onLine(streamStderr, "制品库:存 jar 失败(降级占位):"+err.Error())
+		return false
+	}
+	filename := filepath.Base(jarPath)
+	art.Reference = key
+	art.SizeBytes = size
+	if art.Metadata == nil {
+		art.Metadata = map[string]any{}
+	}
+	art.Metadata["stored"] = true
+	art.Metadata["format"] = "file"
+	art.Metadata["filename"] = filename
+	onLine(streamStdout, "制品库:已归档 jar "+filename+"(句柄 "+key[:12]+"…)")
+	return true
+}
+
+// storeDistDir 把 dist 目录打成 tar.gz 字节流存入制品库,改写 art.Reference 并补 metadata。
+// store 为 nil 或失败 → 不改 art(保持旧占位)。tar 用流式管道,大目录不占额外内存/磁盘临时。
+func (b *Builder) storeDistDir(art *run.Artifact, dirPath string, onLine func(stream, line string)) bool {
+	if b.artStore == nil {
+		return false
+	}
+	pr, pw := io.Pipe()
+	go func() {
+		// 把 dirPath 下内容打成 tar.gz 写入管道(出错经 CloseWithError 传到读端)。
+		pw.CloseWithError(tarGzDir(dirPath, pw))
+	}()
+
+	key, size, err := b.artStore.Put(pr)
+	_ = pr.Close()
+	if err != nil {
+		onLine(streamStderr, "制品库:存 dist(tar.gz)失败(降级占位):"+err.Error())
+		return false
+	}
+	art.Reference = key
+	art.SizeBytes = size
+	if art.Metadata == nil {
+		art.Metadata = map[string]any{}
+	}
+	art.Metadata["stored"] = true
+	art.Metadata["format"] = "tar.gz"
+	onLine(streamStdout, "制品库:已归档 dist 目录为 tar.gz(句柄 "+key[:12]+"…)")
+	return true
+}
+
+// tarGzDir 把 root 目录下的内容(不含 root 本身这层)打成 tar.gz 写入 w。
+// 仅打普通文件与目录(跳过符号链接等特殊文件,避免逃逸/不可移植);路径用相对 root 的斜杠路径。
+func tarGzDir(root string, w io.Writer) error {
+	gz := gzip.NewWriter(w)
+	tw := tar.NewWriter(gz)
+
+	walkErr := filepath.Walk(root, func(p string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if p == root {
+			return nil // 不打 root 自身,只打其内容
+		}
+		rel, rerr := filepath.Rel(root, p)
+		if rerr != nil {
+			return rerr
+		}
+		// 只处理普通文件与目录(符号链接/设备等跳过,防逃逸 + 跨平台可移植)。
+		if !fi.Mode().IsRegular() && !fi.IsDir() {
+			return nil
+		}
+		hdr, herr := tar.FileInfoHeader(fi, "")
+		if herr != nil {
+			return herr
+		}
+		hdr.Name = filepath.ToSlash(rel)
+		if fi.IsDir() {
+			hdr.Name += "/"
+		}
+		if werr := tw.WriteHeader(hdr); werr != nil {
+			return werr
+		}
+		if fi.IsDir() {
+			return nil
+		}
+		f, oerr := os.Open(p)
+		if oerr != nil {
+			return oerr
+		}
+		defer func() { _ = f.Close() }()
+		_, cerr := io.Copy(tw, f)
+		return cerr
+	})
+
+	// 先关 tar/gz 把缓冲刷净,再返回(walk 错误优先)。
+	if cerr := tw.Close(); cerr != nil && walkErr == nil {
+		walkErr = cerr
+	}
+	if cerr := gz.Close(); cerr != nil && walkErr == nil {
+		walkErr = cerr
+	}
+	return walkErr
+}

--- a/internal/build/artifact_persist_test.go
+++ b/internal/build/artifact_persist_test.go
@@ -1,0 +1,117 @@
+package build
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/artifactstore"
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+func newStoreBuilder(t *testing.T) (*Builder, *artifactstore.Store) {
+	t.Helper()
+	st, err := artifactstore.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("artifactstore.New: %v", err)
+	}
+	b := &Builder{driver: &recordingDriver{}, artStore: st}
+	return b, st
+}
+
+func TestLocateJarStoresRealBytes(t *testing.T) {
+	b, st := newStoreBuilder(t)
+	ws := t.TempDir()
+	jarBytes := []byte("PK\x03\x04 real jar bytes \x00\xff")
+	if err := os.WriteFile(filepath.Join(ws, "app.jar"), jarBytes, 0o644); err != nil {
+		t.Fatalf("write jar: %v", err)
+	}
+
+	art := b.locateFileArtifact(pipeline.ArtifactJAR, "shop", ws, func(string, string) {})
+
+	// 产物应是制品库支撑:reference=句柄,metadata.stored=true,filename 记原名。
+	if art.Metadata["stored"] != true {
+		t.Fatalf("jar 产物应 stored=true,metadata=%v", art.Metadata)
+	}
+	if art.Metadata["filename"] != "app.jar" {
+		t.Fatalf("filename 应为 app.jar,got %v", art.Metadata["filename"])
+	}
+	// 句柄取回的字节必须 == 原 jar 字节(真存了)。
+	rc, err := st.Open(art.Reference)
+	if err != nil {
+		t.Fatalf("Open(reference): %v", err)
+	}
+	defer rc.Close()
+	got, _ := io.ReadAll(rc)
+	if !bytes.Equal(got, jarBytes) {
+		t.Fatalf("制品库取回字节与构建 jar 不一致")
+	}
+}
+
+func TestLocateDistStoresTarGz(t *testing.T) {
+	b, st := newStoreBuilder(t)
+	ws := t.TempDir()
+	distDir := filepath.Join(ws, "dist")
+	if err := os.MkdirAll(filepath.Join(distDir, "assets"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	_ = os.WriteFile(filepath.Join(distDir, "index.html"), []byte("<html>hi</html>"), 0o644)
+	_ = os.WriteFile(filepath.Join(distDir, "assets", "app.js"), []byte("console.log(1)"), 0o644)
+
+	art := b.locateFileArtifact(pipeline.ArtifactDist, "shop", ws, func(string, string) {})
+
+	if art.Metadata["stored"] != true || art.Metadata["format"] != "tar.gz" {
+		t.Fatalf("dist 产物应 stored=true format=tar.gz,metadata=%v", art.Metadata)
+	}
+	// 取回 tar.gz 解开,应含 index.html 与 assets/app.js 的真内容。
+	rc, err := st.Open(art.Reference)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer rc.Close()
+	gz, err := gzip.NewReader(rc)
+	if err != nil {
+		t.Fatalf("gzip: %v", err)
+	}
+	tr := tar.NewReader(gz)
+	found := map[string]string{}
+	for {
+		h, e := tr.Next()
+		if e == io.EOF {
+			break
+		}
+		if e != nil {
+			t.Fatalf("tar: %v", e)
+		}
+		if h.Typeflag == tar.TypeReg {
+			b, _ := io.ReadAll(tr)
+			found[h.Name] = string(b)
+		}
+	}
+	if found["index.html"] != "<html>hi</html>" {
+		t.Fatalf("tar.gz 内 index.html 内容不对: %q", found["index.html"])
+	}
+	if found["assets/app.js"] != "console.log(1)" {
+		t.Fatalf("tar.gz 内 assets/app.js 内容不对: %q", found["assets/app.js"])
+	}
+}
+
+// 无制品库注入 → 保持旧占位行为(reference=文件名,无 stored 标记),向后兼容。
+func TestLocateWithoutStoreKeepsPlaceholder(t *testing.T) {
+	b := &Builder{driver: &recordingDriver{}} // artStore=nil
+	ws := t.TempDir()
+	_ = os.WriteFile(filepath.Join(ws, "app.jar"), []byte("x"), 0o644)
+	art := b.locateFileArtifact(pipeline.ArtifactJAR, "shop", ws, func(string, string) {})
+	if art.Reference != "app.jar" {
+		t.Fatalf("无制品库应保持 reference=文件名,got %q", art.Reference)
+	}
+	if _, ok := art.Metadata["stored"]; ok {
+		t.Fatalf("无制品库不应有 stored 标记")
+	}
+	_ = run.ArtifactJar
+}

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/huangchengsir/pipewright/internal/artifactstore"
 	"github.com/huangchengsir/pipewright/internal/pipeline"
 	"github.com/huangchengsir/pipewright/internal/project"
 	"github.com/huangchengsir/pipewright/internal/run"
@@ -46,6 +47,11 @@ type Builder struct {
 	vault    vault.Vault
 	driver   Driver
 	cloner   repoCloner
+	// artStore 是制品库(Story 8-16):非 nil 时构建后把 jar/dist 真字节归档,产物 reference 改存句柄;
+	// nil 则保持旧行为(reference=文件名占位)。由 main 注入(WithArtifactStore)。
+	artStore *artifactstore.Store
+	// disableImageGC 关闭「构建后清悬空镜像」(Story 8-17);默认开(false)。由 main 经 env 设置。
+	disableImageGC bool
 }
 
 // repoCloner 抽象「把仓库在 ref 上克隆到磁盘工作区」的能力(便于 fake 单测注入,
@@ -73,6 +79,21 @@ func WithCloner(c repoCloner) BuilderOption {
 			b.cloner = c
 		}
 	}
+}
+
+// WithArtifactStore 注入制品库(Story 8-16):构建后把 jar/dist 真字节归档,产物 reference 改存句柄。
+// nil 不改(保持旧占位行为)。
+func WithArtifactStore(s *artifactstore.Store) BuilderOption {
+	return func(b *Builder) {
+		if s != nil {
+			b.artStore = s
+		}
+	}
+}
+
+// WithImageGC 开关「构建后清悬空镜像」(Story 8-17);默认开。传 false 关闭(如宿主另有镜像 GC 策略)。
+func WithImageGC(enabled bool) BuilderOption {
+	return func(b *Builder) { b.disableImageGC = !enabled }
 }
 
 // NewBuilder 构造真实 Builder。driver 经 DetectDriver 探测(全无容器 CLI → ErrNoContainerCLI,
@@ -239,6 +260,10 @@ func (b *Builder) Run(ctx context.Context, r *run.Run, sink run.StepSink) error 
 	if artifact != nil {
 		_ = sink.EmitArtifact(ctx, *artifact)
 	}
+
+	// 构建后清悬空镜像(Story 8-17):防中控机镜像缓存随重复构建无限增长。
+	// best-effort、只清 dangling、绝不影响构建结果(已 success);经构建步骤序号喂日志。
+	b.pruneImagesBestEffort(ctx, b.lineSink(sink, len(steps)-1))
 	return nil
 }
 
@@ -439,10 +464,13 @@ func (b *Builder) locateFileArtifact(artifactType, slug, workspace string, onLin
 		if p := findFirst(workspace, ".jar"); p != "" {
 			size := fileSize(p)
 			onLine(streamStdout, "产物:"+filepath.Base(p)+"("+itoa(size)+" bytes)")
-			return &run.Artifact{
+			art := &run.Artifact{
 				Type: run.ArtifactJar, Name: slug, Reference: filepath.Base(p), SizeBytes: size,
 				Metadata: map[string]any{"builder": b.driver.Binary(), "path": filepath.Base(p)},
 			}
+			// 制品库:把 jar 真字节归档,reference 改存句柄(供部署取真字节);未配则保持占位。
+			b.storeJarBytes(art, p, onLine)
+			return art
 		}
 	case pipeline.ArtifactDist:
 		// 常见 dist 输出目录:dist / build / out。
@@ -451,10 +479,13 @@ func (b *Builder) locateFileArtifact(artifactType, slug, workspace string, onLin
 			if isDir(full) {
 				size := dirSize(full)
 				onLine(streamStdout, "产物目录:"+d+"/("+itoa(size)+" bytes)")
-				return &run.Artifact{
+				art := &run.Artifact{
 					Type: run.ArtifactDist, Name: slug + "-dist", Reference: d + "/", SizeBytes: size,
 					Metadata: map[string]any{"builder": b.driver.Binary(), "path": d + "/"},
 				}
+				// 制品库:把 dist 目录打 tar.gz 归档,reference 改存句柄;未配则保持占位。
+				b.storeDistDir(art, full, onLine)
+				return art
 			}
 		}
 	}

--- a/internal/build/image_gc.go
+++ b/internal/build/image_gc.go
@@ -1,0 +1,45 @@
+package build
+
+// image_gc.go 是「镜像缓存自动管理」(Story 8-17 / FR-8-17):构建跑在中控机的容器 daemon 上,
+// `docker run --rm` 只删容器**不删镜像** —— 重复构建会攒下大量**悬空(dangling/<none>)镜像**与层缓存,
+// 磁盘随时间增长。本文件在每次构建后(尽力)清理悬空镜像,默认开启,可经 WithImageGC(false) 关。
+//
+// 安全边界:**只清悬空镜像**(`image prune -f`,即 dangling=true,被新构建顶替的无 tag 旧层),
+// **绝不动有 tag 的镜像**(工具链缓存 node:20 等、本次 localTag 产物镜像都保留),不会误删在用镜像、
+// 不会破坏缓存命中。清理是 best-effort:失败只记日志,绝不影响构建成败。
+
+import "context"
+
+// imagePruner 是「清悬空镜像」的可选能力(shellDriver 实现)。独立于 Driver 接口,
+// 避免给所有 Driver 实现/假驱动新增方法;Builder 经类型断言择优调用。
+type imagePruner interface {
+	// PruneDangling 清理悬空(无 tag)镜像与构建层缓存(`<bin> image prune -f`)。
+	// 返回是否成功执行(退出码 0)。逐行输出经 onLine。
+	PruneDangling(ctx context.Context, onLine func(stream, line string)) (ok bool, err error)
+}
+
+// PruneDangling 实现 imagePruner:`<bin> image prune -f`(只清 dangling,不碰有 tag 镜像)。
+func (d *shellDriver) PruneDangling(ctx context.Context, onLine func(stream, line string)) (bool, error) {
+	args := []string{"image", "prune", "-f"}
+	emitCmd(onLine, d.bin, args)
+	code, err := d.cmdr.Stream(ctx, d.bin, args, "", onLine)
+	if err != nil {
+		return false, err
+	}
+	return code == 0, nil
+}
+
+// pruneImagesBestEffort 在构建后尽力清悬空镜像(Story 8-17):driver 支持且未关 GC 时执行。
+// 任何失败仅记一行日志,绝不影响构建结果(NFR-10:运维便利不能反噬核心 CI/CD)。
+func (b *Builder) pruneImagesBestEffort(ctx context.Context, onLine func(stream, line string)) {
+	if b.disableImageGC {
+		return
+	}
+	pruner, ok := b.driver.(imagePruner)
+	if !ok {
+		return // 远程/桩等不支持本地镜像清理的驱动:跳过(不报错)。
+	}
+	if _, err := pruner.PruneDangling(ctx, onLine); err != nil {
+		onLine(streamStderr, "镜像清理(悬空)失败,忽略不影响构建:"+err.Error())
+	}
+}

--- a/internal/build/image_gc_test.go
+++ b/internal/build/image_gc_test.go
@@ -1,0 +1,52 @@
+package build
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestPruneDanglingRunsImagePrune(t *testing.T) {
+	cmdr := newFakeCommander()
+	cmdr.script("image", fakeCmd{exitCode: 0, stdoutLines: []string{"Total reclaimed space: 1.2GB"}})
+	drv := &shellDriver{bin: "docker", cmdr: cmdr}
+
+	ok, err := drv.PruneDangling(context.Background(), func(string, string) {})
+	if err != nil || !ok {
+		t.Fatalf("PruneDangling ok=%v err=%v", ok, err)
+	}
+	// 只能是 `docker image prune -f`(只清悬空,绝不带 -a / 不删有 tag 镜像)。
+	all := cmdr.allArgsText()
+	if !strings.Contains(all, "image prune -f") {
+		t.Fatalf("应执行 image prune -f,实际:%s", all)
+	}
+	if strings.Contains(all, "prune -a") || strings.Contains(all, "--all") {
+		t.Fatalf("绝不应带 -a/--all(会删有 tag 镜像):%s", all)
+	}
+}
+
+func TestPruneImagesBestEffortRunsWhenEnabled(t *testing.T) {
+	cmdr := newFakeCommander()
+	cmdr.script("image", fakeCmd{exitCode: 0})
+	b := &Builder{driver: &shellDriver{bin: "docker", cmdr: cmdr}}
+	b.pruneImagesBestEffort(context.Background(), func(string, string) {})
+	if !strings.Contains(cmdr.allArgsText(), "image prune -f") {
+		t.Fatalf("默认应清悬空镜像,实际:%s", cmdr.allArgsText())
+	}
+}
+
+func TestPruneImagesBestEffortSkipsWhenDisabled(t *testing.T) {
+	cmdr := newFakeCommander()
+	cmdr.script("image", fakeCmd{exitCode: 0})
+	b := &Builder{driver: &shellDriver{bin: "docker", cmdr: cmdr}, disableImageGC: true}
+	b.pruneImagesBestEffort(context.Background(), func(string, string) {})
+	if strings.Contains(cmdr.allArgsText(), "prune") {
+		t.Fatalf("关闭 GC 后不应清镜像,实际:%s", cmdr.allArgsText())
+	}
+}
+
+// 驱动不支持镜像清理(如远程/桩)→ 静默跳过,不 panic、不报错。
+func TestPruneImagesBestEffortNoopForNonPruner(t *testing.T) {
+	b := &Builder{driver: &recordingDriver{}} // recordingDriver 不实现 imagePruner
+	b.pruneImagesBestEffort(context.Background(), func(string, string) {})
+}

--- a/internal/deploy/artifact_store_centos_e2e_test.go
+++ b/internal/deploy/artifact_store_centos_e2e_test.go
@@ -1,0 +1,102 @@
+package deploy
+
+// artifact_store_centos_e2e_test.go 是「制品库部署真字节」(Story 8-16 / FR-8-16)的**真容器 e2e**:
+// 复用 CentOS+sshd 容器,验 fake 证不到的真实链路 —— 把制品库里的 dist **真 tar.gz 字节**经 SSH
+// (target.Upload = cat > file 流式)落到目标机,远端解包,容器内 cat 出**真文件树**(非占位 reference 串)。
+//
+// 默认 SKIP(PIPEWRIGHT_E2E_DEPLOY=1 启用)。跑法:
+//   PIPEWRIGHT_E2E_DEPLOY=1 go test ./internal/deploy/ -run E2EArtifactStore -v
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/huangchengsir/pipewright/internal/artifactstore"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// TestE2EArtifactStoreDistUntar:制品库存 dist 的 tar.gz → 部署 → 容器内远端解包出真文件树。
+func TestE2EArtifactStoreDistUntar(t *testing.T) {
+	fleet, key := startCentOSFleet(t, 1)
+	h := newMultiHarness(t, fleet, key)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	store, err := artifactstore.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	tarGz := buildTestTarGz(t, map[string]string{
+		"index.html":    "<html>PIPEWRIGHT-REAL</html>",
+		"assets/app.js": "console.log('real dist bytes')",
+	})
+	skey, _, err := store.Put(bytes.NewReader(tarGz))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	runID, artID := seedSuccessRunWithStoredArtifact(t, h.db, h.rsvc, run.ArtifactDist, skey,
+		map[string]any{"stored": true, "format": "tar.gz"})
+
+	base := "/opt/pw-dist-" + uuid.NewString()[:8]
+	dsvc := New(h.targets, h.rsvc, WithArtifactStore(store)) // 注入制品库的部署服务
+	res, err := dsvc.Deploy(ctx, DeployInput{
+		RunID: runID, ArtifactID: artID, ServerIDs: h.serverIDs,
+		Config: map[string]string{"releaseBase": base},
+	})
+	if err != nil {
+		t.Fatalf("dist Deploy: %v", err)
+	}
+	if res[0].Status != run.TargetSuccess {
+		t.Fatalf("dist 部署应 success,实际 %s / %q", res[0].Status, res[0].Message)
+	}
+
+	// 容器内发布目录应被解包出**真文件树**(且无残留临时 tar.gz)。
+	releaseDir := base + "/releases/" + runID
+	idx, err := fleet[0].Exec(t, "cat", releaseDir+"/index.html")
+	if err != nil || !strings.Contains(idx, "PIPEWRIGHT-REAL") {
+		t.Fatalf("容器内 index.html 应为真 dist 内容:%q err=%v", idx, err)
+	}
+	js, err := fleet[0].Exec(t, "cat", releaseDir+"/assets/app.js")
+	if err != nil || !strings.Contains(js, "real dist bytes") {
+		t.Fatalf("容器内 assets/app.js 应为真 dist 内容:%q err=%v", js, err)
+	}
+	if _, err := fleet[0].Exec(t, "test", "-e", releaseDir+"/.pw-artifact.tar.gz"); err == nil {
+		t.Fatal("解包后应删除临时 tar.gz,但仍存在")
+	}
+	// current 软链应已切到本次发布(零停机切换)。
+	cur, _ := fleet[0].Exec(t, "readlink", base+"/current")
+	if strings.TrimSpace(cur) != releaseDir {
+		t.Fatalf("current 应切到本次发布,实际 %q", strings.TrimSpace(cur))
+	}
+	t.Logf("✅ 制品库 dist(tar.gz)经 SSH Upload + 远端解包,CentOS 容器内得到真文件树 + current 软链切换")
+}
+
+// buildTestTarGz 把 files(相对路径→内容)打成 tar.gz 字节(供 e2e 造真 dist 产物)。
+func buildTestTarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		hdr := &tar.Header{Name: name, Mode: 0o644, Size: int64(len(content)), Typeflag: tar.TypeReg}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("tar header: %v", err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("tar write: %v", err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gz close: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/internal/deploy/artifact_store_test.go
+++ b/internal/deploy/artifact_store_test.go
@@ -1,0 +1,124 @@
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/huangchengsir/pipewright/internal/artifactstore"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// seedSuccessRunWithStoredArtifact 像 seedSuccessRunWithArtifact,但产物带制品库句柄 + metadata
+// (Story 8-16:reference=storeKey,stored=true)。
+func seedSuccessRunWithStoredArtifact(t *testing.T, db *sql.DB, rsvc run.Service, artType, storeKey string, meta map[string]any) (string, string) {
+	t.Helper()
+	runID, _ := seedSuccessRunWithArtifact(t, db, rsvc, artType, "placeholder")
+	art, err := rsvc.AddArtifact(context.Background(), run.Artifact{
+		RunID: runID, Type: artType, Name: "shop", Reference: storeKey, Metadata: meta,
+	})
+	if err != nil {
+		t.Fatalf("AddArtifact stored: %v", err)
+	}
+	return runID, art.ID
+}
+
+// 制品库支撑的 jar 部署:目标机落的是**真 jar 字节**(经 Upload),不是占位 reference 串。
+func TestDeployStoredJarUploadsRealBytes(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	store, err := artifactstore.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	jarBytes := []byte("PK\x03\x04 REAL jar payload \x00\xff\xfe")
+	key, _, err := store.Put(bytes.NewReader(jarBytes))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	tgt := &stubTarget{}
+	srv := seedServer(t, tgt, "web-1")
+	runID, artID := seedSuccessRunWithStoredArtifact(t, db, rsvc, run.ArtifactJar, key,
+		map[string]any{"stored": true, "format": "file", "filename": "app.jar"})
+
+	svc := New(tgt, rsvc, WithArtifactStore(store))
+	base := "/srv/app-" + uuid.NewString()[:6]
+	res, err := svc.Deploy(context.Background(), DeployInput{
+		RunID: runID, ArtifactID: artID, ServerIDs: []string{srv.ID},
+		Config: map[string]string{"releaseBase": base},
+	})
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if res[0].Status != run.TargetSuccess {
+		t.Fatalf("status = %s (msg %q), want success", res[0].Status, res[0].Message)
+	}
+	// 目标机发布目录里应被 Upload 了**真 jar 字节**(非 reference 串占位)。
+	wantPath := base + "/releases/" + runID + "/app.jar"
+	got, ok := tgt.uploads[wantPath]
+	if !ok {
+		t.Fatalf("未在 %s 上传产物;uploads=%v", wantPath, keysOf(tgt.uploads))
+	}
+	if !bytes.Equal(got, jarBytes) {
+		t.Fatalf("上传的不是真 jar 字节")
+	}
+	// 且绝不应再走旧的「base64 写 reference 串」占位路径。
+	for _, c := range tgt.calls {
+		if len(c) >= 3 && strings.Contains(strings.Join(c, " "), "base64 -d") {
+			t.Fatalf("制品库产物不应再用 base64 占位写入:%v", c)
+		}
+	}
+}
+
+// 制品库支撑的 dist 部署:上传 tar.gz 并远端解包(命令含 tar -xzf)。
+func TestDeployStoredDistUploadsAndUntars(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	store, _ := artifactstore.New(t.TempDir())
+	key, _, _ := store.Put(bytes.NewReader([]byte("\x1f\x8b fake tar.gz bytes")))
+
+	tgt := &stubTarget{}
+	srv := seedServer(t, tgt, "web-1")
+	runID, artID := seedSuccessRunWithStoredArtifact(t, db, rsvc, run.ArtifactDist, key,
+		map[string]any{"stored": true, "format": "tar.gz"})
+
+	svc := New(tgt, rsvc, WithArtifactStore(store))
+	base := "/srv/web-" + uuid.NewString()[:6]
+	res, err := svc.Deploy(context.Background(), DeployInput{
+		RunID: runID, ArtifactID: artID, ServerIDs: []string{srv.ID},
+		Config: map[string]string{"releaseBase": base},
+	})
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if res[0].Status != run.TargetSuccess {
+		t.Fatalf("status = %s (msg %q), want success", res[0].Status, res[0].Message)
+	}
+	// 应上传了 tar.gz。
+	tarPath := base + "/releases/" + runID + "/.pw-artifact.tar.gz"
+	if _, ok := tgt.uploads[tarPath]; !ok {
+		t.Fatalf("未上传 dist tar.gz 到 %s", tarPath)
+	}
+	// 远端应解包(命令序列含 tar -xzf)。
+	var sawUntar bool
+	for _, c := range tgt.calls {
+		if len(c) >= 2 && c[0] == "tar" && c[1] == "-xzf" {
+			sawUntar = true
+		}
+	}
+	if !sawUntar {
+		t.Fatalf("dist 部署应在远端 tar -xzf 解包;calls=%v", tgt.calls)
+	}
+}
+
+func keysOf(m map[string][]byte) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/huangchengsir/pipewright/internal/artifactstore"
 	"github.com/huangchengsir/pipewright/internal/run"
 	"github.com/huangchengsir/pipewright/internal/target"
 )
@@ -117,6 +118,9 @@ type service struct {
 	// diagnoseHook 是部署失败后的 best-effort 自动诊断钩子(Story 4.6;FR-22 种子)。
 	// 由 main 注入(复用 7-2 NewDiagnoseHook);nil 则跳过。deploy 不 import ai(钩子解耦)。
 	diagnoseHook func(ctx context.Context, runID string)
+	// artStore 是制品库(Story 8-16):非 nil 时部署 release 类「已归档」产物会取真字节经 SSH 上传到
+	// 目标机;nil 或产物非归档 → 旧占位路径(向后兼容)。由 main 注入(WithArtifactStore)。
+	artStore *artifactstore.Store
 }
 
 // Option 配置 deploy.Service(如注入诊断钩子)。
@@ -126,6 +130,15 @@ type Option func(*service)
 // 部署 failed/partial_failed → 合成失败日志(SetFailureLog)+ 触发钩子,让 7-2 诊断飞轮覆盖部署失败。
 func WithDiagnoseHook(fn func(ctx context.Context, runID string)) Option {
 	return func(s *service) { s.diagnoseHook = fn }
+}
+
+// WithArtifactStore 注入制品库(Story 8-16):部署 release 类已归档产物时取真字节上传目标机。
+func WithArtifactStore(st *artifactstore.Store) Option {
+	return func(s *service) {
+		if st != nil {
+			s.artStore = st
+		}
+	}
 }
 
 // New 构造部署 Service。

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -27,6 +27,8 @@ type stubTarget struct {
 	callMu sync.Mutex
 	// calls 记录所有 Exec 命令(断言 array 化:每条是 []string 而非拼接 shell)。
 	calls [][]string
+	// uploads 记录 Upload 的 remotePath→字节(断言部署落的是真产物字节,非占位 reference)。
+	uploads map[string][]byte
 }
 
 func (s *stubTarget) Get(_ context.Context, id string) (*target.Server, error) {
@@ -62,6 +64,18 @@ func (s *stubTarget) ExecStream(context.Context, string, []string) (io.ReadClose
 
 func (s *stubTarget) ExecInteractive(context.Context, string, []string) (target.Session, error) {
 	return nil, errors.New("execinteractive not supported in stub")
+}
+
+// Upload 满足 target.Service(Story 8-16 制品库部署);桩捕获上传字节供断言「部署的是真字节」。
+func (s *stubTarget) Upload(_ context.Context, _ string, content io.Reader, remotePath string) error {
+	b, _ := io.ReadAll(content)
+	s.callMu.Lock()
+	if s.uploads == nil {
+		s.uploads = map[string][]byte{}
+	}
+	s.uploads[remotePath] = b
+	s.callMu.Unlock()
+	return nil
 }
 
 // ---- 测试脚手架 -------------------------------------------------------------

--- a/internal/deploy/multi_target_centos_e2e_test.go
+++ b/internal/deploy/multi_target_centos_e2e_test.go
@@ -121,6 +121,7 @@ type multiHarness struct {
 	db        *sql.DB
 	rsvc      run.Service
 	dsvc      Service
+	targets   target.Service // 暴露真 target(供制品库部署 e2e 重建带 store 的 deploy.Service)
 	serverIDs []string
 }
 
@@ -152,7 +153,7 @@ func newMultiHarness(t *testing.T, fleet []*sshContainer, privKey string) *multi
 		ids = append(ids, srv.ID)
 	}
 	rsvc := run.New(st.DB)
-	return &multiHarness{db: st.DB, rsvc: rsvc, dsvc: New(tgt, rsvc), serverIDs: ids}
+	return &multiHarness{db: st.DB, rsvc: rsvc, dsvc: New(tgt, rsvc), targets: tgt, serverIDs: ids}
 }
 
 // TestE2EMultiTargetDeployAllSuccess 把一份 dist 并行部署到 3 台 CentOS,验全成功 + 每台真落地。

--- a/internal/deploy/release.go
+++ b/internal/deploy/release.go
@@ -135,7 +135,15 @@ func (s *service) stageReleaseOne(ctx context.Context, srv *target.Server, a run
 	// 1) 探测上一发布(readlink current);失败 / 无软链 → prev 为空(首次部署,无可回滚)。
 	st.prev = s.readCurrentRelease(execCtx, srv.ID, st.current)
 
-	// 2) mkdir 发布目录 → 写入产物负载(base64 经 array 命令落地,不拼 shell)。
+	// 2) 放置产物到发布目录。**制品库支撑的产物(Story 8-16)走「上传真字节」**;否则旧占位路径。
+	if isStoredArtifact(a) {
+		if failMsg, ok := s.stageStoredArtifact(execCtx, srv, a, st, file); !ok {
+			return st, failMsg, false
+		}
+		return st, "", true
+	}
+
+	// 旧路径(向后兼容:无制品库的历史产物)——把 reference 串当占位写入(非真字节)。
 	payload := base64.StdEncoding.EncodeToString([]byte(a.Reference + "\n"))
 	placeCmds := [][]string{
 		{"mkdir", "-p", st.release},
@@ -149,6 +157,83 @@ func (s *service) stageReleaseOne(ctx context.Context, srv *target.Server, a run
 		return st, failMsg, false
 	}
 	return st, "", true
+}
+
+// stageStoredArtifact 把制品库里的**真字节**落到目标机发布目录(Story 8-16):
+//   - jar  (format=file)  : 上传到 <release>/<filename>,再探 java -jar 启动命令。
+//   - dist (format=tar.gz): 上传 tar.gz → 远端解包到 <release> → 删临时包。
+//
+// jarFile 是旧占位路径算出的目标文件路径(<release>/<deployFileName>);jar 沿用它,
+// dist 用 metadata 的 tar.gz 临时名。制品库未配 / 取字节失败 / 上传失败 → (人读 message, false)。
+func (s *service) stageStoredArtifact(ctx context.Context, srv *target.Server, a run.Artifact, st releaseState, jarFile string) (string, bool) {
+	if s.artStore == nil {
+		return "部署侧未配置制品库,无法取产物真字节(产物已归档但制品库不可用)", false
+	}
+	rc, err := s.artStore.Open(a.Reference)
+	if err != nil {
+		return "从制品库取产物失败:" + err.Error(), false
+	}
+	defer func() { _ = rc.Close() }()
+
+	// 先建发布目录(Upload 自身也会 mkdir 父目录,这里显式建一次,语义清晰)。
+	if failMsg, ok := s.runStep(ctx, srv.ID, [][]string{{"mkdir", "-p", st.release}}); !ok {
+		return failMsg, false
+	}
+
+	switch artifactFormat(a) {
+	case "tar.gz":
+		// dist:上传 tar.gz → 远端解包 → 删包。
+		tarPath := path.Join(st.release, ".pw-artifact.tar.gz")
+		if err := s.targets.Upload(ctx, srv.ID, rc, tarPath); err != nil {
+			return "上传 dist 制品到目标机失败:" + humanExecError(err), false
+		}
+		unpack := [][]string{
+			{"tar", "-xzf", tarPath, "-C", st.release},
+			{"rm", "-f", tarPath},
+		}
+		if failMsg, ok := s.runStep(ctx, srv.ID, unpack); !ok {
+			return "目标机解包 dist 失败:" + failMsg, false
+		}
+		return "", true
+
+	default:
+		// jar / 其它单文件:上传到目标文件路径。
+		dest := jarFile
+		if name := artifactFilename(a); name != "" {
+			dest = path.Join(st.release, name)
+		}
+		if err := s.targets.Upload(ctx, srv.ID, rc, dest); err != nil {
+			return "上传 jar 制品到目标机失败:" + humanExecError(err), false
+		}
+		if a.Type == run.ArtifactJar {
+			if failMsg, ok := s.runStep(ctx, srv.ID, [][]string{{"java", "-jar", dest, "--version"}}); !ok {
+				return failMsg, false
+			}
+		}
+		return "", true
+	}
+}
+
+// isStoredArtifact 报告产物是否由制品库归档(metadata.stored=true → 部署取真字节)。
+func isStoredArtifact(a run.Artifact) bool {
+	v, ok := a.Metadata["stored"].(bool)
+	return ok && v
+}
+
+// artifactFormat 取产物存储格式(file | tar.gz;缺省 file)。
+func artifactFormat(a run.Artifact) string {
+	if f, ok := a.Metadata["format"].(string); ok && f != "" {
+		return f
+	}
+	return "file"
+}
+
+// artifactFilename 取产物原始文件名(jar 部署落盘名;缺省空)。
+func artifactFilename(a run.Artifact) string {
+	if n, ok := a.Metadata["filename"].(string); ok {
+		return n
+	}
+	return ""
 }
 
 // activateReleaseOne 执行 release 模式的**切换阶段**:原子切换 current → 本次发布 + 切后健康门控 +

--- a/internal/httpapi/container_terminal_test.go
+++ b/internal/httpapi/container_terminal_test.go
@@ -95,6 +95,9 @@ type fakeInteractiveDialer struct {
 func (d *fakeInteractiveDialer) Run(_ context.Context, _ string, _ target.SSHConfig, _ []string) (*target.ExecResult, error) {
 	return &target.ExecResult{}, nil
 }
+func (d *fakeInteractiveDialer) RunWithStdin(_ context.Context, _ string, _ target.SSHConfig, _ []string, _ io.Reader) (*target.ExecResult, error) {
+	return &target.ExecResult{}, nil
+}
 func (d *fakeInteractiveDialer) RunStream(_ context.Context, _ string, _ target.SSHConfig, _ []string) (io.ReadCloser, error) {
 	return io.NopCloser(strings.NewReader("")), nil
 }

--- a/internal/httpapi/server_metrics_test.go
+++ b/internal/httpapi/server_metrics_test.go
@@ -134,6 +134,10 @@ func (d cmdDialer) RunInteractive(_ context.Context, _ string, _ target.SSHConfi
 	return nil, nil
 }
 
+func (d cmdDialer) RunWithStdin(_ context.Context, _ string, _ target.SSHConfig, cmd []string, _ io.Reader) (*target.ExecResult, error) {
+	return d.fn(cmd)
+}
+
 // linuxLikeDialer 模拟一台 Linux 服务器:loadavg/nproc/free/df 全可回显。
 func linuxLikeDialer() cmdDialer {
 	return cmdDialer{fn: func(cmd []string) (*target.ExecResult, error) {

--- a/internal/httpapi/server_ops_test.go
+++ b/internal/httpapi/server_ops_test.go
@@ -102,6 +102,11 @@ func (d *capturingDialer) Run(_ context.Context, _ string, _ target.SSHConfig, c
 	return d.res, d.err
 }
 
+func (d *capturingDialer) RunWithStdin(_ context.Context, _ string, _ target.SSHConfig, cmd []string, _ io.Reader) (*target.ExecResult, error) {
+	d.lastCmd = cmd
+	return d.res, d.err
+}
+
 func (d *capturingDialer) RunStream(_ context.Context, _ string, _ target.SSHConfig, _ []string) (io.ReadCloser, error) {
 	return nil, d.err
 }

--- a/internal/httpapi/servers_test.go
+++ b/internal/httpapi/servers_test.go
@@ -39,6 +39,10 @@ func (d stubDialer) RunInteractive(_ context.Context, _ string, _ target.SSHConf
 	return nil, d.err
 }
 
+func (d stubDialer) RunWithStdin(_ context.Context, _ string, _ target.SSHConfig, _ []string, _ io.Reader) (*target.ExecResult, error) {
+	return d.res, d.err
+}
+
 // setupServerAPI 构造带 auth + vault + target 的测试 server。
 func setupServerAPI(t *testing.T, dialer target.SSHDialer) (*httptest.Server, *http.Client, string) {
 	t.Helper()

--- a/internal/target/ssh.go
+++ b/internal/target/ssh.go
@@ -91,6 +91,60 @@ func (sshDialer) Run(ctx context.Context, addr string, cfg SSHConfig, cmd []stri
 	return res, nil
 }
 
+// RunWithStdin 同 Run,但把 stdin 接到远端命令标准输入(供 `cat > file` 流式上传产物字节)。
+// 与 Run 同样的连接/认证/超时/退出码语义;stdin 读尽即由 session 关闭远端 stdin。
+func (sshDialer) RunWithStdin(ctx context.Context, addr string, cfg SSHConfig, cmd []string, stdin io.Reader) (*ExecResult, error) {
+	auth, err := authMethods(cfg)
+	if err != nil {
+		return nil, err
+	}
+	clientCfg := &ssh.ClientConfig{
+		User:            cfg.User,
+		Auth:            auth,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec // dev-only;生产固定 known_hosts(deferred)
+		Timeout:         resolveTimeout(ctx),
+	}
+	d := net.Dialer{Timeout: clientCfg.Timeout}
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("%w", classifyDialErr(err))
+	}
+	sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, clientCfg)
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("%w", classifyHandshakeErr(err))
+	}
+	client := ssh.NewClient(sshConn, chans, reqs)
+	defer func() { _ = client.Close() }()
+
+	session, err := client.NewSession()
+	if err != nil {
+		return nil, fmt.Errorf("%w", ErrUnreachable)
+	}
+	defer func() { _ = session.Close() }()
+
+	var stdout, stderr bytes.Buffer
+	session.Stdout = &stdout
+	session.Stderr = &stderr
+	session.Stdin = stdin // 产物字节经 stdin 流式喂给远端 `cat > file`(无 argv 长度限)。
+
+	runErr := runWithContext(ctx, session, quoteArgs(cmd))
+	res := &ExecResult{Stdout: stdout.String(), Stderr: stderr.String()}
+	if runErr != nil {
+		var exitErr *ssh.ExitError
+		if errors.As(runErr, &exitErr) {
+			res.ExitCode = exitErr.ExitStatus()
+			return res, nil
+		}
+		if errors.Is(runErr, context.DeadlineExceeded) || errors.Is(runErr, context.Canceled) {
+			return nil, runErr
+		}
+		return nil, fmt.Errorf("%w", ErrUnreachable)
+	}
+	res.ExitCode = 0
+	return res, nil
+}
+
 // RunStream 建连后在 session 上启动 cmd 并返回 stdout 流。底层 client/session 的生命周期
 // 绑定到返回的 ReadCloser:Close()(或 ctx 取消)即关 session + client,释放远端进程与 TCP。
 //

--- a/internal/target/target.go
+++ b/internal/target/target.go
@@ -132,6 +132,11 @@ type Service interface {
 	// (AC-SEC-02);凭据经 vault 即用即弃,绝不日志。调用方关闭 Session(或 ctx 取消)即释放远端
 	// PTY + SSH session/client(不泄漏)。
 	ExecInteractive(ctx context.Context, serverID string, cmd []string) (Session, error)
+	// Upload 把 content 的字节流式写到目标机的 remotePath(Story 8-16 / FR-8-16:制品库部署真字节)。
+	// 实现:经 SSH session 把 content 接到 `cat > <remotePath>` 的 stdin —— 流式、无 argv 长度上限、
+	// 大文件友好;remotePath 作 array 参数 shell 转义(AC-SEC-02),不拼 shell。远端非零退出 / 连接失败
+	// → 人读错误(绝无凭据明文)。供部署把制品库里的 jar/dist 真字节落到目标机。
+	Upload(ctx context.Context, serverID string, content io.Reader, remotePath string) error
 }
 
 // Session 是一个双向交互式 SSH/PTY 会话(Story 6.4;FR-18)。
@@ -160,6 +165,9 @@ type SSHDialer interface {
 	// 返回双向 Session(stdin 写 / stdout+stderr 读 / resize / close)。Session 关闭或 ctx
 	// 取消时,远端 PTY + 底层 SSH session/client 一并关闭(不泄漏)。cmd 经各参数 shell 转义。
 	RunInteractive(ctx context.Context, addr string, cfg SSHConfig, cmd []string) (Session, error)
+	// RunWithStdin 同 Run,但把 stdin 接到远端命令的标准输入(供 `cat > file` 流式上传)。
+	// stdin 读尽即关闭远端 stdin;返回退出码/输出。连接/认证失败映射为 ErrUnreachable / ErrAuth。
+	RunWithStdin(ctx context.Context, addr string, cfg SSHConfig, cmd []string, stdin io.Reader) (*ExecResult, error)
 }
 
 // SSHConfig 是拨号所需的最小认证材料(进程内,用完即弃)。
@@ -437,6 +445,61 @@ func (s *service) Exec(ctx context.Context, serverID string, cmd []string) (*Exe
 		return nil, runErr
 	}
 	return res, nil
+}
+
+// Upload 把 content 流式写到目标机 remotePath(Story 8-16:制品库部署真字节)。
+// 经 SSH 把 content 接到远端 `mkdir -p <dir> && cat > <remotePath>` 的 stdin —— 流式、无 argv 长度限、
+// 大文件友好;remotePath 作位置参数 shell 转义(AC-SEC-02 不拼 shell);凭据明文用完即清。
+// 远端非零退出 → 人读错误(含 stderr 摘要,绝无凭据明文);连接/认证失败 → ErrUnreachable / ErrAuth。
+func (s *service) Upload(ctx context.Context, serverID string, content io.Reader, remotePath string) error {
+	if content == nil {
+		return fmt.Errorf("target: nil content")
+	}
+	if strings.TrimSpace(remotePath) == "" {
+		return fmt.Errorf("target: empty remote path")
+	}
+	srv, err := s.Get(ctx, serverID)
+	if err != nil {
+		return err
+	}
+	if s.vault == nil {
+		return ErrVaultUnconfigured
+	}
+	secret, err := s.vault.Get(srv.CredentialID)
+	if err != nil {
+		switch {
+		case errors.Is(err, vault.ErrVaultUnconfigured):
+			return ErrVaultUnconfigured
+		case errors.Is(err, vault.ErrNotFound):
+			return ErrCredentialNotFound
+		default:
+			return ErrAuth
+		}
+	}
+	cfg := SSHConfig{User: srv.User}
+	if looksLikePEM(secret) {
+		cfg.PrivateKey = secret
+	} else {
+		cfg.Password = secret
+	}
+
+	// remotePath 作 $0(位置参数),绝不拼进脚本体;dir 先建好再写,写整文件经 stdin 流入。
+	cmd := []string{"sh", "-c", `mkdir -p "$(dirname "$0")" && cat > "$0"`, remotePath}
+	addr := fmt.Sprintf("%s:%d", srv.Host, srv.Port)
+	res, runErr := s.dialer.RunWithStdin(ctx, addr, cfg, cmd, content)
+
+	secret = ""
+	cfg.PrivateKey = ""
+	cfg.Password = ""
+	_ = secret
+
+	if runErr != nil {
+		return runErr
+	}
+	if res != nil && res.ExitCode != 0 {
+		return fmt.Errorf("target: upload 失败(退出码 %d):%s", res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	return nil
 }
 
 // ExecStream 取凭据明文装配 SSH 配置并流式跑 array 命令(供实时 tail)。

--- a/internal/target/target_test.go
+++ b/internal/target/target_test.go
@@ -1,6 +1,7 @@
 package target
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"io"
@@ -54,6 +55,7 @@ type capturingDialer struct {
 	gotCmd    []string
 	res       *ExecResult
 	err       error
+	gotStdin  []byte // RunWithStdin 捕获的上传字节
 	streamOut string // RunStream 返回的流内容
 	streamErr error  // RunStream 返回的错误
 
@@ -76,6 +78,16 @@ func (d *capturingDialer) RunStream(_ context.Context, addr string, cfg SSHConfi
 		return nil, d.streamErr
 	}
 	return io.NopCloser(strings.NewReader(d.streamOut)), nil
+}
+
+func (d *capturingDialer) RunWithStdin(_ context.Context, addr string, cfg SSHConfig, cmd []string, stdin io.Reader) (*ExecResult, error) {
+	d.gotAddr = addr
+	d.gotCfg = cfg
+	d.gotCmd = append([]string(nil), cmd...)
+	if stdin != nil {
+		d.gotStdin, _ = io.ReadAll(stdin) // 捕获上传字节,供断言
+	}
+	return d.res, d.err
 }
 
 func (d *capturingDialer) RunInteractive(_ context.Context, addr string, cfg SSHConfig, cmd []string) (Session, error) {
@@ -193,6 +205,51 @@ func TestExecCmdArrayNotShellInjected(t *testing.T) {
 	// 私钥型凭据 → 走 PrivateKey 分支。
 	if dialer.gotCfg.PrivateKey == "" || dialer.gotCfg.Password != "" {
 		t.Fatalf("PEM 凭据应走私钥认证")
+	}
+}
+
+// TestUploadStreamsContentToCatCommand 验证 Upload 把字节经 stdin 流给远端 `cat > path`,
+// 且 remotePath 作位置参数(array 化不拼 shell)。
+func TestUploadStreamsContentToCatCommand(t *testing.T) {
+	db := testDB(t)
+	v := vault.New(db, testMasterKey())
+	credID := newSSHCred(t, v, "-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n-----END OPENSSH PRIVATE KEY-----")
+	dialer := &capturingDialer{res: &ExecResult{ExitCode: 0}}
+	svc := New(db, v, dialer)
+	srv, err := svc.Create(context.Background(), CreateInput{Name: "n", Host: "h", User: "u", CredentialID: credID})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	payload := []byte("real-jar-bytes\x00\x01binary")
+	remotePath := "/srv/app/releases/r1/app.jar"
+	if err := svc.Upload(context.Background(), srv.ID, bytes.NewReader(payload), remotePath); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	// 字节必须原样经 stdin 流到远端。
+	if !bytes.Equal(dialer.gotStdin, payload) {
+		t.Fatalf("上传字节与输入不一致:got %q", dialer.gotStdin)
+	}
+	// 命令应是 sh -c '<mkdir+cat>' <remotePath>,remotePath 作位置参数(不拼进脚本体)。
+	if len(dialer.gotCmd) != 4 || dialer.gotCmd[0] != "sh" || dialer.gotCmd[1] != "-c" || dialer.gotCmd[3] != remotePath {
+		t.Fatalf("upload 命令异常: %v", dialer.gotCmd)
+	}
+	if !strings.Contains(dialer.gotCmd[2], "cat >") {
+		t.Fatalf("upload 脚本体应含 cat >: %q", dialer.gotCmd[2])
+	}
+}
+
+// TestUploadRemoteNonZeroIsError 验证远端写失败(非零退出)→ Upload 报错。
+func TestUploadRemoteNonZeroIsError(t *testing.T) {
+	db := testDB(t)
+	v := vault.New(db, testMasterKey())
+	credID := newSSHCred(t, v, "-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n-----END OPENSSH PRIVATE KEY-----")
+	dialer := &capturingDialer{res: &ExecResult{ExitCode: 1, Stderr: "No space left on device"}}
+	svc := New(db, v, dialer)
+	srv, _ := svc.Create(context.Background(), CreateInput{Name: "n", Host: "h", User: "u", CredentialID: credID})
+	err := svc.Upload(context.Background(), srv.ID, bytes.NewReader([]byte("x")), "/x")
+	if err == nil {
+		t.Fatal("远端非零退出应报错")
 	}
 }
 


### PR DESCRIPTION
## 背景
此前 jar/dist 构建只**采集元数据**(名字/大小),实际字节随临时工作区一起删了,`reference` 只是文件名串,部署写的是**占位**(目标机落的是一个内容为文件名的小文件,不是真 jar/dist)。本 PR 补上「构建产物**真正可部署**」这一层 + 中控机镜像缓存管理。

## 制品库(FR-8-16)
- **`internal/artifactstore`**:内容寻址磁盘库(sha256 分片 + 临时文件原子 rename + 去重),`Put/Open/Stat/Has`,句柄严校防路径穿越。
- **构建归档**:`builder.locateFileArtifact` 在工作区销毁前,把 jar 文件 / dist 目录(流式打 `tar.gz`)的**真字节**存进制品库,`reference` 改存句柄 + `metadata{stored,format,filename}`;未配制品库则保持旧占位(向后兼容)。image 产物不变(走镜像库)。
- **target.Upload**:`Upload(serverID, reader, remotePath)` 经 SSH 把字节接到远端 `cat > file` 的 stdin(新 `sshDialer.RunWithStdin`)—— 流式、**无 argv 长度限**、大文件友好;path 走 array 参数(AC-SEC-02 不拼 shell)。
- **部署取真字节**:`release.go stageReleaseOne` 对已归档产物改为 jar 上传到发布目录、dist 上传 tar.gz 后**远端解包**,替代 base64(reference) 占位。
- **main 装配**:默认 DB 同级 `artifacts/`(`PIPEWRIGHT_ARTIFACT_DIR` 可改),注入 Builder + deploy。

## 镜像缓存管理(FR-8-17)
- `shellDriver.PruneDangling`(`<bin> image prune -f`,**只清悬空、绝不 -a / 不删有 tag 镜像**);Builder 经可选接口断言,**构建成功后 best-effort 清悬空镜像**,防中控机镜像缓存随重复构建无限涨。默认开,`PIPEWRIGHT_NO_IMAGE_GC=1` 关;失败仅记日志不影响构建。

## 验收
- ✅ `gofmt`/`build`/`vet`/`test ./...` 全绿
- ✅ 单测:制品库存取/去重/防穿越;构建归档真字节(jar 文件 / dist tar.gz);`target.Upload` 经 stdin 流字节 + 远端非零报错;部署取真字节上传(jar)+ 远端解包(dist)+ 不再走 base64 占位;镜像 prune **只清悬空、不带 -a**
- ✅ **真 CentOS 容器 e2e**(`PIPEWRIGHT_E2E_DEPLOY=1`):制品库 dist tar.gz → SSH Upload → 远端解包 → 容器内**真文件树** + current 软链切换
- SSHDialer 加 `RunWithStdin`,同步更新 5 个 fake dialer

🤖 Generated with [Claude Code](https://claude.com/claude-code)