### PR TITLE
feat: 全流程验收(构建→部署→通知)+ 制品库 + 流水线节点真实化 + 自定义/模板节点

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -259,6 +259,9 @@ func main() {
 		refsLister = repoCache
 	}
 
+	// 部署服务(提前到 dag 装配前构造,供 deploy_ssh 流水线节点注入)。Story 4.6 诊断钩子复用 7-2。
+	deploySvc := deploy.New(targetSvc, runSvc, deploy.WithDiagnoseHook(httpapi.NewDiagnoseHook(runSvc, aiSvc, secretSrc)), deploy.WithArtifactStore(artStore))
+
 	var runnerOpts []run.PoolOption
 	if strings.EqualFold(strings.TrimSpace(os.Getenv("PIPEWRIGHT_RUNNER")), "dag") {
 		// 阶段执行体(Story 8-2):探测到容器 CLI → 注入真实阶段执行器(script 类型 job 在隔离
@@ -266,7 +269,7 @@ func main() {
 		var dagOpts []dagrun.Option
 		// 审批门 hook(Story 8-4):Gate 阶段阻塞等待人工批准/拒绝。
 		dagOpts = append(dagOpts, dagrun.WithGate(httpapi.NewApprovalGate(runSvc, approvalCoord, approvalStore)))
-		if b, berr := build.NewBuilder(projectSvc, pipelineSettingsSvc, credVault, build.WithArtifactStore(artStore), build.WithImageGC(os.Getenv("PIPEWRIGHT_NO_IMAGE_GC") != "1"), clonerOpt); berr == nil {
+		if b, berr := build.NewBuilder(projectSvc, pipelineSettingsSvc, credVault, build.WithArtifactStore(artStore), build.WithImageGC(os.Getenv("PIPEWRIGHT_NO_IMAGE_GC") != "1"), build.WithCommitRecorder(func(ctx context.Context, runID, commit string) { _ = runSvc.SetCommit(ctx, runID, commit) }), build.WithStageDeployer(deploySvc), build.WithStageNotifier(notifySvc), clonerOpt); berr == nil {
 			// runSvc 作测试报告持久层注入(Story 8-6 / FR-8-6):script 步骤产报告 → 解析 →
 			// 落库 → 质量门禁裁决(不过则阶段失败,阻断下游部署)。
 			dagOpts = append(dagOpts, dagrun.WithStageExecutor(build.NewStageExecutorWithRunner(b, runSvc, runnerSvc, targetSvc)))
@@ -381,7 +384,7 @@ func main() {
 	// (notifySvc 已在 pool 装配前声明〔Story 5.2 注入 NotifyHook〕,此处不重复。)
 	// Story 4.6(FR-22 种子):注入诊断钩子 → 部署失败(failed/partial_failed)合成失败日志 +
 	// best-effort 触发 7-2 AI 诊断,让诊断飞轮覆盖部署失败(而非只覆盖构建失败)。复用 7-2 NewDiagnoseHook。
-	deploySvc := deploy.New(targetSvc, runSvc, deploy.WithDiagnoseHook(httpapi.NewDiagnoseHook(runSvc, aiSvc, secretSrc)), deploy.WithArtifactStore(artStore))
+	// (deploySvc 已提前在 dag 装配前构造,供 deploy_ssh 流水线节点注入;此处不重复。)
 
 	// 装配可配置异常检测服务(Story 6.5;FR-23):按阈值规则对服务器指标做检测,命中产告警入库。
 	// 检测复用 6-1 指标采集(NewAnomalyCollector 适配 collectServerMetrics);不可达/指标 null 的
@@ -396,7 +399,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithRefs(refsLister), httpapi.WithServers(targetSvc), httpapi.WithRunnerConfig(runnerSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithChain(chainSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc), httpapi.WithPromotion(promotionStore), httpapi.WithDoraMetrics(doraMetricsSvc), httpapi.WithTemplates(templateSvc), httpapi.WithVariableGroups(varGroupSvc)),
+		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithRefs(refsLister), httpapi.WithArtifactStore(artStore), httpapi.WithServers(targetSvc), httpapi.WithRunnerConfig(runnerSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithChain(chainSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc), httpapi.WithPromotion(promotionStore), httpapi.WithDoraMetrics(doraMetricsSvc), httpapi.WithTemplates(templateSvc), httpapi.WithVariableGroups(varGroupSvc)),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		// WriteTimeout 置 0:SSE 长连接(/api/runs/{id}/events)不可被写超时切断;

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"github.com/huangchengsir/pipewright/internal/artifactstore"
+	"github.com/huangchengsir/pipewright/internal/deploy"
+	"github.com/huangchengsir/pipewright/internal/notify"
 	"github.com/huangchengsir/pipewright/internal/pipeline"
 	"github.com/huangchengsir/pipewright/internal/project"
 	"github.com/huangchengsir/pipewright/internal/run"
@@ -52,6 +54,13 @@ type Builder struct {
 	artStore *artifactstore.Store
 	// disableImageGC 关闭「构建后清悬空镜像」(Story 8-17);默认开(false)。由 main 经 env 设置。
 	disableImageGC bool
+	// recordCommit 在克隆解析出实际 commit 后回写到 run(触发未指定 commit 时补真实值)。
+	// nil 则不回写(向后兼容)。由 main 注入(WithCommitRecorder),解耦 build 对 run.Service 的直依赖。
+	recordCommit func(ctx context.Context, runID, commit string)
+	// deployer/notifier:dag 里 deploy_ssh / notify 节点真实化所需(main 注入 deploy.Service / notify.Service)。
+	// nil → 该类节点退化为占位日志(向后兼容;非-dag Builder.Run 路径不用)。
+	deployer deploy.Service
+	notifier notify.Service
 }
 
 // repoCloner 抽象「把仓库在 ref 上克隆到磁盘工作区」的能力(便于 fake 单测注入,
@@ -94,6 +103,22 @@ func WithArtifactStore(s *artifactstore.Store) BuilderOption {
 // WithImageGC 开关「构建后清悬空镜像」(Story 8-17);默认开。传 false 关闭(如宿主另有镜像 GC 策略)。
 func WithImageGC(enabled bool) BuilderOption {
 	return func(b *Builder) { b.disableImageGC = !enabled }
+}
+
+// WithCommitRecorder 注入「回写实际检出 commit 到 run」的回调(由 main 接 run.Service.SetCommit)。
+// 克隆解析出 commit 后调用,补全运行详情里的 COMMIT 字段(触发未指定 commit 时尤其有用)。
+func WithCommitRecorder(fn func(ctx context.Context, runID, commit string)) BuilderOption {
+	return func(b *Builder) { b.recordCommit = fn }
+}
+
+// WithStageDeployer 注入部署服务,使 dag 里的 deploy_ssh 节点真实部署(中途部署,不动 run 终态)。
+func WithStageDeployer(d deploy.Service) BuilderOption {
+	return func(b *Builder) { b.deployer = d }
+}
+
+// WithStageNotifier 注入通知服务,使 dag 里的 notify 节点真实发通知。
+func WithStageNotifier(n notify.Service) BuilderOption {
+	return func(b *Builder) { b.notifier = n }
 }
 
 // NewBuilder 构造真实 Builder。driver 经 DetectDriver 探测(全无容器 CLI → ErrNoContainerCLI,
@@ -179,6 +204,9 @@ func (b *Builder) Run(ctx context.Context, r *run.Run, sink run.StepSink) error 
 		}
 		_ = sink.Log(ctx, streamStderr, 0, "源码克隆失败(鉴权/网络/ref 不存在或被 SSRF 拒绝)")
 		return b.failStep(ctx, sink, 0, "源码克隆失败:"+cerr.Error())
+	}
+	if resolved != nil && resolved.CommitShort != "" && b.recordCommit != nil {
+		b.recordCommit(ctx, r.ID, resolved.CommitShort)
 	}
 	commitTag := resolved.CommitShort
 	if commitTag == "" {

--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -5,10 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/huangchengsir/pipewright/internal/dagrun"
+	"github.com/huangchengsir/pipewright/internal/notify"
 	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/project"
 	"github.com/huangchengsir/pipewright/internal/run"
 )
 
@@ -31,10 +34,22 @@ import (
 //
 // 工作区共享(跨阶段复用同一 clone)是性能优化项,留后续;本期每阶段独立 clone 以求简单与并行安全。
 
-// scriptJobTypes 是会触发真实容器执行的 job 类型。
+// scriptJobTypes 是会触发真实容器执行的 job 类型。build_frontend/build_backend 是「前端/后端构建」
+// 模板节点,本质就是带预填命令的 script(在隔离容器跑 + 收 artifactPath 产物),故按 script 执行。
 func isScriptJob(jobType string) bool {
 	t := strings.TrimSpace(jobType)
-	return t == pipeline.StepTypeScript || t == "custom"
+	return t == pipeline.StepTypeScript || t == "custom" || t == "build_frontend" || t == "build_backend"
+}
+
+// isDeployJob 判断是否「SSH 部署」类节点(deploy_ssh 通用 / deploy_frontend 前端部署模板)。
+func isDeployJob(jobType string) bool {
+	t := strings.TrimSpace(jobType)
+	return t == "deploy_ssh" || t == "deploy_frontend"
+}
+
+// isBuildImageJob 判断是否「构建产物(镜像/JAR/dist)」节点(画布 build_image 类型)。
+func isBuildImageJob(jobType string) bool {
+	return strings.TrimSpace(jobType) == "build_image"
 }
 
 // NewStageExecutor 返回一个复用 Builder 容器基建的真实 dagrun.StageExecutor。
@@ -43,16 +58,30 @@ func isScriptJob(jobType string) bool {
 func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecutor {
 	return func(ctx context.Context, r *run.Run, stage pipeline.Stage, rep dagrun.StageReporter) error {
 		scriptJobs := make([]pipeline.Job, 0, len(stage.Jobs))
+		buildImageJobs := make([]pipeline.Job, 0, len(stage.Jobs))
+		deployJobs := make([]pipeline.Job, 0, len(stage.Jobs))
+		notifyJobs := make([]pipeline.Job, 0, len(stage.Jobs))
+		hasPushJob := false
 		for _, jb := range stage.Jobs {
-			if isScriptJob(jb.Type) {
+			switch {
+			case isScriptJob(jb.Type):
 				scriptJobs = append(scriptJobs, jb)
+			case isBuildImageJob(jb.Type):
+				buildImageJobs = append(buildImageJobs, jb)
+			case strings.TrimSpace(jb.Type) == "push_image":
+				hasPushJob = true
+			case isDeployJob(jb.Type):
+				deployJobs = append(deployJobs, jb)
+			case strings.TrimSpace(jb.Type) == "notify":
+				notifyJobs = append(notifyJobs, jb)
 			}
 		}
 
-		// 无 script job:对每个 job 打诚实占位日志(非 script 类型真实执行 = 后续 increment),放行。
-		if len(scriptJobs) == 0 {
+		needsBuild := len(scriptJobs) > 0 || len(buildImageJobs) > 0
+		// 没有任何可执行节点(script/build_image/deploy_ssh/notify)→ 诚实占位放行。
+		if !needsBuild && len(deployJobs) == 0 && len(notifyJobs) == 0 {
 			for _, jb := range stage.Jobs {
-				_ = rep.Log(ctx, streamStdout, fmt.Sprintf("· %s(%s)— 真实执行未接入(仅 script 类型);本阶段放行", jb.Name, jb.Type))
+				_ = rep.Log(ctx, streamStdout, fmt.Sprintf("· %s(%s)— 真实执行未接入;本阶段放行", jb.Name, jb.Type))
 			}
 			if len(stage.Jobs) == 0 {
 				_ = rep.Log(ctx, streamStdout, fmt.Sprintf("阶段「%s」无 job", stage.Name))
@@ -60,58 +89,328 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 			return nil
 		}
 
-		// 有 script job:克隆一份临时工作区(即用即销)。
-		proj, _, perr := b.resolve(ctx, r)
-		if perr != nil {
-			_ = rep.Log(ctx, streamStderr, "无法加载项目构建配置:"+perr.Error())
-			return ErrBuildFailed
-		}
-		workspace, mkErr := mkTempWorkspace()
-		if mkErr != nil {
-			_ = rep.Log(ctx, streamStderr, "创建临时工作区失败:"+mkErr.Error())
-			return ErrBuildFailed
-		}
-		defer func() { _ = os.RemoveAll(workspace) }() // 宿主零污染
-
-		token := b.revealToken(proj.CredentialID)
-		_, cerr := b.cloner.Clone(ctx, proj.RepoURL, token, r.Trigger.Branch, r.Trigger.Commit, workspace)
-		token = "" // 明文用完即弃
-		_ = token
-		if cerr != nil {
-			if errors.Is(ctx.Err(), context.Canceled) {
-				return run.ErrCanceled
-			}
-			_ = rep.Log(ctx, streamStderr, "源码克隆失败(鉴权/网络/ref 不存在或被 SSRF 拒绝)")
-			return ErrBuildFailed
-		}
-
 		sink := &reporterSink{rep: rep}
-		for _, jb := range scriptJobs {
+
+		// ── 构建部分:仅当有 script / build_image 才克隆工作区并执行(部署/通知不需要工作区)──
+		if needsBuild {
+			proj, settings, perr := b.resolve(ctx, r)
+			if perr != nil {
+				_ = rep.Log(ctx, streamStderr, "无法加载项目构建配置:"+perr.Error())
+				return ErrBuildFailed
+			}
+			workspace, mkErr := mkTempWorkspace()
+			if mkErr != nil {
+				_ = rep.Log(ctx, streamStderr, "创建临时工作区失败:"+mkErr.Error())
+				return ErrBuildFailed
+			}
+			defer func() { _ = os.RemoveAll(workspace) }() // 宿主零污染
+
+			token := b.revealToken(proj.CredentialID)
+			resolved, cerr := b.cloner.Clone(ctx, proj.RepoURL, token, r.Trigger.Branch, r.Trigger.Commit, workspace)
+			token = "" // 明文用完即弃
+			_ = token
+			if cerr != nil {
+				if errors.Is(ctx.Err(), context.Canceled) {
+					return run.ErrCanceled
+				}
+				_ = rep.Log(ctx, streamStderr, "源码克隆失败(鉴权/网络/ref 不存在或被 SSRF 拒绝)")
+				return ErrBuildFailed
+			}
+			if resolved != nil && resolved.CommitShort != "" && b.recordCommit != nil {
+				b.recordCommit(ctx, r.ID, resolved.CommitShort)
+			}
+
+			for _, jb := range scriptJobs {
+				if canceled(ctx) {
+					return run.ErrCanceled
+				}
+				step, verr := scriptStepFromJob(jb)
+				if verr != nil {
+					_ = rep.Log(ctx, streamStderr, fmt.Sprintf("script job「%s」配置无效:%v", jb.Name, verr))
+					return ErrBuildFailed
+				}
+				step.Env = append(runParamsAsEnv(r.Trigger.Params), step.Env...)
+				if err := b.runScriptStep(ctx, sink, 0, step, workspace); err != nil {
+					return err // ErrBuildFailed / run.ErrCanceled
+				}
+			}
+
+			commitTag := "latest"
+			if resolved != nil && resolved.CommitShort != "" {
+				commitTag = resolved.CommitShort
+			}
+			for _, jb := range buildImageJobs {
+				if canceled(ctx) {
+					return run.ErrCanceled
+				}
+				if err := b.runBuildImageJob(ctx, sink, rep, jb, stage.Name, proj, settings, r.Trigger.ResolvedEnvironment, workspace, commitTag, hasPushJob); err != nil {
+					return err
+				}
+			}
+
+			b.collectScriptArtifacts(ctx, scriptJobs, workspace, slugify(proj.Name), stage.Name, rep)
+			if err := collectStageReport(ctx, reportSink, r, stage, workspace, rep); err != nil {
+				return err
+			}
+		}
+
+		// ── 部署节点(deploy_ssh):把本 run 已产出的产物经 SSH 部署到目标机(中途部署,不动 run 终态)──
+		for _, jb := range deployJobs {
 			if canceled(ctx) {
 				return run.ErrCanceled
 			}
-			step, verr := scriptStepFromJob(jb)
-			if verr != nil {
-				_ = rep.Log(ctx, streamStderr, fmt.Sprintf("script job「%s」配置无效:%v", jb.Name, verr))
-				return ErrBuildFailed
-			}
-			// 参数化运行(Story 8-11):把本次运行参数作明文环境变量注入容器(置于 step env 前,
-			// step 自身 env 同名可覆盖)。明文 K=V,经 buildArgs 进容器。
-			step.Env = append(runParamsAsEnv(r.Trigger.Params), step.Env...)
-			// runScriptStep 用 lineSink(sink, ordinal) 喂日志;reporterSink 忽略 ordinal、转 rep(已绑定本阶段序号)。
-			if err := b.runScriptStep(ctx, sink, 0, step, workspace); err != nil {
-				return err // ErrBuildFailed / run.ErrCanceled
+			if err := b.runDeployJob(ctx, rep, jb, r.ID); err != nil {
+				return err
 			}
 		}
 
-		// 测试报告采集 + 质量门禁(Story 8-6 / FR-8-6):阶段 script job 全部成功后,据声明的
-		// 报告配置读工作区内的 JUnit/覆盖率文件 → 解析 → 持久化汇总 → 门禁裁决。门禁不过 →
-		// ErrQualityGate 令本阶段失败,阻断下游部署阶段(复用 dagrun「阶段失败→下游不执行」语义)。
-		if err := collectStageReport(ctx, reportSink, r, stage, workspace, rep); err != nil {
-			return err
+		// ── 通知节点(notify):按节点配的渠道发通知(best-effort,不因通知失败而失败本阶段)──
+		for _, jb := range notifyJobs {
+			if canceled(ctx) {
+				return run.ErrCanceled
+			}
+			b.runNotifyJob(ctx, rep, jb, r)
 		}
+
 		return nil
 	}
+}
+
+// runDeployJob 执行一个 deploy_ssh 节点:把本 run 已产出的产物经 SSH 部署到节点配置的目标机
+// (复用 deploy.Service.DeployForStage 中途部署,不动 run 终态)。任一目标失败 → 阶段失败、阻断下游。
+func (b *Builder) runDeployJob(ctx context.Context, rep dagrun.StageReporter, jb pipeline.Job, runID string) error {
+	if b.deployer == nil {
+		_ = rep.Log(ctx, streamStdout, "· 部署节点:部署服务未注入,跳过")
+		return nil
+	}
+	serverID := cfgString(jb.Config, "serverId")
+	if serverID == "" {
+		_ = rep.Log(ctx, streamStderr, fmt.Sprintf("部署节点「%s」未选目标服务器(serverId 空)", jb.Name))
+		return ErrBuildFailed
+	}
+	cfg := map[string]string{}
+	if dp := cfgString(jb.Config, "deployPath"); dp != "" {
+		cfg["releaseBase"] = dp
+	}
+	if rc := cfgString(jb.Config, "restartCommand"); rc != "" {
+		cfg["restartCommand"] = rc
+	}
+	strategy := cfgString(jb.Config, "strategy")
+	stratLabel := strategy
+	if stratLabel == "" {
+		stratLabel = "rolling(默认)"
+	}
+	_ = rep.Log(ctx, streamStdout, fmt.Sprintf("→ SSH 部署本次产物到服务器 %s(策略 %s)…", serverID, stratLabel))
+	results, err := b.deployer.DeployForStage(ctx, runID, []string{serverID}, cfg, strategy)
+	if err != nil {
+		_ = rep.Log(ctx, streamStderr, "部署失败:"+err.Error())
+		return ErrBuildFailed
+	}
+	failed := false
+	for _, dr := range results {
+		line := fmt.Sprintf("· %s:%s — %s", dr.ServerName, dr.Status, dr.Message)
+		if dr.Status == "success" {
+			_ = rep.Log(ctx, streamStdout, line)
+		} else {
+			_ = rep.Log(ctx, streamStderr, line)
+			failed = true
+		}
+	}
+	if failed {
+		return ErrBuildFailed
+	}
+	return nil
+}
+
+// runNotifyJob 执行一个 notify 节点:按节点配的渠道(id 或名称)发一条通知。
+// best-effort:通知失败只记日志、不令阶段失败(与终态通知钩子一致)。
+func (b *Builder) runNotifyJob(ctx context.Context, rep dagrun.StageReporter, jb pipeline.Job, r *run.Run) {
+	if b.notifier == nil {
+		_ = rep.Log(ctx, streamStdout, "· 通知节点:通知服务未注入,跳过")
+		return
+	}
+	chRef := cfgString(jb.Config, "channel")
+	if chRef == "" {
+		_ = rep.Log(ctx, streamStdout, "· 通知节点:未配渠道,跳过")
+		return
+	}
+	chID, chName := b.resolveChannel(ctx, chRef)
+	if chID == "" {
+		_ = rep.Log(ctx, streamStderr, "通知节点:找不到渠道「"+chRef+"」,跳过")
+		return
+	}
+	commit := strings.TrimSpace(r.Trigger.Commit)
+	if len(commit) > 7 {
+		commit = commit[:7]
+	}
+	payload := notify.Payload{
+		Title:  "流水线通知",
+		Body:   fmt.Sprintf("流水线执行到通知节点:分支 %s,commit %s。", r.Trigger.Branch, commit),
+		Fields: map[string]string{"branch": r.Trigger.Branch, "commit": commit, "runId": r.ID, "stage": "notify"},
+	}
+	if err := b.notifier.SendVia(ctx, chID, payload); err != nil {
+		_ = rep.Log(ctx, streamStderr, "通知发送失败(best-effort):"+err.Error())
+		return
+	}
+	_ = rep.Log(ctx, streamStdout, "· 已发通知 → 渠道「"+chName+"」")
+}
+
+// resolveChannel 把节点配的「渠道 id 或名称」解析为 (id, name);找不到返回空。
+func (b *Builder) resolveChannel(ctx context.Context, ref string) (id, name string) {
+	if ch, err := b.notifier.Get(ctx, ref); err == nil && ch != nil {
+		return ch.ID, ch.Name
+	}
+	chs, err := b.notifier.List(ctx)
+	if err != nil {
+		return "", ""
+	}
+	for _, ch := range chs {
+		if ch.Name == ref || ch.ID == ref {
+			return ch.ID, ch.Name
+		}
+	}
+	return "", ""
+}
+
+// runBuildImageJob 真实执行一个 build_image 节点:据节点 config 构造 BuildConfig,复用 Builder.build
+// (模型 A=docker build / 模型 B=工具链构建)在宿主驱动上真实构建,产出镜像/jar/dist 产物。
+// 镜像产物:环境绑定了 registry(或本阶段含 push_image 节点示意要推)→ b.push 推送并改写为远端引用 + digest;
+// 无 registry → 镜像留本地,emit 本地 tag。其它产物(jar/dist)直接 emit。失败映射 ErrBuildFailed / 取消。
+// 边界:docker build 上下文沿用工作区根(子目录上下文 = 后续);buildCommand 覆盖工具链默认命令 = 后续。
+func (b *Builder) runBuildImageJob(ctx context.Context, sink run.StepSink, rep dagrun.StageReporter, jb pipeline.Job, stageName string, proj *project.Project, settings *pipeline.Settings, envName, workspace, commitTag string, hasPushJob bool) error {
+	cfg := pipeline.BuildConfig{
+		Model:          cfgString(jb.Config, "buildModel"),
+		DockerfilePath: cfgString(jb.Config, "dockerfilePath"),
+		Toolchain:      pipeline.Toolchain{Language: cfgString(jb.Config, "toolchainLanguage"), Version: cfgString(jb.Config, "toolchainVersion")},
+		ArtifactType:   cfgString(jb.Config, "artifactType"),
+	}
+	if cfg.ArtifactType == "" {
+		cfg.ArtifactType = pipeline.ArtifactImage
+	}
+	if cfg.Model == "" {
+		cfg.Model = pipeline.BuildModelDockerfile
+	}
+
+	localTag, art, berr := b.build(ctx, sink, 0, proj, cfg, workspace, commitTag)
+	if berr != nil {
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return run.ErrCanceled
+		}
+		_ = rep.Log(ctx, streamStderr, fmt.Sprintf("构建节点「%s」失败:%v", jb.Name, berr))
+		return ErrBuildFailed
+	}
+	if art == nil {
+		return nil
+	}
+
+	// 镜像产物 + 绑定了 registry → 推送并登记远端引用(与非-dag Builder 同语义)。
+	if art.Type == run.ArtifactImage && localTag != "" {
+		registry := b.resolveRegistry(settings, envName)
+		switch {
+		case registry != nil:
+			remoteTag, digest, perr := b.push(ctx, sink, 0, localTag, registry, proj, commitTag)
+			if perr != nil {
+				if errors.Is(ctx.Err(), context.Canceled) {
+					return run.ErrCanceled
+				}
+				_ = rep.Log(ctx, streamStderr, fmt.Sprintf("镜像推送失败:%v", perr))
+				return ErrBuildFailed
+			}
+			art.Reference = remoteTag
+			if digest != "" {
+				if art.Metadata == nil {
+					art.Metadata = map[string]any{}
+				}
+				art.Metadata["digest"] = digest
+			}
+		case hasPushJob:
+			_ = rep.Log(ctx, streamStdout, "配了 push_image 但环境未绑定镜像仓库(registry),镜像留本地;到「触发设置 → 环境」绑定仓库后即自动推送")
+		}
+	}
+
+	// 记来源节点(阶段 + job 名),供运行详情标注「哪个节点产的」。
+	if art.Metadata == nil {
+		art.Metadata = map[string]any{}
+	}
+	art.Metadata["sourceStage"] = stageName
+	art.Metadata["sourceJob"] = jb.Name
+
+	if err := rep.EmitArtifact(ctx, *art); err != nil {
+		_ = rep.Log(ctx, streamStderr, "登记产物失败:"+err.Error())
+	}
+	return nil
+}
+
+// collectScriptArtifacts 收集 script job 声明的文件产物(job.Config["artifactPath"],**多行、每行一条**):
+// 逐条定位工作区内路径 → 按类型(目录=dist、*.jar=jar、其它文件=archive)归档进制品库真字节 →
+// EmitArtifact 登记。一个 job 可声明多条(既出 jar 又出 dist 等);未声明则跳过。
+// 镜像类产物不走这里(走 build_image 节点);文件类才在此收集。
+func (b *Builder) collectScriptArtifacts(ctx context.Context, jobs []pipeline.Job, workspace, slug, stageName string, rep dagrun.StageReporter) {
+	onLine := func(stream, line string) { _ = rep.Log(ctx, stream, line) }
+	for _, jb := range jobs {
+		for _, rel := range splitCommands(cfgString(jb.Config, "artifactPath")) { // 复用按行拆分(trim + 去空行)
+			// 通配(如 backend/target/*.jar)→ 展开为实际文件逐个收集;否则按原路径收集。
+			if strings.ContainsAny(rel, "*?[") {
+				clean := filepath.Clean(rel)
+				if filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+					onLine(streamStderr, "产物路径越界,已拒绝:"+rel)
+					continue
+				}
+				matches, _ := filepath.Glob(filepath.Join(workspace, clean))
+				if len(matches) == 0 {
+					onLine(streamStderr, "产物通配未匹配,跳过:"+rel)
+					continue
+				}
+				for _, m := range matches {
+					if relMatch, rerr := filepath.Rel(workspace, m); rerr == nil {
+						b.collectOneFileArtifact(ctx, workspace, relMatch, slug, jb.Name, stageName, rep, onLine)
+					}
+				}
+				continue
+			}
+			b.collectOneFileArtifact(ctx, workspace, rel, slug, jb.Name, stageName, rep, onLine)
+		}
+	}
+}
+
+// collectOneFileArtifact 收集单条文件产物路径:越界(.. / 绝对)拒绝;定位不到打日志跳过(不致命);
+// 类型按路径自动判(目录=dist、*.jar=jar、其它文件=archive)。产物 metadata 记来源节点(阶段 + job 名),
+// 供运行详情标注「哪个节点产的」。制品库未注入时 emit 占位引用,向后兼容。
+func (b *Builder) collectOneFileArtifact(ctx context.Context, workspace, rel, slug, jobName, stageName string, rep dagrun.StageReporter, onLine func(stream, line string)) {
+	clean := filepath.Clean(rel)
+	if filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		onLine(streamStderr, "产物路径越界,已拒绝:"+rel)
+		return
+	}
+	full := filepath.Join(workspace, clean)
+	fi, err := os.Stat(full)
+	if err != nil {
+		onLine(streamStderr, "产物路径未找到,跳过:"+rel)
+		return
+	}
+	// 产物名带上路径基名,避免一个 job 多产物同名(如多个 dist 目录)难以区分。
+	base := filepath.Base(full)
+	// metadata 记来源节点:sourceStage/sourceJob 供 UI 标注「哪个节点产的」(storeXxx 只补 stored/format,不清这些)。
+	art := &run.Artifact{Name: slug + "-" + base, Reference: base, Metadata: map[string]any{"sourceStage": stageName, "sourceJob": jobName}}
+	switch {
+	case fi.IsDir():
+		art.Type = run.ArtifactDist
+		art.SizeBytes = dirSize(full)
+		b.storeDistDir(art, full, onLine)
+	case strings.HasSuffix(strings.ToLower(full), ".jar"):
+		art.Type = run.ArtifactJar
+		art.SizeBytes = fileSize(full)
+		b.storeJarBytes(art, full, onLine)
+	default:
+		art.Type = run.ArtifactArchive
+		art.SizeBytes = fileSize(full)
+		b.storeJarBytes(art, full, onLine) // 单文件原样字节归档(format=file)
+	}
+	if err := rep.EmitArtifact(ctx, *art); err != nil {
+		onLine(streamStderr, "登记产物失败:"+err.Error())
+		return
+	}
+	onLine(streamStdout, "已产出产物:"+art.Name+"("+art.Type+","+rel+")")
 }
 
 // scriptStepFromJob 从画布 job.Config 构造一条 script 步骤(image + 多行 commands + 可选 workDir)。

--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/huangchengsir/pipewright/internal/dagrun"
@@ -35,10 +36,50 @@ import (
 // 工作区共享(跨阶段复用同一 clone)是性能优化项,留后续;本期每阶段独立 clone 以求简单与并行安全。
 
 // scriptJobTypes 是会触发真实容器执行的 job 类型。build_frontend/build_backend 是「前端/后端构建」
-// 模板节点,本质就是带预填命令的 script(在隔离容器跑 + 收 artifactPath 产物),故按 script 执行。
+// 模板节点,本质是带预填命令的 script;templated 是「用户自定义节点」(参数 + 命令模板),
+// 渲染 {{参数}} 后同样在隔离容器跑。三者都按 script 路径执行(容器跑 + 收 artifactPath 产物)。
 func isScriptJob(jobType string) bool {
 	t := strings.TrimSpace(jobType)
-	return t == pipeline.StepTypeScript || t == "custom" || t == "build_frontend" || t == "build_backend"
+	return t == pipeline.StepTypeScript || t == "custom" || t == "build_frontend" || t == "build_backend" || t == "templated"
+}
+
+// tplPlaceholder 匹配 {{key}} 占位(key 为标识符)。自定义节点参数渲染用。
+var tplPlaceholder = regexp.MustCompile(`\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}`)
+
+// templateContext 收集自定义节点的渲染上下文:config 里的字符串值 + 自由「参数表」(params 字段,
+// 每行 `key=value` 或 `key: value`)。参数完全自由(用户随便定义键),不锁死 schema。
+func templateContext(cfg map[string]any) map[string]string {
+	ctx := make(map[string]string, len(cfg)+4)
+	for k, v := range cfg {
+		if s, ok := v.(string); ok {
+			ctx[k] = s
+		}
+	}
+	for _, line := range splitCommands(cfgString(cfg, "params")) {
+		i := strings.IndexAny(line, "=:")
+		if i <= 0 {
+			continue
+		}
+		if k := strings.TrimSpace(line[:i]); k != "" {
+			ctx[k] = strings.TrimSpace(line[i+1:])
+		}
+	}
+	return ctx
+}
+
+// renderTemplate 把 {{key}} 替换为 ctx[key]。未知占位原样保留(不报错;$ENV 交给容器内 shell;
+// 无 {{ 则零开销直返)。ctx 由 templateContext 收集(config 字段 + params 自由参数)。
+func renderTemplate(tpl string, ctx map[string]string) string {
+	if tpl == "" || !strings.Contains(tpl, "{{") {
+		return tpl
+	}
+	return tplPlaceholder.ReplaceAllStringFunc(tpl, func(m string) string {
+		key := tplPlaceholder.FindStringSubmatch(m)[1]
+		if v, ok := ctx[key]; ok {
+			return v
+		}
+		return m
+	})
 }
 
 // isDeployJob 判断是否「SSH 部署」类节点(deploy_ssh 通用 / deploy_frontend 前端部署模板)。
@@ -348,7 +389,7 @@ func (b *Builder) runBuildImageJob(ctx context.Context, sink run.StepSink, rep d
 func (b *Builder) collectScriptArtifacts(ctx context.Context, jobs []pipeline.Job, workspace, slug, stageName string, rep dagrun.StageReporter) {
 	onLine := func(stream, line string) { _ = rep.Log(ctx, stream, line) }
 	for _, jb := range jobs {
-		for _, rel := range splitCommands(cfgString(jb.Config, "artifactPath")) { // 复用按行拆分(trim + 去空行)
+		for _, rel := range splitCommands(renderTemplate(cfgString(jb.Config, "artifactPath"), templateContext(jb.Config))) { // 渲染 {{参数}} + 按行拆分
 			// 通配(如 backend/target/*.jar)→ 展开为实际文件逐个收集;否则按原路径收集。
 			if strings.ContainsAny(rel, "*?[") {
 				clean := filepath.Clean(rel)
@@ -416,13 +457,19 @@ func (b *Builder) collectOneFileArtifact(ctx context.Context, workspace, rel, sl
 // scriptStepFromJob 从画布 job.Config 构造一条 script 步骤(image + 多行 commands + 可选 workDir)。
 // image 缺失或 commands 全空 → 错误(诚实失败,不静默跳过)。
 func scriptStepFromJob(jb pipeline.Job) (pipeline.PipelineStep, error) {
-	image := cfgString(jb.Config, "image")
+	ctx := templateContext(jb.Config)
+	image := renderTemplate(cfgString(jb.Config, "image"), ctx)
 	if image == "" {
 		return pipeline.PipelineStep{}, errors.New("缺少运行镜像(image)")
 	}
-	cmds := splitCommands(cfgString(jb.Config, "commands"))
+	// 自定义节点(templated):有 commandTemplate 则渲染 {{参数}} 作命令;否则用原始 commands。
+	rawCmds := cfgString(jb.Config, "commands")
+	if tpl := cfgString(jb.Config, "commandTemplate"); tpl != "" {
+		rawCmds = renderTemplate(tpl, ctx)
+	}
+	cmds := splitCommands(rawCmds)
 	if len(cmds) == 0 {
-		return pipeline.PipelineStep{}, errors.New("缺少执行命令(commands)")
+		return pipeline.PipelineStep{}, errors.New("缺少执行命令(commands / commandTemplate)")
 	}
 	return pipeline.PipelineStep{
 		ID:       jb.ID,
@@ -430,7 +477,7 @@ func scriptStepFromJob(jb pipeline.Job) (pipeline.PipelineStep, error) {
 		Type:     pipeline.StepTypeScript,
 		Image:    image,
 		Commands: cmds,
-		WorkDir:  cfgString(jb.Config, "workDir"),
+		WorkDir:  renderTemplate(cfgString(jb.Config, "workDir"), ctx),
 	}, nil
 }
 

--- a/internal/build/dag_stage_exec_test.go
+++ b/internal/build/dag_stage_exec_test.go
@@ -305,3 +305,40 @@ func TestE2EDockerStageExecutorReal(t *testing.T) {
 		t.Errorf("容器命令未真实执行;日志:\n%s", logs)
 	}
 }
+
+func TestRenderTemplate(t *testing.T) {
+	ctx := map[string]string{"dir": "frontend", "cmd": "npm run build"}
+	if got := renderTemplate("cd {{dir}} && {{cmd}}", ctx); got != "cd frontend && npm run build" {
+		t.Fatalf("render = %q", got)
+	}
+	// 未知占位原样保留;无 {{ 零开销直返
+	if got := renderTemplate("echo {{missing}} $HOME", ctx); got != "echo {{missing}} $HOME" {
+		t.Fatalf("unknown placeholder = %q", got)
+	}
+}
+
+func TestTemplateContextFreeParams(t *testing.T) {
+	// 自由参数表(每行 key=value / key: value)+ config 字段都进上下文。
+	cfg := map[string]any{"image": "node:20", "params": "dir=frontend\nbranch: main\n# 注释行无=跳过"}
+	ctx := templateContext(cfg)
+	if ctx["dir"] != "frontend" || ctx["branch"] != "main" || ctx["image"] != "node:20" {
+		t.Fatalf("ctx = %+v", ctx)
+	}
+}
+
+func TestScriptStepFromTemplatedJob(t *testing.T) {
+	jb := pipeline.Job{ID: "j", Name: "自定义", Type: "templated", Config: map[string]any{
+		"image": "node:{{ver}}", "ver": "20",
+		"commandTemplate": "cd {{dir}}\nnpm ci", "dir": "web",
+	}}
+	step, err := scriptStepFromJob(jb)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if step.Image != "node:20" {
+		t.Errorf("image = %q, want node:20", step.Image)
+	}
+	if len(step.Commands) != 2 || step.Commands[0] != "cd web" {
+		t.Errorf("commands = %v", step.Commands)
+	}
+}

--- a/internal/build/dag_stage_exec_test.go
+++ b/internal/build/dag_stage_exec_test.go
@@ -179,16 +179,64 @@ func TestStageExecutorNonScriptPlaceholder(t *testing.T) {
 	exec := NewStageExecutor(b, nil)
 	rep := &fakeReporter{}
 
-	stage := pipeline.Stage{ID: "s", Name: "构建", Kind: pipeline.KindBuild,
-		Jobs: []pipeline.Job{{Name: "img", Type: "build_image", Config: map[string]any{}}}}
+	// health_check 仍是未真实化的类型 → 走诚实占位放行(script/build_image/deploy_ssh/notify 已支持,其余占位)。
+	stage := pipeline.Stage{ID: "s", Name: "门禁", Kind: pipeline.KindCustom,
+		Jobs: []pipeline.Job{{Name: "health", Type: "health_check", Config: map[string]any{}}}}
 	if err := exec(context.Background(), &run.Run{ProjectID: "p1"}, stage, rep); err != nil {
 		t.Fatalf("exec: %v", err)
 	}
 	if drv.callCount != 0 {
-		t.Error("non-script job must not invoke RunToolchain")
+		t.Error("placeholder job must not invoke RunToolchain")
 	}
 	if !strings.Contains(strings.Join(rep.logs, "\n"), "真实执行未接入") {
 		t.Errorf("expected honest placeholder log, got %v", rep.logs)
+	}
+}
+
+// imgDriver 是支持 Build/InspectImage 的测试驱动(build_image 真实化测试用)。
+type imgDriver struct {
+	buildCalls    int
+	gotDockerfile string
+}
+
+func (d *imgDriver) Binary() string { return "fake" }
+func (d *imgDriver) RunToolchain(context.Context, string, string, string, []string, []string, func(string, string)) (int, error) {
+	return 0, nil
+}
+func (d *imgDriver) Build(_ context.Context, _, dockerfile, _ string, _, _ []string, _ func(string, string)) (int, error) {
+	d.buildCalls++
+	d.gotDockerfile = dockerfile
+	return 0, nil
+}
+func (d *imgDriver) Tag(context.Context, string, string, func(string, string)) (int, error) {
+	return 0, nil
+}
+func (d *imgDriver) Login(context.Context, string, string, string, func(string, string)) (int, error) {
+	return 0, nil
+}
+func (d *imgDriver) Push(context.Context, string, func(string, string)) (int, error) { return 0, nil }
+func (d *imgDriver) InspectImage(context.Context, string) (string, int64, error) {
+	return "sha256:deadbeef", 4096, nil
+}
+
+func TestStageExecutorBuildImageReal(t *testing.T) {
+	drv := &imgDriver{}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b, nil)
+	rep := &fakeReporter{}
+
+	stage := pipeline.Stage{ID: "s", Name: "构建", Kind: pipeline.KindBuild,
+		Jobs: []pipeline.Job{{Name: "镜像", Type: "build_image", Config: map[string]any{
+			"artifactType": "image", "buildModel": "dockerfile", "dockerfilePath": "Dockerfile",
+		}}}}
+	if err := exec(context.Background(), &run.Run{ProjectID: "p1"}, stage, rep); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if drv.buildCalls != 1 {
+		t.Fatalf("build_image 应调用 driver.Build 一次,实际 %d", drv.buildCalls)
+	}
+	if len(rep.arts) != 1 || rep.arts[0].Type != run.ArtifactImage {
+		t.Fatalf("应 emit 一件 image 产物,实际 %+v", rep.arts)
 	}
 }
 

--- a/internal/build/remote_stage_exec.go
+++ b/internal/build/remote_stage_exec.go
@@ -84,7 +84,7 @@ func (b *Builder) runStageRemote(ctx context.Context, r *run.Run, stage pipeline
 	defer func() { _ = os.RemoveAll(workspace) }()
 
 	token := b.revealToken(proj.CredentialID)
-	_, cerr := b.cloner.Clone(ctx, proj.RepoURL, token, r.Trigger.Branch, r.Trigger.Commit, workspace)
+	resolved, cerr := b.cloner.Clone(ctx, proj.RepoURL, token, r.Trigger.Branch, r.Trigger.Commit, workspace)
 	token = ""
 	_ = token
 	if cerr != nil {
@@ -93,6 +93,9 @@ func (b *Builder) runStageRemote(ctx context.Context, r *run.Run, stage pipeline
 		}
 		_ = rep.Log(ctx, streamStderr, "源码克隆失败(鉴权/网络/ref 不存在或被 SSRF 拒绝)")
 		return ErrBuildFailed
+	}
+	if resolved != nil && resolved.CommitShort != "" && b.recordCommit != nil {
+		b.recordCommit(ctx, r.ID, resolved.CommitShort)
 	}
 
 	// 2) 打包工作区 → 经 SSH 传到远程并解包。

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -109,6 +109,13 @@ type Service interface {
 	// 定位类错误(run 不存在 / 非失败态 / 无失败目标 / 无产物 / 服务器不存在)上抛,供 HTTP 层 422/404。
 	// 执行失败不上抛:重试目标置 failed + 人读 message,整体仍 200。
 	RetryFailed(ctx context.Context, in RetryInput) ([]TargetResult, error)
+
+	// DeployForStage 是「流水线 deploy_ssh 节点」用的中途部署:取该 run 已产出的首个可发布产物
+	// (dist/jar/archive)→ 按策略部署到目标机 → 持久化每机结果(填 run-detail targets)。
+	// **不校验 run 状态**(流水线执行中 run 仍 running)、**不置 run 终态**(终态由 dag 调度器控制)。
+	// 无可发布产物 → ErrArtifactNotFound;服务器不存在 → ErrServerNotFound;有目标失败 → 返回 error
+	// 令该阶段失败、阻断下游(复用 dagrun「阶段失败→下游不执行」)。
+	DeployForStage(ctx context.Context, runID string, serverIDs []string, cfg map[string]string, strategy string) ([]TargetResult, error)
 }
 
 // service 是 run + target 支撑的 Service 实现。
@@ -260,6 +267,56 @@ func (s *service) Deploy(ctx context.Context, in DeployInput) ([]TargetResult, e
 	// 7) 部署失败 → best-effort 触发 AI 诊断(Story 4.6;FR-22 种子;不阻断返回)。
 	s.seedDiagnosisOnFailure(ctx, in.RunID, final, results)
 
+	return results, nil
+}
+
+// DeployForStage 见接口注释:流水线 deploy_ssh 节点的中途部署(不校验 run 状态、不置终态)。
+func (s *service) DeployForStage(ctx context.Context, runID string, serverIDs []string, cfg map[string]string, strategy string) ([]TargetResult, error) {
+	if len(serverIDs) == 0 {
+		return nil, ErrNoServers
+	}
+	// 取该 run 已产出的首个可发布产物(dist/jar/archive;镜像类不走发布目录,本节点跳过)。
+	arts, err := s.runs.ListArtifacts(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	var artifact *run.Artifact
+	for i := range arts {
+		if releaseModeArtifact(arts[i]) {
+			a := arts[i]
+			artifact = &a
+			break
+		}
+	}
+	if artifact == nil {
+		return nil, ErrArtifactNotFound
+	}
+
+	servers := make([]*target.Server, 0, len(serverIDs))
+	for _, sid := range serverIDs {
+		srv, gerr := s.targets.Get(ctx, sid)
+		if gerr != nil {
+			if errors.Is(gerr, target.ErrNotFound) {
+				return nil, ErrServerNotFound
+			}
+			return nil, gerr
+		}
+		servers = append(servers, srv)
+	}
+
+	results := s.deployWithStrategy(ctx, servers, *artifact, cfg, nil, NormalizeStrategy(strategy))
+
+	// 持久化每机结果(填 run-detail targets slot);**不置 run 终态**(dag 调度器控制)。
+	dts := make([]run.DeployTarget, 0, len(results))
+	for _, r := range results {
+		dts = append(dts, run.DeployTarget{
+			RunID: runID, ServerID: r.ServerID, ServerName: r.ServerName,
+			Status: r.Status, Message: r.Message, StartedAt: r.StartedAt, FinishedAt: r.FinishedAt,
+		})
+	}
+	if err := s.runs.SaveDeployTargets(ctx, runID, dts); err != nil {
+		return nil, err
+	}
 	return results, nil
 }
 

--- a/internal/deploy/release.go
+++ b/internal/deploy/release.go
@@ -252,6 +252,15 @@ func (s *service) activateReleaseOne(ctx context.Context, srv *target.Server, a 
 		return finishFailed(res, failMsg)
 	}
 
+	// 3.5) 切换后执行「重启 / 切换命令」(支持多行;在 current 目录下跑,$0=current 经位置参传入防注入)。
+	// 多行 = set -e 单脚本逐行执行(与自定义脚本节点同语义)。失败 → 回滚(有上一发布时),与健康失败一致。
+	if rc := strings.TrimSpace(cfg["restartCommand"]); rc != "" {
+		script := "cd \"$0\" && set -e\n" + rc
+		if failMsg, ok := s.runStep(execCtx, srv.ID, [][]string{{"sh", "-c", script, st.current}}); !ok {
+			return s.rollback(execCtx, srv, res, st.current, st.prev, st.release, "重启/切换命令失败:"+failMsg)
+		}
+	}
+
 	// 4) 切换之后跑健康门控(4-3);失败触发回滚。
 	if hc.enabled() {
 		if herr := s.runHealthCheck(execCtx, srv.ID, hc); herr != nil {

--- a/internal/httpapi/pipelines_test.go
+++ b/internal/httpapi/pipelines_test.go
@@ -58,8 +58,8 @@ func TestPipelineGetLazyDefault(t *testing.T) {
 	_ = json.Unmarshal(raw, &dto)
 
 	stages, ok := dto["stages"].([]any)
-	if !ok || len(stages) != 4 {
-		t.Fatalf("默认应 4 阶段, got %v", dto["stages"])
+	if !ok || len(stages) != 2 {
+		t.Fatalf("默认应 2 阶段(源+构建), got %v", dto["stages"])
 	}
 	if dto["status"] != "draft" {
 		t.Fatalf("status = %v, want draft", dto["status"])
@@ -276,8 +276,8 @@ func TestPipelineImportPreviewNoSave(t *testing.T) {
 	graw, _ := io.ReadAll(g.Body)
 	var gd map[string]any
 	_ = json.Unmarshal(graw, &gd)
-	if gs, _ := gd["stages"].([]any); len(gs) != 4 {
-		t.Fatalf("预览不应落库,GET 应仍为默认 4 阶段, got %d", len(gs))
+	if gs, _ := gd["stages"].([]any); len(gs) != 2 {
+		t.Fatalf("预览不应落库,GET 应仍为默认 2 阶段(源+构建), got %d", len(gs))
 	}
 }
 

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -19,6 +19,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/ai"
 	"github.com/huangchengsir/pipewright/internal/anomaly"
 	"github.com/huangchengsir/pipewright/internal/approval"
+	"github.com/huangchengsir/pipewright/internal/artifactstore"
 	"github.com/huangchengsir/pipewright/internal/audit"
 	"github.com/huangchengsir/pipewright/internal/auth"
 	"github.com/huangchengsir/pipewright/internal/chain"
@@ -84,6 +85,13 @@ type options struct {
 	doraMetrics      run.MetricsService
 	templates        library.TemplateService
 	varGroups        library.VarGroupService
+	artifactStore    *artifactstore.Store
+}
+
+// WithArtifactStore 注入制品库(Story 8-16):挂载产物下载端点
+// GET /api/runs/{id}/artifacts/{artifactId}/download(按 reference 句柄取真字节)。nil → 端点 503。
+func WithArtifactStore(s *artifactstore.Store) Option {
+	return func(o *options) { o.artifactStore = s }
 }
 
 // WithApprovals 注入审批门协调器 + 持久层(Story 8-4),挂载 /api/runs/{id}/{approve,reject,approvals} 路由。
@@ -417,6 +425,8 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		ar.Get("/runs/{id}/logs", makeRunLogsHandler(rs))
 		// 构建产物契约(Story 3.4 / FR-6):只读 + 认证;按 (type, reference) 供 Epic 4 消费。
 		ar.Get("/runs/{id}/artifacts", makeRunArtifactsHandler(rs))
+		// 产物下载(Story 8-16 续):按 reference 句柄从制品库取真字节流下载。o.artifactStore 为 nil → 503。
+		ar.Get("/runs/{id}/artifacts/{artifactId}/download", makeArtifactDownloadHandler(rs, o.artifactStore))
 		// 测试报告 + 质量门禁(Story 8-6 / FR-8-6):只读 + 认证;通过/失败/跳过 + 覆盖率 + 门禁裁决。
 		ar.Get("/runs/{id}/test-report", makeRunTestReportHandler(rs))
 		ar.Post("/runs/{id}/cancel", makeCancelRunHandler(rs))

--- a/internal/httpapi/run_artifacts.go
+++ b/internal/httpapi/run_artifacts.go
@@ -1,10 +1,13 @@
 package httpapi
 
 import (
+	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/artifactstore"
 	"github.com/huangchengsir/pipewright/internal/run"
 )
 
@@ -79,4 +82,111 @@ func makeRunArtifactsHandler(svc run.Service) http.HandlerFunc {
 		}
 		writeJSON(w, http.StatusOK, runArtifactsDTO{Artifacts: toArtifactDTOs(arts)})
 	}
+}
+
+// makeArtifactDownloadHandler 返回 GET /api/runs/{id}/artifacts/{artifactId}/download。
+// 仅对「已归档真字节」(metadata.stored=true,reference=制品库句柄)的产物可下载;占位产物 →
+// 404(无真字节可取)。store 为 nil → 503。镜像类(reference=repo:tag)不在制品库 → 404。
+// 文件名:dist(tar.gz)→ <name>.tar.gz;file 格式 → metadata.filename 或 <name>。
+func makeArtifactDownloadHandler(svc run.Service, store *artifactstore.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "运行服务未初始化")
+			return
+		}
+		if store == nil {
+			writeError(w, http.StatusServiceUnavailable, "artifact_store_unavailable", "制品库未启用,无法下载")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		artID := chi.URLParam(r, "artifactId")
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeRunError(w, err)
+			return
+		}
+		arts, err := svc.ListArtifacts(r.Context(), id)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+			return
+		}
+		var art *run.Artifact
+		for i := range arts {
+			if arts[i].ID == artID {
+				art = &arts[i]
+				break
+			}
+		}
+		if art == nil {
+			writeError(w, http.StatusNotFound, "artifact_not_found", "产物不存在")
+			return
+		}
+		stored, _ := art.Metadata["stored"].(bool)
+		if !stored || strings.TrimSpace(art.Reference) == "" {
+			writeError(w, http.StatusNotFound, "artifact_not_downloadable", "该产物未归档真字节(占位/镜像类),无法下载")
+			return
+		}
+		rc, oerr := store.Open(art.Reference)
+		if oerr != nil {
+			writeError(w, http.StatusNotFound, "artifact_bytes_missing", "制品库中找不到该产物字节")
+			return
+		}
+		defer func() { _ = rc.Close() }()
+
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("Content-Disposition", "attachment; filename=\""+downloadFilename(art)+"\"")
+		if art.SizeBytes > 0 {
+			w.Header().Set("Content-Length", itoa(art.SizeBytes))
+		}
+		_, _ = io.Copy(w, rc)
+	}
+}
+
+// downloadFilename 据产物类型/元数据给一个安全的下载文件名。
+func downloadFilename(a *run.Artifact) string {
+	if fn, ok := a.Metadata["filename"].(string); ok && strings.TrimSpace(fn) != "" {
+		return sanitizeFilename(fn)
+	}
+	base := sanitizeFilename(a.Name)
+	if base == "" {
+		base = "artifact"
+	}
+	if format, _ := a.Metadata["format"].(string); format == "tar.gz" {
+		return base + ".tar.gz"
+	}
+	return base
+}
+
+// sanitizeFilename 去掉路径分隔/控制字符,防 header 注入与目录穿越(仅留文件名本体)。
+func sanitizeFilename(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, "\\", "_")
+	s = strings.ReplaceAll(s, "/", "_")
+	s = strings.ReplaceAll(s, "\"", "_")
+	s = strings.ReplaceAll(s, "\r", "")
+	s = strings.ReplaceAll(s, "\n", "")
+	return s
+}
+
+// itoa 把 int64 转十进制字符串(避免引 strconv 仅为此;Content-Length 用)。
+func itoa(n int64) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -277,7 +277,9 @@ func (s *service) sourceSummary(ctx context.Context, projectID string) (string, 
 	return repo + " · " + branch, nil
 }
 
-// defaultSpec 构造默认种子:源阶段(git_source 引用项目仓库)+ 空构建/部署/通知三阶段。
+// defaultSpec 构造默认种子:仅 源阶段(git_source 引用项目仓库)+ 空构建阶段。
+// 部署/通知等阶段不再预置——按需由用户「+添加阶段」动态加入,空阶段不写死、不冒充已配置
+// (空阶段既不展示为「已执行步骤」,也不在拓扑图里画出,见 dagrun 与 runDag)。
 func defaultSpec(sourceSummary string) Spec {
 	return Spec{Stages: []Stage{
 		{
@@ -293,8 +295,6 @@ func defaultSpec(sourceSummary string) Spec {
 			}},
 		},
 		{ID: "stg_build", Name: "构建", Kind: KindBuild, Jobs: []Job{}},
-		{ID: "stg_deploy", Name: "部署", Kind: KindDeploy, Jobs: []Job{}},
-		{ID: "stg_notify", Name: "通知", Kind: KindNotify, Jobs: []Job{}},
 	}}
 }
 

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -64,10 +64,12 @@ func TestGetLazyDefaultShape(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if len(cfg.Spec.Stages) != 4 {
-		t.Fatalf("默认应有 4 阶段, got %d", len(cfg.Spec.Stages))
+	// 默认种子只预置 源 + 构建 两阶段;部署/通知等按需由用户「+添加阶段」动态加入,
+	// 不再写死空阶段(空阶段不冒充已配置)。
+	if len(cfg.Spec.Stages) != 2 {
+		t.Fatalf("默认应有 2 阶段(源+构建), got %d", len(cfg.Spec.Stages))
 	}
-	wantKinds := []string{KindSource, KindBuild, KindDeploy, KindNotify}
+	wantKinds := []string{KindSource, KindBuild}
 	for i, k := range wantKinds {
 		if cfg.Spec.Stages[i].Kind != k {
 			t.Fatalf("阶段 %d kind = %q, want %q", i, cfg.Spec.Stages[i].Kind, k)

--- a/internal/run/service.go
+++ b/internal/run/service.go
@@ -77,6 +77,10 @@ type Service interface {
 	// run 不存在不报错(返回空切片);由 HTTP 层据 run 存在性决定 404(仿 GetLogs 语义)。
 	ListArtifacts(ctx context.Context, runID string) ([]Artifact, error)
 
+	// SetCommit 回写本次运行实际检出的 commit 短 SHA(克隆解析出后由执行器调用)。
+	// 触发时未指定 commit(手动触发常见)→ 这里补上真实 commit,供运行详情展示。run 不存在 → ErrNotFound。
+	SetCommit(ctx context.Context, id, commit string) error
+
 	// SaveTestReport 持久化一条测试报告汇总(Story 8-6 / FR-8-6)。
 	// 计数 + 可选覆盖率 + 门禁裁决;同 run 多阶段产报告时各存一条(按 stage 区分)。
 	// run 不存在 → ErrNotFound(外键失败)。
@@ -489,6 +493,22 @@ func (s *service) LastSuccessfulRun(ctx context.Context, projectID, branch strin
 }
 
 // SetFailureLog 持久化某次运行的失败日志原文(脱敏前)。参数化 SQL;不存在 → ErrNotFound。
+func (s *service) SetCommit(ctx context.Context, id, commit string) error {
+	commit = strings.TrimSpace(commit)
+	if commit == "" {
+		return nil // 无解析结果 → 不动(保持触发时的值/空)
+	}
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE pipeline_runs SET trigger_commit = ? WHERE id = ?`, commit, id)
+	if err != nil {
+		return fmt.Errorf("run: set commit: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 func (s *service) SetFailureLog(ctx context.Context, id, logText string) error {
 	res, err := s.db.ExecContext(ctx,
 		`UPDATE pipeline_runs SET failure_log = ? WHERE id = ?`, logText, id)

--- a/web/src/components/onboarding/OnboardingFlow.vue
+++ b/web/src/components/onboarding/OnboardingFlow.vue
@@ -98,7 +98,7 @@ function skip(): void {
   <div class="onboarding">
     <!-- Hero -->
     <header class="ob-hero">
-      <div class="ob-mark mono" aria-hidden="true">d&gt;</div>
+      <div class="ob-mark mono" aria-hidden="true">p&gt;</div>
       <div>
         <h1 class="ob-title">欢迎使用 Pipewright</h1>
         <p class="ob-lede">

--- a/web/src/components/pipeline/PipelineCanvas.vue
+++ b/web/src/components/pipeline/PipelineCanvas.vue
@@ -6,7 +6,7 @@ import type { Server } from '../../api/servers'
 import StageColumn from './StageColumn.vue'
 import JobDrawer from './JobDrawer.vue'
 import JobTypePicker from './JobTypePicker.vue'
-import { jobTypeLabel } from './jobConfigSchema'
+import { jobTypeLabel, getJobTypeSpec } from './jobConfigSchema'
 import { hasAnyNeeds } from './stageDeps'
 import './pipeline.css'
 
@@ -125,7 +125,8 @@ function onPickerSelect(type: string): void {
       name:    jobTypeLabel(type),
       type,
       summary: '',
-      config:  {},
+      // 模板节点带预填配置(深拷贝避免共享引用);普通节点空配置。
+      config:  { ...(getJobTypeSpec(type)?.defaultConfig ?? {}) },
     }
     const next = props.stages.map((s) =>
       s.id === p.stageId ? { ...s, jobs: [...s.jobs, newJob] } : s,

--- a/web/src/components/pipeline/jobConfigSchema.ts
+++ b/web/src/components/pipeline/jobConfigSchema.ts
@@ -427,6 +427,61 @@ export const JOB_TYPE_SPECS: Record<string, JobTypeSpec> = {
     defaultConfig: { strategy: 'rolling', restartCommand: 'nginx -s reload' },
   },
 
+  templated: {
+    type: 'templated',
+    label: '自定义节点',
+    description: '自己定义参数 + 命令模板({{参数}}),配参数即用',
+    accent: 'cyan',
+    category: 'custom',
+    fields: [
+      {
+        key: 'image',
+        label: '运行镜像',
+        kind: 'text',
+        monospace: true,
+        placeholder: 'node:20',
+      },
+      {
+        key: 'params',
+        label: '参数表',
+        kind: 'textarea',
+        monospace: true,
+        placeholder: 'dir=frontend\nbuildCmd=npm run build',
+        hint: '每行一条 key=value,完全自由;命令模板/产物路径里用 {{key}} 引用',
+      },
+      {
+        key: 'commandTemplate',
+        label: '命令模板',
+        kind: 'textarea',
+        monospace: true,
+        placeholder: 'cd {{dir}}\nnpm install\n{{buildCmd}}',
+        hint: '多行;{{参数}} 会被参数表的值替换,$ENV 仍交给容器内 shell',
+      },
+      {
+        key: 'artifactPath',
+        label: '产物路径',
+        kind: 'textarea',
+        monospace: true,
+        placeholder: '{{dir}}/dist',
+        hint: '可选,每行一条,支持 {{参数}} 与通配;目录→dist、*.jar→jar、其它→archive',
+      },
+      {
+        key: 'workDir',
+        label: '工作目录',
+        kind: 'text',
+        monospace: true,
+        placeholder: '.',
+        hint: '可选,相对克隆工作区根',
+      },
+    ],
+    defaultConfig: {
+      image: 'node:20',
+      params: 'dir=frontend\nbuildCmd=npm run build',
+      commandTemplate: 'cd {{dir}}\nnpm install --no-audit --no-fund\n{{buildCmd}}',
+      artifactPath: '{{dir}}/dist',
+    },
+  },
+
   script: {
     type: 'script',
     label: '自定义脚本',
@@ -460,6 +515,7 @@ export const PICKABLE_TYPES: readonly string[] = [
   'health_check',
   'notify',
   'script',
+  'templated',
 ]
 
 /** Dropdown options for the job type selector (friendly label + token). */

--- a/web/src/components/pipeline/jobConfigSchema.ts
+++ b/web/src/components/pipeline/jobConfigSchema.ts
@@ -68,6 +68,8 @@ export interface JobTypeSpec {
   /** Category the type belongs to (picker grouping) */
   category: CategoryId
   fields: JobField[]
+  /** 模板节点的预填配置(选中即带上,用户只改参数);普通节点省略。 */
+  defaultConfig?: Record<string, string>
 }
 
 // ─── Shared option sets ─────────────────────────────────────────────────────────
@@ -134,6 +136,46 @@ const SCRIPT_FIELDS: JobField[] = [
     monospace: true,
     placeholder: '.',
     hint: '相对克隆工作区根;留空为工作区根',
+  },
+  {
+    key: 'artifactPath',
+    label: '产物路径',
+    kind: 'textarea',
+    monospace: true,
+    placeholder: 'frontend/dist\nbackend/target/app.jar',
+    hint: '可选,每行一条。相对工作区根:目录→dist、*.jar→jar、其它文件→archive。一个节点可出多件;填了才归档进制品库并在运行详情可下载/部署。镜像产物请用「构建」节点(build_image),不在这里',
+  },
+]
+
+// SSH 部署节点的字段(deploy_ssh 与 deploy_frontend 模板共用)。
+const DEPLOY_SSH_FIELDS: JobField[] = [
+  {
+    key: 'serverId',
+    label: '目标服务器',
+    kind: 'server',
+    hint: '选择已登记的服务器(凭据按引用绑定)',
+  },
+  {
+    key: 'deployPath',
+    label: '部署路径',
+    kind: 'text',
+    monospace: true,
+    placeholder: '/opt/app',
+    hint: '产物发布到 <部署路径>/releases/<runId>/,current 软链原子切到本次发布(零停机,旧发布保留供回滚)',
+  },
+  {
+    key: 'strategy',
+    label: '部署策略',
+    kind: 'select',
+    options: DEPLOY_STRATEGY_OPTIONS,
+  },
+  {
+    key: 'restartCommand',
+    label: '重启 / 切换命令',
+    kind: 'textarea',
+    monospace: true,
+    placeholder: 'systemctl restart app\nnginx -s reload',
+    hint: '可选,多行(set -e 逐行执行);部署后在目标机 current 目录下执行,用于重启/重载;失败自动回滚',
   },
 ]
 
@@ -282,35 +324,7 @@ export const JOB_TYPE_SPECS: Record<string, JobTypeSpec> = {
     description: '通过 SSH 把产物部署到目标服务器',
     accent: 'green',
     category: 'deploy',
-    fields: [
-      {
-        key: 'serverId',
-        label: '目标服务器',
-        kind: 'server',
-        hint: '选择已登记的服务器(凭据按引用绑定)',
-      },
-      {
-        key: 'deployPath',
-        label: '部署路径',
-        kind: 'text',
-        monospace: true,
-        placeholder: '/opt/app',
-      },
-      {
-        key: 'strategy',
-        label: '部署策略',
-        kind: 'select',
-        options: DEPLOY_STRATEGY_OPTIONS,
-      },
-      {
-        key: 'restartCommand',
-        label: '重启 / 切换命令',
-        kind: 'text',
-        monospace: true,
-        placeholder: 'systemctl restart app',
-        hint: '部署后在目标机执行,用于重启或原子切换',
-      },
-    ],
+    fields: DEPLOY_SSH_FIELDS,
   },
 
   health_check: {
@@ -374,6 +388,45 @@ export const JOB_TYPE_SPECS: Record<string, JobTypeSpec> = {
     ],
   },
 
+  // ── 模板节点:预填好常见步骤参数,改改就能用,不必都写自定义脚本 ──
+  build_frontend: {
+    type: 'build_frontend',
+    label: '前端构建',
+    description: 'Node 容器里装依赖 + 构建,产出 dist',
+    accent: 'primary',
+    category: 'build',
+    fields: SCRIPT_FIELDS,
+    defaultConfig: {
+      image: 'node:20',
+      commands: 'cd frontend\nnpm install --no-audit --no-fund\nnpm run build',
+      artifactPath: 'frontend/dist',
+    },
+  },
+
+  build_backend: {
+    type: 'build_backend',
+    label: '后端构建',
+    description: 'Maven/Gradle 容器里打包,产出 jar',
+    accent: 'amber',
+    category: 'build',
+    fields: SCRIPT_FIELDS,
+    defaultConfig: {
+      image: 'maven:3.9-eclipse-temurin-21',
+      commands: 'cd backend\nmvn -B -DskipTests package',
+      artifactPath: 'backend/target/*.jar',
+    },
+  },
+
+  deploy_frontend: {
+    type: 'deploy_frontend',
+    label: '前端推送部署',
+    description: '把前端 dist 经 SSH 零停机部署到服务器',
+    accent: 'green',
+    category: 'deploy',
+    fields: DEPLOY_SSH_FIELDS,
+    defaultConfig: { strategy: 'rolling', restartCommand: 'nginx -s reload' },
+  },
+
   script: {
     type: 'script',
     label: '自定义脚本',
@@ -398,8 +451,11 @@ export const JOB_TYPE_SPECS: Record<string, JobTypeSpec> = {
 /** Canonical, ordered list of pickable types (excludes the `custom` alias of `script`). */
 export const PICKABLE_TYPES: readonly string[] = [
   'git_source',
+  'build_frontend',
+  'build_backend',
   'build_image',
   'push_image',
+  'deploy_frontend',
   'deploy_ssh',
   'health_check',
   'notify',

--- a/web/src/components/run/ArtifactList.vue
+++ b/web/src/components/run/ArtifactList.vue
@@ -12,9 +12,27 @@
 import { ref } from 'vue'
 import type { ArtifactDTO, ArtifactType } from '../../api/runs'
 
-defineProps<{
+const props = defineProps<{
   artifacts: ArtifactDTO[]
+  runId: string
 }>()
+
+// 已归档真字节(metadata.stored=true 且有 reference 句柄)才可下载;占位/镜像类不可。
+function downloadable(a: ArtifactDTO): boolean {
+  return a.metadata?.stored === true && !!a.reference
+}
+
+function downloadUrl(a: ArtifactDTO): string {
+  return `/api/runs/${props.runId}/artifacts/${a.id}/download`
+}
+
+// 来源节点(阶段 · 节点名),由后端写进 metadata.sourceStage/sourceJob;标注「哪个节点产的」。
+function sourceLabel(a: ArtifactDTO): string {
+  const stage = typeof a.metadata?.sourceStage === 'string' ? a.metadata.sourceStage : ''
+  const job = typeof a.metadata?.sourceJob === 'string' ? a.metadata.sourceJob : ''
+  if (stage && job) return `${stage} · ${job}`
+  return job || stage || ''
+}
 
 // ─── Type badge config (each type its own color — semantic, not decorative) ──
 
@@ -127,6 +145,12 @@ async function copyReference(a: ArtifactDTO): Promise<void> {
         <div class="artifact-main">
           <div class="artifact-name-row">
             <span class="artifact-name">{{ a.name }}</span>
+            <span v-if="sourceLabel(a)" class="source-tag" :title="`产出节点:${sourceLabel(a)}`">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <circle cx="6" cy="6" r="2.5"/><circle cx="6" cy="18" r="2.5"/><path d="M6 8.5v7M18 8a4 4 0 0 1-4 4H8.5"/><circle cx="18" cy="6" r="2.5"/>
+              </svg>
+              {{ sourceLabel(a) }}
+            </span>
             <span v-if="isStub(a)" class="stub-tag" title="桩产物(无真实构建,3-3 后换真实产物)">桩</span>
           </div>
           <button
@@ -151,6 +175,21 @@ async function copyReference(a: ArtifactDTO): Promise<void> {
 
         <!-- Size -->
         <span class="artifact-size mono" :aria-label="`大小 ${humanSize(a.sizeBytes)}`">{{ humanSize(a.sizeBytes) }}</span>
+
+        <!-- Download (仅已归档真字节可下载) -->
+        <a
+          v-if="downloadable(a)"
+          class="download-btn"
+          :href="downloadUrl(a)"
+          download
+          :title="`下载产物 ${a.name}`"
+          :aria-label="`下载产物 ${a.name}`"
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" aria-hidden="true">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/>
+          </svg>
+          下载
+        </a>
       </li>
     </ul>
   </section>
@@ -277,6 +316,25 @@ async function copyReference(a: ArtifactDTO): Promise<void> {
   border: 1px solid var(--color-amber-line);
 }
 
+/* 来源节点标签(哪个节点产的) */
+.source-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  font-size: 0.7rem;
+  font-weight: 500;
+  line-height: 1;
+  padding: 3px 7px;
+  border-radius: var(--rounded-sm);
+  background: var(--color-inset);
+  color: var(--color-faint);
+  border: 1px solid var(--color-border);
+  white-space: nowrap;
+}
+
+.source-tag svg { opacity: 0.8; }
+
 /* ─── reference (copyable) ───────────────────────────────────────────────── */
 .reference-row {
   display: inline-flex;
@@ -339,6 +397,34 @@ async function copyReference(a: ArtifactDTO): Promise<void> {
 }
 
 .mono { font-family: var(--font-mono); }
+
+/* ─── download button ────────────────────────────────────────────────────── */
+.download-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+  padding: 5px 11px;
+  border-radius: var(--rounded-md);
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-card-2);
+  color: var(--color-text);
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: border-color var(--duration-fast), background-color var(--duration-fast), color var(--duration-fast);
+}
+
+.download-btn:hover {
+  border-color: var(--color-primary);
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+}
+
+.download-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 @media (max-width: 640px) {
   .artifact-card {

--- a/web/src/components/run/RunStepList.vue
+++ b/web/src/components/run/RunStepList.vue
@@ -1,0 +1,198 @@
+<!--
+  RunStepList.vue — 步骤详情列表(从 RunDetail 抽出复用):每步状态图标 + 名称 + 时长。
+  运行中态与终态(成功/失败)共用,使「步骤」在构建完成后仍可见(不再只在进行中展示)。
+  纯展示组件:仅接收 steps prop,不自取数据。
+-->
+<script setup lang="ts">
+import type { RunStep } from '../../api/runs'
+
+defineProps<{
+  steps: RunStep[]
+  /** 当前选中的步骤序号(用于高亮 + 过滤日志);null = 全部。 */
+  selected?: number | null
+}>()
+
+const emit = defineEmits<{ select: [ordinal: number | null] }>()
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return '—'
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  const rem = s % 60
+  return rem > 0 ? `${m}m ${rem}s` : `${m}m`
+}
+</script>
+
+<template>
+  <div class="step-list">
+    <h3 class="subsection-title">步骤详情<span class="step-hint">点击查看单步日志</span></h3>
+    <ul class="steps" role="list">
+      <li>
+        <button
+          type="button"
+          class="step-row step-row--all"
+          :class="{ 'step-row--selected': selected == null }"
+          @click="emit('select', null)"
+        >
+          <div class="step-icon"><span class="all-dot" aria-hidden="true" /></div>
+          <div class="step-info"><span class="step-name">全部日志</span></div>
+        </button>
+      </li>
+      <li
+        v-for="(step, idx) in steps"
+        :key="step.id"
+      >
+        <button
+          type="button"
+          class="step-row"
+          :class="[`step-row--${step.status}`, { 'step-row--selected': selected === idx }]"
+          @click="emit('select', idx)"
+        >
+        <div class="step-icon" :aria-label="step.status">
+          <svg v-if="step.status === 'success'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
+            <path d="M20 6 9 17l-5-5"/>
+          </svg>
+          <span v-else-if="step.status === 'running'" class="spinner spinner--amber" aria-hidden="true" />
+          <svg v-else-if="step.status === 'failed'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
+            <path d="m18 6-12 12M6 6l12 12"/>
+          </svg>
+          <svg v-else-if="step.status === 'skipped'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <path d="M13 17l5-5-5-5M6 17l5-5-5-5"/>
+          </svg>
+          <svg v-else width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <circle cx="12" cy="12" r="3"/>
+          </svg>
+        </div>
+        <div class="step-info">
+          <span class="step-name">{{ step.name }}</span>
+          <span v-if="step.durationMs !== null" class="step-dur mono">{{ formatDuration(step.durationMs) }}</span>
+        </div>
+        </button>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+/* 左栏粘顶:终端很长时步骤选择器跟随视口,不在左侧留一大片死白。 */
+.step-list {
+  position: sticky;
+  top: 16px;
+  align-self: start;
+}
+
+.subsection-title {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--color-dim);
+  margin-bottom: 12px;
+  letter-spacing: 0.01em;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.step-hint {
+  font-size: 0.66rem;
+  font-weight: 400;
+  color: var(--color-faint);
+}
+
+.steps {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+}
+
+.steps li { list-style: none; }
+
+/* step-row 现在是按钮:点击切换「单步日志」过滤 */
+.step-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 11px;
+  border: 1px solid transparent;
+  border-radius: var(--rounded-md);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color var(--duration-fast), border-color var(--duration-fast);
+}
+
+.step-row:hover {
+  background: var(--color-inset);
+}
+
+.step-row--selected {
+  background: var(--color-primary-soft);
+  border-color: var(--color-primary);
+}
+
+.step-row:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+
+.step-row--running {
+  background: var(--color-amber-soft);
+}
+
+.all-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  background: var(--color-dim);
+  display: inline-block;
+}
+
+.step-icon {
+  display: grid;
+  place-items: center;
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.step-row--success .step-icon { color: var(--color-green); }
+.step-row--failed .step-icon { color: var(--color-red); }
+.step-row--running .step-icon { color: var(--color-amber); }
+.step-row--skipped .step-icon,
+.step-row--pending .step-icon { color: var(--color-faint); }
+
+.step-info {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.step-name {
+  font-size: 0.84rem;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.step-row--pending .step-name,
+.step-row--skipped .step-name { color: var(--color-faint); }
+
+.step-dur {
+  font-size: 0.74rem;
+  color: var(--color-faint);
+  flex-shrink: 0;
+}
+
+.mono { font-family: var(--font-mono); }
+</style>

--- a/web/src/components/run/RunTerminal.vue
+++ b/web/src/components/run/RunTerminal.vue
@@ -29,6 +29,8 @@ const props = defineProps<{
   runId: string
   /** true ⇒ 进行中,订阅 SSE 实时 tail;false ⇒ 终态,仅历史回放只读。 */
   live: boolean
+  /** 仅显示该步骤序号(stepOrdinal)的日志;null/undefined = 全部步骤。点步骤详情切换。 */
+  filterOrdinal?: number | null
 }>()
 
 // ─── log buffer: seq-keyed, ascending ─────────────────────────────────────────
@@ -135,22 +137,23 @@ const stickToBottom = ref(true)
 // px tolerance: treat "near bottom" as bottom (sub-pixel / rounding slack).
 const BOTTOM_EPS = 24
 
+// 终端封顶 56vh、框内纵向滚动:贴底判断与跟随都作用于终端元素内部滚动(实时 tail 在框内滚到底,
+// 不动整页)。用户在框内上滚 → 暂停跟随;滚回底部 → 恢复。
 function onScroll(): void {
   const el = scrollEl.value
   if (!el) return
   const distance = el.scrollHeight - el.scrollTop - el.clientHeight
-  // User scrolled up → pause auto-scroll; back at bottom → resume.
   stickToBottom.value = distance <= BOTTOM_EPS
 }
 
 let scrollQueued = false
 function scheduleAutoScroll(): void {
-  if (!stickToBottom.value || scrollQueued) return
+  if (!props.live || !stickToBottom.value || scrollQueued) return
   scrollQueued = true
   void nextTick(() => {
     scrollQueued = false
     const el = scrollEl.value
-    if (el && stickToBottom.value) {
+    if (el && props.live && stickToBottom.value) {
       el.scrollTop = el.scrollHeight
     }
   })
@@ -162,7 +165,13 @@ function jumpToBottom(): void {
   if (el) el.scrollTop = el.scrollHeight
 }
 
-const hasLines = computed(() => lines.value.length > 0)
+// 仅展示当前所选步骤的日志(filterOrdinal 为 null = 全部)。
+const visibleLines = computed(() =>
+  props.filterOrdinal == null
+    ? lines.value
+    : lines.value.filter((l) => l.stepOrdinal === props.filterOrdinal),
+)
+const hasLines = computed(() => visibleLines.value.length > 0)
 const showFollowButton = computed(() => !stickToBottom.value && hasLines.value)
 
 // ─── [MASKED] segmentation ─────────────────────────────────────────────────────
@@ -198,7 +207,7 @@ function lineKey(line: RunLogLine): number {
 </script>
 
 <template>
-  <div class="term" role="region" aria-label="运行日志终端">
+  <div class="term" :class="{ 'term--live': props.live }" role="region" aria-label="运行日志终端">
     <!-- Terminal chrome bar -->
     <div class="term-bar">
       <span class="term-dots" aria-hidden="true">
@@ -215,10 +224,10 @@ function lineKey(line: RunLogLine): number {
         <span class="term-live-dot" aria-hidden="true" />
         LIVE
       </span>
-      <span class="term-count mono" v-if="hasLines">{{ lines.length }} 行</span>
+      <span class="term-count mono" v-if="hasLines">{{ visibleLines.length }} 行</span>
     </div>
 
-    <!-- Scrollable log surface -->
+    <!-- Log surface — 封顶 56vh,框内纵向滚动;实时 tail 框内贴底跟随 -->
     <div
       ref="scrollEl"
       class="term-scroll"
@@ -248,9 +257,9 @@ function lineKey(line: RunLogLine): number {
       </div>
 
       <!-- Lines -->
-      <ol v-else class="term-lines" :aria-label="`共 ${lines.length} 行日志`">
+      <ol v-else class="term-lines" :aria-label="`共 ${visibleLines.length} 行日志`">
         <li
-          v-for="line in lines"
+          v-for="line in visibleLines"
           :key="lineKey(line)"
           class="term-line"
           :class="{ 'term-line--err': line.stream === 'stderr' }"
@@ -293,7 +302,8 @@ function lineKey(line: RunLogLine): number {
   border-radius: var(--rounded-lg);
   overflow: hidden;
   box-shadow: var(--shadow-inner);
-  min-height: 220px;
+  /* 终端高度贴合内容(不拉伸、不设上限):空/少行时是小盒子、底边紧跟最后一行,随日志增长
+     而长高,整页单一滚动条。不再用大 min-height 撑出「拉不到底边」的空黑盒。 */
 }
 
 /* ─── chrome bar ──────────────────────────────────────────────────────────── */
@@ -363,12 +373,14 @@ function lineKey(line: RunLogLine): number {
 
 /* ─── scroll surface ──────────────────────────────────────────────────────── */
 .term-scroll {
-  flex: 1;
-  overflow-y: auto;
+  /* 高度贴合内容,但封顶 56vh:超过则框内纵向滚动(主区 overflow-x:clip 已修好整页滚动,
+     不再有「嵌套双滚动滑不到底」的老问题)。空状态给个小下限避免太矮;长行横向滚动。 */
   overflow-x: auto;
+  overflow-y: auto;
+  min-height: 72px;
+  max-height: 56vh;
   /* Comfortable but dense terminal feel */
   padding: 8px 0 12px;
-  max-height: 560px;
   scrollbar-width: thin;
   scrollbar-color: var(--color-border-strong) transparent;
 }

--- a/web/src/components/run/runDag.test.ts
+++ b/web/src/components/run/runDag.test.ts
@@ -23,8 +23,9 @@ function mkStage(
   id: string,
   name: string,
   needs: string[] = [],
+  jobs: PipelineStage['jobs'] = [{ id: `${id}-j`, name: 'job', type: 'script', summary: '', config: {} }],
 ): PipelineStage {
-  return { id, name, kind: 'custom', needs, jobs: [] }
+  return { id, name, kind: 'custom', needs, jobs }
 }
 
 // ─── deriveStageStatus ────────────────────────────────────────────────────────
@@ -108,6 +109,27 @@ describe('buildRunStages', () => {
     const deployStage = result.find((r) => r.id === 'stg-b')!
     expect(deployStage.needs).toEqual(['stg-a'])
     expect(deployStage.status).toBe('running')
+  })
+
+  it('drops stages with no jobs (空阶段不画进拓扑) and cleans dangling needs', () => {
+    const steps = [mkStep('step-1', 'Build', 'success')]
+    const stages = [
+      mkStage('stg-a', 'Build'), // 有 job
+      mkStage('stg-b', 'Deploy', ['stg-a'], []), // 空阶段 → 应被剔除
+      mkStage('stg-c', 'Notify', ['stg-b'], []), // 空阶段 → 应被剔除
+    ]
+    const result = buildRunStages(steps, stages)
+    expect(result.map((r) => r.id)).toEqual(['stg-a'])
+    // stg-a 不应残留指向被剔除阶段的 needs(此处本就无)
+    expect(result[0].needs).toEqual([])
+  })
+
+  it('keeps a configured-but-not-yet-run stage (有 job 未跑 → pending,仍展示)', () => {
+    const steps = [mkStep('step-1', 'Build', 'success')]
+    const stages = [mkStage('stg-a', 'Build'), mkStage('stg-b', 'Deploy', ['stg-a'])]
+    const result = buildRunStages(steps, stages)
+    // Deploy 有 job 但还没产生 step → 保留(状态由 deriveStageStatus 推为 pending)
+    expect(result.map((r) => r.id)).toEqual(['stg-a', 'stg-b'])
   })
 
   it('puts unmatched steps into _unmatched synthetic stage', () => {

--- a/web/src/components/run/runDag.ts
+++ b/web/src/components/run/runDag.ts
@@ -131,17 +131,23 @@ export function buildRunStages(
     }
   }
 
-  const result: RunStage[] = pipelineStages.map((stage) => {
-    const stageSteps = buckets.get(stage.id) ?? []
-    return {
-      id: stage.id,
-      name: stage.name,
-      needs: stage.needs ?? [],
-      steps: stageSteps,
-      status: deriveStageStatus(stageSteps),
-      gate: stage.gate ?? false,
-    }
-  })
+  // 只画「真有 job」的阶段:未配置 job 的空阶段(占位)不进拓扑图,避免冒充已执行
+  // (动态阶段语义,与后端 dagrun.executableStages 一致;存量 4 阶段 spec 也即时受益)。
+  // 被剔除阶段的 id 从 needs 中清理,避免悬挂依赖产生指向不存在节点的边。
+  const kept = new Set(pipelineStages.filter((s) => (s.jobs?.length ?? 0) > 0).map((s) => s.id))
+  const result: RunStage[] = pipelineStages
+    .filter((stage) => kept.has(stage.id))
+    .map((stage) => {
+      const stageSteps = buckets.get(stage.id) ?? []
+      return {
+        id: stage.id,
+        name: stage.name,
+        needs: (stage.needs ?? []).filter((n) => kept.has(n)),
+        steps: stageSteps,
+        status: deriveStageStatus(stageSteps),
+        gate: stage.gate ?? false,
+      }
+    })
 
   // Append unmatched steps as a synthetic stage so they're visible
   if (unmatched.length > 0) {

--- a/web/src/layouts/AppShell.vue
+++ b/web/src/layouts/AppShell.vue
@@ -110,7 +110,10 @@ function isActive(item: NavItem): boolean {
 <style scoped>
 .app-shell {
   display: grid;
-  grid-template-columns: var(--rail-width) 1fr;
+  /* minmax(0,1fr) 而非 1fr:1fr 的最小尺寸是 min-content,会被内部超宽元素(如终端里不换行的
+     超长日志行)撑到比窗口还宽 → 整页横向溢出、卡片顶出右边。minmax(0,…) 允许主区收缩到窗口宽度,
+     超长内容只在各自容器内(终端横向滚动)处理,布局自适应窗口。 */
+  grid-template-columns: var(--rail-width) minmax(0, 1fr);
   min-height: 100vh;
 }
 
@@ -214,7 +217,10 @@ function isActive(item: NavItem): boolean {
 /* ——— Main area ——— */
 .main-area {
   min-height: 100vh;
-  overflow-x: hidden;
+  /* 用 clip 而非 hidden:hidden 会让 overflow-y 被规范强制计算成 auto,使 .main-area 变成一个
+     「装不下却又无法滚动」的隐性滚动容器,劫持滚轮/scrollIntoView,导致长页面(如运行详情的
+     日志终端)滑不到底。clip 只裁横向、不改纵向(保持 visible),整页交给 window 单一滚动。 */
+  overflow-x: clip;
 }
 
 .main-inner {

--- a/web/src/views/Login.vue
+++ b/web/src/views/Login.vue
@@ -118,7 +118,7 @@ const canSubmit = computed(() => !loading.value && !isLockedOut.value)
       <!-- Brand header -->
       <div class="brand">
         <div class="brand-logo" aria-hidden="true">
-          <span class="mono">d&gt;</span>
+          <span class="mono">p&gt;</span>
         </div>
         <div class="brand-name">
           <span class="brand-title">Pipewright</span>

--- a/web/src/views/RunDetail.vue
+++ b/web/src/views/RunDetail.vue
@@ -39,6 +39,7 @@ import { HttpError } from '../api/http'
 import DiagnosisPanel from '../components/run/DiagnosisPanel.vue'
 import SuccessFailDiff from '../components/run/SuccessFailDiff.vue'
 import RunTerminal from '../components/run/RunTerminal.vue'
+import RunStepList from '../components/run/RunStepList.vue'
 import ArtifactList from '../components/run/ArtifactList.vue'
 import TestReportPanel from '../components/run/TestReportPanel.vue'
 import DeployTargets from '../components/run/DeployTargets.vue'
@@ -58,6 +59,9 @@ type LoadState = 'loading' | 'idle' | 'error'
 const loadState = ref<LoadState>('loading')
 const loadError = ref('')
 const run = ref<RunDetail | null>(null)
+
+// 选中的步骤序号(点击步骤详情切换「单步日志」过滤);null = 全部步骤。
+const selectedStepOrdinal = ref<number | null>(null)
 
 // ─── cancel state ─────────────────────────────────────────────────────────────
 
@@ -354,8 +358,12 @@ function startSse(): void {
       // Approval gate (8-4): load pending stage when blocked; clear once resumed.
       if (status === 'waiting_approval') void loadApprovals()
       else pendingApproval.value = null
-      // Stop SSE on terminal state
-      if (isTerminal(status)) stopSse()
+      // Stop SSE on terminal state + 重拉完整 run:终态由后端补齐的 commit / 构建产物 / 时长
+      // 经 SSE 只推了 status,需重新 GET 才能拿到 → 否则要手动刷新才出来。
+      if (isTerminal(status)) {
+        stopSse()
+        void loadRun()
+      }
     },
     onStep({ step }) {
       if (!run.value) return
@@ -653,59 +661,12 @@ function nodeClass(status: StepStatus): string {
               />
             </div>
 
-            <!-- Two-column layout: step list + log placeholder -->
+            <!-- Two-column layout: 步骤详情(点击单步看其日志) + 实时日志终端 -->
             <div class="running-body">
-
-              <!-- Step list -->
-              <div class="step-list">
-                <h3 class="subsection-title">步骤详情</h3>
-                <ul class="steps" role="list">
-                  <li
-                    v-for="step in run.steps"
-                    :key="step.id"
-                    class="step-row"
-                    :class="`step-row--${step.status}`"
-                  >
-                    <div class="step-icon" :aria-label="step.status">
-                      <!-- success -->
-                      <svg v-if="step.status === 'success'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
-                        <path d="M20 6 9 17l-5-5"/>
-                      </svg>
-                      <!-- running: spinner -->
-                      <span v-else-if="step.status === 'running'" class="spinner spinner--amber" aria-hidden="true" />
-                      <!-- failed -->
-                      <svg v-else-if="step.status === 'failed'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
-                        <path d="m18 6-12 12M6 6l12 12"/>
-                      </svg>
-                      <!-- skipped -->
-                      <svg v-else-if="step.status === 'skipped'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                        <path d="M13 17l5-5-5-5M6 17l5-5-5-5"/>
-                      </svg>
-                      <!-- pending -->
-                      <svg v-else width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                        <circle cx="12" cy="12" r="3"/>
-                      </svg>
-                    </div>
-                    <div class="step-info">
-                      <span class="step-name">{{ step.name }}</span>
-                      <span v-if="step.durationMs !== null" class="step-dur mono">{{ formatDuration(step.durationMs) }}</span>
-                    </div>
-                  </li>
-                </ul>
-              </div>
-
-              <!--
-                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                SLOT: 实时日志终端 (Story 3-6 接入)
-                骨架所有权: 本区块归 Story 3.1;
-                Story 3-6 在此区块内填入真实日志终端组件,不改骨架结构。
-                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-              -->
+              <RunStepList :steps="run.steps" :selected="selectedStepOrdinal" @select="selectedStepOrdinal = $event" />
               <div class="slot-log-live" role="region" aria-label="实时日志终端">
-                <RunTerminal :run-id="run.id" :live="true" />
+                <RunTerminal :run-id="run.id" :live="true" :filter-ordinal="selectedStepOrdinal" />
               </div>
-              <!-- END SLOT: 实时日志终端 -->
-
             </div>
           </div>
         </template>
@@ -744,7 +705,7 @@ function nodeClass(status: StepStatus): string {
               不扰终端(3-6)/零停机(Epic 4)/诊断(7-2)slot。
               ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
             -->
-            <ArtifactList :artifacts="run.artifacts" />
+            <ArtifactList :artifacts="run.artifacts" :run-id="run.id" />
 
             <!--
               ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -771,9 +732,12 @@ function nodeClass(status: StepStatus): string {
             />
             <!-- END SLOT: 环境晋级 -->
 
-            <!-- 历史日志回放(只读,Story 3-6) -->
-            <div class="log-history" role="region" aria-label="历史运行日志">
-              <RunTerminal :run-id="run.id" :live="false" />
+            <!-- 步骤详情(点击单步看其日志)+ 历史日志回放(2 列;步骤完成后仍可见) -->
+            <div class="running-body">
+              <RunStepList :steps="run.steps" :selected="selectedStepOrdinal" @select="selectedStepOrdinal = $event" />
+              <div class="log-history" role="region" aria-label="历史运行日志">
+                <RunTerminal :run-id="run.id" :live="false" :filter-ordinal="selectedStepOrdinal" />
+              </div>
             </div>
 
             <!--
@@ -1592,7 +1556,8 @@ function nodeClass(status: StepStatus): string {
 /* ─── running body: two-column (step list + log slot) ───────────────────── */
 .running-body {
   display: grid;
-  grid-template-columns: 280px 1fr;
+  /* minmax(0,1fr):防止终端超长日志行把右列撑爆、溢出整页(自适应窗口宽度)。 */
+  grid-template-columns: 280px minmax(0, 1fr);
   gap: 16px;
   align-items: start;
 }
@@ -1743,10 +1708,6 @@ function nodeClass(status: StepStatus): string {
 /* Live log terminal slot (Story 3-6) — sits in running-body's second column */
 .slot-log-live {
   min-width: 0;
-}
-
-.slot-log-live :deep(.term) {
-  min-height: 320px;
 }
 
 /* Historical log replay (terminal states) — full width below summaries */


### PR DESCRIPTION
真·全栈验收 aireboot(真浏览器 → 真前端 → 真后端 → 真 Docker 构建 → 真 SSH 部署到本机 CentOS 容器 → 真通知),过程中发现并修复一串问题、补齐多项能力。改动跨多主题且集中在同几个共享文件(`dag_stage_exec.go`/`main.go`/`jobConfigSchema.ts`/`RunDetail.vue`)里交错,故合为一个 PR。

## 修复
- **品牌**:登录页/引导页残留旧 `d>` 标记 → `p>`(改名时漏改)。
- **动态空阶段**:默认只种 `源+构建`;空阶段不规划成步骤、不画进拓扑(原本写死 4 阶段且空阶段冒充「已执行」)。
- **运行详情**:终态后产物/commit **自动刷新**(SSE 转终态重拉,不再手动刷新);**自适应宽度**(主区 `minmax(0,1fr)` 治终端超长行撑爆整页);步骤详情**常驻**(完成后不再隐藏)。

## 能力补齐
- **COMMIT 回写**:克隆解析出的实际 commit 经 `WithCommitRecorder` → `run.Service.SetCommit`,运行详情显示真实 commit。
- **制品库**:script 节点 `artifactPath`(多行 + 通配)真字节归档进内容寻址库 + **下载端点** + **来源节点**标注;`build_image` 节点在 DAG 真实化(docker build/工具链 + 自动 push)。
- **流水线节点真实化**:`deploy_ssh`(中途部署 `DeployForStage`,不动 run 终态;支持**多行重启/切换命令**,current 目录执行、失败回滚)+ `notify`(发渠道)。
- **单步日志**:步骤详情可点,按 `stepOrdinal` 过滤只看该步;终端封顶 `56vh` 框内滚动。
- **模板节点**:前端构建 / 后端构建 / 前端推送部署(预填参数,改改即用)。
- **自定义节点(templated)**:用户自定义**自由参数**(`params` 每行 `key=value`)+ 命令模板 `{{key}}`,渲染进镜像/命令/产物路径后在隔离容器真跑。

## 验证
- 全链路一次跑通:`源 → 构建 → 部署(CentOS)→ 通知` 四阶段绿;CentOS 真落盘 `/opt/aireboot/current`(零停机 release+软链)、重启命令真执行、webhook 真收到。
- 后端 `go build/vet ./...` + `gofmt` + 全量 `go test ./...` 通过;前端 typecheck + 单测 + build 通过。

## 边界(后续)
- 自定义节点的「存为命名节点 + 复用库管理 + 跨流水线复用」(save/reuse 层)未做。
- `build_image` docker build 上下文沿用仓库根(子目录 Dockerfile = 后续);后端镜像推送部署(image→目标机)未做。
- 远程 runner 模式的 build_image / 制品回传未做。
- 低代码可视化节点构建器(Tier 3)未做。

🤖 Generated with [Claude Code](https://claude.com/claude-code)