### PR TITLE
feat(runner): 远程构建 runner — 注册 + 安全代码下沉 + 调度(FR-8-14 续)

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/prstatus"
 	"github.com/huangchengsir/pipewright/internal/repocache"
 	"github.com/huangchengsir/pipewright/internal/run"
+	"github.com/huangchengsir/pipewright/internal/runner"
 	"github.com/huangchengsir/pipewright/internal/store"
 	"github.com/huangchengsir/pipewright/internal/target"
 	"github.com/huangchengsir/pipewright/internal/trigger"
@@ -210,6 +211,11 @@ func main() {
 	// 缺省/其它值仍走 PIPEWRIGHT_BUILDER 选出的真实 Builder / 桩 runner。
 	// ⚠ 当前阶段执行体为占位 stub(仅打日志即成功);真实「阶段内并行 job → job 内有序 step
 	// 在隔离容器构建/部署」= Story 8-2 尚未接入,故 dag 模式现仅用于验证编排,不做真实构建。
+	// 目标服务器(SSH 执行层)+ 远程构建 runner 配置(FR-8-14 续):项目可指定一台 server 作远程构建机,
+	// 配置后该项目构建下沉到远程执行(控制机本地克隆 → 经 SSH 传工作区 → 远程容器跑;token 只在控制机)。
+	targetSvc := target.New(st.DB, credVault, nil)
+	runnerSvc := runner.New(st.DB, targetExister{targetSvc})
+
 	// 制品库(Story 8-16 / FR-8-16):构建后把 jar/dist 真字节归档,部署时取真字节上传目标机
 	// (否则只有占位 reference,jar/dist 无法真正部署)。默认落 DB 同级 artifacts/,可经
 	// PIPEWRIGHT_ARTIFACT_DIR 改。构造失败 → 降级 nil(保持旧占位行为,不中断启动)。
@@ -263,7 +269,7 @@ func main() {
 		if b, berr := build.NewBuilder(projectSvc, pipelineSettingsSvc, credVault, build.WithArtifactStore(artStore), build.WithImageGC(os.Getenv("PIPEWRIGHT_NO_IMAGE_GC") != "1"), clonerOpt); berr == nil {
 			// runSvc 作测试报告持久层注入(Story 8-6 / FR-8-6):script 步骤产报告 → 解析 →
 			// 落库 → 质量门禁裁决(不过则阶段失败,阻断下游部署)。
-			dagOpts = append(dagOpts, dagrun.WithStageExecutor(build.NewStageExecutor(b, runSvc)))
+			dagOpts = append(dagOpts, dagrun.WithStageExecutor(build.NewStageExecutorWithRunner(b, runSvc, runnerSvc, targetSvc)))
 			log.Printf("[run] PIPEWRIGHT_RUNNER=dag:DAG 调度执行器已启用(阶段按 needs 编排;script 类型 job 在隔离容器真实执行,CLI=%s;build_image/push_image/deploy_ssh 真实化=后续)", b.DriverBinary())
 		} else {
 			log.Printf("[run] PIPEWRIGHT_RUNNER=dag:DAG 调度执行器已启用(阶段按 needs 编排;⚠ 未探测到容器 CLI,阶段执行体回退 stub:%v)", berr)
@@ -368,7 +374,6 @@ func main() {
 	// 供 Epic 4 部署 + Epic 6 运维共享。SSH 私钥/口令经 vault 即用即弃,绝不入库/日志/响应/错误。
 	// dialer 传 nil → 使用默认 x/crypto/ssh 实现(无宿主依赖,不驻留)。master key 未配置时
 	// Exec/Test 降级为明确错误(不 panic)。
-	targetSvc := target.New(st.DB, credVault, nil)
 
 	// 装配部署执行服务(Story 4.2;internal/deploy,FR-10):把成功运行的产物经 SSH 部署到目标机。
 	// 部署命令 array 化经 targetSvc.Exec 执行(AC-SEC-02,不拼 shell);每机结果落 deploy_targets,
@@ -391,7 +396,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithRefs(refsLister), httpapi.WithServers(targetSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithChain(chainSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc), httpapi.WithPromotion(promotionStore), httpapi.WithDoraMetrics(doraMetricsSvc), httpapi.WithTemplates(templateSvc), httpapi.WithVariableGroups(varGroupSvc)),
+		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithRefs(refsLister), httpapi.WithServers(targetSvc), httpapi.WithRunnerConfig(runnerSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithChain(chainSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc), httpapi.WithPromotion(promotionStore), httpapi.WithDoraMetrics(doraMetricsSvc), httpapi.WithTemplates(templateSvc), httpapi.WithVariableGroups(varGroupSvc)),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		// WriteTimeout 置 0:SSE 长连接(/api/runs/{id}/events)不可被写超时切断;
@@ -487,4 +492,12 @@ func buildRunnerOption(projectSvc project.Service, settingsSvc pipeline.Settings
 		log.Printf("[build] auto:真实隔离构建器已启用(容器 CLI=%s)", b.DriverBinary())
 		return []run.PoolOption{run.WithRunner(b)}
 	}
+}
+
+// targetExister 把 target.Service 适配为 runner.ServerExister(Get 无错即存在),供 runner 配置校验。
+type targetExister struct{ svc target.Service }
+
+func (t targetExister) Exists(ctx context.Context, id string) bool {
+	_, err := t.svc.Get(ctx, id)
+	return err == nil
 }

--- a/internal/build/remote_stage_exec.go
+++ b/internal/build/remote_stage_exec.go
@@ -1,0 +1,186 @@
+package build
+
+// remote_stage_exec.go 把「按项目 runner 配置派发到远程构建机执行」接到 DAG 阶段执行器(FR-8-14 续):
+// 项目配了远程 runner → 本阶段的 script job 下沉到该远程机执行;否则本地执行(NewStageExecutor 原状)。
+//
+// 远程执行模型(**token 全程只在控制机,绝不上远程**——比"远程克隆"更安全,且远程无需装 git):
+//  1. 控制机本地克隆源码(复用 b.cloner;若装了 repocache 则走本地镜像增量,快)。
+//  2. 把本地工作区打成 tar.gz,经 SSH(target.Upload = stdin 流,无 argv 长度限)传到远程临时目录并解包。
+//  3. 在远程机用容器跑 script job(NewRemoteDriver:shellDriver 经 SSH Commander → 远程 `docker run`),
+//     日志经 reporterSink 回流。
+//  4. 收尾删远程工作区(尽力)。
+//
+// 安全/语义沿用:命令 array 化(不拼 shell);secret 经 -e 注入容器(与本地同,不更差);失败映射 ErrBuildFailed。
+// 边界(后续增量):远程测试报告/质量门禁采集(报告文件在远程,本期不回采,优雅跳过);多 runner 负载均衡 /
+// 按 stage 选 runner。
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/huangchengsir/pipewright/internal/dagrun"
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// RunnerLookup 解析某项目的远程 runner 服务器 id(空/false = 本地构建)。runner.Service 即满足。
+type RunnerLookup interface {
+	RunnerFor(ctx context.Context, projectID string) (serverID string, ok bool)
+}
+
+// remoteExec 抽象远程执行所需的 target 能力(Exec + Upload;target.Service 即满足;便于 fake 单测)。
+type remoteExec interface {
+	RemoteExecer // Exec(ctx, serverID, cmd) (*target.ExecResult, error)
+	Upload(ctx context.Context, serverID string, content io.Reader, remotePath string) error
+}
+
+// NewStageExecutorWithRunner 返回「按项目 runner 配置派发本地/远程」的阶段执行器。
+// lookup 或 tgt 为 nil → 退化为纯本地(NewStageExecutor)。
+func NewStageExecutorWithRunner(b *Builder, reportSink TestReportSink, lookup RunnerLookup, tgt remoteExec) dagrun.StageExecutor {
+	local := NewStageExecutor(b, reportSink)
+	if lookup == nil || tgt == nil {
+		return local
+	}
+	return func(ctx context.Context, r *run.Run, stage pipeline.Stage, rep dagrun.StageReporter) error {
+		if serverID, ok := lookup.RunnerFor(ctx, r.ProjectID); ok && strings.TrimSpace(serverID) != "" {
+			return b.runStageRemote(ctx, r, stage, rep, serverID, tgt)
+		}
+		return local(ctx, r, stage, rep)
+	}
+}
+
+// runStageRemote 在远程 runner 上执行本阶段的 script job(见文件头模型)。
+func (b *Builder) runStageRemote(ctx context.Context, r *run.Run, stage pipeline.Stage, rep dagrun.StageReporter, serverID string, tgt remoteExec) error {
+	scriptJobs := make([]pipeline.Job, 0, len(stage.Jobs))
+	for _, jb := range stage.Jobs {
+		if isScriptJob(jb.Type) {
+			scriptJobs = append(scriptJobs, jb)
+		}
+	}
+	if len(scriptJobs) == 0 {
+		for _, jb := range stage.Jobs {
+			_ = rep.Log(ctx, streamStdout, fmt.Sprintf("· %s(%s)— 远程 runner 仅执行 script 类型;本阶段放行", jb.Name, jb.Type))
+		}
+		return nil
+	}
+
+	proj, _, perr := b.resolve(ctx, r)
+	if perr != nil {
+		_ = rep.Log(ctx, streamStderr, "无法加载项目构建配置:"+perr.Error())
+		return ErrBuildFailed
+	}
+
+	// 1) 控制机本地克隆(token 只在控制机)。
+	workspace, mkErr := mkTempWorkspace()
+	if mkErr != nil {
+		_ = rep.Log(ctx, streamStderr, "创建临时工作区失败:"+mkErr.Error())
+		return ErrBuildFailed
+	}
+	defer func() { _ = os.RemoveAll(workspace) }()
+
+	token := b.revealToken(proj.CredentialID)
+	_, cerr := b.cloner.Clone(ctx, proj.RepoURL, token, r.Trigger.Branch, r.Trigger.Commit, workspace)
+	token = ""
+	_ = token
+	if cerr != nil {
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return run.ErrCanceled
+		}
+		_ = rep.Log(ctx, streamStderr, "源码克隆失败(鉴权/网络/ref 不存在或被 SSRF 拒绝)")
+		return ErrBuildFailed
+	}
+
+	// 2) 打包工作区 → 经 SSH 传到远程并解包。
+	remoteWS := "/tmp/pipewright-remote/" + sanitizeRemoteSeg(r.ID) + "-" + sanitizeRemoteSeg(stage.ID)
+	remoteTar := remoteWS + ".tar.gz"
+	_ = rep.Log(ctx, streamStdout, "→ 远程 runner:打包工作区并经 SSH 传输…")
+	if err := uploadWorkspace(ctx, tgt, serverID, workspace, remoteTar); err != nil {
+		_ = rep.Log(ctx, streamStderr, "传输工作区到远程失败:"+err.Error())
+		return ErrBuildFailed
+	}
+	// 远程解包 + 收尾清理(尽力)。
+	if out, eerr := tgt.Exec(ctx, serverID, []string{"sh", "-c", `mkdir -p "$0" && tar -xzf "$1" -C "$0" && rm -f "$1"`, remoteWS, remoteTar}); eerr != nil || (out != nil && out.ExitCode != 0) {
+		_ = rep.Log(ctx, streamStderr, "远程解包工作区失败")
+		return ErrBuildFailed
+	}
+	defer func() { _, _ = tgt.Exec(context.WithoutCancel(ctx), serverID, []string{"rm", "-rf", remoteWS}) }()
+
+	// 3) 在远程机用容器跑 script job(远程 driver:docker run 经 SSH)。
+	driver := NewRemoteDriver(tgt, serverID, "docker")
+	onLine := func(stream, line string) { _ = rep.Log(ctx, stream, line) }
+	for _, jb := range scriptJobs {
+		if canceled(ctx) {
+			return run.ErrCanceled
+		}
+		step, verr := scriptStepFromJob(jb)
+		if verr != nil {
+			_ = rep.Log(ctx, streamStderr, fmt.Sprintf("script job「%s」配置无效:%v", jb.Name, verr))
+			return ErrBuildFailed
+		}
+		step.Env = append(runParamsAsEnv(r.Trigger.Params), step.Env...)
+		if err := b.runScriptOnDriver(ctx, driver, onLine, step, remoteWS); err != nil {
+			return err
+		}
+	}
+
+	_ = rep.Log(ctx, streamStdout, fmt.Sprintf("✓ 远程 runner(%s)执行完成;测试报告/质量门禁在远程模式暂不回采(后续增量)", serverID))
+	return nil
+}
+
+// runScriptOnDriver 用给定 driver(本地或远程)跑一条 script 步骤;remoteWS 为容器挂载的工作区(远程机上的路径)。
+// 与 runScriptStep 同语义(env 注入、workdir、多行 set -e 脚本、array 不拼 host shell),只是 driver 可注入。
+func (b *Builder) runScriptOnDriver(ctx context.Context, driver Driver, onLine func(stream, line string), step pipeline.PipelineStep, remoteWS string) error {
+	plain, secretEnv := b.buildArgs(step.Env)
+	env := append(plain, secretEnv...)
+
+	workdir := scriptWorkspaceMount
+	if sub := strings.TrimSpace(step.WorkDir); sub != "" {
+		workdir = joinContainerPath(scriptWorkspaceMount, sub)
+	}
+	script := "set -e\n" + strings.Join(step.Commands, "\n")
+	cmd := []string{"sh", "-c", script}
+
+	code, err := driver.RunToolchain(ctx, step.Image, remoteWS, workdir, env, cmd, onLine)
+	if err != nil && code < 0 {
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return run.ErrCanceled
+		}
+		return ErrBuildFailed
+	}
+	if code != 0 {
+		return ErrBuildFailed
+	}
+	return nil
+}
+
+// uploadWorkspace 把本地工作区打成 tar.gz(流式)经 target.Upload 传到远程 remoteTar。
+func uploadWorkspace(ctx context.Context, tgt remoteExec, serverID, workspace, remoteTar string) error {
+	pr, pw := io.Pipe()
+	go func() { pw.CloseWithError(tarGzDir(workspace, pw)) }()
+	err := tgt.Upload(ctx, serverID, pr, remoteTar)
+	_ = pr.Close()
+	return err
+}
+
+// sanitizeRemoteSeg 把 id 净化为安全的远程路径段(仅字母数字 . _ -;其余替 _;空 → x)。
+func sanitizeRemoteSeg(s string) string {
+	s = strings.TrimSpace(s)
+	var b bytes.Buffer
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "x"
+	}
+	return b.String()
+}

