### PR TITLE
feat: commit 列表下拉 + image/archive 蓝绿部署

### DIFF
--- a/internal/deploy/image_release.go
+++ b/internal/deploy/image_release.go
@@ -1,0 +1,153 @@
+package deploy
+
+// image_release.go 把 image 产物也纳入「蓝绿(stage→cutover→回滚)」编排(Story 8-8 续 / FR-8-8):
+//
+// 容器无文件软链可切,故 image 蓝绿用「**全机先 pull(预备,不切换)→ 全机统一停旧起新(切换)→
+// 切换阶段任一机健康失败则把已切换成功的机回滚到上一镜像**」的语义:
+//   - stageImageOne   : docker pull 新镜像(只拉,不停旧容器)+ 探测当前容器镜像(回滚目标)。
+//   - activateImageOne: docker rm -f 旧容器 + docker run 新镜像 + 切后健康门控;失败回滚到上一镜像。
+//
+// 与 release 文件模式一致的安全/语义:命令 array 化(不拼 shell)、错误不上抛(映射 status+人读)、
+// message 无明文密钥。非 proxy 流量切分(单二进制轻量定位不引入 LB);提供机群一致切换 + 回滚。
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/huangchengsir/pipewright/internal/run"
+	"github.com/huangchengsir/pipewright/internal/target"
+)
+
+// imageState 是一台机的 image 蓝绿中间态(stageImageOne 产出,activateImageOne 消费)。
+type imageState struct {
+	name      string // 容器名(sanitizeName(产物名))
+	ref       string // 本次新镜像 ref(repo:tag / image id)
+	prevImage string // 切换前容器所用镜像(回滚目标;"" = 无上一容器,首次部署)
+}
+
+// imageContainerName 取部署容器名(产物名净化;空 → app)。
+func imageContainerName(a run.Artifact) string {
+	n := sanitizeName(a.Name)
+	if n == "" {
+		n = "app"
+	}
+	return n
+}
+
+// stageImageOne 执行 image 蓝绿**预备阶段**:pull 新镜像(不停旧容器)+ 探测当前容器镜像(回滚目标)。
+// 拉取失败 → (中间态, 人读 message, false)。
+func (s *service) stageImageOne(ctx context.Context, srv *target.Server, a run.Artifact) (imageState, string, bool) {
+	st := imageState{name: imageContainerName(a), ref: strings.TrimSpace(a.Reference)}
+	if st.ref == "" {
+		return st, "image 产物缺少 reference(repo:tag 或镜像 id)", false
+	}
+	execCtx, cancel := context.WithTimeout(ctx, execTimeout)
+	defer cancel()
+
+	// 探测当前同名容器所用镜像(供回滚);无容器 / 读失败 → 空(首次部署,无可回滚)。
+	st.prevImage = s.readContainerImage(execCtx, srv.ID, st.name)
+
+	// 仅 pull,不动旧容器(零中断预备)。
+	if failMsg, ok := s.runStep(execCtx, srv.ID, [][]string{{"docker", "pull", st.ref}}); !ok {
+		return st, failMsg, false
+	}
+	return st, "", true
+}
+
+// activateImageOne 执行 image 蓝绿**切换阶段**:停旧容器 + 起新镜像容器 + 切后健康门控 + 失败回滚。
+func (s *service) activateImageOne(ctx context.Context, srv *target.Server, a run.Artifact, hc *HealthCheck, st imageState, started time.Time) TargetResult {
+	res := TargetResult{ServerID: srv.ID, ServerName: srv.Name, StartedAt: started}
+	execCtx, cancel := context.WithTimeout(ctx, execTimeout)
+	defer cancel()
+
+	// 切换:移除同名旧容器(幂等)→ 后台起新镜像容器。
+	swap := [][]string{
+		{"docker", "rm", "-f", st.name},
+		{"docker", "run", "-d", "--name", st.name, st.ref},
+	}
+	if failMsg, ok := s.runStep(execCtx, srv.ID, swap); !ok {
+		return finishFailed(res, failMsg)
+	}
+
+	// 切后健康门控;失败触发回滚到上一镜像。
+	if hc.enabled() {
+		if herr := s.runHealthCheck(execCtx, srv.ID, hc); herr != nil {
+			return s.rollbackImage(execCtx, srv, res, st, herr.Error())
+		}
+	}
+
+	finish := time.Now().UTC()
+	res.Status = run.TargetSuccess
+	if hc.enabled() {
+		res.Message = fmt.Sprintf("image 蓝绿部署完成 → 容器 %s(%s,健康检查通过)", st.name, st.ref)
+	} else {
+		res.Message = fmt.Sprintf("image 蓝绿部署完成 → 容器 %s(%s)", st.name, st.ref)
+	}
+	res.FinishedAt = &finish
+	return res
+}
+
+// rollbackImage 在健康失败后把容器回滚到上一镜像(rm 新容器 → run 上一镜像)。
+// 无上一镜像(首次部署)→ failed;回滚命令失败仍记 rolled_back(尽力)。
+func (s *service) rollbackImage(ctx context.Context, srv *target.Server, res TargetResult, st imageState, healthMsg string) TargetResult {
+	finish := time.Now().UTC()
+	res.FinishedAt = &finish
+	if st.prevImage == "" {
+		res.Status = run.TargetFailed
+		res.Message = fmt.Sprintf("健康检查失败且无上一镜像可回滚(首次部署):%s", healthMsg)
+		return res
+	}
+	var rbErr error
+	for _, cmd := range [][]string{
+		{"docker", "rm", "-f", st.name},
+		{"docker", "run", "-d", "--name", st.name, st.prevImage},
+	} {
+		if _, e := s.targets.Exec(ctx, srv.ID, cmd); e != nil {
+			rbErr = e
+			break
+		}
+	}
+	res.Status = run.TargetRolledBack
+	if rbErr != nil {
+		res.Message = fmt.Sprintf("健康检查失败,已尝试回滚容器 %s → 上一镜像 %s,但回滚命令失败:%s(健康原因:%s)",
+			st.name, st.prevImage, humanExecError(rbErr), healthMsg)
+		return res
+	}
+	res.Message = fmt.Sprintf("健康检查失败,已回滚容器 %s → 上一镜像 %s(健康原因:%s)", st.name, st.prevImage, healthMsg)
+	return res
+}
+
+// fleetRollbackImageOne 把一台「本机切换成功、但机群其它机失败」的容器回滚到上一镜像(蓝绿机群级原子性)。
+func (s *service) fleetRollbackImageOne(ctx context.Context, srv *target.Server, st imageState, res *TargetResult) {
+	execCtx, cancel := context.WithTimeout(ctx, execTimeout)
+	defer cancel()
+	var rbErr error
+	for _, cmd := range [][]string{
+		{"docker", "rm", "-f", st.name},
+		{"docker", "run", "-d", "--name", st.name, st.prevImage},
+	} {
+		if _, e := s.targets.Exec(execCtx, srv.ID, cmd); e != nil {
+			rbErr = e
+			break
+		}
+	}
+	finish := time.Now().UTC()
+	res.Status = run.TargetRolledBack
+	res.FinishedAt = &finish
+	if rbErr != nil {
+		res.Message = "蓝绿:其它机切换失败,本机尝试回滚到上一镜像但回滚命令失败:" + humanExecError(rbErr)
+		return
+	}
+	res.Message = "蓝绿:其它机切换失败,本机已回滚到上一镜像(机群级原子性:要么全切要么全退)"
+}
+
+// readContainerImage 读同名容器当前所用镜像(docker inspect);无容器 / 读失败 → ""。
+func (s *service) readContainerImage(ctx context.Context, serverID, name string) string {
+	out, err := s.targets.Exec(ctx, serverID, []string{"docker", "inspect", "--format", "{{.Config.Image}}", name})
+	if err != nil || out == nil || out.ExitCode != 0 {
+		return ""
+	}
+	return strings.TrimSpace(out.Stdout)
+}

