### PR TITLE
feat(library): 自定义节点存 & 复用层(复用库 Tier 2)

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -119,6 +119,8 @@ func main() {
 	// 变量集合,镜像每流水线变量模型;secret 经 credVault 校验存在性、只存引用,明文绝不入库。
 	templateSvc := library.NewTemplateService(st.DB, pipelineSvc)
 	varGroupSvc := library.NewVarGroupService(st.DB, credVault)
+	// 自定义节点(复用库 Tier 2):命名、可复用的「单节点」(nodeType + config 快照),供选择器复用。
+	customNodeSvc := library.NewCustomNodeService(st.DB)
 
 	// 装配项目级并发上限配置服务(FR-8-10 并发/队列控制):每项目一份 max_concurrent。
 	// 注入 worker pool 做准入(下方);经 /api/projects/{id}/concurrency 读写。
@@ -399,7 +401,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithRefs(refsLister), httpapi.WithArtifactStore(artStore), httpapi.WithServers(targetSvc), httpapi.WithRunnerConfig(runnerSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithChain(chainSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc), httpapi.WithPromotion(promotionStore), httpapi.WithDoraMetrics(doraMetricsSvc), httpapi.WithTemplates(templateSvc), httpapi.WithVariableGroups(varGroupSvc)),
+		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithRefs(refsLister), httpapi.WithArtifactStore(artStore), httpapi.WithServers(targetSvc), httpapi.WithRunnerConfig(runnerSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithChain(chainSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc), httpapi.WithPromotion(promotionStore), httpapi.WithDoraMetrics(doraMetricsSvc), httpapi.WithTemplates(templateSvc), httpapi.WithVariableGroups(varGroupSvc), httpapi.WithCustomNodes(customNodeSvc)),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		// WriteTimeout 置 0:SSE 长连接(/api/runs/{id}/events)不可被写超时切断;

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -48,6 +48,10 @@ const (
 	ActionVarGroupCreate = "variable_group_create"
 	ActionVarGroupUpdate = "variable_group_update"
 	ActionVarGroupDelete = "variable_group_delete"
+	// 自定义节点(复用库 Tier 2)。
+	ActionCustomNodeCreate = "custom_node_create"
+	ActionCustomNodeUpdate = "custom_node_update"
+	ActionCustomNodeDelete = "custom_node_delete"
 )
 
 // 目标类型枚举(供 TargetType 填值;非强制白名单,便于后续 story 扩展)。
@@ -61,6 +65,7 @@ const (
 	TargetServer     = "server"
 	TargetTemplate   = "template"
 	TargetVarGroup   = "variable_group"
+	TargetCustomNode = "custom_node"
 )
 
 // Entry 是一条审计写入入参(冻结契约)。Detail 写库前过 Masker,绝不含明文 secret。

--- a/internal/httpapi/custom_nodes.go
+++ b/internal/httpapi/custom_nodes.go
@@ -1,0 +1,200 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/audit"
+	"github.com/huangchengsir/pipewright/internal/library"
+)
+
+// custom_nodes.go 暴露自定义节点端点(复用库 Tier 2 · 对标 Jenkins 自定义步骤 / 云效自建任务模板)。
+//
+//	GET    /api/custom-nodes       → 列自定义节点(选择器/复用库画廊)
+//	POST   /api/custom-nodes       → 建自定义节点(name + nodeType + config 快照)
+//	GET    /api/custom-nodes/{id}  → 取单自定义节点(含完整 config)
+//	PUT    /api/custom-nodes/{id}  → 覆盖自定义节点
+//	DELETE /api/custom-nodes/{id}  → 删自定义节点
+//
+// config 为 Job.Config 自由 KV 快照,不含明文 secret(与流水线 spec 同形状,secret 走保险库引用)。
+// 写操作过 auth + CSRF + 审计(detail 仅元数据:名称 + 类型,绝无 config 明文)。
+
+// customNodeDTO 是自定义节点对外 DTO(冻结契约;camelCase;含完整 config 供回填)。
+type customNodeDTO struct {
+	ID          string         `json:"id"`
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	NodeType    string         `json:"nodeType"`
+	Summary     string         `json:"summary"`
+	Config      map[string]any `json:"config"`
+	CreatedAt   string         `json:"createdAt"`
+	UpdatedAt   string         `json:"updatedAt"`
+}
+
+func toCustomNodeDTO(n *library.CustomNode) customNodeDTO {
+	cfg := n.Config
+	if cfg == nil {
+		cfg = map[string]any{}
+	}
+	return customNodeDTO{
+		ID:          n.ID,
+		Name:        n.Name,
+		Description: n.Description,
+		NodeType:    n.NodeType,
+		Summary:     n.Summary,
+		Config:      cfg,
+		CreatedAt:   n.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:   n.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+// writeCustomNodeError 把自定义节点领域错误映射为契约错误码/状态码。
+func writeCustomNodeError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, library.ErrCustomNodeNotFound):
+		writeError(w, http.StatusNotFound, "custom_node_not_found", "自定义节点不存在")
+	case errors.Is(err, library.ErrCustomNodeNameTaken):
+		writeError(w, http.StatusConflict, "custom_node_name_taken", "自定义节点名已被占用")
+	case errors.Is(err, library.ErrInvalidCustomNode):
+		writeError(w, http.StatusUnprocessableEntity, "invalid_custom_node", err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+	}
+}
+
+// customNodeReqBody 是建/改自定义节点的请求体。Config 为自由 KV(不含明文 secret)。
+type customNodeReqBody struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	NodeType    string         `json:"nodeType"`
+	Summary     string         `json:"summary"`
+	Config      map[string]any `json:"config"`
+}
+
+func (b customNodeReqBody) toInput() library.CustomNodeInput {
+	return library.CustomNodeInput{
+		Name:        b.Name,
+		Description: b.Description,
+		NodeType:    b.NodeType,
+		Summary:     b.Summary,
+		Config:      b.Config,
+	}
+}
+
+func makeListCustomNodesHandler(svc library.CustomNodeService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "自定义节点服务未初始化")
+			return
+		}
+		list, err := svc.List(r.Context())
+		if err != nil {
+			writeCustomNodeError(w, err)
+			return
+		}
+		out := make([]customNodeDTO, 0, len(list))
+		for i := range list {
+			out = append(out, toCustomNodeDTO(&list[i]))
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"customNodes": out})
+	}
+}
+
+func makeGetCustomNodeHandler(svc library.CustomNodeService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "自定义节点服务未初始化")
+			return
+		}
+		n, err := svc.Get(r.Context(), chi.URLParam(r, "id"))
+		if err != nil {
+			writeCustomNodeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, toCustomNodeDTO(n))
+	}
+}
+
+func makeCreateCustomNodeHandler(svc library.CustomNodeService, aud audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "自定义节点服务未初始化")
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<18) // 256KB
+		var req customNodeReqBody
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		n, err := svc.Create(r.Context(), req.toInput())
+		if err != nil {
+			writeCustomNodeError(w, err)
+			return
+		}
+		recordAudit(r.Context(), aud, audit.Entry{
+			Actor:      auditActor,
+			Action:     audit.ActionCustomNodeCreate,
+			TargetType: audit.TargetCustomNode,
+			TargetID:   n.ID,
+			Detail:     map[string]any{"name": n.Name, "nodeType": n.NodeType},
+			IP:         clientIP(r),
+		})
+		writeJSON(w, http.StatusCreated, toCustomNodeDTO(n))
+	}
+}
+
+func makeUpdateCustomNodeHandler(svc library.CustomNodeService, aud audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "自定义节点服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<18)
+		var req customNodeReqBody
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		n, err := svc.Update(r.Context(), id, req.toInput())
+		if err != nil {
+			writeCustomNodeError(w, err)
+			return
+		}
+		recordAudit(r.Context(), aud, audit.Entry{
+			Actor:      auditActor,
+			Action:     audit.ActionCustomNodeUpdate,
+			TargetType: audit.TargetCustomNode,
+			TargetID:   n.ID,
+			Detail:     map[string]any{"name": n.Name, "nodeType": n.NodeType},
+			IP:         clientIP(r),
+		})
+		writeJSON(w, http.StatusOK, toCustomNodeDTO(n))
+	}
+}
+
+func makeDeleteCustomNodeHandler(svc library.CustomNodeService, aud audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "自定义节点服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		if err := svc.Delete(r.Context(), id); err != nil {
+			writeCustomNodeError(w, err)
+			return
+		}
+		recordAudit(r.Context(), aud, audit.Entry{
+			Actor:      auditActor,
+			Action:     audit.ActionCustomNodeDelete,
+			TargetType: audit.TargetCustomNode,
+			TargetID:   id,
+			IP:         clientIP(r),
+		})
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -85,6 +85,7 @@ type options struct {
 	doraMetrics      run.MetricsService
 	templates        library.TemplateService
 	varGroups        library.VarGroupService
+	customNodes      library.CustomNodeService
 	artifactStore    *artifactstore.Store
 }
 
