### PR TITLE
feat(pipeline): 节点内可视化步骤构建器(低代码 · Tier 3)

### DIFF
--- a/web/src/components/pipeline/JobDrawer.stepBuilder.test.ts
+++ b/web/src/components/pipeline/JobDrawer.stepBuilder.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import JobDrawer from './JobDrawer.vue'
+import StepBuilder from './StepBuilder.vue'
+import type { PipelineJob, PipelineStage } from '../../api/pipeline'
+
+const stage: PipelineStage = { id: 's1', name: '构建', kind: 'build', jobs: [] }
+
+function scriptJob(config: Record<string, string>): PipelineJob {
+  return { id: 'j1', name: '隔离构建', type: 'script', summary: '', config }
+}
+
+describe('JobDrawer + StepBuilder integration', () => {
+  it('shows the step builder by default for a fresh script node', () => {
+    const wrapper = mount(JobDrawer, {
+      props: { job: scriptJob({ image: 'node:20' }), stage },
+    })
+    expect(wrapper.findComponent(StepBuilder).exists()).toBe(true)
+    // the view switch is present with two tabs
+    expect(wrapper.findAll('.view-tab').length).toBe(2)
+  })
+
+  it('compiles builder steps into commands/artifactPath via emit("update")', async () => {
+    const job = scriptJob({ image: 'node:20', commands: 'npm ci', artifactPath: '' })
+    const wrapper = mount(JobDrawer, { props: { job, stage } })
+
+    const builder = wrapper.findComponent(StepBuilder)
+    // simulate the builder emitting a compiled fragment (env + cd + cmd, plus artifact)
+    builder.vm.$emit('update', {
+      commands: "export CI='true'\ncd 'frontend'\nnpm run build",
+      artifactPath: 'frontend/dist',
+    })
+    await wrapper.vm.$nextTick()
+
+    const events = wrapper.emitted('update')
+    expect(events).toBeTruthy()
+    const last = events!.at(-1)![0] as Partial<PipelineJob>
+    expect(last.config!.commands).toBe("export CI='true'\ncd 'frontend'\nnpm run build")
+    expect(last.config!.artifactPath).toBe('frontend/dist')
+    // node-level field preserved
+    expect(last.config!.image).toBe('node:20')
+  })
+
+  it('reparses an existing config back into ordered step blocks on open', () => {
+    const job = scriptJob({
+      image: 'node:20',
+      commands: "export NODE_ENV='production'\ncd 'frontend'\nnpm ci\nnpm run build",
+      artifactPath: 'frontend/dist',
+    })
+    const wrapper = mount(JobDrawer, { props: { job, stage } })
+    const builder = wrapper.findComponent(StepBuilder)
+    // 4 command-derived steps + 1 artifact step = 5 step rows
+    expect(builder.findAll('.sb-step').length).toBe(5)
+    // first step is the env block (compiled from export line)
+    expect(builder.findAll('.sb-kind')[0].text()).toBe('设环境变量')
+    expect(builder.findAll('.sb-kind')[1].text()).toBe('切目录')
+  })
+
+  it('defaults to raw view for a templated node (commandTemplate present)', () => {
+    const job: PipelineJob = {
+      id: 'j2',
+      name: '自定义',
+      type: 'templated',
+      summary: '',
+      config: { image: 'node:20', commandTemplate: 'cd {{dir}}\nnpm run build', params: 'dir=frontend' },
+    }
+    const wrapper = mount(JobDrawer, { props: { job, stage } })
+    // step builder hidden because config uses the template render path
+    expect(wrapper.findComponent(StepBuilder).exists()).toBe(false)
+  })
+
+  it('does not show the step builder for a non-script node (e.g. notify)', () => {
+    const job: PipelineJob = { id: 'j3', name: '通知', type: 'notify', summary: '', config: {} }
+    const wrapper = mount(JobDrawer, { props: { job, stage } })
+    expect(wrapper.findComponent(StepBuilder).exists()).toBe(false)
+    expect(wrapper.findAll('.view-tab').length).toBe(0)
+  })
+})

--- a/web/src/components/pipeline/JobDrawer.vue
+++ b/web/src/components/pipeline/JobDrawer.vue
@@ -7,10 +7,13 @@ import {
   getJobTypeSpec,
   splitConfig,
   jobTypeLabel,
+  isScriptClassType,
   type JobField,
 } from './jobConfigSchema'
+import { configUsesTemplate } from './stepCompile'
 import { createCustomNode } from '../../api/customNodes'
 import JobTypeIcon from './JobTypeIcon.vue'
