### PR TITLE
feat(deploy): 流水线部署节点支持镜像产物部署

### DIFF
--- a/internal/deploy/commands.go
+++ b/internal/deploy/commands.go
@@ -128,20 +128,18 @@ func buildJarDeploy(a run.Artifact, cfg map[string]string) ([][]string, string, 
 }
 
 // buildImageDeploy 构造 image 的 `docker pull` + `docker run`(目标无 docker → failed 人读)。
+// 容器名 / 端口映射 / run 参数由 cfg 解析(参数自由,不写死;见 imageContainerName / imageRunArgs)。
 func buildImageDeploy(a run.Artifact, cfg map[string]string) ([][]string, string, error) {
 	ref := strings.TrimSpace(a.Reference)
 	if ref == "" {
 		return nil, "", fmt.Errorf("image 产物缺少 reference(repo:tag 或镜像 id)")
 	}
-	name := sanitizeName(a.Name)
-	if name == "" {
-		name = "app"
-	}
+	name := imageContainerName(a, cfg)
 	cmds := [][]string{
 		{"docker", "pull", ref},
-		// 先移除同名旧容器(幂等;无则忽略由 docker 处理),再后台起新容器。
+		// 先移除同名旧容器(幂等;无则忽略由 docker 处理),再后台起新容器(带 cfg 端口 / run 参数)。
 		{"docker", "rm", "-f", name},
-		{"docker", "run", "-d", "--name", name, ref},
+		dockerRunCmd(name, imageRunArgs(cfg), ref),
 	}
 	return cmds, fmt.Sprintf("image 部署完成 → 已拉取并启动容器 %s(%s)", name, ref), nil
 }

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -275,19 +275,14 @@ func (s *service) DeployForStage(ctx context.Context, runID string, serverIDs []
 	if len(serverIDs) == 0 {
 		return nil, ErrNoServers
 	}
-	// 取该 run 已产出的首个可发布产物(dist/jar/archive;镜像类不走发布目录,本节点跳过)。
+	// 取该 run 已产出的可部署产物。dist/jar/archive 走文件发布;image 走容器 pull→停旧起新→
+	// 健康→回滚(复用 image_release.go)。二者都在时按节点 cfg["artifactType"] 选(空 → 默认优先
+	// 文件发布,保持既有行为;显式 image → 选镜像)。选定后由 deployWithStrategy 据产物类型自动路由。
 	arts, err := s.runs.ListArtifacts(ctx, runID)
 	if err != nil {
 		return nil, err
 	}
-	var artifact *run.Artifact
-	for i := range arts {
-		if releaseModeArtifact(arts[i]) {
-			a := arts[i]
-			artifact = &a
-			break
-		}
-	}
+	artifact := pickStageArtifact(arts, strings.TrimSpace(cfg["artifactType"]))
 	if artifact == nil {
 		return nil, ErrArtifactNotFound
 	}
@@ -318,6 +313,57 @@ func (s *service) DeployForStage(ctx context.Context, runID string, serverIDs []
 		return nil, err
 	}
 	return results, nil
+}
+
+// deployableStageArtifact 判定产物在「流水线部署节点」可被部署:文件发布类(dist/jar/archive)
+// 或镜像类(image)。其余类型不可部署(无对应编排)。
+func deployableStageArtifact(a run.Artifact) bool {
+	return releaseModeArtifact(a) || a.Type == run.ArtifactImage
+}
+
+// pickStageArtifact 从该 run 的产物里挑「部署节点」要部署的一件,返回 nil = 无可部署产物。
+//
+// 选取规则(参数自由,不写死单一类型):
+//   - prefer == "image":优先选首个 image 产物;无 image → 退回首个文件发布产物(尽力部署)。
+//   - prefer 为文件类(dist/jar/archive):优先选该精确类型;无则退回任一文件发布产物。
+//   - prefer 空:默认优先文件发布产物(保持既有行为),无文件发布则退回 image。
+//
+// 任何情况下都只在「可部署产物」(deployableStageArtifact)中挑选;选定的类型由
+// deployWithStrategy 自动路由到文件发布 or 镜像编排。
+func pickStageArtifact(arts []run.Artifact, prefer string) *run.Artifact {
+	prefer = strings.ToLower(prefer)
+	var firstImage, firstRelease, firstExact *run.Artifact
+	for i := range arts {
+		a := arts[i]
+		if !deployableStageArtifact(a) {
+			continue
+		}
+		if firstExact == nil && prefer != "" && a.Type == prefer {
+			firstExact = &arts[i]
+		}
+		if a.Type == run.ArtifactImage && firstImage == nil {
+			firstImage = &arts[i]
+		}
+		if releaseModeArtifact(a) && firstRelease == nil {
+			firstRelease = &arts[i]
+		}
+	}
+	// 1) 显式偏好且精确命中 → 选它。
+	if firstExact != nil {
+		return firstExact
+	}
+	// 2) 显式偏好 image(未精确命中走这里)→ image 优先,退回文件发布。
+	if prefer == run.ArtifactImage {
+		if firstImage != nil {
+			return firstImage
+		}
+		return firstRelease
+	}
+	// 3) 默认 / 偏好文件类:文件发布优先(保持既有行为),退回 image。
+	if firstRelease != nil {
+		return firstRelease
+	}
+	return firstImage
 }
 
 // RetryFailed 仅重试该 run 当前 failed/rolled_back 的目标(Story 4.5;FR-13)。见 Service 接口注释。