@@ -129,6 +130,13 @@ func WithTemplates(s library.TemplateService) Option {
 // 不传则相关端点返回 503(服务未初始化)。
 func WithVariableGroups(s library.VarGroupService) Option {
 	return func(o *options) { o.varGroups = s }
+}
+
+// WithCustomNodes 注入自定义节点服务(复用库 Tier 2),挂载 /api/custom-nodes* 路由。
+// GET 过 auth;POST/PUT/DELETE 过 auth + CSRF + 审计。config 为自由 KV 快照,不含明文 secret。
+// 不传则相关端点返回 503(服务未初始化)。
+func WithCustomNodes(s library.CustomNodeService) Option {
+	return func(o *options) { o.customNodes = s }
 }
 
 // WithVault 注入凭据保险库,挂载 /api/credentials* 路由。
@@ -642,6 +650,16 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		ar.Get("/variable-groups/{id}", makeGetVarGroupHandler(vg))
 		ar.Put("/variable-groups/{id}", makeUpdateVarGroupHandler(vg, aud))
 		ar.Delete("/variable-groups/{id}", makeDeleteVarGroupHandler(vg, aud))
+
+		// 自定义节点(复用库 Tier 2):命名、可复用的「单节点」(nodeType + config 快照)。
+		// cn 为 nil → handler 返回 503。GET 过 auth;POST/PUT/DELETE 为写方法,过 auth + CSRF + 审计。
+		// config 为自由 KV 快照,不含明文 secret。
+		cn := o.customNodes
+		ar.Get("/custom-nodes", makeListCustomNodesHandler(cn))
+		ar.Post("/custom-nodes", makeCreateCustomNodeHandler(cn, aud))
+		ar.Get("/custom-nodes/{id}", makeGetCustomNodeHandler(cn))
+		ar.Put("/custom-nodes/{id}", makeUpdateCustomNodeHandler(cn, aud))
+		ar.Delete("/custom-nodes/{id}", makeDeleteCustomNodeHandler(cn, aud))
 
 		// 后续 story 在此挂载其他 API 路由。
 	})