+import StepBuilder from './StepBuilder.vue'
 
 const props = defineProps<{
   job: PipelineJob
@@ -62,20 +65,64 @@ function splitOnType(type: string, config: Record<string, string>): void {
   typedConfig.value = typed
   extraRows.value = extras.map(([k, v]) => ({ _key: ++_kvSeq, k, v }))
   showAdvanced.value = extras.length > 0
+  pickViewMode(config)
 }
 
-// Resync when the selected job changes
+// Resync when the selected job changes (initial hydrate runs after the
+// step-builder computeds below are declared, to avoid a temporal dead zone).
 watch(() => props.job, (next) => hydrate(next))
-hydrate(props.job)
 
 // ─── Field schema for the current type ────────────────────────────────────────
 
 const spec = computed(() => getJobTypeSpec(localType.value))
 
+/** 步骤构建器拥有的 config 键(commands 多行 / artifactPath 多行)。 */
+const STEP_OWNED_KEYS = new Set(['commands', 'artifactPath'])
+
+/** 该类型能用可视化步骤构建器吗(脚本类 + 有 commands/artifactPath 字段)。 */
+const canUseStepBuilder = computed<boolean>(() => {
+  if (!isScriptClassType(localType.value)) return false
+  if (!spec.value) return false
+  return spec.value.fields.some((f) => STEP_OWNED_KEYS.has(f.key))
+})
+
+/**
+ * 视图模式:'steps' 走可视化步骤构建器,'raw' 走原始 typed 表单。
+ * 默认对脚本类显示步骤视图;但若 config 用了模板渲染(commandTemplate/params,
+ * 步骤构建器不覆盖那套语义)则回退到原始视图,避免误编译丢数据。
+ */
+const viewMode = ref<'steps' | 'raw'>('raw')
+
+function pickViewMode(config: Record<string, string>): void {
+  if (canUseStepBuilder.value && !configUsesTemplate(config)) {
+    viewMode.value = 'steps'
+  } else {
+    viewMode.value = 'raw'
+  }
+}
+
+/** 步骤模式下,typed 表单只渲染「非步骤拥有」的字段(image/workDir/模板字段等)。 */
 const visibleFields = computed<JobField[]>(() => {
   if (!spec.value) return []
-  return spec.value.fields.filter((f) => !f.when || f.when(typedConfig.value))
+  return spec.value.fields.filter((f) => {
+    if (f.when && !f.when(typedConfig.value)) return false
+    if (viewMode.value === 'steps' && STEP_OWNED_KEYS.has(f.key)) return false
+    return true
+  })
 })
+
+/** 步骤构建器回传的编译片段并入 typedConfig 落库。 */
+function onStepsUpdate(patch: { commands: string; artifactPath: string }): void {
+  typedConfig.value = {
+    ...typedConfig.value,
+    commands: patch.commands,
+    artifactPath: patch.artifactPath,
+  }
+  flush()
+}
+
+// Initial hydrate (after the computeds above are declared, see watch comment).
+hydrate(props.job)
 
 function credentialOptions(field: JobField): Credential[] {
   const all = props.credentials ?? []
@@ -265,7 +312,29 @@ async function confirmSave(): Promise<void> {
 
     <!-- Typed config section (per-type form) -->
     <div v-if="spec" class="drawer-section">
-      <div class="drawer-section-label">{{ spec.label }}配置</div>
+      <div class="drawer-section-head">
+        <div class="drawer-section-label">{{ spec.label }}配置</div>
+        <div v-if="canUseStepBuilder" class="view-switch" role="tablist" aria-label="配置视图">
+          <button
+            class="view-tab"
+            :class="{ 'view-tab--active': viewMode === 'steps' }"
+            role="tab"
+            :aria-selected="viewMode === 'steps'"
+            @click="viewMode = 'steps'"
+          >
+            可视化步骤
+          </button>
+          <button
+            class="view-tab"
+            :class="{ 'view-tab--active': viewMode === 'raw' }"
+            role="tab"
+            :aria-selected="viewMode === 'raw'"
+            @click="viewMode = 'raw'"
+          >
+            原始参数
+          </button>
+        </div>
+      </div>
 
       <div
         v-for="field in visibleFields"
@@ -353,6 +422,14 @@ async function confirmSave(): Promise<void> {
         />
 
         <p v-if="field.hint && field.kind !== 'toggle'" class="field-hint">{{ field.hint }}</p>
+      </div>
+
+      <!-- 可视化步骤构建器(脚本类节点;编译进 commands/artifactPath,经 update 落库) -->
+      <div v-if="canUseStepBuilder && viewMode === 'steps'" class="drawer-field step-builder-field">
+        <StepBuilder :config="typedConfig" @update="onStepsUpdate" />
+        <p class="field-hint">
+          步骤会编译成多行命令在隔离容器内执行;切目录 / 设环境变量对后续命令生效。可随时切「原始参数」查看。
+        </p>
       </div>
     </div>
 
@@ -460,6 +537,57 @@ async function confirmSave(): Promise<void> {
 </template>
 
 <style scoped>
+.drawer-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 9px;
+}
+
+.drawer-section-head .drawer-section-label {
+  margin-bottom: 0;
+}
+
+.view-switch {
+  display: inline-flex;
+  padding: 2px;
+  background: var(--color-inset);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-full);
+}
+
+.view-tab {
+  padding: 3px 10px;
+  background: none;
+  border: none;
+  border-radius: var(--rounded-full);
+  color: var(--color-faint);
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color var(--duration-fast), background-color var(--duration-fast);
+}
+
+.view-tab:hover {
+  color: var(--color-text);
+}
+
+.view-tab--active {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.view-tab:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.step-builder-field {
+  margin-top: 4px;
+}
+
 .kv-empty {
   font-size: 0.78rem;
   color: var(--color-faint);

--- a/web/src/components/pipeline/StepBuilder.vue
+++ b/web/src/components/pipeline/StepBuilder.vue
@@ -1,0 +1,592 @@
+<script setup lang="ts">
+/**
+ * StepBuilder — 节点内可视化步骤构建器(低代码 · Tier 3)。
+ *
+ * 用「加步骤」+ 拖拽/上下移排序拼出脚本块,实时编译成现有可执行 config 键
+ * (commands 多行 / artifactPath 多行),经 emit('update') 落库。绝不新增执行语义:
+ * 编译/反解析全在 stepCompile.ts 的纯函数里(见其文件头契约)。
+ *
+ * 父级(JobDrawer)负责持有 image/workDir 等节点级字段;本组件只管「步骤」那部分,
+ * 把 commands + artifactPath 这两个键回传。
+ */
+import { ref, watch, computed } from 'vue'
+import {
+  type StepBlock,
+  type StepKind,
+  STEP_KIND_META,
+  nextStepId,
+  parseSteps,
+  compileSteps,
+} from './stepCompile'
+
+const props = defineProps<{
+  /** 当前节点的完整 config(用于初始反解析) */
+  config: Record<string, string>
+}>()
+
+const emit = defineEmits<{
+  /** 步骤变更后回传编译出的 config 片段(只含 commands / artifactPath) */
+  (e: 'update', patch: { commands: string; artifactPath: string }): void
+}>()
+
+const steps = ref<StepBlock[]>([])
+
+/** 初次 / 切换节点时从 config 反解析步骤(允许有损,空则起手给一个空命令步骤)。 */
+function hydrate(config: Record<string, string>): void {
+  const parsed = parseSteps(config)
+  steps.value = parsed.length > 0 ? parsed : [blank('command')]
+}
+
+/**
+ * 只在「外部」变更时重建步骤(切换节点、原始视图改 commands 等)。我们自己 flush 回传后,
+ * 父级会把同一份 config 透传回来 —— 这种「自激」更新不能重建,否则正在编辑的空步骤(空 env/空 cd,
+ * 编译成空串)会被反解析丢掉。判据:incoming 的 commands/artifactPath 与当前步骤的编译结果一致 → 自激,跳过。
+ */
+let hydrated = false
+watch(
+  () => props.config,
+  (next) => {
+    if (hydrated) {
+      const mine = compileSteps(steps.value)
+      if ((next.commands ?? '') === mine.commands && (next.artifactPath ?? '') === mine.artifactPath) {
+        return
+      }
+    }
+    hydrated = true
+    hydrate(next)
+  },
+  { immediate: true },
+)
+
+function blank(kind: StepKind): StepBlock {
+  return { id: nextStepId(), kind }
+}
+
+/** 编译当前步骤并回传给父级落库。 */
+function flush(): void {
+  emit('update', compileSteps(steps.value))
+}
+
+// ─── 增删步骤 ──────────────────────────────────────────────────────────────────
+
+const addMenuOpen = ref(false)
+
+const addOptions: ReadonlyArray<{ kind: StepKind; label: string; desc: string }> = [
+  { kind: 'command', label: STEP_KIND_META.command.label, desc: 'shell 命令(可多行)' },
+  { kind: 'env', label: STEP_KIND_META.env.label, desc: 'KEY=VALUE 注入环境' },
+  { kind: 'workDir', label: STEP_KIND_META.workDir.label, desc: '切换后续命令工作目录' },
+  { kind: 'artifact', label: STEP_KIND_META.artifact.label, desc: 'glob 归档产物' },
+]
+
+function addStep(kind: StepKind): void {
+  steps.value = [...steps.value, blank(kind)]
+  addMenuOpen.value = false
+  flush()
+}
+
+function removeStep(id: string): void {
+  steps.value = steps.value.filter((s) => s.id !== id)
+  flush()
+}
+
+function patchStep(id: string, patch: Partial<StepBlock>): void {
+  steps.value = steps.value.map((s) => (s.id === id ? { ...s, ...patch } : s))
+}
+
+// ─── 排序:上下移按钮 + 原生 HTML5 拖拽 ─────────────────────────────────────────
+
+function move(index: number, delta: number): void {
+  const next = index + delta
+  if (next < 0 || next >= steps.value.length) return
+  const arr = [...steps.value]
+  const [item] = arr.splice(index, 1)
+  arr.splice(next, 0, item)
+  steps.value = arr
+  flush()
+}
+
+const dragIndex = ref<number | null>(null)
+const overIndex = ref<number | null>(null)
+
+function onDragStart(index: number): void {
+  dragIndex.value = index
+}
+
+function onDragOver(index: number, e: DragEvent): void {
+  e.preventDefault()
+  overIndex.value = index
+}
+
+function onDrop(index: number): void {
+  const from = dragIndex.value
+  dragIndex.value = null
+  overIndex.value = null
+  if (from === null || from === index) return
+  const arr = [...steps.value]
+  const [item] = arr.splice(from, 1)
+  arr.splice(index, 0, item)
+  steps.value = arr
+  flush()
+}
+
+function onDragEnd(): void {
+  dragIndex.value = null
+  overIndex.value = null
+}
+
+const stepCount = computed(() => steps.value.length)
+</script>
+
+<template>
+  <div class="step-builder">
+    <div class="sb-head">
+      <span class="sb-head-label">可视化步骤</span>
+      <span class="sb-count" aria-label="步骤数量">{{ stepCount }}</span>
+    </div>
+
+    <ol class="sb-list">
+      <li
+        v-for="(step, index) in steps"
+        :key="step.id"
+        class="sb-step"
+        :class="[
+          `sb-step--${step.kind}`,
+          { 'sb-step--dragging': dragIndex === index, 'sb-step--over': overIndex === index && dragIndex !== index },
+        ]"
+        draggable="true"
+        @dragstart="onDragStart(index)"
+        @dragover="onDragOver(index, $event)"
+        @drop="onDrop(index)"
+        @dragend="onDragEnd"
+      >
+        <div class="sb-step-bar">
+          <span class="sb-grip" aria-hidden="true" title="拖拽排序">
+            <svg width="10" height="14" viewBox="0 0 10 14" fill="currentColor">
+              <circle cx="2.5" cy="2" r="1.3" /><circle cx="7.5" cy="2" r="1.3" />
+              <circle cx="2.5" cy="7" r="1.3" /><circle cx="7.5" cy="7" r="1.3" />
+              <circle cx="2.5" cy="12" r="1.3" /><circle cx="7.5" cy="12" r="1.3" />
+            </svg>
+          </span>
+          <span class="sb-kind">{{ STEP_KIND_META[step.kind].label }}</span>
+          <span class="sb-order">{{ index + 1 }}</span>
+          <span class="sb-step-actions">
+            <button
+              class="sb-move"
+              :disabled="index === 0"
+              :aria-label="`上移步骤 ${index + 1}`"
+              @click="move(index, -1)"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true"><path d="M18 15l-6-6-6 6" /></svg>
+            </button>
+            <button
+              class="sb-move"
+              :disabled="index === steps.length - 1"
+              :aria-label="`下移步骤 ${index + 1}`"
+              @click="move(index, 1)"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true"><path d="M6 9l6 6 6-6" /></svg>
+            </button>
+            <button
+              class="sb-del"
+              :aria-label="`删除步骤 ${index + 1}`"
+              @click="removeStep(step.id)"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12" /></svg>
+            </button>
+          </span>
+        </div>
+
+        <!-- 运行命令 -->
+        <textarea
+          v-if="step.kind === 'command'"
+          :value="step.command ?? ''"
+          class="sb-input sb-textarea is-mono"
+          rows="2"
+          placeholder="npm ci&#10;npm run build"
+          :aria-label="`命令 ${index + 1}`"
+          @input="patchStep(step.id, { command: ($event.target as HTMLTextAreaElement).value })"
+          @blur="flush"
+        ></textarea>
+
+        <!-- 设环境变量 -->
+        <div v-else-if="step.kind === 'env'" class="sb-env">
+          <input
+            :value="step.envKey ?? ''"
+            class="sb-input is-mono"
+            type="text"
+            placeholder="KEY"
+            :aria-label="`环境变量名 ${index + 1}`"
+            @input="patchStep(step.id, { envKey: ($event.target as HTMLInputElement).value })"
+            @blur="flush"
+          />
+          <span class="sb-eq" aria-hidden="true">=</span>
+          <input
+            :value="step.envValue ?? ''"
+            class="sb-input is-mono"
+            type="text"
+            placeholder="value"
+            :aria-label="`环境变量值 ${index + 1}`"
+            @input="patchStep(step.id, { envValue: ($event.target as HTMLInputElement).value })"
+            @blur="flush"
+          />
+        </div>
+
+        <!-- 切目录 -->
+        <input
+          v-else-if="step.kind === 'workDir'"
+          :value="step.dir ?? ''"
+          class="sb-input is-mono"
+          type="text"
+          placeholder="frontend"
+          :aria-label="`目录 ${index + 1}`"
+          @input="patchStep(step.id, { dir: ($event.target as HTMLInputElement).value })"
+          @blur="flush"
+        />
+
+        <!-- 上传产物 -->
+        <input
+          v-else
+          :value="step.artifact ?? ''"
+          class="sb-input is-mono"
+          type="text"
+          placeholder="frontend/dist"
+          :aria-label="`产物路径 ${index + 1}`"
+          @input="patchStep(step.id, { artifact: ($event.target as HTMLInputElement).value })"
+          @blur="flush"
+        />
+      </li>
+    </ol>
+
+    <div v-if="steps.length === 0" class="sb-empty">还没有步骤,点下方「加步骤」开始</div>
+
+    <div class="sb-add">
+      <button
+        class="sb-add-btn"
+        :class="{ 'sb-add-btn--open': addMenuOpen }"
+        :aria-expanded="addMenuOpen"
+        @click="addMenuOpen = !addMenuOpen"
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true"><path d="M12 5v14M5 12h14" /></svg>
+        加步骤
+      </button>
+      <div v-if="addMenuOpen" class="sb-add-menu" role="menu">
+        <button
+          v-for="opt in addOptions"
+          :key="opt.kind"
+          class="sb-add-item"
+          :class="`sb-add-item--${opt.kind}`"
+          role="menuitem"
+          @click="addStep(opt.kind)"
+        >
+          <span class="sb-add-dot" aria-hidden="true"></span>
+          <span class="sb-add-body">
+            <span class="sb-add-name">{{ opt.label }}</span>
+            <span class="sb-add-desc">{{ opt.desc }}</span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.step-builder {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+.sb-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.sb-head-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--color-faint);
+}
+
+.sb-count {
+  display: inline-grid;
+  place-items: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  font-size: 0.66rem;
+  font-weight: 700;
+}
+
+.sb-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* Each step is a left-accented card; the accent encodes the kind. */
+.sb-step {
+  position: relative;
+  background: var(--color-inset);
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--accent, var(--color-border-strong));
+  border-radius: var(--rounded-md);
+  padding: 8px 9px 9px;
+  transition: border-color var(--duration-fast), box-shadow var(--duration-fast),
+    opacity var(--duration-fast), transform var(--duration-fast);
+}
+
+.sb-step--command { --accent: var(--color-primary); }
+.sb-step--env { --accent: var(--color-cyan); }
+.sb-step--workDir { --accent: var(--color-amber); }
+.sb-step--artifact { --accent: var(--color-green); }
+
+.sb-step--dragging {
+  opacity: 0.5;
+}
+
+.sb-step--over {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px var(--color-primary-soft);
+  transform: translateY(1px);
+}
+
+.sb-step-bar {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 7px;
+}
+
+.sb-grip {
+  color: var(--color-faint);
+  cursor: grab;
+  display: inline-flex;
+}
+
+.sb-grip:active {
+  cursor: grabbing;
+}
+
+.sb-kind {
+  font-size: 0.76rem;
+  font-weight: 650;
+  color: var(--accent, var(--color-text));
+}
+
+.sb-order {
+  display: inline-grid;
+  place-items: center;
+  min-width: 15px;
+  height: 15px;
+  padding: 0 3px;
+  border-radius: 7px;
+  background: var(--color-border);
+  color: var(--color-faint);
+  font-size: 0.62rem;
+  font-weight: 700;
+  font-family: var(--font-mono);
+}
+
+.sb-step-actions {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.sb-move,
+.sb-del {
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  color: var(--color-faint);
+  cursor: pointer;
+  padding: 0;
+  transition: color var(--duration-fast), background-color var(--duration-fast);
+}
+
+.sb-move:hover:not(:disabled) {
+  color: var(--color-text);
+  background: var(--color-border);
+}
+
+.sb-move:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.sb-del:hover {
+  color: var(--color-red);
+  background: var(--color-red-soft);
+}
+
+.sb-move:focus-visible,
+.sb-del:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+
+.sb-input {
+  width: 100%;
+  height: 30px;
+  background: var(--color-bg, var(--color-inset));
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded-md);
+  padding: 0 9px;
+  color: var(--color-text);
+  font: inherit;
+  font-size: 0.8rem;
+  transition: border-color var(--duration-fast), box-shadow var(--duration-fast);
+}
+
+.sb-textarea {
+  height: auto;
+  min-height: 52px;
+  padding: 7px 9px;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.is-mono {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+}
+
+.sb-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px var(--color-primary-soft);
+}
+
+.sb-env {
+  display: grid;
+  grid-template-columns: 1fr auto 1.4fr;
+  align-items: center;
+  gap: 6px;
+}
+
+.sb-eq {
+  color: var(--color-faint);
+  font-family: var(--font-mono);
+  font-weight: 700;
+}
+
+.sb-empty {
+  font-size: 0.78rem;
+  color: var(--color-faint);
+  font-style: italic;
+  padding: 4px 0;
+}
+
+.sb-add {
+  position: relative;
+}
+
+.sb-add-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 30px;
+  padding: 0 11px;
+  background: none;
+  border: 1px dashed var(--color-border-strong);
+  border-radius: var(--rounded-md);
+  color: var(--color-primary);
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color var(--duration-fast), background-color var(--duration-fast);
+}
+
+.sb-add-btn:hover,
+.sb-add-btn--open {
+  border-color: var(--color-primary);
+  background: var(--color-primary-soft);
+}
+
+.sb-add-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.sb-add-menu {
+  margin-top: 6px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  padding: 7px;
+  background: var(--color-inset);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded);
+}
+
+.sb-add-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 9px;
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-md);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color var(--duration-fast), background-color var(--duration-fast);
+}
+
+.sb-add-item:hover {
+  border-color: var(--item-accent, var(--color-primary));
+  background: var(--color-border);
+}
+
+.sb-add-item:focus-visible {
+  outline: 2px solid var(--item-accent, var(--color-primary));
+  outline-offset: 1px;
+}
+
+.sb-add-item--command { --item-accent: var(--color-primary); }
+.sb-add-item--env { --item-accent: var(--color-cyan); }
+.sb-add-item--workDir { --item-accent: var(--color-amber); }
+.sb-add-item--artifact { --item-accent: var(--color-green); }
+
+.sb-add-dot {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  margin-top: 4px;
+  border-radius: 50%;
+  background: var(--item-accent, var(--color-primary));
+}
+
+.sb-add-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.sb-add-name {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.sb-add-desc {
+  font-size: 0.68rem;
+  color: var(--color-faint);
+  line-height: 1.3;
+}
+</style>

--- a/web/src/components/pipeline/jobConfigSchema.ts
+++ b/web/src/components/pipeline/jobConfigSchema.ts
@@ -576,3 +576,20 @@ export function splitConfig(
   const extras = Object.entries(config).filter(([k]) => !owned.has(k))
   return { extras }
 }
+
+/**
+ * 「脚本类」节点:后端 `isScriptJob`(internal/build/dag_stage_exec.go)按 script 路径执行
+ * (容器跑 + 收 artifactPath 产物)的那批 type。可视化步骤构建器只对这些 type 出现,
+ * 因为它编译/反解析的就是这套 commands/artifactPath 键。与后端保持一致。
+ */
+const SCRIPT_CLASS_TYPES = new Set<string>([
+  'script',
+  'custom',
+  'build_frontend',
+  'build_backend',
+  'templated',
+])
+
+export function isScriptClassType(type: string): boolean {
+  return SCRIPT_CLASS_TYPES.has(type.trim())
+}

--- a/web/src/components/pipeline/stepCompile.test.ts
+++ b/web/src/components/pipeline/stepCompile.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest'
+import {
+  type StepBlock,
+  shellQuote,
+  shellUnquote,
+  stepToCommandLines,
+  compileSteps,
+  lineToStep,
+  parseSteps,
+  configUsesTemplate,
+  nextStepId,
+  STEP_KIND_META,
+} from './stepCompile'
+
+function step(partial: Partial<StepBlock> & { kind: StepBlock['kind'] }): StepBlock {
+  return { id: nextStepId(), ...partial }
+}
+
+describe('stepCompile', () => {
+  describe('shellQuote / shellUnquote round-trip', () => {
+    const cases = ['hello', 'a b c', "it's", 'has "quotes"', '$VAR && rm -rf', '', "a'b'c"]
+    for (const v of cases) {
+      it(`round-trips ${JSON.stringify(v)}`, () => {
+        expect(shellUnquote(shellQuote(v))).toBe(v)
+      })
+    }
+
+    it('quotes wrap the value in single quotes', () => {
+      expect(shellQuote('abc')).toBe("'abc'")
+    })
+
+    it('unquote returns bare tokens unchanged (not single-quoted)', () => {
+      expect(shellUnquote('plain')).toBe('plain')
+    })
+  })
+
+  describe('stepToCommandLines', () => {
+    it('splits a multiline command step, dropping blank lines', () => {
+      expect(stepToCommandLines(step({ kind: 'command', command: 'npm ci\n\nnpm run build' }))).toEqual([
+        'npm ci',
+        'npm run build',
+      ])
+    })
+
+    it('compiles env into an export line with a quoted value', () => {
+      expect(stepToCommandLines(step({ kind: 'env', envKey: 'NODE_ENV', envValue: 'production' }))).toEqual([
+        "export NODE_ENV='production'",
+      ])
+    })
+
+    it('drops env steps with an empty key', () => {
+      expect(stepToCommandLines(step({ kind: 'env', envKey: '', envValue: 'x' }))).toEqual([])
+    })
+
+    it('compiles workDir into a cd line', () => {
+      expect(stepToCommandLines(step({ kind: 'workDir', dir: 'frontend' }))).toEqual(["cd 'frontend'"])
+    })
+
+    it('artifact steps produce no command lines', () => {
+      expect(stepToCommandLines(step({ kind: 'artifact', artifact: 'dist' }))).toEqual([])
+    })
+  })
+
+  describe('compileSteps', () => {
+    it('compiles an ordered mix into commands + artifactPath', () => {
+      const steps: StepBlock[] = [
+        step({ kind: 'env', envKey: 'CI', envValue: 'true' }),
+        step({ kind: 'workDir', dir: 'frontend' }),
+        step({ kind: 'command', command: 'npm ci\nnpm run build' }),
+        step({ kind: 'artifact', artifact: 'frontend/dist' }),
+        step({ kind: 'artifact', artifact: '*.log' }),
+      ]
+      const out = compileSteps(steps)
+      expect(out.commands).toBe("export CI='true'\ncd 'frontend'\nnpm ci\nnpm run build")
+      expect(out.artifactPath).toBe('frontend/dist\n*.log')
+    })
+
+    it('preserves step ordering (cd before the command that depends on it)', () => {
+      const out = compileSteps([
+        step({ kind: 'workDir', dir: 'api' }),
+        step({ kind: 'command', command: 'go build ./...' }),
+      ])
+      expect(out.commands.split('\n')).toEqual(["cd 'api'", 'go build ./...'])
+    })
+
+    it('yields empty strings for no steps', () => {
+      expect(compileSteps([])).toEqual({ commands: '', artifactPath: '' })
+    })
+  })
+
+  describe('lineToStep', () => {
+    it('classifies an export line as env', () => {
+      const s = lineToStep("export TOKEN='abc'")
+      expect(s.kind).toBe('env')
+      expect(s.envKey).toBe('TOKEN')
+      expect(s.envValue).toBe('abc')
+    })
+
+    it('classifies a cd line as workDir', () => {
+      const s = lineToStep("cd 'frontend'")
+      expect(s.kind).toBe('workDir')
+      expect(s.dir).toBe('frontend')
+    })
+
+    it('falls back to command for anything else (lossless, keeps the raw line)', () => {
+      const s = lineToStep('npm run build && echo done')
+      expect(s.kind).toBe('command')
+      expect(s.command).toBe('npm run build && echo done')
+    })
+
+    it('does not misread an unquoted cd without single quotes', () => {
+      const s = lineToStep('cd frontend')
+      expect(s.kind).toBe('workDir')
+      expect(s.dir).toBe('frontend')
+    })
+  })
+
+  describe('parseSteps', () => {
+    it('reverses compileSteps for a representative config (round-trip)', () => {
+      const original: StepBlock[] = [
+        step({ kind: 'env', envKey: 'NODE_ENV', envValue: 'production' }),
+        step({ kind: 'workDir', dir: 'frontend' }),
+        step({ kind: 'command', command: 'npm ci' }),
+        step({ kind: 'command', command: 'npm run build' }),
+        step({ kind: 'artifact', artifact: 'frontend/dist' }),
+      ]
+      const compiled = compileSteps(original)
+      const parsed = parseSteps({ commands: compiled.commands, artifactPath: compiled.artifactPath })
+
+      // ids differ, compare structurally
+      const shape = (s: StepBlock) => ({
+        kind: s.kind,
+        command: s.command,
+        envKey: s.envKey,
+        envValue: s.envValue,
+        dir: s.dir,
+        artifact: s.artifact,
+      })
+      expect(parsed.map(shape)).toEqual(original.map(shape))
+    })
+
+    it('splits multiline commands into one step per line (lossy by design)', () => {
+      const parsed = parseSteps({ commands: 'echo a\necho b\necho c' })
+      expect(parsed.map((s) => s.command)).toEqual(['echo a', 'echo b', 'echo c'])
+    })
+
+    it('parses artifactPath lines into artifact steps', () => {
+      const parsed = parseSteps({ commands: '', artifactPath: 'dist\n*.jar' })
+      expect(parsed.map((s) => [s.kind, s.artifact])).toEqual([
+        ['artifact', 'dist'],
+        ['artifact', '*.jar'],
+      ])
+    })
+
+    it('returns an empty list for empty config (caller decides fallback)', () => {
+      expect(parseSteps({})).toEqual([])
+    })
+
+    it('preserves complex command lines without mangling them', () => {
+      const cmd = 'for f in *.go; do gofmt -l "$f"; done'
+      const parsed = parseSteps({ commands: cmd })
+      expect(parsed).toHaveLength(1)
+      expect(parsed[0].kind).toBe('command')
+      expect(parsed[0].command).toBe(cmd)
+    })
+  })
+
+  describe('configUsesTemplate', () => {
+    it('detects commandTemplate / params', () => {
+      expect(configUsesTemplate({ commandTemplate: 'cd {{dir}}' })).toBe(true)
+      expect(configUsesTemplate({ params: 'dir=frontend' })).toBe(true)
+    })
+
+    it('is false for plain script config', () => {
+      expect(configUsesTemplate({ commands: 'npm ci', image: 'node:20' })).toBe(false)
+      expect(configUsesTemplate({})).toBe(false)
+    })
+  })
+
+  it('STEP_KIND_META covers every kind', () => {
+    expect(Object.keys(STEP_KIND_META).sort()).toEqual(['artifact', 'command', 'env', 'workDir'])
+  })
+})

--- a/web/src/components/pipeline/stepCompile.ts
+++ b/web/src/components/pipeline/stepCompile.ts
@@ -1,0 +1,208 @@
+/**
+ * stepCompile — 可视化「步骤构建器」与现有可执行 config 的双向纯函数转换。
+ *
+ * 设计契约(绝不改后端执行语义):
+ * 脚本类节点(script/custom/build_frontend/build_backend/templated)在后端经
+ * `scriptStepFromJob` 读取这些 config 键执行:
+ *   - `image`        运行镜像(节点级,非步骤)
+ *   - `commands`     多行命令字符串,按 `\n` 拆成逐行命令,在容器内拼成一个
+ *                    `set -e` 单脚本经 `sh -c` 执行(见 internal/build/dag_stage_exec.go:25)
+ *   - `workDir`      步骤起始工作目录(节点级)
+ *   - `artifactPath` 多行产物路径(每行一条 glob)
+ * 后端**不读** `env` 这类键 —— 所以「设环境变量」步骤被编译成 `export K=V` 命令行;
+ * 「切目录」步骤被编译成 `cd DIR` 命令行。因为所有命令同处一个 shell 脚本,
+ * `export` / `cd` 对后续命令生效,顺序语义被忠实保留,且零后端改动。
+ *
+ * 编译(steps → config):把有序步骤列表展开为 `commands` 多行串,产物路径汇入
+ * `artifactPath`;`image`/`workDir` 作为节点级字段单独保留(由调用方合并)。
+ *
+ * 反解析(config → steps):把 `commands` 按行拆开,逐行识别成「设环境变量」/「切目录」/
+ * 「运行命令」三类步骤(`artifactPath` 的每一行还原成「上传产物」步骤)。
+ * 反解析允许有损(注释、奇异语法仍归类为「运行命令」原样保留),绝不丢用户数据。
+ */
+
+// ─── 步骤模型 ──────────────────────────────────────────────────────────────────
+
+export type StepKind = 'command' | 'env' | 'workDir' | 'artifact'
+
+export interface StepBlock {
+  /** 稳定的本地标识(列表 key / 拖拽用),不进 config */
+  id: string
+  kind: StepKind
+  /** command:整段命令(可多行) */
+  command?: string
+  /** env:环境变量名 */
+  envKey?: string
+  /** env:环境变量值 */
+  envValue?: string
+  /** workDir:目标目录 */
+  dir?: string
+  /** artifact:产物路径(glob) */
+  artifact?: string
+}
+
+/** 编译产出:展开后的 config 片段(只含步骤拥有的键)。 */
+export interface CompiledSteps {
+  commands: string
+  artifactPath: string
+}
+
+let _seq = 0
+/** 生成稳定的步骤 id(仅前端,不进 config)。 */
+export function nextStepId(): string {
+  _seq += 1
+  return `step-${_seq}-${Math.random().toString(36).slice(2, 7)}`
+}
+
+// ─── 编译:steps → config ───────────────────────────────────────────────────────
+
+/** POSIX shell 单引号转义:把值安全包进 '...'(内部单引号 → '\''). */
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+/**
+ * 把一个步骤编译成 0 条或多条命令行。
+ * - command:原样多行(空步骤跳过)
+ * - env:`export K=V`(K 合法才发;值做单引号转义)
+ * - workDir:`cd DIR`(DIR 做单引号转义)
+ * - artifact:不产生命令(进 artifactPath)
+ */
+export function stepToCommandLines(step: StepBlock): string[] {
+  switch (step.kind) {
+    case 'command': {
+      const raw = (step.command ?? '').replace(/\r/g, '')
+      return raw.split('\n').filter((l) => l.trim() !== '')
+    }
+    case 'env': {
+      const key = (step.envKey ?? '').trim()
+      if (!key) return []
+      return [`export ${key}=${shellQuote(step.envValue ?? '')}`]
+    }
+    case 'workDir': {
+      const dir = (step.dir ?? '').trim()
+      if (!dir) return []
+      return [`cd ${shellQuote(dir)}`]
+    }
+    case 'artifact':
+      return []
+    default:
+      return []
+  }
+}
+
+/** 把有序步骤列表编译成可执行 config 片段(commands 多行 + artifactPath 多行)。 */
+export function compileSteps(steps: readonly StepBlock[]): CompiledSteps {
+  const cmdLines: string[] = []
+  const artifacts: string[] = []
+  for (const step of steps) {
+    if (step.kind === 'artifact') {
+      const p = (step.artifact ?? '').trim()
+      if (p) artifacts.push(p)
+      continue
+    }
+    cmdLines.push(...stepToCommandLines(step))
+  }
+  return {
+    commands: cmdLines.join('\n'),
+    artifactPath: artifacts.join('\n'),
+  }
+}
+
+// ─── 反解析:config → steps ─────────────────────────────────────────────────────
+
+const ENV_LINE = /^export\s+([A-Za-z_][A-Za-z0-9_]*)=(.*)$/
+const CD_LINE = /^cd\s+(.+)$/
+
+/**
+ * 反单引号转义:把 shellQuote 产出的 '...'(内含 '\'' 续接)还原为原始字符串。
+ * 逐字符状态机:引号内原样吃,引号外只认 `\'`(转义单引号)= 字面 `'`,其余在引号外的
+ * 字符按字面吃(容错)。非单引号开头的 token 原样返回(有损但不丢字符)。
+ */
+export function shellUnquote(token: string): string {
+  const t = token.trim()
+  if (!t.startsWith("'")) return t
+  let out = ''
+  let i = 0
+  let inQuote = false
+  while (i < t.length) {
+    const ch = t[i]
+    if (inQuote) {
+      if (ch === "'") {
+        inQuote = false
+        i += 1
+      } else {
+        out += ch
+        i += 1
+      }
+      continue
+    }
+    // 引号外
+    if (ch === "'") {
+      inQuote = true
+      i += 1
+    } else if (ch === '\\' && i + 1 < t.length && t[i + 1] === "'") {
+      // shellQuote 用 '\'' 表达一个字面单引号
+      out += "'"
+      i += 2
+    } else {
+      out += ch
+      i += 1
+    }
+  }
+  return out
+}
+
+/**
+ * 把一行命令分类成步骤:
+ * - `export K=V`  → env(值反转义)
+ * - `cd DIR`      → workDir(DIR 反转义)
+ * - 其它          → command(原样,有损归类不丢内容)
+ */
+export function lineToStep(line: string): StepBlock {
+  const trimmed = line.trim()
+  const env = ENV_LINE.exec(trimmed)
+  if (env) {
+    return { id: nextStepId(), kind: 'env', envKey: env[1], envValue: shellUnquote(env[2]) }
+  }
+  const cd = CD_LINE.exec(trimmed)
+  if (cd) {
+    return { id: nextStepId(), kind: 'workDir', dir: shellUnquote(cd[1]) }
+  }
+  return { id: nextStepId(), kind: 'command', command: line }
+}
+
+/**
+ * 从 config 反解析出步骤列表。`commands` 逐行分类;`artifactPath` 每行还原成上传产物步骤
+ * (追加在末尾,顺序无关)。空 → 空列表(由调用方决定是否兜底)。
+ */
+export function parseSteps(config: Record<string, string>): StepBlock[] {
+  const steps: StepBlock[] = []
+  const commands = config.commands ?? ''
+  for (const line of commands.replace(/\r/g, '').split('\n')) {
+    if (line.trim() === '') continue
+    steps.push(lineToStep(line))
+  }
+  const artifactPath = config.artifactPath ?? ''
+  for (const line of artifactPath.replace(/\r/g, '').split('\n')) {
+    const p = line.trim()
+    if (p) steps.push({ id: nextStepId(), kind: 'artifact', artifact: p })
+  }
+  return steps
+}
+
+/**
+ * 判断该类型的 config 能否被步骤构建器无歧义地处理(模板节点用 commandTemplate/params,
+ * 步骤构建器不覆盖那套渲染语义 → 让它们走原始视图,避免误编译丢数据)。
+ */
+export function configUsesTemplate(config: Record<string, string>): boolean {
+  return Boolean((config.commandTemplate ?? '').trim() || (config.params ?? '').trim())
+}
+
+/** 步骤类型的展示元信息(标签 + accent token 名),供 UI 复用。 */
+export const STEP_KIND_META: Record<StepKind, { label: string; accent: string }> = {
+  command: { label: '运行命令', accent: 'primary' },
+  env: { label: '设环境变量', accent: 'cyan' },
+  workDir: { label: '切目录', accent: 'amber' },
+  artifact: { label: '上传产物', accent: 'green' },
+}


### PR DESCRIPTION
## 这是什么

脚本类节点(`script`/`custom`/`build_frontend`/`build_backend`/`templated`)现在靠手写多行 `commands`。本 PR 加一个**节点内可视化「步骤构建器」**(低代码):用「加步骤」+ 拖拽/上下移排序拼出步骤块,实时**编译成现有可执行 config**,**绝不新增后端执行语义、不改后端**。

## 步骤块类型

| 块 | 编译进 config | 说明 |
|---|---|---|
| 运行命令 | `commands`(多行) | 一行/多行 shell,逐行执行 |
| 设环境变量 | `commands` 里的 `export K=V` | 后端 `scriptStepFromJob` 不读 `env` config 键;命令同处一个 `set -e` 脚本,`export` 对后续命令生效 → 走命令行才真生效 |
| 切目录 | `commands` 里的 `cd DIR` | 顺序语义忠实保留(可在命令之间插切目录) |
| 上传产物 | `artifactPath`(多行 glob) | 直填,与现有归档逻辑一致 |

`image` / `workDir` 仍由 typed 表单作**节点级字段**持有。

## 设计

- **新增 `stepCompile.ts`(纯函数,便于单测)**:`compileSteps`(steps→config)、`parseSteps`(config→steps)。编译出的键(`commands`/`artifactPath`)与 `internal/build/dag_stage_exec.go` 的 `scriptStepFromJob` 所读**完全一致,能真跑**。shell 值做单引号转义,反解析时反转义。
- **反解析允许有损、绝不丢数据**:`export`/`cd` 行还原成对应步骤,其余原样归类「运行命令」;模板节点(`commandTemplate`/`params`)自动回退原始视图,避免误编译。
- **`StepBuilder.vue`**:步骤卡片按类型上色(复用 pipeline.css 设计 token + 抽屉风格),order 序号、grip 手柄、上下移/删除控件。排序用**原生 HTML5 拖拽 + 上下移按钮**(零新依赖 — package.json 无 draggable/sortable)。
- **JobDrawer 集成**「可视化步骤 / 原始参数」切换(默认对脚本类显示步骤视图),编辑经现有 `emit('update', {config})` 落库。StepBuilder **守卫自激更新**,避免回传后反解析丢掉正在编辑的空步骤。
- **不破坏现有节点**:非脚本类(notify 等)与没用步骤构建器的节点照常工作;参数不写死。

## 改了哪些文件

- `web/src/components/pipeline/stepCompile.ts`(新增,纯函数双向转换)
- `web/src/components/pipeline/StepBuilder.vue`(新增,可视化构建器组件)
- `web/src/components/pipeline/JobDrawer.vue`(集成视图切换 + 嵌入构建器)
- `web/src/components/pipeline/jobConfigSchema.ts`(加 `isScriptClassType`,镜像后端 `isScriptJob`)
- `web/src/components/pipeline/stepCompile.test.ts`、`JobDrawer.stepBuilder.test.ts`(新增单测/集成测,共 22 例)

## 验证结果

- `npm run lint` — **0 error**(仅既有他人文件的 warning)
- `npm run typecheck` — **无输出(过)**
- `npm run test` — **227 测试全过(24 文件)**,含新增 stepCompile + JobDrawer 集成 22 例
- `npm run build` — **过**
- **真 headless Chromium 全栈验过**:加 env/workDir 步骤 → 编译进 `commands`(`export NODE_ENV='production'`、`cd 'frontend'`)→ 上下移重排 → 切「原始参数」核对 textarea 与编译一致 → 切回步骤反解析回正确有序块 → 配置零丢失、零 console 错误。

## 遗留坑 / 取舍

- 「条件包裹」(第 5 种可选块)未做(任务标注可选;简单 shell 条件易与现有 `set -e` 语义打架,先不做,后续可加)。
- 反解析按设计是有损的:多行命令拆成逐行「运行命令」块、引号风格规范化;语义等价,但 textarea 原样格式可能被规整(用户随时可切「原始参数」拿回完全控制)。
- 步骤构建器只处理 `commands`/`artifactPath`;`image`/`workDir`/模板字段仍走 typed 表单,符合后端读法。

🤖 Generated with [Claude Code](https://claude.com/claude-code)