--- a/internal/deploy/release.go
+++ b/internal/deploy/release.go
@@ -43,11 +43,12 @@ const defaultKeepReleases = 1
 // maxKeepReleases 夹紧保留份数上限(防误配留太多撑爆磁盘)。
 const maxKeepReleases = 50
 
-// releaseModeArtifact 判定产物是否走「发布目录 + current 软链」零停机模式。
-// dist / jar 走 release 模式;image 本期仍 docker run(commands.go),archive 维持文件部署。
+// releaseModeArtifact 判定产物是否走「发布目录 + current 软链」零停机模式(含蓝绿/canary 编排)。
+// dist / jar / archive 走文件 release 模式(archive 与 dist 同形:制品库 tar.gz 远端解包 / 占位);
+// image 另走容器蓝绿(image_release.go,docker pull/swap/回滚)。
 func releaseModeArtifact(a run.Artifact) bool {
 	switch a.Type {
-	case run.ArtifactDist, run.ArtifactJar:
+	case run.ArtifactDist, run.ArtifactJar, run.ArtifactArchive:
 		return true
 	default:
 		return false

--- a/internal/deploy/strategy.go
+++ b/internal/deploy/strategy.go
@@ -54,11 +54,16 @@ func (s *service) deployWithStrategy(ctx context.Context, servers []*target.Serv
 	case StrategyCanary:
 		return s.deployCanary(ctx, servers, a, cfg, hc)
 	case StrategyBlueGreen:
-		// 蓝绿需要 stage/cutover 两阶段,仅 release 类产物(dist/jar)成立;其余退化滚动。
-		if releaseModeArtifact(a) {
+		// 蓝绿需 stage/cutover 两阶段:release 类文件产物(dist/jar/archive)走软链切换;image 走
+		// pull→停旧起新→回滚上一镜像;其余类型无两阶段语义 → 退化滚动。
+		switch {
+		case releaseModeArtifact(a):
 			return s.deployBlueGreen(ctx, servers, a, cfg, hc)
+		case a.Type == run.ArtifactImage:
+			return s.deployBlueGreenImage(ctx, servers, a, hc)
+		default:
+			return s.deployFanout(ctx, servers, a, cfg, hc)
 		}
-		return s.deployFanout(ctx, servers, a, cfg, hc)
 	default:
 		return s.deployFanout(ctx, servers, a, cfg, hc)
 	}
@@ -210,6 +215,68 @@ func (s *service) deployBlueGreen(ctx context.Context, servers []*target.Server,
 		}, func(idx int, srv *target.Server) {
 			// 回滚异常:保留原成功结果,不致命(尽力回滚)。
 		})
+	}
+	return results
+}
+
+// deployBlueGreenImage 镜像蓝绿:stage-all(全机 pull)→ cutover-all(全机停旧起新+健康)→
+// 切换阶段任一失败则把已成功切换的机一并回滚到上一镜像(机群级原子性)。语义同 deployBlueGreen,
+// 只是单机原语换成 stageImageOne/activateImageOne(容器 pull/swap 而非软链切换)。
+func (s *service) deployBlueGreenImage(ctx context.Context, servers []*target.Server, a run.Artifact, hc *HealthCheck) []TargetResult {
+	n := len(servers)
+	if n == 0 {
+		return nil
+	}
+	results := make([]TargetResult, n)
+	states := make([]imageState, n)
+	staged := make([]bool, n)
+	started := make([]time.Time, n)
+
+	// 阶段 1:全机 pull(不停旧容器)。
+	s.forEachServer(servers, func(idx int, srv *target.Server) {
+		started[idx] = time.Now().UTC()
+		st, failMsg, ok := s.stageImageOne(ctx, srv, a)
+		states[idx] = st
+		if !ok {
+			results[idx] = finishFailed(TargetResult{ServerID: srv.ID, ServerName: srv.Name, StartedAt: started[idx]}, failMsg)
+			return
+		}
+		staged[idx] = true
+	}, func(idx int, srv *target.Server) {
+		results[idx] = abortedResult(srv, "蓝绿预备(pull)阶段执行异常中断(本机未切换)")
+	})
+
+	allStaged := true
+	for i := range staged {
+		if !staged[i] {
+			allStaged = false
+			break
+		}
+	}
+	if !allStaged {
+		for i, srv := range servers {
+			if staged[i] {
+				results[i] = abortedResult(srv, "蓝绿:预备(pull)阶段其它机失败,已中止本机切换(旧容器仍在跑)")
+			}
+		}
+		return results
+	}
+
+	// 阶段 2:全机统一停旧起新 + 健康。
+	s.forEachServer(servers, func(idx int, srv *target.Server) {
+		results[idx] = s.activateImageOne(ctx, srv, a, hc, states[idx], started[idx])
+	}, func(idx int, srv *target.Server) {
+		results[idx] = abortedResult(srv, "蓝绿切换阶段执行异常中断")
+	})
+
+	// 阶段 3:切换任一失败 → 已成功切换且有上一镜像的机一并回滚。
+	if !allSuccess(results) {
+		s.forEachServer(servers, func(idx int, srv *target.Server) {
+			if results[idx].Status != run.TargetSuccess || states[idx].prevImage == "" {
+				return
+			}
+			s.fleetRollbackImageOne(ctx, srv, states[idx], &results[idx])
+		}, func(idx int, srv *target.Server) {})
 	}
 	return results
 }