--- a/internal/library/customnode.go
+++ b/internal/library/customnode.go
@@ -1,0 +1,235 @@
+package library
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// customnode.go 是「自定义节点」复用基座的领域层(复用库 Tier 2 · 对标 Jenkins 自定义步骤 /
+// 云效自建任务模板)。
+//
+// 自定义节点(CustomNode):一份命名、可复用的「单节点」定义 —— 底层 Job 类型 + config 快照。
+// 用户在画布把某节点(常为 templated/script 自定义节点,也可任意内建类型)配好后「存为自定义节点」,
+// 之后从选择器挑选即插入一个预填好 config 的 Job。与流水线模板(整段 stages)互补。
+//
+// 参数自由:Config 是 Job.Config 的原样快照(自由 KV),领域层不强加 schema(单管理员场景,
+// 留足自定义自由度);只校验 name 非空 + nodeType 非空。绝不存任何明文 secret(config 与流水线
+// spec 同形状,secret 走保险库引用)。领域包无 init() 副作用、无包级重对象,避免抬高空载内存。
+
+// 自定义节点领域错误。错误体不含任何明文 secret。
+var (
+	// ErrCustomNodeNotFound 表示引用的自定义节点不存在。
+	ErrCustomNodeNotFound = errors.New("library: custom node not found")
+	// ErrInvalidCustomNode 表示自定义节点校验失败(名称空 / 类型空)。
+	ErrInvalidCustomNode = errors.New("library: invalid custom node")
+	// ErrCustomNodeNameTaken 表示自定义节点名已被占用(唯一约束)。
+	ErrCustomNodeNameTaken = errors.New("library: custom node name already in use")
+)
+
+// CustomNode 是一份命名、可复用的单节点定义(NodeType + Config 快照)。
+type CustomNode struct {
+	ID          string
+	Name        string
+	Description string
+	NodeType    string
+	Summary     string
+	Config      map[string]any
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// CustomNodeInput 是创建/更新自定义节点的入参。Config 为自由 KV(不含明文 secret)。
+type CustomNodeInput struct {
+	Name        string
+	Description string
+	NodeType    string
+	Summary     string
+	Config      map[string]any
+}
+
+// CustomNodeService 定义自定义节点领域对外接口。
+type CustomNodeService interface {
+	// List 返回所有自定义节点(按名称升序),供选择器/复用库画廊。
+	List(ctx context.Context) ([]CustomNode, error)
+	// Get 返回单个自定义节点;不存在 → ErrCustomNodeNotFound。
+	Get(ctx context.Context, id string) (*CustomNode, error)
+	// Create 校验(名称 + 类型非空)→ 持久化 config 快照 → 回读。名称重复 → ErrCustomNodeNameTaken。
+	Create(ctx context.Context, in CustomNodeInput) (*CustomNode, error)
+	// Update 同 Create 的校验/持久化,按 id 覆盖;不存在 → ErrCustomNodeNotFound。
+	Update(ctx context.Context, id string, in CustomNodeInput) (*CustomNode, error)
+	// Delete 删除自定义节点;不存在 → ErrCustomNodeNotFound。
+	Delete(ctx context.Context, id string) error
+}
+
+type customNodeService struct {
+	db *sql.DB
+}
+
+// NewCustomNodeService 构造 CustomNodeService(经参数化 SQL 触库)。
+// 不在此做任何重活(无 init() 副作用,避免抬高空载内存)。
+func NewCustomNodeService(db *sql.DB) CustomNodeService {
+	return &customNodeService{db: db}
+}
+
+func (s *customNodeService) List(ctx context.Context) ([]CustomNode, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, name, description, node_type, summary, config_json, created_at, updated_at
+		 FROM custom_nodes ORDER BY name ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("library: list custom nodes: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]CustomNode, 0)
+	for rows.Next() {
+		n, err := scanCustomNode(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *n)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("library: iterate custom nodes: %w", err)
+	}
+	return out, nil
+}
+
+func (s *customNodeService) Get(ctx context.Context, id string) (*CustomNode, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT id, name, description, node_type, summary, config_json, created_at, updated_at
+		 FROM custom_nodes WHERE id = ?`, strings.TrimSpace(id))
+	n, err := scanCustomNode(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrCustomNodeNotFound
+	}
+	return n, err
+}
+
+func (s *customNodeService) Create(ctx context.Context, in CustomNodeInput) (*CustomNode, error) {
+	name, nodeType, configJSON, err := validateCustomNode(in)
+	if err != nil {
+		return nil, err
+	}
+
+	id := uuid.NewString()
+	nowStr := time.Now().UTC().Format(time.RFC3339)
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO custom_nodes (id, name, description, node_type, summary, config_json, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, name, strings.TrimSpace(in.Description), nodeType, strings.TrimSpace(in.Summary), configJSON, nowStr, nowStr,
+	)
+	if err != nil {
+		if isUniqueErr(err) {
+			return nil, ErrCustomNodeNameTaken
+		}
+		return nil, fmt.Errorf("library: insert custom node: %w", err)
+	}
+	return s.Get(ctx, id)
+}
+
+func (s *customNodeService) Update(ctx context.Context, id string, in CustomNodeInput) (*CustomNode, error) {
+	id = strings.TrimSpace(id)
+	// 先确认存在(给明确 404,而非静默 0 行)。
+	if _, err := s.Get(ctx, id); err != nil {
+		return nil, err
+	}
+	name, nodeType, configJSON, err := validateCustomNode(in)
+	if err != nil {
+		return nil, err
+	}
+
+	nowStr := time.Now().UTC().Format(time.RFC3339)
+	_, err = s.db.ExecContext(ctx,
+		`UPDATE custom_nodes SET name = ?, description = ?, node_type = ?, summary = ?, config_json = ?, updated_at = ?
+		 WHERE id = ?`,
+		name, strings.TrimSpace(in.Description), nodeType, strings.TrimSpace(in.Summary), configJSON, nowStr, id,
+	)
+	if err != nil {
+		if isUniqueErr(err) {
+			return nil, ErrCustomNodeNameTaken
+		}
+		return nil, fmt.Errorf("library: update custom node: %w", err)
+	}
+	return s.Get(ctx, id)
+}
+
+func (s *customNodeService) Delete(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM custom_nodes WHERE id = ?`, strings.TrimSpace(id))
+	if err != nil {
+		return fmt.Errorf("library: delete custom node: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("library: delete custom node rows: %w", err)
+	}
+	if n == 0 {
+		return ErrCustomNodeNotFound
+	}
+	return nil
+}
+
+// validateCustomNode 校验名称 + 类型非空,返回 trim 后名称/类型 + config 快照 JSON(nil 补 {})。
+// 不对 config 强加 schema(留足自定义自由度);config 与流水线 spec 同形状,不含明文 secret。
+func validateCustomNode(in CustomNodeInput) (name, nodeType, configJSON string, err error) {
+	name = strings.TrimSpace(in.Name)
+	if name == "" {
+		return "", "", "", fmt.Errorf("%w: name must not be empty", ErrInvalidCustomNode)
+	}
+	nodeType = strings.TrimSpace(in.NodeType)
+	if nodeType == "" {
+		return "", "", "", fmt.Errorf("%w: node type must not be empty", ErrInvalidCustomNode)
+	}
+	cfg := in.Config
+	if cfg == nil {
+		cfg = map[string]any{}
+	}
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		return "", "", "", fmt.Errorf("library: marshal custom node config: %w", err)
+	}
+	return name, nodeType, string(raw), nil
+}
+
+func scanCustomNode(row rowScanner) (*CustomNode, error) {
+	var (
+		id, name, desc, nodeType, summary, configJSON string
+		createdStr, updatedStr                        string
+	)
+	if err := row.Scan(&id, &name, &desc, &nodeType, &summary, &configJSON, &createdStr, &updatedStr); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, sql.ErrNoRows
+		}
+		return nil, fmt.Errorf("library: scan custom node: %w", err)
+	}
+
+	var config map[string]any
+	if strings.TrimSpace(configJSON) != "" {
+		if err := json.Unmarshal([]byte(configJSON), &config); err != nil {
+			return nil, fmt.Errorf("library: parse custom node config: %w", err)
+		}
+	}
+	if config == nil {
+		config = map[string]any{}
+	}
+
+	created, _ := time.Parse(time.RFC3339, createdStr)
+	updated, _ := time.Parse(time.RFC3339, updatedStr)
+	return &CustomNode{
+		ID:          id,
+		Name:        name,
+		Description: desc,
+		NodeType:    nodeType,
+		Summary:     summary,
+		Config:      config,
+		CreatedAt:   created,
+		UpdatedAt:   updated,
+	}, nil
+}

