### PR TITLE
fix(deploy): 滚动/金丝雀镜像部署补失败回滚(对齐蓝绿)

### DIFF
--- a/internal/deploy/commands.go
+++ b/internal/deploy/commands.go
@@ -33,9 +33,9 @@ func buildCommands(a run.Artifact, cfg map[string]string) ([][]string, string, e
 		return buildFileDeploy(a, cfg)
 	case run.ArtifactJar:
 		return buildJarDeploy(a, cfg)
-	case run.ArtifactImage:
-		return buildImageDeploy(a, cfg)
 	default:
+		// image 产物已在 deployOne 早于 buildCommands 拦截,走 deployImageOne
+		//(pull→停旧起新→健康→失败回滚上一镜像);故此处不再构造扁平 image 命令。
 		return nil, "", fmt.Errorf("不支持的产物类型:%s", a.Type)
 	}
 }
@@ -125,21 +125,4 @@ func buildJarDeploy(a run.Artifact, cfg map[string]string) ([][]string, string, 
 		{"java", "-jar", jarPath, "--version"},
 	}
 	return cmds, fmt.Sprintf("jar 部署完成 → %s(已调起 java -jar)", jarPath), nil
-}
-
-// buildImageDeploy 构造 image 的 `docker pull` + `docker run`(目标无 docker → failed 人读)。
-// 容器名 / 端口映射 / run 参数由 cfg 解析(参数自由,不写死;见 imageContainerName / imageRunArgs)。
-func buildImageDeploy(a run.Artifact, cfg map[string]string) ([][]string, string, error) {
-	ref := strings.TrimSpace(a.Reference)
-	if ref == "" {
-		return nil, "", fmt.Errorf("image 产物缺少 reference(repo:tag 或镜像 id)")
-	}
-	name := imageContainerName(a, cfg)
-	cmds := [][]string{
-		{"docker", "pull", ref},
-		// 先移除同名旧容器(幂等;无则忽略由 docker 处理),再后台起新容器(带 cfg 端口 / run 参数)。
-		{"docker", "rm", "-f", name},
-		dockerRunCmd(name, imageRunArgs(cfg), ref),
-	}
-	return cmds, fmt.Sprintf("image 部署完成 → 已拉取并启动容器 %s(%s)", name, ref), nil
 }

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -532,10 +532,15 @@ func (s *service) deployFanout(ctx context.Context, servers []*target.Server, a 
 // 探测通过 → success(message 含"健康检查通过");重试耗尽仍失败 → failed + 人读 message。
 // 执行错误**不上抛**:映射为 status=failed + 人读 message(绝无明文密钥)。
 func (s *service) deployOne(ctx context.Context, srv *target.Server, a run.Artifact, cfg map[string]string, hc *HealthCheck) TargetResult {
-	// dist / jar 走「发布目录 + current 软链原子切换 + 健康门控 + 失败回滚」零停机模式(Story 4.4)。
-	// image 本期仍 docker run、archive 维持文件部署,走下方既有命令链路。
+	// dist / jar / archive 走「发布目录 + current 软链原子切换 + 健康门控 + 失败回滚」零停机模式(Story 4.4)。
 	if releaseModeArtifact(a) {
 		return s.deployReleaseOne(ctx, srv, a, cfg, hc)
+	}
+
+	// image 走「pull → 停旧起新 → 健康门控 → 失败回滚上一镜像」(复用蓝绿单机原语,每机独立)。
+	// 补齐此前 buildImageDeploy 扁平路径无回滚的缺口:滚动 / 金丝雀 image 部署失败也能回滚。
+	if a.Type == run.ArtifactImage {
+		return s.deployImageOne(ctx, srv, a, cfg, hc, time.Now().UTC())
 	}
 
 	started := time.Now().UTC()

--- a/internal/deploy/image_release.go
+++ b/internal/deploy/image_release.go
@@ -100,8 +100,24 @@ func (s *service) stageImageOne(ctx context.Context, srv *target.Server, a run.A
 	return st, "", true
 }
 
-// activateImageOne 执行 image 蓝绿**切换阶段**:停旧容器 + 起新镜像容器 + 切后健康门控 + 失败回滚。
-func (s *service) activateImageOne(ctx context.Context, srv *target.Server, a run.Artifact, hc *HealthCheck, st imageState, started time.Time) TargetResult {
+// deployImageOne 执行**滚动 / 金丝雀**单机 image 部署:pull 新镜像(捕获上一镜像作回滚目标)→
+// 停旧起新 + 切后健康门控 → 健康失败回滚到上一镜像。复用蓝绿单机原语 stageImageOne/activateImageOne,
+// 但每机独立(无机群协调)。
+//
+// 这补齐了此前缺口:旧的 buildImageDeploy 扁平命令路径(pull→rm→run)**无任何回滚** —— 新容器起不来
+// 或切后健康失败时,旧容器已被 rm,目标机被留在「无容器 / 坏容器」状态。现在与蓝绿一致:失败即回滚
+// 到上一镜像(首次部署无上一镜像可回滚则记 failed)。
+func (s *service) deployImageOne(ctx context.Context, srv *target.Server, a run.Artifact, cfg map[string]string, hc *HealthCheck, started time.Time) TargetResult {
+	st, failMsg, ok := s.stageImageOne(ctx, srv, a, cfg)
+	if !ok {
+		return finishFailed(TargetResult{ServerID: srv.ID, ServerName: srv.Name, StartedAt: started}, failMsg)
+	}
+	return s.activateImageOne(ctx, srv, a, hc, st, started, "")
+}
+
+// activateImageOne 执行 image **切换阶段**:停旧容器 + 起新镜像容器 + 切后健康门控 + 失败回滚到上一镜像。
+// modeLabel 仅用于成功文案区分编排策略("蓝绿" / 空=滚动/金丝雀);回滚文案策略无关。
+func (s *service) activateImageOne(ctx context.Context, srv *target.Server, a run.Artifact, hc *HealthCheck, st imageState, started time.Time, modeLabel string) TargetResult {
 	res := TargetResult{ServerID: srv.ID, ServerName: srv.Name, StartedAt: started}
 	execCtx, cancel := context.WithTimeout(ctx, execTimeout)
 	defer cancel()
@@ -112,7 +128,8 @@ func (s *service) activateImageOne(ctx context.Context, srv *target.Server, a ru
 		dockerRunCmd(st.name, st.runArgs, st.ref),
 	}
 	if failMsg, ok := s.runStep(execCtx, srv.ID, swap); !ok {
-		return finishFailed(res, failMsg)
+		// 起新容器失败:尽力回滚到上一镜像(与健康失败同语义),避免目标机被留在坏状态。
+		return s.rollbackImage(execCtx, srv, res, st, failMsg)
 	}
 
 	// 切后健康门控;失败触发回滚到上一镜像。
@@ -125,9 +142,9 @@ func (s *service) activateImageOne(ctx context.Context, srv *target.Server, a ru
 	finish := time.Now().UTC()
 	res.Status = run.TargetSuccess
 	if hc.enabled() {
-		res.Message = fmt.Sprintf("image 蓝绿部署完成 → 容器 %s(%s,健康检查通过)", st.name, st.ref)
+		res.Message = fmt.Sprintf("image %s部署完成 → 容器 %s(%s,健康检查通过)", modeLabel, st.name, st.ref)
 	} else {
-		res.Message = fmt.Sprintf("image 蓝绿部署完成 → 容器 %s(%s)", st.name, st.ref)
+		res.Message = fmt.Sprintf("image %s部署完成 → 容器 %s(%s)", modeLabel, st.name, st.ref)
 	}
 	res.FinishedAt = &finish
 	return res

--- a/internal/deploy/stage_image_test.go
+++ b/internal/deploy/stage_image_test.go
@@ -254,6 +254,108 @@ func TestStageImageBlueGreenRollback(t *testing.T) {
 	}
 }
 
+// hasRunWithRef 报告命令序列里是否有「docker run … <ref>」(ref 为末参,用于断言回滚到上一镜像)。
+func hasRunWithRef(calls [][]string, ref string) bool {
+	for _, c := range calls {
+		if len(c) >= 3 && c[0] == "docker" && c[1] == "run" && c[len(c)-1] == ref {
+			return true
+		}
+	}
+	return false
+}
+
+// TestRollingImageHealthFailureRollsBack 滚动(默认)image 部署:切后健康失败 → 回滚到上一镜像
+// (rolled_back)。此前 buildImageDeploy 扁平路径无回滚,健康失败会把目标机留在坏容器上。
+func TestRollingImageHealthFailureRollsBack(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	rec := &touchRecorder{
+		inspectImage: "registry/app:v1", // 已有上一镜像 → 可回滚
+		failOn: func(_ string, cmd []string) bool {
+			return len(cmd) > 0 && cmd[0] == "true" // 健康命令失败
+		},
+	}
+	tgt := &stubTarget{execFn: rec.exec}
+	srv := seedServer(t, tgt, "web-1")
+	runID, artID := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactImage, "registry/app:v2")
+
+	svc := New(tgt, rsvc)
+	hc := &HealthCheck{Type: HealthCheckCommand, Command: []string{"true"}, Retries: 1}
+	res, err := svc.Deploy(context.Background(), DeployInput{
+		RunID: runID, ArtifactID: artID, ServerIDs: []string{srv.ID},
+		Strategy: "rolling", HealthCheck: hc,
+	})
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if len(res) != 1 || res[0].Status != run.TargetRolledBack {
+		t.Fatalf("滚动 image 健康失败应 rolled_back,实际 %+v", res)
+	}
+	if !hasRunWithRef(rec.calls2, "registry/app:v1") {
+		t.Fatalf("应回滚到上一镜像 registry/app:v1: %v", rec.calls2)
+	}
+}
+
+// TestRollingImageFirstDeployHealthFailureFails 滚动 image 首次部署(无上一镜像)健康失败 → failed
+// (无可回滚目标,不谎报回滚)。
+func TestRollingImageFirstDeployHealthFailureFails(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	rec := &touchRecorder{
+		// inspectImage 空 → 无上一镜像(首次部署)。
+		failOn: func(_ string, cmd []string) bool {
+			return len(cmd) > 0 && cmd[0] == "true"
+		},
+	}
+	tgt := &stubTarget{execFn: rec.exec}
+	srv := seedServer(t, tgt, "web-1")
+	runID, artID := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactImage, "registry/app:v2")
+
+	svc := New(tgt, rsvc)
+	hc := &HealthCheck{Type: HealthCheckCommand, Command: []string{"true"}, Retries: 1}
+	res, err := svc.Deploy(context.Background(), DeployInput{
+		RunID: runID, ArtifactID: artID, ServerIDs: []string{srv.ID},
+		Strategy: "rolling", HealthCheck: hc,
+	})
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if len(res) != 1 || res[0].Status != run.TargetFailed {
+		t.Fatalf("首次部署健康失败应 failed,实际 %+v", res)
+	}
+}
+
+// TestRollingImageSwapFailureRollsBack 滚动 image 部署:起新容器(docker run 新镜像)失败 →
+// 回滚到上一镜像(避免目标机被 rm 旧容器后留在无容器状态)。
+func TestRollingImageSwapFailureRollsBack(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	rec := &touchRecorder{
+		inspectImage: "registry/app:v1",
+		failOn: func(_ string, cmd []string) bool {
+			// 仅让「起新容器」(docker run … v2)失败;回滚的 docker run v1 放行。
+			return len(cmd) >= 3 && cmd[0] == "docker" && cmd[1] == "run" && cmd[len(cmd)-1] == "registry/app:v2"
+		},
+	}
+	tgt := &stubTarget{execFn: rec.exec}
+	srv := seedServer(t, tgt, "web-1")
+	runID, artID := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactImage, "registry/app:v2")
+
+	svc := New(tgt, rsvc)
+	res, err := svc.Deploy(context.Background(), DeployInput{
+		RunID: runID, ArtifactID: artID, ServerIDs: []string{srv.ID}, Strategy: "rolling",
+	})
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if len(res) != 1 || res[0].Status != run.TargetRolledBack {
+		t.Fatalf("起新容器失败应回滚 rolled_back,实际 %+v", res)
+	}
+	if !hasRunWithRef(rec.calls2, "registry/app:v1") {
+		t.Fatalf("应回滚到上一镜像 v1: %v", rec.calls2)
+	}
+}
+
 // mustArtID 取该 run 首件产物 id(测试便捷)。
 func mustArtID(t *testing.T, rsvc run.Service, runID string) string {
 	t.Helper()

--- a/internal/deploy/strategy.go
+++ b/internal/deploy/strategy.go
@@ -264,7 +264,7 @@ func (s *service) deployBlueGreenImage(ctx context.Context, servers []*target.Se
 
 	// 阶段 2:全机统一停旧起新 + 健康。
 	s.forEachServer(servers, func(idx int, srv *target.Server) {
-		results[idx] = s.activateImageOne(ctx, srv, a, hc, states[idx], started[idx])
+		results[idx] = s.activateImageOne(ctx, srv, a, hc, states[idx], started[idx], "蓝绿")
 	}, func(idx int, srv *target.Server) {
 		results[idx] = abortedResult(srv, "蓝绿切换阶段执行异常中断")
 	})


### PR DESCRIPTION
## 问题

image 产物的**滚动(默认)/ 金丝雀**部署此前走 `buildImageDeploy` 扁平命令路径(`docker pull → rm 旧 → run 新`),**无任何回滚**:新容器起不来、或切后健康检查失败时,旧容器已被 `rm`,目标机被留在「无容器 / 坏容器」状态。蓝绿(blue_green)早已有回滚,滚动/金丝雀没有 —— 这是上一轮 #51 合并时留的尾巴。

## 修法(复用既有,不新造)

`deployOne` 对 image 产物路由到新增 `deployImageOne`,复用蓝绿的单机原语 `stageImageOne`/`activateImageOne`(每机独立、无机群协调):

- **pull 新镜像** + 探测当前容器镜像作回滚目标 → **停旧起新** → **切后健康门控** → **失败回滚到上一镜像**。
- `activateImageOne` 加 `modeLabel` 参数区分成功文案("蓝绿" / 空=滚动/金丝雀),并把「起新容器失败」也纳入回滚(此前仅健康失败回滚)。回滚文案策略无关;**首次部署无上一镜像可回 → failed**(不谎报回滚)。
- 退役死代码 `buildImageDeploy`(image 已在 `deployOne` 早于 `buildCommands` 拦截)。

金丝雀 image 部署因复用 `deployOne` 同样白拿单机回滚。蓝绿 image 编排不变。命令全程 array 化不拼 shell(AC-SEC-02)。

## 验证

- 新增单测:滚动 image 健康失败→回滚上一镜像、起新容器失败→回滚、首次部署健康失败→failed(无可回滚)。
- 既有蓝绿 image 回滚 / 文件部署单测全绿;`go build/vet/test ./...` + `gofmt` 全过。
- **真 CentOS 容器 deploy e2e**(`PIPEWRIGHT_E2E_DEPLOY=1` E2EStrategy/E2EMultiTarget)全绿无回归。
- **诚实缺口**:真 docker-in-docker 镜像回滚 e2e 未跑(harness 的 sshd 目标容器无 docker;与基础镜像部署特性同一已知缺口)。回滚逻辑与蓝绿 image 回滚同源,后者已单测覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)