--- a/internal/deploy/image_release.go
+++ b/internal/deploy/image_release.go
@@ -22,13 +22,17 @@ import (
 
 // imageState 是一台机的 image 蓝绿中间态(stageImageOne 产出,activateImageOne 消费)。
 type imageState struct {
-	name      string // 容器名(sanitizeName(产物名))
-	ref       string // 本次新镜像 ref(repo:tag / image id)
-	prevImage string // 切换前容器所用镜像(回滚目标;"" = 无上一容器,首次部署)
+	name      string   // 容器名(cfg["containerName"] 优先,否则 sanitizeName(产物名))
+	ref       string   // 本次新镜像 ref(repo:tag / image id)
+	prevImage string   // 切换前容器所用镜像(回滚目标;"" = 无上一容器,首次部署)
+	runArgs   []string // docker run 的附加参数(端口映射 / env 等;由 cfg 解析,参数自由)
 }
 
-// imageContainerName 取部署容器名(产物名净化;空 → app)。
-func imageContainerName(a run.Artifact) string {
+// imageContainerName 取部署容器名:cfg["containerName"] 显式优先(净化),否则产物名净化(空 → app)。
+func imageContainerName(a run.Artifact, cfg map[string]string) string {
+	if c := sanitizeName(strings.TrimSpace(cfg["containerName"])); c != "" {
+		return c
+	}
 	n := sanitizeName(a.Name)
 	if n == "" {
 		n = "app"
@@ -36,10 +40,50 @@ func imageContainerName(a run.Artifact) string {
 	return n
 }
 
+// imageRunArgs 解析 docker run 的附加参数(端口映射 / 自定义 run 参数;参数自由,不写死)。
+// 各参数原样作为 array 元素(绝不拼接 shell;AC-SEC-02),依序拼到 `docker run -d --name <name>` 之后、
+// 镜像 ref 之前:
+//   - cfg["ports"]   : 端口映射,逗号 / 空白分隔,每项展开为 `-p <map>`(如 "8080:80,9000:9000")。
+//   - cfg["runArgs"] : 任意 docker run 参数,按空白切词逐元素追加(如 "-e KEY=v --restart always")。
+//
+// 注意:凭据绝不经此进命令(registry 凭据沿用既有 docker login 模式);此处仅承载端口 / 运行参数。
+func imageRunArgs(cfg map[string]string) []string {
+	if cfg == nil {
+		return nil
+	}
+	var args []string
+	for _, p := range splitImageList(cfg["ports"]) {
+		args = append(args, "-p", p)
+	}
+	args = append(args, strings.Fields(cfg["runArgs"])...)
+	return args
+}
+
+// splitImageList 按逗号 / 空白切分并去空(端口列表用)。
+func splitImageList(s string) []string {
+	var out []string
+	for _, f := range strings.FieldsFunc(s, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n'
+	}) {
+		if f = strings.TrimSpace(f); f != "" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// dockerRunCmd 组装 `docker run -d --name <name> [runArgs...] <ref>`(各元素独立,不拼 shell)。
+func dockerRunCmd(name string, runArgs []string, ref string) []string {
+	cmd := []string{"docker", "run", "-d", "--name", name}
+	cmd = append(cmd, runArgs...)
+	cmd = append(cmd, ref)
+	return cmd
+}
+
 // stageImageOne 执行 image 蓝绿**预备阶段**:pull 新镜像(不停旧容器)+ 探测当前容器镜像(回滚目标)。
 // 拉取失败 → (中间态, 人读 message, false)。
-func (s *service) stageImageOne(ctx context.Context, srv *target.Server, a run.Artifact) (imageState, string, bool) {
-	st := imageState{name: imageContainerName(a), ref: strings.TrimSpace(a.Reference)}
+func (s *service) stageImageOne(ctx context.Context, srv *target.Server, a run.Artifact, cfg map[string]string) (imageState, string, bool) {
+	st := imageState{name: imageContainerName(a, cfg), ref: strings.TrimSpace(a.Reference), runArgs: imageRunArgs(cfg)}
 	if st.ref == "" {
 		return st, "image 产物缺少 reference(repo:tag 或镜像 id)", false
 	}
@@ -62,10 +106,10 @@ func (s *service) activateImageOne(ctx context.Context, srv *target.Server, a ru
 	execCtx, cancel := context.WithTimeout(ctx, execTimeout)
 	defer cancel()
 
-	// 切换:移除同名旧容器(幂等)→ 后台起新镜像容器。
+	// 切换:移除同名旧容器(幂等)→ 后台起新镜像容器(带 cfg 解析的端口 / run 参数)。
 	swap := [][]string{
 		{"docker", "rm", "-f", st.name},
-		{"docker", "run", "-d", "--name", st.name, st.ref},
+		dockerRunCmd(st.name, st.runArgs, st.ref),
 	}
 	if failMsg, ok := s.runStep(execCtx, srv.ID, swap); !ok {
 		return finishFailed(res, failMsg)
@@ -102,7 +146,7 @@ func (s *service) rollbackImage(ctx context.Context, srv *target.Server, res Tar
 	var rbErr error
 	for _, cmd := range [][]string{
 		{"docker", "rm", "-f", st.name},
-		{"docker", "run", "-d", "--name", st.name, st.prevImage},
+		dockerRunCmd(st.name, st.runArgs, st.prevImage),
 	} {
 		if _, e := s.targets.Exec(ctx, srv.ID, cmd); e != nil {
 			rbErr = e
@@ -126,7 +170,7 @@ func (s *service) fleetRollbackImageOne(ctx context.Context, srv *target.Server,
 	var rbErr error
 	for _, cmd := range [][]string{
 		{"docker", "rm", "-f", st.name},
-		{"docker", "run", "-d", "--name", st.name, st.prevImage},
+		dockerRunCmd(st.name, st.runArgs, st.prevImage),
 	} {
 		if _, e := s.targets.Exec(execCtx, srv.ID, cmd); e != nil {
 			rbErr = e

--- a/internal/deploy/stage_image_test.go
+++ b/internal/deploy/stage_image_test.go
@@ -1,0 +1,304 @@
+package deploy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// stage_image_test.go 覆盖「流水线部署节点」(DeployForStage)对 **镜像产物** 的部署编排:
+//   - 仅镜像产物时,DeployForStage 选中镜像并 docker pull → rm → run(不再 ErrArtifactNotFound)。
+//   - 镜像 + 文件产物并存时的优先级(默认文件优先;cfg["artifactType"]=image 选镜像)。
+//   - cfg 驱动的容器名 / 端口 / runArgs 原样进 docker run(array 化,不拼 shell)。
+//   - 蓝绿策略下镜像走 stage(pull)→ cutover(run);健康失败回滚上一镜像。
+//   - 文件产物路径不受影响(回归保护)。
+// 全部用 stubTarget / touchRecorder 捕获命令断言,不触真实 SSH / docker。
+
+// addArtifact 给已有 run 追加一件产物(用于「镜像+文件并存」场景)。
+func addArtifact(t *testing.T, rsvc run.Service, runID, artType, name, ref string) {
+	t.Helper()
+	if _, err := rsvc.AddArtifact(context.Background(), run.Artifact{
+		RunID: runID, Type: artType, Name: name, Reference: ref,
+	}); err != nil {
+		t.Fatalf("AddArtifact(%s): %v", artType, err)
+	}
+}
+
+// hasCmd 报告命令序列里是否出现「以 prefix 开头」的命令。
+func hasCmd(calls [][]string, prefix ...string) bool {
+	for _, c := range calls {
+		if len(c) < len(prefix) {
+			continue
+		}
+		ok := true
+		for i := range prefix {
+			if c[i] != prefix[i] {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+// runCmd 取序列里首个 `docker run` 命令(无则 nil)。
+func runCmd(calls [][]string) []string {
+	for _, c := range calls {
+		if len(c) >= 2 && c[0] == "docker" && c[1] == "run" {
+			return c
+		}
+	}
+	return nil
+}
+
+// TestStageDeploysImageArtifact 仅镜像产物 → DeployForStage 部署镜像(此前被跳过 → ErrArtifactNotFound)。
+func TestStageDeploysImageArtifact(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	tgt := &stubTarget{}
+	srv := seedServer(t, tgt, "web-1")
+	runID, _ := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactImage, "registry/shop:1.0")
+
+	svc := New(tgt, rsvc)
+	res, err := svc.DeployForStage(context.Background(), runID, []string{srv.ID}, nil, "")
+	if err != nil {
+		t.Fatalf("DeployForStage: %v", err)
+	}
+	if len(res) != 1 || res[0].Status != run.TargetSuccess {
+		t.Fatalf("want 1 success, got %+v", res)
+	}
+	if !hasCmd(tgt.calls, "docker", "pull", "registry/shop:1.0") {
+		t.Fatalf("应有 docker pull 镜像: %v", tgt.calls)
+	}
+	if !hasCmd(tgt.calls, "docker", "run") {
+		t.Fatalf("应有 docker run 起容器: %v", tgt.calls)
+	}
+	// 不应走文件发布(无 mkdir releases / ln -sfn)。
+	if hasCmd(tgt.calls, "ln", "-sfn") {
+		t.Fatalf("镜像部署不应出现软链切换: %v", tgt.calls)
+	}
+}
+
+// TestStagePrefersFileArtifactByDefault 镜像+文件并存,默认(cfg 空)优先文件发布(保持既有行为)。
+func TestStagePrefersFileArtifactByDefault(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	tgt := &stubTarget{}
+	srv := seedServer(t, tgt, "web-1")
+	runID, _ := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactImage, "registry/shop:1.0")
+	addArtifact(t, rsvc, runID, run.ArtifactDist, "web", "dist/shop.tar.gz")
+
+	svc := New(tgt, rsvc)
+	res, err := svc.DeployForStage(context.Background(), runID, []string{srv.ID}, nil, "")
+	if err != nil {
+		t.Fatalf("DeployForStage: %v", err)
+	}
+	if len(res) != 1 || res[0].Status != run.TargetSuccess {
+		t.Fatalf("want 1 success, got %+v", res)
+	}
+	// 默认应走文件发布(dist → ln -sfn current),不应 docker pull。
+	if !hasCmd(tgt.calls, "ln", "-sfn") {
+		t.Fatalf("默认应走文件发布(软链切换): %v", tgt.calls)
+	}
+	if hasCmd(tgt.calls, "docker", "pull") {
+		t.Fatalf("默认不应部署镜像: %v", tgt.calls)
+	}
+}
+
+// TestStageSelectsImageWhenConfigured 镜像+文件并存,cfg["artifactType"]=image → 选镜像。
+func TestStageSelectsImageWhenConfigured(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	tgt := &stubTarget{}
+	srv := seedServer(t, tgt, "web-1")
+	runID, _ := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactDist, "dist/shop.tar.gz")
+	addArtifact(t, rsvc, runID, run.ArtifactImage, "shop", "registry/shop:2.0")
+
+	svc := New(tgt, rsvc)
+	res, err := svc.DeployForStage(context.Background(), runID, []string{srv.ID},
+		map[string]string{"artifactType": "image"}, "")
+	if err != nil {
+		t.Fatalf("DeployForStage: %v", err)
+	}
+	if len(res) != 1 || res[0].Status != run.TargetSuccess {
+		t.Fatalf("want 1 success, got %+v", res)
+	}
+	if !hasCmd(tgt.calls, "docker", "pull", "registry/shop:2.0") {
+		t.Fatalf("cfg image 偏好应部署镜像: %v", tgt.calls)
+	}
+	if hasCmd(tgt.calls, "ln", "-sfn") {
+		t.Fatalf("选镜像时不应走文件发布: %v", tgt.calls)
+	}
+}
+
+// TestStageImageHonorsContainerNamePortsRunArgs 验证 cfg 的容器名 / 端口 / runArgs 原样进 docker run。
+func TestStageImageHonorsContainerNamePortsRunArgs(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	tgt := &stubTarget{}
+	srv := seedServer(t, tgt, "web-1")
+	runID, _ := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactImage, "registry/shop:1.0")
+
+	svc := New(tgt, rsvc)
+	cfg := map[string]string{
+		"containerName": "shopapp",
+		"ports":         "8080:80, 9000:9000",
+		"runArgs":       "-e KEY=value --restart always",
+	}
+	res, err := svc.DeployForStage(context.Background(), runID, []string{srv.ID}, cfg, "")
+	if err != nil {
+		t.Fatalf("DeployForStage: %v", err)
+	}
+	if res[0].Status != run.TargetSuccess {
+		t.Fatalf("want success, got %+v", res)
+	}
+	rc := runCmd(tgt.calls)
+	if rc == nil {
+		t.Fatalf("无 docker run 命令: %v", tgt.calls)
+	}
+	// 期望:docker run -d --name shopapp -p 8080:80 -p 9000:9000 -e KEY=value --restart always registry/shop:1.0
+	want := []string{
+		"docker", "run", "-d", "--name", "shopapp",
+		"-p", "8080:80", "-p", "9000:9000",
+		"-e", "KEY=value", "--restart", "always",
+		"registry/shop:1.0",
+	}
+	if len(rc) != len(want) {
+		t.Fatalf("docker run 参数不符\n got: %v\nwant: %v", rc, want)
+	}
+	for i := range want {
+		if rc[i] != want[i] {
+			t.Fatalf("docker run[%d]=%q, want %q\n got: %v", i, rc[i], want[i], rc)
+		}
+	}
+	// rm 旧容器也应用 cfg 容器名(幂等替换)。
+	if !hasCmd(tgt.calls, "docker", "rm", "-f", "shopapp") {
+		t.Fatalf("应按 cfg 容器名移除旧容器: %v", tgt.calls)
+	}
+}
+
+// TestStageImageBlueGreen 蓝绿策略下镜像走 stage(pull)→ cutover(run),且 run 带 cfg runArgs。
+func TestStageImageBlueGreen(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	rec := &touchRecorder{}
+	tgt := &stubTarget{execFn: rec.exec}
+	s1 := seedServer(t, tgt, "web-1")
+	s2 := seedServer(t, tgt, "web-2")
+	runID, _ := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactImage, "registry/shop:2.0")
+
+	svc := New(tgt, rsvc)
+	cfg := map[string]string{"containerName": "shop", "ports": "80:80"}
+	res, err := svc.DeployForStage(context.Background(), runID, []string{s1.ID, s2.ID}, cfg, "blue_green")
+	if err != nil {
+		t.Fatalf("DeployForStage: %v", err)
+	}
+	for i, r := range res {
+		if r.Status != run.TargetSuccess {
+			t.Fatalf("蓝绿镜像目标 %d 应 success,实际 %s / %q", i, r.Status, r.Message)
+		}
+	}
+	if !hasCmd(rec.calls2, "docker", "pull", "registry/shop:2.0") {
+		t.Fatalf("蓝绿应有 pull(预备): %v", rec.calls2)
+	}
+	rc := runCmd(rec.calls2)
+	if rc == nil {
+		t.Fatalf("蓝绿应有 docker run(切换): %v", rec.calls2)
+	}
+	// cutover 的 run 应带 cfg 容器名与端口。
+	if !hasCmd(rec.calls2, "docker", "run", "-d", "--name", "shop", "-p", "80:80", "registry/shop:2.0") {
+		t.Fatalf("蓝绿切换 run 应带 cfg 容器名 + 端口: %v", rec.calls2)
+	}
+}
+
+// TestStageImageBlueGreenRollback 蓝绿镜像:一机健康失败 → 已切换成功的机回滚到上一镜像。
+func TestStageImageBlueGreenRollback(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	badID := ""
+	rec := &touchRecorder{
+		inspectImage: "registry/shop:1.0", // 模拟上一镜像存在 → 可回滚
+		failOn: func(serverID string, cmd []string) bool {
+			return serverID == badID && len(cmd) > 0 && cmd[0] == "true" // bad 机健康失败
+		},
+	}
+	tgt := &stubTarget{execFn: rec.exec}
+	good := seedServer(t, tgt, "web-good")
+	bad := seedServer(t, tgt, "web-bad")
+	badID = bad.ID
+	runID, _ := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactImage, "registry/shop:2.0")
+
+	svc := New(tgt, rsvc)
+	// DeployForStage 不带 HealthCheck 入参,这里直接调内部蓝绿编排验证回滚(健康门控经 hc)。
+	hc := &HealthCheck{Type: HealthCheckCommand, Command: []string{"true"}, Retries: 1}
+	res, err := svc.Deploy(context.Background(), DeployInput{
+		RunID: runID, ArtifactID: mustArtID(t, rsvc, runID), ServerIDs: []string{good.ID, bad.ID},
+		Strategy: "blue_green", HealthCheck: hc,
+		Config: map[string]string{"containerName": "shop"},
+	})
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	for i, r := range res {
+		if r.Status != run.TargetRolledBack {
+			t.Fatalf("镜像机群回滚:目标 %d (%s) 应 rolled_back,实际 %s / %q", i, r.ServerName, r.Status, r.Message)
+		}
+	}
+	// 回滚应 docker run 上一镜像(带 cfg 容器名)。
+	if !hasCmd(rec.calls2, "docker", "run", "-d", "--name", "shop", "registry/shop:1.0") {
+		t.Fatalf("回滚应以 cfg 容器名起上一镜像: %v", rec.calls2)
+	}
+}
+
+// mustArtID 取该 run 首件产物 id(测试便捷)。
+func mustArtID(t *testing.T, rsvc run.Service, runID string) string {
+	t.Helper()
+	arts, err := rsvc.ListArtifacts(context.Background(), runID)
+	if err != nil || len(arts) == 0 {
+		t.Fatalf("ListArtifacts: %v / %d", err, len(arts))
+	}
+	return arts[0].ID
+}
+
+// TestPickStageArtifact 单测产物选取优先级矩阵。
+func TestPickStageArtifact(t *testing.T) {
+	img := run.Artifact{Type: run.ArtifactImage, Reference: "img:1"}
+	dist := run.Artifact{Type: run.ArtifactDist, Reference: "dist"}
+	jar := run.Artifact{Type: run.ArtifactJar, Reference: "app.jar"}
+
+	cases := []struct {
+		name   string
+		arts   []run.Artifact
+		prefer string
+		want   string // 期望选中的 Type;"" = nil
+	}{
+		{"empty", nil, "", ""},
+		{"image only / no prefer", []run.Artifact{img}, "", run.ArtifactImage},
+		{"file only / no prefer", []run.Artifact{dist}, "", run.ArtifactDist},
+		{"both / no prefer → file first", []run.Artifact{img, dist}, "", run.ArtifactDist},
+		{"both / prefer image", []run.Artifact{img, dist}, "image", run.ArtifactImage},
+		{"both / prefer image (order swapped)", []run.Artifact{dist, img}, "image", run.ArtifactImage},
+		{"prefer image but none → fall back file", []run.Artifact{dist}, "image", run.ArtifactDist},
+		{"prefer jar exact", []run.Artifact{dist, jar}, "jar", run.ArtifactJar},
+		{"prefer dist but only jar → any release", []run.Artifact{jar}, "dist", run.ArtifactJar},
+		{"unknown type skipped", []run.Artifact{{Type: "weird"}}, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pickStageArtifact(tc.arts, tc.prefer)
+			if tc.want == "" {
+				if got != nil {
+					t.Fatalf("want nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil || got.Type != tc.want {
+				t.Fatalf("want %s, got %+v", tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/deploy/strategy.go
+++ b/internal/deploy/strategy.go
@@ -60,7 +60,7 @@ func (s *service) deployWithStrategy(ctx context.Context, servers []*target.Serv
 		case releaseModeArtifact(a):
 			return s.deployBlueGreen(ctx, servers, a, cfg, hc)
 		case a.Type == run.ArtifactImage:
-			return s.deployBlueGreenImage(ctx, servers, a, hc)
+			return s.deployBlueGreenImage(ctx, servers, a, cfg, hc)
 		default:
 			return s.deployFanout(ctx, servers, a, cfg, hc)
 		}
@@ -222,7 +222,7 @@ func (s *service) deployBlueGreen(ctx context.Context, servers []*target.Server,
 // deployBlueGreenImage 镜像蓝绿:stage-all(全机 pull)→ cutover-all(全机停旧起新+健康)→
 // 切换阶段任一失败则把已成功切换的机一并回滚到上一镜像(机群级原子性)。语义同 deployBlueGreen,
 // 只是单机原语换成 stageImageOne/activateImageOne(容器 pull/swap 而非软链切换)。
-func (s *service) deployBlueGreenImage(ctx context.Context, servers []*target.Server, a run.Artifact, hc *HealthCheck) []TargetResult {
+func (s *service) deployBlueGreenImage(ctx context.Context, servers []*target.Server, a run.Artifact, cfg map[string]string, hc *HealthCheck) []TargetResult {
 	n := len(servers)
 	if n == 0 {
 		return nil
@@ -235,7 +235,7 @@ func (s *service) deployBlueGreenImage(ctx context.Context, servers []*target.Se
 	// 阶段 1:全机 pull(不停旧容器)。
 	s.forEachServer(servers, func(idx int, srv *target.Server) {
 		started[idx] = time.Now().UTC()
-		st, failMsg, ok := s.stageImageOne(ctx, srv, a)
+		st, failMsg, ok := s.stageImageOne(ctx, srv, a, cfg)
 		states[idx] = st
 		if !ok {
 			results[idx] = finishFailed(TargetResult{ServerID: srv.ID, ServerName: srv.Name, StartedAt: started[idx]}, failMsg)

--- a/web/src/components/pipeline/jobConfigSchema.ts
+++ b/web/src/components/pipeline/jobConfigSchema.ts
@@ -104,6 +104,16 @@ const PROBE_MODE_OPTIONS: SelectOption[] = [
   { value: 'command', label: '命令探测' },
 ]
 
+// 部署节点的产物类型偏好(本 run 同时产出镜像与文件产物时,挑哪件部署)。
+// 留空 = 自动:优先文件产物(dist/jar/archive),没有文件产物才用镜像。
+const DEPLOY_ARTIFACT_OPTIONS: SelectOption[] = [
+  { value: '', label: '自动(优先文件产物,无则用镜像)' },
+  { value: 'image', label: '容器镜像 (image)' },
+  { value: 'dist', label: '静态资源 (dist)' },
+  { value: 'jar', label: 'JAR 包 (jar)' },
+  { value: 'archive', label: '归档包 (archive)' },
+]
+
 // `when` helpers
 const modelIs = (v: string) => (c: Record<string, string>) =>
   (c.buildModel || 'dockerfile') === v
@@ -156,12 +166,47 @@ const DEPLOY_SSH_FIELDS: JobField[] = [
     hint: '选择已登记的服务器(凭据按引用绑定)',
   },
   {
+    key: 'artifactType',
+    label: '部署产物类型',
+    kind: 'select',
+    options: DEPLOY_ARTIFACT_OPTIONS,
+    hint: '本 run 同时产出镜像与文件产物时挑哪件;镜像走目标机 docker pull → 起新容器 → 健康检查 → 失败回滚上一镜像',
+  },
+  {
     key: 'deployPath',
     label: '部署路径',
     kind: 'text',
     monospace: true,
     placeholder: '/opt/app',
-    hint: '产物发布到 <部署路径>/releases/<runId>/,current 软链原子切到本次发布(零停机,旧发布保留供回滚)',
+    hint: '文件产物:发布到 <部署路径>/releases/<runId>/,current 软链原子切到本次发布(零停机,旧发布保留供回滚)',
+    when: (c) => c.artifactType !== 'image',
+  },
+  {
+    key: 'containerName',
+    label: '容器名',
+    kind: 'text',
+    monospace: true,
+    placeholder: 'app',
+    hint: '镜像部署的目标容器名;留空则用产物名。同名旧容器会被替换并可回滚到上一镜像',
+    when: (c) => c.artifactType === 'image',
+  },
+  {
+    key: 'ports',
+    label: '端口映射',
+    kind: 'text',
+    monospace: true,
+    placeholder: '8080:80, 9000:9000',
+    hint: '镜像部署:逗号 / 空白分隔,每项展开为 docker run -p <map>',
+    when: (c) => c.artifactType === 'image',
+  },
+  {
+    key: 'runArgs',
+    label: 'docker run 参数',
+    kind: 'text',
+    monospace: true,
+    placeholder: '-e KEY=value --restart always',
+    hint: '镜像部署:原样追加到 docker run(参数自由;凭据请用 registry 登录,勿写进此处)',
+    when: (c) => c.artifactType === 'image',
   },
   {
     key: 'strategy',
@@ -176,6 +221,7 @@ const DEPLOY_SSH_FIELDS: JobField[] = [
     monospace: true,
     placeholder: 'systemctl restart app\nnginx -s reload',
     hint: '可选,多行(set -e 逐行执行);部署后在目标机 current 目录下执行,用于重启/重载;失败自动回滚',
+    when: (c) => c.artifactType !== 'image',
   },
 ]
 


### PR DESCRIPTION
## 现状调研结论

部署在本仓有两条路径:
- **HTTP 触发的策略部署**(`Deploy`/`deployWithStrategy`):dist/jar/archive 走 release 软链切换,**镜像蓝绿已实现**(`image_release.go` 的 `stageImageOne`/`activateImageOne`/`deployBlueGreenImage`),rolling 镜像走 `deployOne`→`buildImageDeploy`。
- **流水线部署节点**(`runDeployJob`→`DeployForStage`):**这里是缺口**。`DeployForStage`(`deploy.go`)原先只挑 `releaseModeArtifact`(dist/jar/archive),镜像产物被显式跳过(注释「镜像类不走发布目录,本节点跳过」)。后果:一个只产出镜像的 run 进到部署节点必然 `ErrArtifactNotFound` → 阶段失败。

所以这是真实缺口,不是误判。`Deploy` 早已能部署镜像,只是 `DeployForStage` 没接上同一套编排。

## 实现方案(最大化复用,不重写)

1. **产物选取** `DeployForStage` 改用新增的 `pickStageArtifact(arts, prefer)`:在「文件发布产物 + 镜像产物」两类可部署产物里按优先级挑一件——
   - 默认(cfg 空)优先文件发布(**保持既有行为**),无文件发布才用镜像;
   - `cfg["artifactType"]=image` → 镜像优先,无镜像退回文件;
   - 精确类型偏好(dist/jar/archive/image)命中优先。
   选定后**由既有 `deployWithStrategy` 据产物类型自动路由**:文件走 release 软链,镜像走 `docker pull`(stage,不停旧)→ 停旧起新 + 健康(cutover)→ 失败回滚上一镜像。蓝绿镜像复用 `deployBlueGreenImage` 的机群级 stage→cutover→回滚。

2. **docker run 参数自由化(用户铁律)**:新增 `cfg["containerName"|"ports"|"runArgs"]`,经新增 `imageContainerName`/`imageRunArgs`/`dockerRunCmd` 把端口与 run 参数**原样作为 array 元素**拼进 `docker run`(绝不拼接 shell,守 AC-SEC-02)。rolling(`buildImageDeploy`)与 blue_green(`stageImageOne`/`activateImageOne` + 两处回滚)两条镜像路径统一消费;回滚起上一镜像也带同一参数。registry 凭据沿用既有 docker login 模式,绝不进命令明文。

3. **前端 schema**:`jobConfigSchema.ts` 的 deploy 节点新增「部署产物类型 / 容器名 / 端口映射 / docker run 参数」字段(`artifactType=image` 时显示;文件字段在非 image 时显示),参数自由不写死。

**无需数据库迁移**(0034 未动)。

## 单测覆盖(`internal/deploy/stage_image_test.go`,均绿)

- `TestStageDeploysImageArtifact`:仅镜像产物 → `DeployForStage` 部署镜像(此前会 `ErrArtifactNotFound`),断言出现 `docker pull`/`docker run`、不走软链。
- `TestStagePrefersFileArtifactByDefault`:镜像+文件并存,默认走文件发布(回归保护)。
- `TestStageSelectsImageWhenConfigured`:`cfg artifactType=image` → 选镜像。
- `TestStageImageHonorsContainerNamePortsRunArgs`:断言 `docker run -d --name <name> -p ... -e ... <ref>` 逐元素精确匹配 + rm 用同名。
- `TestStageImageBlueGreen`:蓝绿镜像 stage(pull)→ cutover(run 带 cfg 容器名/端口)。
- `TestStageImageBlueGreenRollback`:一机健康失败 → 已切换机回滚到上一镜像(带 cfg 容器名)。
- `TestPickStageArtifact`:10 组优先级矩阵。

既有 `deploy_test.go`/`strategy_test.go` 全绿;`go build/vet/test ./...` + `gofmt -l` 全过;前端 lint(0 error)/typecheck/test(193)/build 全过,未提交 dist churn。

## 留给 in-loop 真机 e2e

- 真·多机容器 e2e(`PIPEWRIGHT_E2E_DEPLOY=1` / `strategy_centos_e2e_test.go` 那套)未跑——单测用 fake target/commander 验编排,真实 `docker pull/run/health/回滚` 端到端需真容器,建议合并后 in-loop 亲跑。
- rolling 策略下镜像走 `deployOne`(docker run + 可选健康),**无回滚到上一镜像**(与既有 rolling 镜像语义一致;要回滚请用 blue_green)——如需 rolling 也回滚可后续增量。

🤖 Generated with [Claude Code](https://claude.com/claude-code)