--- a/internal/library/customnode_test.go
+++ b/internal/library/customnode_test.go
@@ -1,0 +1,116 @@
+package library
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestCustomNodeCRUD 覆盖自定义节点的建/列/取/改/删全链路 + config 快照原样回读。
+func TestCustomNodeCRUD(t *testing.T) {
+	db := testDB(t)
+	svc := NewCustomNodeService(db)
+	ctx := context.Background()
+
+	created, err := svc.Create(ctx, CustomNodeInput{
+		Name:        "前端构建",
+		Description: "node 构建 + 产物收集",
+		NodeType:    "templated",
+		Summary:     "node:20 → dist",
+		Config: map[string]any{
+			"image":           "node:{{ver}}",
+			"commandTemplate": "npm ci\nnpm run build",
+			"params":          "ver=20",
+			"artifactPath":    "dist/**",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("Create: empty id")
+	}
+
+	// config 快照应原样回读(自由 KV 不被裁剪)。
+	if created.Config["image"] != "node:{{ver}}" || created.Config["commandTemplate"] != "npm ci\nnpm run build" {
+		t.Fatalf("Create: config not preserved: %#v", created.Config)
+	}
+
+	// List 含刚建的节点。
+	list, err := svc.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 || list[0].Name != "前端构建" {
+		t.Fatalf("List: unexpected %#v", list)
+	}
+
+	// Get 回读。
+	got, err := svc.Get(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.NodeType != "templated" || got.Summary != "node:20 → dist" {
+		t.Fatalf("Get: unexpected %#v", got)
+	}
+
+	// Update 覆盖。
+	updated, err := svc.Update(ctx, created.ID, CustomNodeInput{
+		Name:     "前端构建 v2",
+		NodeType: "templated",
+		Config:   map[string]any{"image": "node:22"},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.Name != "前端构建 v2" || updated.Config["image"] != "node:22" {
+		t.Fatalf("Update: unexpected %#v", updated)
+	}
+
+	// Delete + 二次取应 404。
+	if err := svc.Delete(ctx, created.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := svc.Get(ctx, created.ID); !errors.Is(err, ErrCustomNodeNotFound) {
+		t.Fatalf("Get after delete: want ErrCustomNodeNotFound, got %v", err)
+	}
+}
+
+// TestCustomNodeValidation 覆盖名称/类型空校验 + 重名冲突。
+func TestCustomNodeValidation(t *testing.T) {
+	db := testDB(t)
+	svc := NewCustomNodeService(db)
+	ctx := context.Background()
+
+	if _, err := svc.Create(ctx, CustomNodeInput{Name: "  ", NodeType: "script"}); !errors.Is(err, ErrInvalidCustomNode) {
+		t.Fatalf("empty name: want ErrInvalidCustomNode, got %v", err)
+	}
+	if _, err := svc.Create(ctx, CustomNodeInput{Name: "x", NodeType: " "}); !errors.Is(err, ErrInvalidCustomNode) {
+		t.Fatalf("empty type: want ErrInvalidCustomNode, got %v", err)
+	}
+
+	if _, err := svc.Create(ctx, CustomNodeInput{Name: "dup", NodeType: "script"}); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	if _, err := svc.Create(ctx, CustomNodeInput{Name: "dup", NodeType: "script"}); !errors.Is(err, ErrCustomNodeNameTaken) {
+		t.Fatalf("dup name: want ErrCustomNodeNameTaken, got %v", err)
+	}
+
+	// nil config 应补 {} 而非崩。
+	n, err := svc.Create(ctx, CustomNodeInput{Name: "nilcfg", NodeType: "script", Config: nil})
+	if err != nil {
+		t.Fatalf("nil config create: %v", err)
+	}
+	if n.Config == nil {
+		t.Fatal("nil config: want non-nil empty map")
+	}
+}
+
+// TestCustomNodeUpdateNotFound 校验更新不存在节点报 404。
+func TestCustomNodeUpdateNotFound(t *testing.T) {
+	db := testDB(t)
+	svc := NewCustomNodeService(db)
+	if _, err := svc.Update(context.Background(), "missing", CustomNodeInput{Name: "x", NodeType: "script"}); !errors.Is(err, ErrCustomNodeNotFound) {
+		t.Fatalf("Update missing: want ErrCustomNodeNotFound, got %v", err)
+	}
+}

--- a/internal/store/migrations/0033_custom_nodes.sql
+++ b/internal/store/migrations/0033_custom_nodes.sql
@@ -1,0 +1,28 @@
+-- 0033 自定义节点(复用库 Tier 2 · 对标 Jenkins 自定义步骤 / 云效自建任务模板)。
+--
+-- custom_nodes:命名、可复用的「单节点」定义。用户在画布把某个节点(常为 templated/script
+-- 自定义节点,也可是任意内建类型)配好后「存为自定义节点」,落一份 config 快照;之后从节点选择器
+-- 挑选该自定义节点,即插入一个预填好 config 的 Job(免去重复填参)。与模板(整条流水线)互补:
+-- 模板复用「一段 stages」,自定义节点复用「一个 job」。跨项目共享、与具体项目解耦。
+--
+-- 参数自由:config_json 是 Job.Config 的原样快照(自由 KV),不强加 schema(单管理员场景,
+-- 留足自定义自由度)。绝不存任何明文 secret —— config 与流水线 spec 同形状,secret 走保险库引用。
+--   id          : 自定义节点主键(uuid)
+--   name        : 节点名(去空白后非空;库内唯一,便于挑选)
+--   description : 说明(可空)
+--   node_type   : 底层 Job 类型(如 templated/script/build_frontend;决定执行语义与图标)
+--   summary     : 卡片副标题展示文本(可空,镜像 Job.Summary)
+--   config_json : Job.Config 的 JSON 快照(自由 KV;不含明文 secret)
+CREATE TABLE IF NOT EXISTS custom_nodes (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    node_type   TEXT NOT NULL,
+    summary     TEXT NOT NULL DEFAULT '',
+    config_json TEXT NOT NULL DEFAULT '{}',
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+
+-- 名称唯一(挑选时人读、避免重名歧义)。
+CREATE UNIQUE INDEX IF NOT EXISTS idx_custom_nodes_name ON custom_nodes (name);

--- a/web/src/api/customNodes.ts
+++ b/web/src/api/customNodes.ts
@@ -1,0 +1,67 @@
+/**
+ * Custom nodes API — reuse library Tier 2 (à la Jenkins custom steps / 云效自建任务模板).
+ *
+ * Named, reusable single-node definitions: an underlying job type + a config snapshot.
+ * The user configures a node on the canvas (often a `templated`/`script` custom node),
+ * saves it ("存为自定义节点"), then picks it from the node picker to insert a Job with the
+ * saved config pre-filled. Complements pipeline templates (which reuse a whole stage span).
+ *
+ *   GET    /api/custom-nodes       → { customNodes: CustomNode[] }
+ *   POST   /api/custom-nodes       → CustomNode   (needs CSRF)
+ *   GET    /api/custom-nodes/{id}  → CustomNode
+ *   PUT    /api/custom-nodes/{id}  → CustomNode   (needs CSRF)
+ *   DELETE /api/custom-nodes/{id}  → 204          (needs CSRF)
+ *
+ * config is a free-form KV snapshot of Job.config (no schema enforced); carries no
+ * plaintext secret (same shape as a pipeline spec — secrets stay vault references).
+ */
+
+import { http } from './http'
+
+export interface CustomNode {
+  id: string
+  name: string
+  description: string
+  /** Underlying job type (e.g. 'templated', 'script', 'build_frontend'). */
+  nodeType: string
+  summary: string
+  config: Record<string, unknown>
+  createdAt: string
+  updatedAt: string
+}
+
+export interface SaveCustomNodeInput {
+  name: string
+  description?: string
+  nodeType: string
+  summary?: string
+  config: Record<string, unknown>
+}
+
+interface ListCustomNodesResponse {
+  customNodes: CustomNode[]
+}
+
+export async function listCustomNodes(): Promise<CustomNode[]> {
+  const res = await http.get<ListCustomNodesResponse>('/api/custom-nodes')
+  return res.customNodes ?? []
+}
+
+export async function getCustomNode(id: string): Promise<CustomNode> {
+  return http.get<CustomNode>(`/api/custom-nodes/${id}`)
+}
+
+export async function createCustomNode(input: SaveCustomNodeInput): Promise<CustomNode> {
+  return http.post<CustomNode>('/api/custom-nodes', input)
+}
+
+export async function updateCustomNode(
+  id: string,
+  input: SaveCustomNodeInput,
+): Promise<CustomNode> {
+  return http.put<CustomNode>(`/api/custom-nodes/${id}`, input)
+}
+
+export async function deleteCustomNode(id: string): Promise<void> {
+  await http.delete<void>(`/api/custom-nodes/${id}`)
+}

--- a/web/src/components/pipeline/JobDrawer.vue
+++ b/web/src/components/pipeline/JobDrawer.vue
@@ -9,6 +9,7 @@ import {
   jobTypeLabel,
   type JobField,
 } from './jobConfigSchema'
+import { createCustomNode } from '../../api/customNodes'
 import JobTypeIcon from './JobTypeIcon.vue'
 
 const props = defineProps<{
@@ -126,15 +127,68 @@ function extrasToObject(rows: KVRow[]): Record<string, string> {
 
 // ─── Flush ─────────────────────────────────────────────────────────────────────
 
+/** Build the full config object from typed form + advanced extras (typed wins on conflict). */
+function currentConfig(): Record<string, string> {
+  return { ...extrasToObject(extraRows.value), ...typedConfig.value }
+}
+
 function flush(): void {
-  // typed wins over extras on key conflict (they should never overlap).
-  const config = { ...extrasToObject(extraRows.value), ...typedConfig.value }
   emit('update', {
     name:    localName.value.trim() || props.job.name,
     type:    localType.value.trim() || props.job.type,
     summary: localSummary.value,
-    config,
+    config:  currentConfig(),
   })
+}
+
+// ─── Save as custom node (复用库 Tier 2) ──────────────────────────────────────
+// Snapshot this node's type + summary + config into the reuse library so it can be
+// picked into any pipeline later, pre-filled. Free-form config (no schema enforced).
+
+const savePanelOpen = ref(false)
+const saveName      = ref('')
+const saveDesc      = ref('')
+const saving        = ref(false)
+const saveError     = ref('')
+const saveOk        = ref(false)
+
+function openSavePanel(): void {
+  saveName.value = localName.value.trim()
+  saveDesc.value = ''
+  saveError.value = ''
+  saveOk.value = false
+  savePanelOpen.value = true
+}
+
+function cancelSave(): void {
+  savePanelOpen.value = false
+  saveError.value = ''
+}
+
+async function confirmSave(): Promise<void> {
+  const name = saveName.value.trim()
+  if (!name) {
+    saveError.value = '请填写节点名称'
+    return
+  }
+  saving.value = true
+  saveError.value = ''
+  try {
+    await createCustomNode({
+      name,
+      description: saveDesc.value.trim(),
+      nodeType: localType.value.trim() || props.job.type,
+      summary: localSummary.value,
+      config: currentConfig(),
+    })
+    saveOk.value = true
+    savePanelOpen.value = false
+  } catch (err) {
+    saveError.value =
+      err instanceof Error && err.message ? err.message : '保存失败,请重试(可能重名)'
+  } finally {
+    saving.value = false
+  }
 }
 </script>
 
@@ -361,6 +415,47 @@ function flush(): void {
         </button>
       </div>
     </div>
+
+    <!-- Save as custom node (复用库 Tier 2) -->
+    <div class="drawer-section drawer-reuse">
+      <div v-if="!savePanelOpen" class="reuse-row">
+        <button class="reuse-btn" @click="openSavePanel">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/>
+            <path d="M17 21v-8H7v8M7 3v5h8"/>
+          </svg>
+          存为自定义节点
+        </button>
+        <span v-if="saveOk" class="reuse-ok" role="status">✓ 已存入复用库</span>
+      </div>
+
+      <div v-else class="reuse-panel">
+        <div class="reuse-panel-title">存为自定义节点</div>
+        <p class="reuse-panel-hint">把当前节点的类型与参数快照存入复用库,之后可在任意流水线挑选复用。</p>
+        <input
+          v-model="saveName"
+          class="drawer-input"
+          type="text"
+          placeholder="节点名称(库内唯一)"
+          aria-label="自定义节点名称"
+          @keydown.enter.prevent="confirmSave"
+        />
+        <input
+          v-model="saveDesc"
+          class="drawer-input"
+          type="text"
+          placeholder="说明(可选)"
+          aria-label="自定义节点说明"
+        />
+        <p v-if="saveError" class="reuse-error" role="alert">{{ saveError }}</p>
+        <div class="reuse-actions">
+          <button class="reuse-cancel" :disabled="saving" @click="cancelSave">取消</button>
+          <button class="reuse-confirm" :disabled="saving" @click="confirmSave">
+            {{ saving ? '保存中…' : '保存' }}
+          </button>
+        </div>
+      </div>
+    </div>
   </aside>
 </template>
 
@@ -510,5 +605,117 @@ function flush(): void {
 
 .advanced-body {
   margin-top: 11px;
+}
+
+/* ——— Save as custom node ——— */
+.drawer-reuse {
+  border-top: 1px dashed var(--color-border);
+  padding-top: 14px;
+}
+
+.reuse-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.reuse-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 12px;
+  background: var(--color-inset);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded);
+  color: var(--color-text);
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color var(--duration-fast), color var(--duration-fast);
+}
+
+.reuse-btn:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.reuse-ok {
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: var(--color-green, var(--color-primary));
+}
+
+.reuse-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  background: var(--color-inset);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded);
+}
+
+.reuse-panel-title {
+  font-size: 0.84rem;
+  font-weight: 650;
+  color: var(--color-text);
+}
+
+.reuse-panel-hint {
+  margin: 0;
+  font-size: 0.73rem;
+  line-height: 1.45;
+  color: var(--color-faint);
+}
+
+.reuse-error {
+  margin: 0;
+  font-size: 0.74rem;
+  color: var(--color-red, #d33);
+}
+
+.reuse-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.reuse-cancel,
+.reuse-confirm {
+  padding: 6px 14px;
+  border-radius: var(--rounded);
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity var(--duration-fast), background-color var(--duration-fast);
+}
+
+.reuse-cancel {
+  background: none;
+  border: 1px solid var(--color-border-strong);
+  color: var(--color-dim);
+}
+
+.reuse-cancel:hover:not(:disabled) {
+  color: var(--color-text);
+}
+
+.reuse-confirm {
+  background: var(--color-primary);
+  border: 1px solid var(--color-primary);
+  color: #fff;
+}
+
+.reuse-confirm:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.reuse-cancel:disabled,
+.reuse-confirm:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 </style>

--- a/web/src/components/pipeline/JobTypePicker.vue
+++ b/web/src/components/pipeline/JobTypePicker.vue
@@ -10,6 +10,7 @@
  */
 import { ref, watch, nextTick } from 'vue'
 import { groupedJobTypes } from './jobConfigSchema'
+import { listCustomNodes, type CustomNode } from '../../api/customNodes'
 import JobTypeIcon from './JobTypeIcon.vue'
 
 const props = defineProps<{
@@ -22,6 +23,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'select', type: string): void
+  (e: 'select-custom', node: CustomNode): void
   (e: 'close'): void
 }>()
 
@@ -29,8 +31,28 @@ const groups = groupedJobTypes()
 const dialogRef = ref<HTMLElement | null>(null)
 let focusedBeforeOpen: HTMLElement | null = null
 
+// 复用库 Tier 2:挑选时加载已保存的自定义节点(选中即插入预填好 config 的 Job)。
+const customNodes = ref<CustomNode[]>([])
+const customLoading = ref(false)
+
+async function loadCustomNodes(): Promise<void> {
+  customLoading.value = true
+  try {
+    customNodes.value = await listCustomNodes()
+  } catch {
+    // 复用库为附加能力,加载失败不阻断挑选内建类型。
+    customNodes.value = []
+  } finally {
+    customLoading.value = false
+  }
+}
+
 function choose(type: string): void {
   emit('select', type)
+}
+
+function chooseCustom(node: CustomNode): void {
+  emit('select-custom', node)
 }
 
 function onKeydown(e: KeyboardEvent): void {
@@ -46,6 +68,7 @@ watch(
   async (isOpen) => {
     if (isOpen) {
       focusedBeforeOpen = document.activeElement as HTMLElement | null
+      void loadCustomNodes()
       await nextTick()
       dialogRef.value?.querySelector<HTMLElement>('.type-card')?.focus()
     } else {
@@ -82,6 +105,30 @@ watch(
           </header>
 
           <div class="jtp-body">
+            <!-- 复用库 Tier 2:我的自定义节点(已保存的单节点,选中即预填 config) -->
+            <section v-if="customLoading || customNodes.length" class="jtp-group">
+              <h3 class="jtp-group-label">我的自定义节点</h3>
+              <p v-if="customLoading" class="jtp-custom-hint">加载中…</p>
+              <div v-else class="jtp-grid">
+                <button
+                  v-for="node in customNodes"
+                  :key="node.id"
+                  class="type-card type-card--custom"
+                  @click="chooseCustom(node)"
+                >
+                  <JobTypeIcon :type="node.nodeType" :size="38" />
+                  <span class="type-card-body">
+                    <span class="type-card-name">
+                      {{ node.name }}
+                      <span class="type-card-badge type-card-badge--custom">自定义</span>
+                    </span>
+                    <span class="type-card-desc">{{ node.description || node.summary || '已保存的自定义节点' }}</span>
+                    <code class="type-card-token">{{ node.nodeType }}</code>
+                  </span>
+                </button>
+              </div>
+            </section>
+
             <section v-for="group in groups" :key="group.id" class="jtp-group">
               <h3 class="jtp-group-label">{{ group.label }}</h3>
               <div class="jtp-grid">
@@ -224,6 +271,21 @@ watch(
 .type-card--current {
   border-color: var(--color-primary);
   background: var(--color-primary-soft);
+}
+
+/* 自定义节点卡:左侧强调条,与内建类型区分 */
+.type-card--custom {
+  border-left: 3px solid var(--color-primary);
+}
+
+.type-card-badge--custom {
+  background: var(--color-accent, var(--color-primary));
+}
+
+.jtp-custom-hint {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--color-faint);
 }
 
 .type-card-body {

--- a/web/src/components/pipeline/PipelineCanvas.vue
+++ b/web/src/components/pipeline/PipelineCanvas.vue
@@ -6,6 +6,7 @@ import type { Server } from '../../api/servers'
 import StageColumn from './StageColumn.vue'
 import JobDrawer from './JobDrawer.vue'
 import JobTypePicker from './JobTypePicker.vue'
+import type { CustomNode } from '../../api/customNodes'
 import { jobTypeLabel, getJobTypeSpec } from './jobConfigSchema'
 import { hasAnyNeeds } from './stageDeps'
 import './pipeline.css'
@@ -128,15 +129,47 @@ function onPickerSelect(type: string): void {
       // 模板节点带预填配置(深拷贝避免共享引用);普通节点空配置。
       config:  { ...(getJobTypeSpec(type)?.defaultConfig ?? {}) },
     }
-    const next = props.stages.map((s) =>
-      s.id === p.stageId ? { ...s, jobs: [...s.jobs, newJob] } : s,
-    )
-    emit('update', next)
-    selectedJobId.value = newJob.id
+    addJobToStage(p.stageId, newJob)
   } else {
     updateJob(p.stageId, p.jobId, { type })
   }
   closePicker()
+}
+
+/**
+ * Insert a saved custom node (复用库 Tier 2): a new Job pre-filled with the saved
+ * type + summary + config snapshot. On "change" mode we overwrite type & config in place.
+ */
+function onPickerSelectCustom(node: CustomNode): void {
+  const p = picker.value
+  // config 快照转字符串 KV(Job.config 为 string KV;后端以 any 存,值实为字符串)。
+  const config: Record<string, string> = {}
+  for (const [k, v] of Object.entries(node.config ?? {})) {
+    config[k] = typeof v === 'string' ? v : JSON.stringify(v)
+  }
+  if (p.mode === 'add') {
+    const stage = props.stages.find((s) => s.id === p.stageId)
+    if (!stage) return closePicker()
+    const newJob: PipelineJob = {
+      id:      `job_${uid()}`,
+      name:    node.name || jobTypeLabel(node.nodeType),
+      type:    node.nodeType,
+      summary: node.summary ?? '',
+      config,
+    }
+    addJobToStage(p.stageId, newJob)
+  } else {
+    updateJob(p.stageId, p.jobId, { type: node.nodeType, summary: node.summary ?? '', config })
+  }
+  closePicker()
+}
+
+function addJobToStage(stageId: string, newJob: PipelineJob): void {
+  const next = props.stages.map((s) =>
+    s.id === stageId ? { ...s, jobs: [...s.jobs, newJob] } : s,
+  )
+  emit('update', next)
+  selectedJobId.value = newJob.id
 }
 
 function reorderJob(stageId: string, from: number, to: number): void {
@@ -333,6 +366,7 @@ function handleDrawerUpdate(patch: Partial<PipelineJob>): void {
       :current="picker.mode === 'change' ? picker.current : ''"
       :title="picker.mode === 'change' ? '更换任务类型' : '添加任务'"
       @select="onPickerSelect"
+      @select-custom="onPickerSelectCustom"
       @close="closePicker"
     />
   </div>

--- a/web/src/views/Library.vue
+++ b/web/src/views/Library.vue
@@ -25,8 +25,14 @@ import {
   type VariableGroupVarInput,
 } from '../api/variableGroups'
 import { listCredentials, type Credential } from '../api/credentials'
+import {
+  listCustomNodes,
+  deleteCustomNode,
+  type CustomNode,
+} from '../api/customNodes'
+import { jobTypeLabel } from '../components/pipeline/jobConfigSchema'
 
-type Tab = 'templates' | 'variableGroups'
+type Tab = 'templates' | 'variableGroups' | 'customNodes'
 type LoadState = 'idle' | 'loading' | 'error'
 
 const message = useMessage()
@@ -210,15 +216,54 @@ async function removeGroup(g: VariableGroup): Promise<void> {
   }
 }
 
+// ─── custom nodes(复用库 Tier 2) ──────────────────────────────────────────────
+const cnState = ref<LoadState>('idle')
+const cnError = ref('')
+const customNodes = ref<CustomNode[]>([])
+
+async function loadCustomNodes(): Promise<void> {
+  cnState.value = 'loading'
+  cnError.value = ''
+  try {
+    customNodes.value = await listCustomNodes()
+    cnState.value = 'idle'
+  } catch (err: unknown) {
+    cnState.value = 'error'
+    cnError.value = err instanceof HttpError
+      ? err.apiError?.message ?? `加载自定义节点失败(${err.status})`
+      : '加载自定义节点失败'
+  }
+}
+
+async function removeCustomNode(n: CustomNode): Promise<void> {
+  if (!window.confirm(`删除自定义节点「${n.name}」?此操作不可撤销。`)) return
+  try {
+    await deleteCustomNode(n.id)
+    message.success(`已删除自定义节点「${n.name}」`)
+    await loadCustomNodes()
+  } catch (err: unknown) {
+    message.error(err instanceof HttpError ? err.apiError?.message ?? '删除失败' : '删除失败')
+  }
+}
+
+/** config 快照前若干键,供卡片预览(纯展示,不含 secret 明文)。 */
+function configPreview(n: CustomNode): Array<{ k: string; v: string }> {
+  return Object.entries(n.config ?? {})
+    .slice(0, 4)
+    .map(([k, v]) => ({ k, v: typeof v === 'string' ? v : JSON.stringify(v) }))
+}
+
 function switchTab(t: Tab): void {
   tab.value = t
   if (t === 'templates' && templates.value.length === 0 && tplState.value !== 'error') loadTemplates()
   if (t === 'variableGroups' && variableGroups.value.length === 0 && vgState.value !== 'error') loadVariableGroups()
+  if (t === 'customNodes' && customNodes.value.length === 0 && cnState.value !== 'error') loadCustomNodes()
 }
 
 onMounted(() => {
   loadTemplates()
   loadVariableGroups()
+  loadCustomNodes()
 })
 </script>
 
@@ -227,7 +272,7 @@ onMounted(() => {
     <header class="page-header">
       <div>
         <h1 class="page-title">复用库</h1>
-        <p class="page-sub">跨项目共享的流水线模板与变量组 · 一处定义,处处复用</p>
+        <p class="page-sub">跨项目共享的流水线模板、变量组与自定义节点 · 一处定义,处处复用</p>
       </div>
       <button
         v-if="tab === 'variableGroups'"
@@ -259,6 +304,16 @@ onMounted(() => {
       >
         变量组
         <span class="seg-count">{{ variableGroups.length }}</span>
+      </button>
+      <button
+        class="seg-item"
+        role="tab"
+        :aria-selected="tab === 'customNodes'"
+        :class="{ 'seg-item--active': tab === 'customNodes' }"
+        @click="switchTab('customNodes')"
+      >
+        自定义节点
+        <span class="seg-count">{{ customNodes.length }}</span>
       </button>
     </div>
 
@@ -347,6 +402,54 @@ onMounted(() => {
           <div class="vg-card-foot">
             <button class="btn-secondary btn-sm" @click="openEditGroup(g)">编辑</button>
             <button class="link-danger" @click="removeGroup(g)">删除</button>
+          </div>
+        </li>
+      </ul>
+    </div>
+
+    <!-- ─── Custom Nodes(复用库 Tier 2) ─── -->
+    <div v-show="tab === 'customNodes'" class="panel">
+      <div v-if="cnState === 'error'" class="banner banner--error">
+        <span>{{ cnError }}</span>
+        <button class="banner-retry" @click="loadCustomNodes">↻ 重试</button>
+      </div>
+
+      <div v-if="cnState === 'loading'" class="skeleton-grid">
+        <div v-for="i in 3" :key="i" class="skeleton-card" />
+      </div>
+
+      <div
+        v-else-if="cnState === 'idle' && customNodes.length === 0"
+        class="empty-state"
+      >
+        <div class="empty-icon">◇</div>
+        <p class="empty-label">还没有自定义节点</p>
+        <p class="empty-hint">
+          在项目流水线编辑器里把任意节点(尤其是自定义/模板节点)配好参数后,点「存为自定义节点」
+          即可沉淀到这里,之后在任意流水线的节点选择器里一键复用,免去重复填参。
+        </p>
+      </div>
+
+      <ul v-else class="card-grid" role="list">
+        <li v-for="n in customNodes" :key="n.id" class="cn-card">
+          <div class="cn-card-head">
+            <h3 class="cn-name">{{ n.name }}</h3>
+            <span class="cn-type-pill">{{ jobTypeLabel(n.nodeType) }}</span>
+          </div>
+          <p class="cn-desc">{{ n.description || n.summary || '无说明' }}</p>
+          <ul class="cn-cfg-list" role="list">
+            <li v-for="item in configPreview(n)" :key="item.k" class="cn-cfg">
+              <code class="cn-cfg-key">{{ item.k }}</code>
+              <span class="cn-cfg-val">{{ item.v || '空' }}</span>
+            </li>
+            <li v-if="Object.keys(n.config ?? {}).length > 4" class="cn-cfg cn-cfg--more">
+              +{{ Object.keys(n.config).length - 4 }} 个参数…
+            </li>
+            <li v-if="Object.keys(n.config ?? {}).length === 0" class="cn-cfg cn-cfg--more">无参数</li>
+          </ul>
+          <div class="cn-card-foot">
+            <span class="cn-time">更新于 {{ new Date(n.updatedAt).toLocaleDateString() }}</span>
+            <button class="link-danger" @click="removeCustomNode(n)">删除</button>
           </div>
         </li>
       </ul>
@@ -527,7 +630,8 @@ onMounted(() => {
 }
 
 .tpl-card,
-.vg-card {
+.vg-card,
+.cn-card {
   display: flex;
   flex-direction: column;
   gap: 0.7rem;
@@ -539,20 +643,23 @@ onMounted(() => {
   transition: transform var(--duration-fast, 150ms), border-color var(--duration-fast, 150ms);
 }
 .tpl-card:hover,
-.vg-card:hover {
+.vg-card:hover,
+.cn-card:hover {
   transform: translateY(-2px);
   border-color: var(--color-border-strong);
 }
 
 .tpl-card-head,
-.vg-card-head {
+.vg-card-head,
+.cn-card-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
 }
 .tpl-name,
-.vg-name {
+.vg-name,
+.cn-name {
   margin: 0;
   font-size: 1.05rem;
   font-weight: 640;
@@ -563,7 +670,8 @@ onMounted(() => {
   white-space: nowrap;
 }
 .tpl-stage-pill,
-.vg-count-pill {
+.vg-count-pill,
+.cn-type-pill {
   flex-shrink: 0;
   font-size: 0.72rem;
   font-weight: 600;
@@ -573,12 +681,61 @@ onMounted(() => {
   background: var(--color-primary-soft);
 }
 .tpl-desc,
-.vg-desc {
+.vg-desc,
+.cn-desc {
   margin: 0;
   font-size: 0.86rem;
   color: var(--color-dim);
   line-height: 1.45;
   min-height: 1.2em;
+}
+
+/* Custom-node config preview — mirrors the variable-group var list */
+.cn-cfg-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.6rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  border-top: 1px solid var(--color-border);
+}
+.cn-cfg {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.82rem;
+  min-width: 0;
+}
+.cn-cfg-key {
+  flex-shrink: 0;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  color: var(--color-text);
+  background: var(--color-inset);
+  padding: 0.1rem 0.4rem;
+  border-radius: 6px;
+}
+.cn-cfg-val {
+  color: var(--color-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cn-cfg--more {
+  color: var(--color-faint);
+  font-style: italic;
+}
+.cn-card-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: auto;
+  padding-top: 0.4rem;
+}
+.cn-time {
+  font-size: 0.76rem;
+  color: var(--color-faint);
 }
 
 .vg-var-list {


### PR DESCRIPTION
## 背景

承接复用库 Tier 1(流水线模板 + 变量组),补齐 **自定义节点「存 & 复用」层**:把任意流水线节点(尤其 `templated`/`script` 自定义节点)的「类型 + 参数快照」沉淀为命名、可复用的自定义节点,之后在任意流水线的节点选择器里**一键复用**,免去重复填参。

与流水线模板互补:模板复用「一段 stages」,自定义节点复用「一个 job」。

## 后端(`internal/library` + `internal/httpapi`)

- **迁移 0033** `custom_nodes`:`name`(唯一)/ `node_type` / `config_json` 快照。config 为 `Job.config` 自由 KV **原样快照,不强加 schema**(单管理员场景留足自定义自由度),与流水线 spec 同形状、**不含明文 secret**。
- `library.CustomNodeService`:`List/Get/Create/Update/Delete`;名称+类型非空校验、重名冲突 → `ErrCustomNodeNameTaken`;nil config 补 `{}`。
- `/api/custom-nodes*` CRUD:GET 过 auth;写过 **auth + CSRF + 审计**(detail 仅元数据)。
- 审计:`custom_node_{create,update,delete}` / `TargetCustomNode`。

## 前端(`web`)

- `api/customNodes.ts`:CRUD 客户端。
- **JobDrawer**:抽屉底部「存为自定义节点」面板(名称 + 说明)。
- **JobTypePicker**:挑选时加载已存自定义节点,顶部「我的自定义节点」分组;选中插入预填好 config 的 Job(快照转 string KV)。
- **Library**:新增「自定义节点」tab(卡片含类型 pill + config 预览 + 删除)。

## 验证(真浏览器,非 mock)

存为自定义节点 → 复用库可见 → 选择器分组出现 → 选中插入并回填多行 config(`{{ver}}` 模板 / 命令模板原样保留)**全链路通过**。

- 后端 `go vet`/`build`/`test` + `gofmt` 全绿(新增 `customnode_test.go` 覆盖 CRUD/校验/重名/404)。
- 前端 `lint`(0 error)/ `typecheck` / `test`(193 passed)/ `build` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)