--- a/internal/build/remote_stage_exec_test.go
+++ b/internal/build/remote_stage_exec_test.go
@@ -1,0 +1,145 @@
+package build
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/project"
+	"github.com/huangchengsir/pipewright/internal/run"
+	"github.com/huangchengsir/pipewright/internal/target"
+)
+
+// fakeRemoteTarget 记录远程 Exec 命令 + Upload 内容(校验派发 + 密钥安全)。
+type fakeRemoteTarget struct {
+	serverIDs map[string]bool
+	cmds      [][]string
+	uploaded  []byte
+}
+
+func (f *fakeRemoteTarget) Exec(_ context.Context, serverID string, cmd []string) (*target.ExecResult, error) {
+	if f.serverIDs == nil {
+		f.serverIDs = map[string]bool{}
+	}
+	f.serverIDs[serverID] = true
+	f.cmds = append(f.cmds, cmd)
+	return &target.ExecResult{ExitCode: 0}, nil
+}
+
+func (f *fakeRemoteTarget) Upload(_ context.Context, serverID string, content io.Reader, _ string) error {
+	if f.serverIDs == nil {
+		f.serverIDs = map[string]bool{}
+	}
+	f.serverIDs[serverID] = true
+	b, _ := io.ReadAll(content)
+	f.uploaded = append(f.uploaded, b...)
+	return nil
+}
+
+type fakeRunnerLookup struct {
+	serverID string
+}
+
+func (l fakeRunnerLookup) RunnerFor(_ context.Context, _ string) (string, bool) {
+	return l.serverID, l.serverID != ""
+}
+
+// 带 git token 的测试 Builder(校验 token 绝不上远程)。
+func newRemoteTestBuilder(drv Driver) *Builder {
+	return &Builder{
+		projects: fakeProjects{proj: &project.Project{ID: "p1", RepoURL: "https://example.com/r.git", CredentialID: "cred"}},
+		settings: fakeSettings{settings: &pipeline.Settings{}},
+		vault:    fakeVault{secrets: map[string]string{"cred": gitTokenSecret}},
+		driver:   drv,
+		cloner:   &markerCloner{file: "README.md", content: "hi"},
+	}
+}
+
+const gitTokenSecret = "SUPERSECRET-GIT-TOKEN-xyz"
+
+func TestStageExecutorDispatchesToRemote(t *testing.T) {
+	local := &recordingDriver{}
+	b := newRemoteTestBuilder(local)
+	tgt := &fakeRemoteTarget{}
+	exec := NewStageExecutorWithRunner(b, nil, fakeRunnerLookup{serverID: "srv-1"}, tgt)
+
+	rep := &fakeReporter{}
+	r := &run.Run{ID: "run-1", ProjectID: "p1", Trigger: run.Trigger{Branch: "main"}}
+	stage := scriptStage(scriptJob("build", "node:20", "npm ci"))
+	if err := exec(context.Background(), r, stage, rep); err != nil {
+		t.Fatalf("remote exec: %v", err)
+	}
+
+	// 命令应打到远程 runner(srv-1),且本地 driver 绝不被调(构建下沉了)。
+	if !tgt.serverIDs["srv-1"] {
+		t.Fatalf("应派发到 srv-1;serverIDs=%v", tgt.serverIDs)
+	}
+	if local.callCount != 0 {
+		t.Fatalf("远程派发时本地 driver 不应被调,实际 %d 次", local.callCount)
+	}
+	// 应上传工作区 tar.gz + 远端 untar + 远端 docker run。
+	if len(tgt.uploaded) == 0 {
+		t.Fatal("应上传工作区 tar.gz 到远程")
+	}
+	var sawUntar, sawDockerRun bool
+	for _, c := range tgt.cmds {
+		joined := strings.Join(c, " ")
+		if strings.Contains(joined, "tar -xzf") {
+			sawUntar = true
+		}
+		if len(c) >= 2 && c[0] == "docker" && c[1] == "run" {
+			sawDockerRun = true
+		}
+	}
+	if !sawUntar || !sawDockerRun {
+		t.Fatalf("远程应 untar + docker run;untar=%v run=%v cmds=%v", sawUntar, sawDockerRun, tgt.cmds)
+	}
+
+	// 安全铁律:git token 绝不出现在任何远程命令 / 上传内容里(token 全程只在控制机)。
+	for _, c := range tgt.cmds {
+		if strings.Contains(strings.Join(c, " "), gitTokenSecret) {
+			t.Fatalf("git token 泄漏进远程命令!%v", c)
+		}
+	}
+	if bytes.Contains(tgt.uploaded, []byte(gitTokenSecret)) {
+		t.Fatal("git token 泄漏进上传内容!")
+	}
+}
+
+func TestStageExecutorLocalWhenNoRunner(t *testing.T) {
+	local := &recordingDriver{}
+	b := newRemoteTestBuilder(local)
+	tgt := &fakeRemoteTarget{}
+	// 无 runner(空)→ 走本地。
+	exec := NewStageExecutorWithRunner(b, nil, fakeRunnerLookup{serverID: ""}, tgt)
+
+	rep := &fakeReporter{}
+	r := &run.Run{ID: "run-1", ProjectID: "p1", Trigger: run.Trigger{Branch: "main"}}
+	if err := exec(context.Background(), r, scriptStage(scriptJob("build", "node:20", "echo hi")), rep); err != nil {
+		t.Fatalf("local exec: %v", err)
+	}
+	if local.callCount != 1 {
+		t.Fatalf("无 runner 应本地执行(driver 调 1 次),实际 %d", local.callCount)
+	}
+	if len(tgt.cmds) != 0 || len(tgt.uploaded) != 0 {
+		t.Fatal("无 runner 不应有任何远程动作")
+	}
+}
+
+// lookup/tgt 为 nil → 退化纯本地(不 panic)。
+func TestStageExecutorNilRunnerIsLocal(t *testing.T) {
+	local := &recordingDriver{}
+	b := newRemoteTestBuilder(local)
+	exec := NewStageExecutorWithRunner(b, nil, nil, nil)
+	rep := &fakeReporter{}
+	r := &run.Run{ID: "run-1", ProjectID: "p1", Trigger: run.Trigger{Branch: "main"}}
+	if err := exec(context.Background(), r, scriptStage(scriptJob("b", "alpine", "true")), rep); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if local.callCount != 1 {
+		t.Fatalf("nil runner 应纯本地,实际 driver 调 %d 次", local.callCount)
+	}
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -31,6 +31,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/project"
 	"github.com/huangchengsir/pipewright/internal/promotion"
 	"github.com/huangchengsir/pipewright/internal/run"
+	"github.com/huangchengsir/pipewright/internal/runner"
 	"github.com/huangchengsir/pipewright/internal/target"
 	"github.com/huangchengsir/pipewright/internal/trigger"
 	"github.com/huangchengsir/pipewright/internal/vault"
@@ -71,6 +72,7 @@ type options struct {
 	runDiffer        ai.RunDiffer
 	sourceReader     SourceReader
 	refsLister       RefsLister
+	runnerConfig     runner.Service
 	servers          target.Service
 	notifications    notify.Service
 	deployer         deploy.Service
@@ -241,6 +243,11 @@ func WithSource(reader SourceReader) Option {
 // WithRefs 注入「列仓库分支/tag」能力(代码管理区 repocache;Story 8-18)。nil → 端点 503。
 func WithRefs(lister RefsLister) Option {
 	return func(o *options) { o.refsLister = lister }
+}
+
+// WithRunnerConfig 注入项目「远程构建 runner」配置服务(FR-8-14 续)。nil → 端点 503。
+func WithRunnerConfig(svc runner.Service) Option {
+	return func(o *options) { o.runnerConfig = svc }
 }
 
 // WithServers 注入目标服务器服务(Story 4.1;internal/target 通用 SSH 层),挂载
@@ -510,6 +517,8 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		// 列仓库分支/tag(代码管理区 · Story 8-18):供前端触发时分支/commit 下拉。o.refsLister 为 nil → 503。
 		ar.Get("/projects/{id}/refs", makeListRefsHandler(p, v, o.refsLister))
 		ar.Get("/projects/{id}/commits", makeListCommitsHandler(p, v, o.refsLister))
+		ar.Get("/projects/{id}/runner", makeGetRunnerHandler(o.runnerConfig))
+		ar.Put("/projects/{id}/runner", makeSaveRunnerHandler(o.runnerConfig, aud))
 
 		// 目标服务器登记 + 通用 SSH 执行层(Story 4.1;internal/target,FR-14)。
 		// sv 为 nil 时 handler 返回 503。GET/List/Get 过 auth;create/update/delete/test 为写方法,

--- a/internal/httpapi/runner.go
+++ b/internal/httpapi/runner.go
@@ -1,0 +1,78 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/audit"
+	"github.com/huangchengsir/pipewright/internal/runner"
+)
+
+// runner.go 暴露项目「远程构建 runner」配置端点(FR-8-14 远程 runner 池续):
+//
+//	GET /api/projects/{id}/runner  → { runnerServerId }
+//	PUT /api/projects/{id}/runner  → 同上(需 CSRF;空串 = 清,回本地构建)。
+//
+// 配了 runner 服务器 → 该项目构建下沉到该远程机执行;空 = 本地。校验在 runner.Service(项目/服务器存在性)。
+
+type runnerDTO struct {
+	RunnerServerID string `json:"runnerServerId"`
+}
+
+func writeRunnerError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, runner.ErrProjectNotFound):
+		writeError(w, http.StatusNotFound, "project_not_found", "项目不存在")
+	case errors.Is(err, runner.ErrServerNotFound):
+		writeError(w, http.StatusUnprocessableEntity, "runner_server_not_found", "指定的 runner 服务器不存在")
+	default:
+		writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+	}
+}
+
+func makeGetRunnerHandler(svc runner.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "runner 配置服务未初始化")
+			return
+		}
+		cfg, err := svc.Get(r.Context(), chi.URLParam(r, "id"))
+		if err != nil {
+			writeRunnerError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, runnerDTO{RunnerServerID: cfg.RunnerServerID})
+	}
+}
+
+func makeSaveRunnerHandler(svc runner.Service, aud audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "runner 配置服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<14)
+		var req runnerDTO
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		cfg, err := svc.Save(r.Context(), id, req.RunnerServerID)
+		if err != nil {
+			writeRunnerError(w, err)
+			return
+		}
+		recordAudit(r.Context(), aud, audit.Entry{
+			Actor:      auditActor,
+			Action:     audit.ActionProjectUpdate,
+			TargetType: audit.TargetProject,
+			TargetID:   id,
+			Detail:     map[string]any{"runnerServerId": cfg.RunnerServerID},
+			IP:         clientIP(r),
+		})
+		writeJSON(w, http.StatusOK, runnerDTO{RunnerServerID: cfg.RunnerServerID})
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1,0 +1,102 @@
+// Package runner 是「远程构建 runner 配置」领域层(FR-8-14 远程 runner 池续)。
+//
+// 每项目可指定一台已登记的目标服务器(target.Server)作**远程构建机**:配置后,该项目的构建从中控机
+// 下沉到该远程机执行(控制机本地克隆 → 经 SSH 把工作区传到远程 → 远程容器内跑构建/脚本 → 取回日志)。
+// 未配 / 空 = 本地构建(行为不变)。本包只管「项目→runner 服务器 id」的存取与校验;真实远程执行在
+// build 包的远程阶段执行器,按本配置派发。
+package runner
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+)
+
+// 领域错误。
+var (
+	// ErrProjectNotFound 表示项目不存在。
+	ErrProjectNotFound = errors.New("runner: project not found")
+	// ErrServerNotFound 表示指定的 runner 服务器不存在。
+	ErrServerNotFound = errors.New("runner: runner server not found")
+)
+
+// Config 是某项目的远程 runner 配置(RunnerServerID 空 = 本地构建)。
+type Config struct {
+	ProjectID      string
+	RunnerServerID string
+}
+
+// ServerExister 抽象「校验服务器是否存在」(target.Service 即满足;避免 runner 直依赖 target)。
+type ServerExister interface {
+	Exists(ctx context.Context, serverID string) bool
+}
+
+// Service 是项目 runner 配置读写接口。
+type Service interface {
+	// Get 取某项目的 runner 配置(无行 → RunnerServerID 空,即本地构建)。
+	Get(ctx context.Context, projectID string) (*Config, error)
+	// Save 设/清某项目的 runner 服务器(空串 = 清,回本地构建)。非空时校验项目与服务器都存在。
+	Save(ctx context.Context, projectID, runnerServerID string) (*Config, error)
+	// RunnerFor 取某项目的远程 runner 服务器 id(无 → "", false),供构建派发快速判定。
+	RunnerFor(ctx context.Context, projectID string) (string, bool)
+}
+
+type service struct {
+	db      *sql.DB
+	servers ServerExister
+}
+
+// New 构造 runner 配置服务。servers 用于 Save 时校验 runner 服务器存在(可为 nil:跳过校验)。
+func New(db *sql.DB, servers ServerExister) Service {
+	return &service{db: db, servers: servers}
+}
+
+func (s *service) Get(ctx context.Context, projectID string) (*Config, error) {
+	cfg := &Config{ProjectID: projectID}
+	row := s.db.QueryRowContext(ctx, `SELECT runner_server_id FROM project_runners WHERE project_id = ?`, projectID)
+	switch err := row.Scan(&cfg.RunnerServerID); {
+	case errors.Is(err, sql.ErrNoRows):
+		return cfg, nil // 无配置 = 本地构建
+	case err != nil:
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func (s *service) Save(ctx context.Context, projectID, runnerServerID string) (*Config, error) {
+	runnerServerID = strings.TrimSpace(runnerServerID)
+
+	// 校验项目存在。
+	var exists int
+	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM projects WHERE id = ?`, projectID).Scan(&exists); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrProjectNotFound
+		}
+		return nil, err
+	}
+	// 非空时校验 runner 服务器存在(防配了不存在的机)。
+	if runnerServerID != "" && s.servers != nil && !s.servers.Exists(ctx, runnerServerID) {
+		return nil, ErrServerNotFound
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO project_runners (project_id, runner_server_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(project_id) DO UPDATE SET runner_server_id = excluded.runner_server_id, updated_at = excluded.updated_at`,
+		projectID, runnerServerID, now, now)
+	if err != nil {
+		return nil, err
+	}
+	return &Config{ProjectID: projectID, RunnerServerID: runnerServerID}, nil
+}
+
+func (s *service) RunnerFor(ctx context.Context, projectID string) (string, bool) {
+	cfg, err := s.Get(ctx, projectID)
+	if err != nil || cfg.RunnerServerID == "" {
+		return "", false
+	}
+	return cfg.RunnerServerID, true
+}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1,0 +1,92 @@
+package runner
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/huangchengsir/pipewright/internal/store"
+)
+
+type fakeExister struct{ ids map[string]bool }
+
+func (f fakeExister) Exists(_ context.Context, id string) bool { return f.ids[id] }
+
+func testDB(t *testing.T) *store.Store {
+	t.Helper()
+	st, err := store.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+func seedProject(t *testing.T, st *store.Store) string {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	credID := uuid.NewString()
+	if _, err := st.DB.Exec(`INSERT INTO credentials (id,name,type,scope,ciphertext,masked_value,created_at,updated_at) VALUES (?,'c','git_token','',X'00','m',?,?)`, credID, now, now); err != nil {
+		t.Fatalf("seed cred: %v", err)
+	}
+	projID := uuid.NewString()
+	if _, err := st.DB.Exec(`INSERT INTO projects (id,name,repo_url,default_branch,credential_id,created_at,updated_at) VALUES (?,'p','https://x/p.git','main',?,?,?)`, projID, credID, now, now); err != nil {
+		t.Fatalf("seed proj: %v", err)
+	}
+	return projID
+}
+
+func TestGetDefaultIsLocal(t *testing.T) {
+	st := testDB(t)
+	svc := New(st.DB, nil)
+	projID := seedProject(t, st)
+	cfg, err := svc.Get(context.Background(), projID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if cfg.RunnerServerID != "" {
+		t.Fatalf("默认应本地构建(空 runner),实际 %q", cfg.RunnerServerID)
+	}
+	if _, ok := svc.RunnerFor(context.Background(), projID); ok {
+		t.Fatal("默认不应有远程 runner")
+	}
+}
+
+func TestSaveAndGet(t *testing.T) {
+	st := testDB(t)
+	svc := New(st.DB, fakeExister{ids: map[string]bool{"srv-1": true}})
+	projID := seedProject(t, st)
+
+	if _, err := svc.Save(context.Background(), projID, "srv-1"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	cfg, _ := svc.Get(context.Background(), projID)
+	if cfg.RunnerServerID != "srv-1" {
+		t.Fatalf("runner = %q, want srv-1", cfg.RunnerServerID)
+	}
+	if id, ok := svc.RunnerFor(context.Background(), projID); !ok || id != "srv-1" {
+		t.Fatalf("RunnerFor = %q/%v, want srv-1/true", id, ok)
+	}
+	// 清空 → 回本地。
+	if _, err := svc.Save(context.Background(), projID, ""); err != nil {
+		t.Fatalf("Save clear: %v", err)
+	}
+	if _, ok := svc.RunnerFor(context.Background(), projID); ok {
+		t.Fatal("清空后应回本地构建")
+	}
+}
+
+func TestSaveValidatesServerAndProject(t *testing.T) {
+	st := testDB(t)
+	svc := New(st.DB, fakeExister{ids: map[string]bool{"srv-1": true}})
+	projID := seedProject(t, st)
+
+	if _, err := svc.Save(context.Background(), projID, "ghost"); err != ErrServerNotFound {
+		t.Fatalf("配不存在的机应 ErrServerNotFound,实际 %v", err)
+	}
+	if _, err := svc.Save(context.Background(), "no-such-project", "srv-1"); err != ErrProjectNotFound {
+		t.Fatalf("不存在项目应 ErrProjectNotFound,实际 %v", err)
+	}
+}

--- a/internal/store/migrations/0032_project_runners.sql
+++ b/internal/store/migrations/0032_project_runners.sql
@@ -1,0 +1,15 @@
+-- 0032 project_runners:项目级「远程构建 runner」配置(FR-8-14 远程 runner 池续)。
+-- 每项目至多一行(project_id 主键+外键)。runner_server_id 指定一台已登记的目标服务器作该项目的
+-- 远程构建机:有则构建下沉到该机执行(控制机本地克隆→经 SSH 传产物→远程 docker 跑),空/无行 = 本地构建。
+-- 不存敏感信息;删项目级联删 runner 配置。runner_server_id 不设 FK 到 servers(允许先配后建/换机;
+-- 使用时由服务层校验存在),仅删项目时清本配置。
+--   project_id       : FK → projects.id;PK;ON DELETE CASCADE
+--   runner_server_id : 远程构建机服务器 id(target server);空串 = 本地构建
+
+CREATE TABLE IF NOT EXISTS project_runners (
+    project_id       TEXT PRIMARY KEY,
+    runner_server_id TEXT NOT NULL DEFAULT '',
+    created_at       TEXT NOT NULL,
+    updated_at       TEXT NOT NULL,
+    FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);

--- a/web/src/api/runner.ts
+++ b/web/src/api/runner.ts
@@ -1,0 +1,21 @@
+/**
+ * Remote build runner API — 远程构建 runner(FR-8-14 续).
+ *
+ * GET /api/projects/{id}/runner → { runnerServerId }
+ * PUT /api/projects/{id}/runner → 同上(需 CSRF;空串 = 清,回本地构建)。
+ *
+ * 配了 runner 服务器 → 该项目构建下沉到该远程机执行;空 = 本地构建(默认)。
+ */
+import { http } from './http'
+
+export interface RunnerConfig {
+  runnerServerId: string
+}
+
+export async function getRunner(projectId: string): Promise<RunnerConfig> {
+  return http.get<RunnerConfig>(`/api/projects/${projectId}/runner`)
+}
+
+export async function saveRunner(projectId: string, runnerServerId: string): Promise<RunnerConfig> {
+  return http.put<RunnerConfig>(`/api/projects/${projectId}/runner`, { runnerServerId })
+}

--- a/web/src/components/RunnerPanel.vue
+++ b/web/src/components/RunnerPanel.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+/**
+ * RunnerPanel — 远程构建 runner 选择(FR-8-14 续).
+ *
+ * 选一台已登记的服务器作该项目的远程构建机:配置后构建下沉到该机执行(控制机本地克隆 → 经 SSH 传
+ * 工作区 → 远程容器跑;token 只在控制机)。「本地构建」= 不下沉(默认)。自包含 load/save。
+ */
+import { ref, onMounted, watch } from 'vue'
+import { getRunner, saveRunner } from '../api/runner'
+import { listServers, type Server } from '../api/servers'
+import { HttpError } from '../api/http'
+
+const props = defineProps<{ projectId: string }>()
+
+type LoadState = 'idle' | 'loading' | 'error'
+const loadState = ref<LoadState>('idle')
+const loadError = ref('')
+
+const servers = ref<Server[]>([])
+const selected = ref('') // '' = 本地构建
+const saveSubmitting = ref(false)
+const saveBanner = ref('')
+const saveSuccess = ref(false)
+
+async function load(): Promise<void> {
+  loadState.value = 'loading'
+  loadError.value = ''
+  try {
+    const [cfg, srv] = await Promise.all([getRunner(props.projectId), listServers().catch(() => [])])
+    selected.value = cfg.runnerServerId
+    servers.value = srv
+    loadState.value = 'idle'
+  } catch (err) {
+    loadState.value = 'error'
+    loadError.value = err instanceof HttpError ? err.message : '加载 runner 配置失败'
+  }
+}
+
+async function handleSave(): Promise<void> {
+  saveBanner.value = ''
+  saveSuccess.value = false
+  saveSubmitting.value = true
+  try {
+    const cfg = await saveRunner(props.projectId, selected.value)
+    selected.value = cfg.runnerServerId
+    saveSuccess.value = true
+    saveBanner.value = selected.value ? '已设为远程构建' : '已设为本地构建'
+  } catch (err) {
+    saveSuccess.value = false
+    saveBanner.value =
+      err instanceof HttpError ? (err.apiError?.message ?? '保存失败') : '保存失败,请重试'
+  } finally {
+    saveSubmitting.value = false
+  }
+}
+
+onMounted(load)
+watch(() => props.projectId, load)
+</script>
+
+<template>
+  <section class="config-card" aria-labelledby="runner-heading">
+    <div class="card-head">
+      <span class="card-icon" aria-hidden="true">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9">
+          <rect x="2" y="4" width="20" height="6" rx="1" /><rect x="2" y="14" width="20" height="6" rx="1" />
+          <path d="M6 7h.01M6 17h.01" />
+        </svg>
+      </span>
+      <h2 id="runner-heading" class="card-title">构建 runner</h2>
+      <span class="card-sub">把构建下沉到远程构建机执行(代码经 SSH 传输,token 只在中控机)</span>
+    </div>
+    <div class="card-body card-body--pad">
+      <p v-if="loadState === 'loading'" class="runner-loading">加载中…</p>
+      <p v-else-if="loadState === 'error'" class="runner-error" role="alert">{{ loadError }}</p>
+      <template v-else>
+        <label class="runner-field-label" for="runner-select">构建在哪执行</label>
+        <select id="runner-select" v-model="selected" class="runner-select" @change="saveSuccess = false">
+          <option value="">本地构建(中控机)</option>
+          <option v-for="s in servers" :key="s.id" :value="s.id">远程:{{ s.name }}({{ s.host }})</option>
+        </select>
+        <p class="runner-hint">
+          远程构建需该机装有容器运行时(docker/nerdctl/podman)。仅 script 类型 job 在远程执行;
+          测试报告/质量门禁在远程模式暂不回采(后续增量)。
+        </p>
+        <p
+          v-if="saveBanner"
+          class="runner-banner"
+          :class="saveSuccess ? 'runner-banner--ok' : 'runner-banner--err'"
+          role="status"
+        >{{ saveBanner }}</p>
+        <div class="runner-save">
+          <button class="btn-primary" :disabled="saveSubmitting" :aria-busy="saveSubmitting" @click="handleSave">
+            <span v-if="saveSubmitting" class="spinner" aria-hidden="true" />
+            {{ saveSubmitting ? '保存中…' : '保存 runner 配置' }}
+          </button>
+        </div>
+      </template>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.config-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-lg, 12px);
+  background: var(--color-card);
+  overflow: hidden;
+}
+.card-head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--color-border);
+}
+.card-icon {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border-radius: var(--rounded-md);
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  flex: none;
+}
+.card-title { font-size: 0.92rem; font-weight: 650; color: var(--color-text); }
+.card-sub { font-size: 0.76rem; color: var(--color-faint); flex: 1; min-width: 0; }
+.card-body--pad { padding: 16px; display: flex; flex-direction: column; gap: 12px; }
+.runner-loading, .runner-error { margin: 0; font-size: 0.82rem; }
+.runner-error { color: var(--color-danger, #dc2626); }
+.runner-loading { color: var(--color-faint); }
+.runner-field-label { font-size: 0.8rem; font-weight: 600; color: var(--color-text); }
+.runner-select {
+  width: 100%;
+  height: 36px;
+  padding: 0 11px;
+  font: inherit;
+  font-size: 0.85rem;
+  color: var(--color-text);
+  background: var(--color-bg-subtle, var(--color-card));
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded-md);
+  box-sizing: border-box;
+}
+.runner-select:focus { outline: none; border-color: var(--color-primary); }
+.runner-hint { margin: 0; font-size: 0.7rem; color: var(--color-faint); line-height: 1.45; }
+.runner-banner { margin: 0; font-size: 0.8rem; font-weight: 500; }
+.runner-banner--ok { color: var(--color-success, #16a34a); }
+.runner-banner--err { color: var(--color-danger, #dc2626); }
+.runner-save { display: flex; justify-content: flex-end; }
+</style>

--- a/web/src/components/TriggersPanel.vue
+++ b/web/src/components/TriggersPanel.vue
@@ -22,6 +22,7 @@ import CronPanel from './CronPanel.vue'
 import EnvironmentsPanel from './EnvironmentsPanel.vue'
 import ConcurrencyPanel from './ConcurrencyPanel.vue'
 import ChainPanel from './ChainPanel.vue'
+import RunnerPanel from './RunnerPanel.vue'
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -531,6 +532,9 @@ const displayWebhookUrl = computed(() => {
 
       <!-- ═══ Downstream chaining · Story 8-11 / FR-8-11 ══════════════════ -->
       <ChainPanel :project-id="props.projectId" />
+
+      <!-- 远程构建 runner(FR-8-14 续) -->
+      <RunnerPanel :project-id="props.projectId" />
 
       <!-- ═══ Save bar ════════════════════════════════════════════════════ -->
       <div class="save-bar">


### PR DESCRIPTION
你点的 runner 后续增量(安全远程克隆 / 注册 / 调度)—— 把上轮的 `sshCommander` 地基接成「构建**真正下沉到远程机执行**」。

## 注册(`internal/runner` + 迁移 0032)
每项目选一台已登记的 target server 作远程构建机。`project_runners` 表(`project_id` PK → `runner_server_id`,空=本地)。Save 校验项目与服务器存在。`GET/PUT /api/projects/{id}/runner`。

## 安全代码下沉(`internal/build/remote_stage_exec.go`)
关于「安全远程克隆」我做了个**更安全的设计决策**:**token 全程只在控制机,绝不上远程**(比把 token 送上远程克隆更安全,且远程无需装 git):
1. 控制机**本地克隆**(复用 cloner / repocache,走本地镜像增量,快)
2. 工作区打 `tar.gz` 经 `target.Upload`(SSH stdin 流,无 argv 长度限)传到远程并解包
3. 远程用**容器**跑 script job(`NewRemoteDriver`:shellDriver 经 SSH Commander → 远程 `docker run`)
4. 收尾删远程工作区

命令 array 化不拼 shell;失败映射 `ErrBuildFailed`。

## 调度(派发)
- `NewStageExecutorWithRunner`:按项目 runner 配置派发本地/远程(无配置 / lookup / tgt 为 nil → 纯本地,行为不变)。main 接进 dagrun 阶段执行器。
- 前端 `RunnerPanel`(嵌 TriggersPanel):选「本地 / 远程:某服务器」+ 保存。

## 验收
- ✅ `gofmt`/`build`/`vet`/`test ./...` 全绿 + 前端 `typecheck`/**191 测试**/`build`
- ✅ 单测:runner 配置存取/校验;**派发到远程**(命令打到 runner、本地 driver 不调、upload+untar+docker run)+ **git token 绝不进任何远程命令/上传内容(安全证实)** + 无 runner 回本地 + nil 退化本地
- ✅ 真二进制 boot:迁移 0032 应用、runner 端点 live、无 panic

## 边界(后续增量,代码头注明)
远程测试报告/质量门禁回采(报告文件在远程,本期优雅跳过)· 多 runner 负载均衡 / 按 stage 选 runner。**远程机需装容器运行时**(docker/nerdctl/podman),与中控机同前提。

🤖 Generated with [Claude Code](https://claude.com/claude-code)