--- a/internal/deploy/strategy_test.go
+++ b/internal/deploy/strategy_test.go
@@ -56,11 +56,13 @@ func TestCanaryCount(t *testing.T) {
 
 // recordingTarget 包装 stubTarget 语义:execFn 据 (serverID, cmd) 决定结果,并记录触达的 serverID。
 type touchRecorder struct {
-	mu       sync.Mutex
-	touched  map[string]bool // 被 Exec 过的 serverID
-	sawMv    bool            // 是否出现过 cutover 切换(mv -T → current)
-	failOn   func(serverID string, cmd []string) bool
-	prevLink string // 非空 → readlink current 返回该路径(模拟已有上一发布)
+	mu           sync.Mutex
+	touched      map[string]bool // 被 Exec 过的 serverID
+	sawMv        bool            // 是否出现过 cutover 切换(mv -T → current)
+	calls2       [][]string      // 全部命令(image 蓝绿断言 pull/run 用)
+	failOn       func(serverID string, cmd []string) bool
+	prevLink     string // 非空 → readlink current 返回该路径(模拟已有上一发布)
+	inspectImage string // 非空 → docker inspect 返回该镜像(模拟已有上一镜像)
 }
 
 func (r *touchRecorder) exec(serverID string, cmd []string) (*target.ExecResult, error) {
@@ -69,6 +71,7 @@ func (r *touchRecorder) exec(serverID string, cmd []string) (*target.ExecResult,
 		r.touched = map[string]bool{}
 	}
 	r.touched[serverID] = true
+	r.calls2 = append(r.calls2, cmd)
 	if cmd[0] == "mv" {
 		r.sawMv = true
 	}
@@ -77,6 +80,13 @@ func (r *touchRecorder) exec(serverID string, cmd []string) (*target.ExecResult,
 	if cmd[0] == "readlink" {
 		if r.prevLink != "" {
 			return &target.ExecResult{ExitCode: 0, Stdout: r.prevLink}, nil
+		}
+		return &target.ExecResult{ExitCode: 0}, nil
+	}
+	// 模拟 docker inspect → 上一镜像(供 image 机群回滚有 prevImage 可回)。
+	if len(cmd) >= 2 && cmd[0] == "docker" && cmd[1] == "inspect" {
+		if r.inspectImage != "" {
+			return &target.ExecResult{ExitCode: 0, Stdout: r.inspectImage}, nil
 		}
 		return &target.ExecResult{ExitCode: 0}, nil
 	}
@@ -271,5 +281,75 @@ func TestDeployBlueGreenFleetRollbackOnPartialFailure(t *testing.T) {
 	// good 机回滚 message 应点明机群级回滚。
 	if !strings.Contains(res[0].Message, "机群") && !strings.Contains(res[0].Message, "其它机") {
 		t.Fatalf("good 机 message = %q, want 含机群级回滚说明", res[0].Message)
+	}
+}
+
+// ---- image 蓝绿 ----------------------------------------------------------------
+
+func TestDeployBlueGreenImageSuccess(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	rec := &touchRecorder{}
+	tgt := &stubTarget{execFn: rec.exec}
+	s1 := seedServer(t, tgt, "web-1")
+	s2 := seedServer(t, tgt, "web-2")
+	runID, artID := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactImage, "registry/app:v2")
+
+	svc := New(tgt, rsvc)
+	res, err := svc.Deploy(context.Background(), DeployInput{
+		RunID: runID, ArtifactID: artID, ServerIDs: []string{s1.ID, s2.ID}, Strategy: "blue_green",
+	})
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	for i, r := range res {
+		if r.Status != run.TargetSuccess {
+			t.Fatalf("image 蓝绿目标 %d 应 success,实际 %s / %q", i, r.Status, r.Message)
+		}
+	}
+	// 应发生 docker pull(预备)与 docker run(切换)。
+	var sawPull, sawRun bool
+	for _, c := range rec.calls2 {
+		if len(c) >= 2 && c[0] == "docker" && c[1] == "pull" {
+			sawPull = true
+		}
+		if len(c) >= 2 && c[0] == "docker" && c[1] == "run" {
+			sawRun = true
+		}
+	}
+	if !sawPull || !sawRun {
+		t.Fatalf("image 蓝绿应有 pull + run;pull=%v run=%v", sawPull, sawRun)
+	}
+}
+
+func TestDeployBlueGreenImageFleetRollback(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	badID := ""
+	rec := &touchRecorder{
+		inspectImage: "registry/app:v1", // 模拟已有上一镜像 → 可回滚
+		failOn: func(serverID string, cmd []string) bool {
+			return serverID == badID && len(cmd) > 0 && cmd[0] == "true" // bad 机健康失败
+		},
+	}
+	tgt := &stubTarget{execFn: rec.exec}
+	good := seedServer(t, tgt, "web-good")
+	bad := seedServer(t, tgt, "web-bad")
+	badID = bad.ID
+	runID, artID := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactImage, "registry/app:v2")
+
+	svc := New(tgt, rsvc)
+	hc := &HealthCheck{Type: HealthCheckCommand, Command: []string{"true"}, Retries: 1}
+	res, err := svc.Deploy(context.Background(), DeployInput{
+		RunID: runID, ArtifactID: artID, ServerIDs: []string{good.ID, bad.ID},
+		Strategy: "blue_green", HealthCheck: hc,
+	})
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	for i, r := range res {
+		if r.Status != run.TargetRolledBack {
+			t.Fatalf("image 机群回滚:目标 %d (%s) 应 rolled_back,实际 %s / %q", i, r.ServerName, r.Status, r.Message)
+		}
 	}
 }

--- a/internal/httpapi/refs.go
+++ b/internal/httpapi/refs.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/huangchengsir/pipewright/internal/project"
@@ -19,9 +21,10 @@ import (
 // 数据取自中控机本地仓库镜像(repocache,先增量 fetch 再读本地,不每次全量触网),供前端触发流水线时
 // 把「分支 / commit」从手敲升级为下拉选择。镜像不可用 → 503(优雅,前端回退手填)。
 
-// RefsLister 抽象「列仓库分支/tag」能力(*repocache.Cache 即满足)。
+// RefsLister 抽象「列仓库分支/tag + 某 ref 的最近 commit」能力(*repocache.Cache 即满足)。
 type RefsLister interface {
 	ListRefs(ctx context.Context, repoURL, token string) (*repocache.Refs, error)
+	ListCommits(ctx context.Context, repoURL, token, ref string, limit int) ([]repocache.Commit, error)
 }
 
 type refDTO struct {
@@ -79,5 +82,66 @@ func makeListRefsHandler(projects project.Service, v vault.Vault, lister RefsLis
 			out.Tags = append(out.Tags, refDTO{Name: tg.Name, Commit: tg.Commit})
 		}
 		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+type commitDTO struct {
+	Sha     string `json:"sha"`
+	Short   string `json:"short"`
+	Subject string `json:"subject"`
+	Author  string `json:"author"`
+	When    string `json:"when"` // RFC3339
+}
+
+// makeListCommitsHandler 返回 GET /api/projects/{id}/commits?ref=&limit= handler(认证;只读)。
+// 列某 ref(分支/tag/commit;空=默认分支)的最近提交,供前端选 commit 下拉。
+func makeListCommitsHandler(projects project.Service, v vault.Vault, lister RefsLister) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if lister == nil || projects == nil {
+			writeError(w, http.StatusServiceUnavailable, "repocache_disabled", "代码管理区未启用,无法列提交")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		proj, err := projects.Get(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, project.ErrNotFound) {
+				writeError(w, http.StatusNotFound, "project_not_found", "项目不存在")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+			return
+		}
+		ref := strings.TrimSpace(r.URL.Query().Get("ref"))
+		if ref == "" {
+			ref = proj.DefaultBranch
+		}
+		limit := 30
+		if n := strings.TrimSpace(r.URL.Query().Get("limit")); n != "" {
+			if v, perr := strconv.Atoi(n); perr == nil {
+				limit = v
+			}
+		}
+
+		token := ""
+		if v != nil && strings.TrimSpace(proj.CredentialID) != "" {
+			if t, terr := v.Get(proj.CredentialID); terr == nil {
+				token = t
+			}
+		}
+		commits, lerr := lister.ListCommits(r.Context(), proj.RepoURL, token, ref, limit)
+		token = ""
+		_ = token
+		if lerr != nil {
+			writeError(w, http.StatusBadGateway, "commits_unavailable", "无法读取仓库提交(仓库不可达或凭据无效)")
+			return
+		}
+		out := make([]commitDTO, 0, len(commits))
+		for _, co := range commits {
+			out = append(out, commitDTO{
+				Sha: co.SHA, Short: co.Short, Subject: co.Subject, Author: co.Author,
+				When: co.When.UTC().Format(time.RFC3339),
+			})
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"commits": out})
 	}
 }

--- a/internal/httpapi/refs_test.go
+++ b/internal/httpapi/refs_test.go
@@ -14,12 +14,17 @@ import (
 )
 
 type fakeRefsLister struct {
-	refs *repocache.Refs
-	err  error
+	refs    *repocache.Refs
+	commits []repocache.Commit
+	err     error
 }
 
 func (f fakeRefsLister) ListRefs(_ context.Context, _, _ string) (*repocache.Refs, error) {
 	return f.refs, f.err
+}
+
+func (f fakeRefsLister) ListCommits(_ context.Context, _, _, _ string, _ int) ([]repocache.Commit, error) {
+	return f.commits, f.err
 }
 
 func setupRefsServer(t *testing.T, lister RefsLister) (string, *http.Client, string, string) {
@@ -62,6 +67,28 @@ func TestListRefsEndpointReturnsBranchesAndTags(t *testing.T) {
 	}
 	if len(body.Tags) != 1 || body.Tags[0].Name != "v1.0" {
 		t.Fatalf("tags 不对: %+v", body.Tags)
+	}
+}
+
+func TestListCommitsEndpoint(t *testing.T) {
+	lister := fakeRefsLister{commits: []repocache.Commit{
+		{SHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Short: "aaaaaaa", Subject: "feat: x", Author: "me"},
+	}}
+	srv, client, _, projID := setupRefsServer(t, lister)
+	resp, err := client.Get(srv + "/api/projects/" + projID + "/commits?ref=main&limit=10")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var body struct {
+		Commits []commitDTO `json:"commits"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if len(body.Commits) != 1 || body.Commits[0].Short != "aaaaaaa" || body.Commits[0].Subject != "feat: x" {
+		t.Fatalf("commits 不对: %+v", body.Commits)
 	}
 }
 

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -509,6 +509,7 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 
 		// 列仓库分支/tag(代码管理区 · Story 8-18):供前端触发时分支/commit 下拉。o.refsLister 为 nil → 503。
 		ar.Get("/projects/{id}/refs", makeListRefsHandler(p, v, o.refsLister))
+		ar.Get("/projects/{id}/commits", makeListCommitsHandler(p, v, o.refsLister))
 
 		// 目标服务器登记 + 通用 SSH 执行层(Story 4.1;internal/target,FR-14)。
 		// sv 为 nil 时 handler 返回 503。GET/List/Get 过 auth;create/update/delete/test 为写方法,

--- a/internal/repocache/cache.go
+++ b/internal/repocache/cache.go
@@ -26,6 +26,7 @@ import (
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 
 	"github.com/huangchengsir/pipewright/internal/build"
 	"github.com/huangchengsir/pipewright/internal/gitauth"
@@ -221,6 +222,91 @@ func (c *Cache) ListRefs(ctx context.Context, repoURL, token string) (*Refs, err
 	sort.Slice(out.Branches, func(i, j int) bool { return out.Branches[i].Name < out.Branches[j].Name })
 	sort.Slice(out.Tags, func(i, j int) bool { return out.Tags[i].Name < out.Tags[j].Name })
 	return out, nil
+}
+
+// Commit 是一条提交摘要(供前端 commit 下拉:sha + 首行说明 + 作者 + 时刻)。
+type Commit struct {
+	SHA     string // 完整 sha
+	Short   string // 7 位短 sha
+	Subject string // 提交说明首行
+	Author  string // 作者名
+	When    time.Time
+}
+
+// ListCommits 列出某 ref(分支名/tag/commit sha)上最近 limit 条提交(镜像增量更新后从本地 git log 读)。
+// ref 空 → 用镜像 HEAD;limit<=0 或过大 → 夹到 [1,200]。供前端选 commit 提供数据。
+func (c *Cache) ListCommits(ctx context.Context, repoURL, token, ref string, limit int) ([]Commit, error) {
+	if limit <= 0 {
+		limit = 30
+	}
+	if limit > 200 {
+		limit = 200
+	}
+	lock := c.repoLock(repoURL)
+	lock.Lock()
+	defer lock.Unlock()
+
+	mirror, err := c.ensureMirror(ctx, repoURL, token)
+	if err != nil {
+		return nil, err
+	}
+	repo, oerr := gogit.PlainOpen(mirror)
+	if oerr != nil {
+		return nil, oerr
+	}
+
+	// 解析起点 hash:ref 是分支/tag 名 → 解析其引用;否则当 commit sha;空 → HEAD。
+	var from plumbing.Hash
+	ref = strings.TrimSpace(ref)
+	switch {
+	case ref == "":
+		h, herr := repo.Head()
+		if herr != nil {
+			return nil, herr
+		}
+		from = h.Hash()
+	default:
+		if h, rerr := repo.ResolveRevision(plumbing.Revision(ref)); rerr == nil && h != nil {
+			from = *h
+		} else {
+			from = plumbing.NewHash(ref)
+		}
+	}
+
+	iter, lerr := repo.Log(&gogit.LogOptions{From: from})
+	if lerr != nil {
+		return nil, lerr
+	}
+	defer iter.Close()
+
+	out := make([]Commit, 0, limit)
+	_ = iter.ForEach(func(co *object.Commit) error {
+		sha := co.Hash.String()
+		out = append(out, Commit{
+			SHA:     sha,
+			Short:   shortSHA(sha),
+			Subject: firstLine(co.Message),
+			Author:  co.Author.Name,
+			When:    co.Author.When,
+		})
+		if len(out) >= limit {
+			return errStopIter
+		}
+		return nil
+	})
+	return out, nil
+}
+
+// errStopIter 是提前结束 commit 遍历的哨兵(达到 limit)。
+var errStopIter = errors.New("stop")
+
+// firstLine 取多行提交说明的首行(去空白)。
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return s
 }
 
 // shortSHA 取 commit 的 7 位短 sha(与 build.Cloner 同语义)。

--- a/internal/repocache/cache_test.go
+++ b/internal/repocache/cache_test.go
@@ -130,6 +130,31 @@ func TestListRefs(t *testing.T) {
 	}
 }
 
+func TestListCommits(t *testing.T) {
+	src, _ := makeSourceRepo(t)
+	addCommit(t, src, "a.txt", "a")
+	addCommit(t, src, "b.txt", "b")
+	c := newTestCache(t)
+
+	commits, err := c.ListCommits(context.Background(), src, "", "master", 10)
+	if err != nil {
+		t.Fatalf("ListCommits: %v", err)
+	}
+	if len(commits) < 3 {
+		t.Fatalf("应至少 3 条提交(c1 + a + b),实际 %d", len(commits))
+	}
+	if commits[0].Subject != "add b.txt" {
+		t.Fatalf("最新提交说明应为 add b.txt,实际 %q", commits[0].Subject)
+	}
+	if commits[0].Short == "" || len(commits[0].SHA) != 40 {
+		t.Fatalf("commit sha 异常: short=%q sha=%q", commits[0].Short, commits[0].SHA)
+	}
+	one, _ := c.ListCommits(context.Background(), src, "", "master", 1)
+	if len(one) != 1 {
+		t.Fatalf("limit=1 应只返回 1 条,实际 %d", len(one))
+	}
+}
+
 // fakeFallback 记录是否被调用。
 type fakeFallback struct{ called bool }
 

--- a/web/src/api/refs.ts
+++ b/web/src/api/refs.ts
@@ -20,3 +20,26 @@ export interface RepoRefs {
 export async function listRefs(projectId: string): Promise<RepoRefs> {
   return http.get<RepoRefs>(`/api/projects/${projectId}/refs`)
 }
+
+export interface GitCommit {
+  sha: string
+  short: string
+  subject: string
+  author: string
+  when: string
+}
+
+// GET /api/projects/{id}/commits?ref=&limit= → 某分支/ref 最近提交(供选 commit 下拉)。
+export async function listCommits(
+  projectId: string,
+  ref: string,
+  limit = 30,
+): Promise<GitCommit[]> {
+  const qs = new URLSearchParams()
+  if (ref) qs.set('ref', ref)
+  qs.set('limit', String(limit))
+  const res = await http.get<{ commits: GitCommit[] }>(
+    `/api/projects/${projectId}/commits?${qs.toString()}`,
+  )
+  return res.commits
+}

--- a/web/src/views/Projects.vue
+++ b/web/src/views/Projects.vue
@@ -14,7 +14,7 @@ import {
 } from '../api/projects'
 import { listCredentials, type Credential } from '../api/credentials'
 import { triggerManual, type RunDetail, type TriggerManualInput } from '../api/runs'
-import { listRefs, type GitRef } from '../api/refs'
+import { listRefs, listCommits, type GitRef, type GitCommit } from '../api/refs'
 import RunParamsEditor from '../components/RunParamsEditor.vue'
 import { HttpError } from '../api/http'
 
@@ -397,16 +397,36 @@ function openTriggerModal(p: Project): void {
   void loadBranchOptions(p.id)
 }
 
-// 代码管理区(Story 8-18):拉取真实分支供下拉建议(datalist);未启用/失败 → 静默回退手填。
+// 代码管理区(Story 8-18):拉取真实分支/commit 供下拉建议(datalist);未启用/失败 → 静默回退手填。
 const branchOptions = ref<GitRef[]>([])
+const commitOptions = ref<GitCommit[]>([])
 async function loadBranchOptions(projectId: string): Promise<void> {
   branchOptions.value = []
+  commitOptions.value = []
   try {
     const refs = await listRefs(projectId)
     branchOptions.value = [...refs.branches, ...refs.tags]
   } catch {
     // 代码管理区未启用(503)或仓库不可达:静默,保持纯文本输入(优雅降级)。
   }
+  void loadCommitOptions(projectId, triggerForm.value.branch)
+}
+
+// 据当前分支拉最近 commit 供 commit 下拉(分支变化时刷新);失败静默。
+let commitLoadSeq = 0
+async function loadCommitOptions(projectId: string, ref: string): Promise<void> {
+  const seq = ++commitLoadSeq
+  try {
+    const commits = await listCommits(projectId, ref, 30)
+    if (seq === commitLoadSeq) commitOptions.value = commits
+  } catch {
+    if (seq === commitLoadSeq) commitOptions.value = []
+  }
+}
+
+function onTriggerBranchInput(): void {
+  triggerBranchError.value = ''
+  if (triggerProject.value) void loadCommitOptions(triggerProject.value.id, triggerForm.value.branch)
 }
 
 function closeTriggerModal(): void {
@@ -862,7 +882,7 @@ const STATUS_CONFIG: Record<RunStatus, StatusConfig> = {
               :disabled="triggerSubmitting"
               :aria-invalid="triggerBranchError ? 'true' : undefined"
               :aria-describedby="triggerBranchError ? 'trigger-branch-err' : undefined"
-              @input="triggerBranchError = ''"
+              @input="onTriggerBranchInput"
             />
             <!-- 代码管理区:真实分支/tag 下拉建议(空则纯文本输入,优雅降级) -->
             <datalist id="trigger-branch-options">
@@ -889,8 +909,13 @@ const STATUS_CONFIG: Record<RunStatus, StatusConfig> = {
               type="text"
               placeholder="例:a3f1c2d"
               autocomplete="off"
+              list="trigger-commit-options"
               :disabled="triggerSubmitting"
             />
+            <!-- 代码管理区:当前分支最近 commit 下拉建议(短 sha — 首行说明) -->
+            <datalist id="trigger-commit-options">
+              <option v-for="c in commitOptions" :key="c.sha" :value="c.short">{{ c.subject }}</option>
+            </datalist>
           </div>
 
           <!-- Parameters (optional · Story 8-11) -->


### PR DESCRIPTION
你点的两个收尾,都做了。

## commit 列表下拉(代码管理区续 · FR-8-18)
- `repocache.ListCommits(ref, limit)`:从本地镜像 `git log` 列某分支/ref 最近提交(sha / 短sha / 首行说明 / 作者 / 时刻),limit 夹 [1,200]。
- `GET /api/projects/{id}/commits?ref=&limit=`(`RefsLister` 扩 `ListCommits`)。
- 前端触发弹窗 **commit 输入加 datalist**:据当前分支拉最近 commit(分支变化即刷新),显示 `短sha — 首行说明`;优雅降级(代码管理区未启用/失败 → 静默回退手填)。

## image/archive 蓝绿(FR-8-8 续)
- **archive**:纳入 release 文件模式(`releaseModeArtifact +ArtifactArchive`)→ 与 dist 同形(制品库 tar.gz 远端解包 / 占位),**白拿 canary + 蓝绿**编排。
- **image**:新 `internal/deploy/image_release.go` —— 容器蓝绿 `stageImageOne`(`docker pull`,不停旧容器 + 探测当前容器镜像作回滚目标)+ `activateImageOne`(rm 旧 + run 新 + 切后健康 + 失败回滚到上一镜像);`deployBlueGreenImage` 做 **stage-all → cutover-all → 机群回滚**(机群级原子性)。canary 本就支持全类型。
  - 取舍:**非 proxy 流量切分**(单二进制轻量定位不引 LB),提供「全机先 pull、再统一停旧起新、失败机群回滚上一镜像」的一致切换 + 回滚。

## 验收
- ✅ `gofmt`/`build`/`vet`/`test ./...` 全绿 + 前端 `typecheck`/**191 测试**/`build`
- ✅ 新单测:repocache `ListCommits`(最新在前 + limit)、commits 端点(返回 + 未启用 503)、**image 蓝绿成功**(pull+run)+ **机群回滚**(一机健康失败 → 两机回滚上一镜像)
- ✅ 既有 deploy / archive 测试**零回归**(archive 改走 release 模式)

🤖 Generated with [Claude Code](https://claude.com/claude-code)