### PR TITLE
feat(pipeline): 步骤构建器加「条件守卫」步骤(Tier 3 收尾 · set -e 安全)

### DIFF
--- a/web/src/components/pipeline/StepBuilder.vue
+++ b/web/src/components/pipeline/StepBuilder.vue
@@ -75,6 +75,7 @@ const addOptions: ReadonlyArray<{ kind: StepKind; label: string; desc: string }>
   { kind: 'command', label: STEP_KIND_META.command.label, desc: 'shell 命令(可多行)' },
   { kind: 'env', label: STEP_KIND_META.env.label, desc: 'KEY=VALUE 注入环境' },
   { kind: 'workDir', label: STEP_KIND_META.workDir.label, desc: '切换后续命令工作目录' },
+  { kind: 'condition', label: STEP_KIND_META.condition.label, desc: '不成立则跳过后续步骤' },
   { kind: 'artifact', label: STEP_KIND_META.artifact.label, desc: 'glob 归档产物' },
 ]
 
@@ -243,6 +244,23 @@ const stepCount = computed(() => steps.value.length)
           @blur="flush"
         />
 
+        <!-- 条件守卫 -->
+        <div v-else-if="step.kind === 'condition'" class="sb-cond">
+          <input
+            :value="step.condition ?? ''"
+            class="sb-input is-mono"
+            type="text"
+            placeholder='[ "$BRANCH" = "main" ]'
+            :aria-label="`条件 ${index + 1}`"
+            @input="patchStep(step.id, { condition: ($event.target as HTMLInputElement).value })"
+            @blur="flush"
+          />
+          <p class="sb-cond-hint">
+            shell 条件,不成立则<strong>跳过后续所有步骤</strong>(成功结束)。如
+            <code>[ -f package.json ]</code>
+          </p>
+        </div>
+
         <!-- 上传产物 -->
         <input
           v-else
@@ -348,6 +366,7 @@ const stepCount = computed(() => steps.value.length)
 .sb-step--env { --accent: var(--color-cyan); }
 .sb-step--workDir { --accent: var(--color-amber); }
 .sb-step--artifact { --accent: var(--color-green); }
+.sb-step--condition { --accent: var(--color-red); }
 
 .sb-step--dragging {
   opacity: 0.5;
@@ -484,6 +503,33 @@ const stepCount = computed(() => steps.value.length)
   font-weight: 700;
 }
 
+.sb-cond {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.sb-cond-hint {
+  margin: 0;
+  font-size: 0.68rem;
+  line-height: 1.45;
+  color: var(--color-faint);
+}
+
+.sb-cond-hint strong {
+  color: var(--color-red);
+  font-weight: 600;
+}
+
+.sb-cond-hint code {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  padding: 0 3px;
+  border-radius: 3px;
+  background: var(--color-border);
+  color: var(--color-dim);
+}
+
 .sb-empty {
   font-size: 0.78rem;
   color: var(--color-faint);
@@ -560,6 +606,7 @@ const stepCount = computed(() => steps.value.length)
 .sb-add-item--command { --item-accent: var(--color-primary); }
 .sb-add-item--env { --item-accent: var(--color-cyan); }
 .sb-add-item--workDir { --item-accent: var(--color-amber); }
+.sb-add-item--condition { --item-accent: var(--color-red); }
 .sb-add-item--artifact { --item-accent: var(--color-green); }
 
 .sb-add-dot {

--- a/web/src/components/pipeline/stepCompile.test.ts
+++ b/web/src/components/pipeline/stepCompile.test.ts
@@ -5,6 +5,7 @@ import {
   shellUnquote,
   stepToCommandLines,
   compileSteps,
+  conditionGuardLine,
   lineToStep,
   parseSteps,
   configUsesTemplate,
@@ -165,6 +166,57 @@ describe('stepCompile', () => {
     })
   })
 
+  describe('condition guard (set -e safe)', () => {
+    it('compiles to a single-line if-guard that exits 0 when condition fails', () => {
+      const line = conditionGuardLine('[ "$BRANCH" = "main" ]')
+      expect(line).toBe(
+        `if ! ( [ "$BRANCH" = "main" ] ); then echo '条件不成立,跳过后续步骤'; exit 0; fi`,
+      )
+      // 单行(逐行 round-trip 不破裂)。
+      expect(line.includes('\n')).toBe(false)
+      // 条件在 if 测试上下文(set -e 豁免),命中走 exit 0(干净早退)。
+      expect(line.startsWith('if ! (')).toBe(true)
+      expect(line.includes('; exit 0; fi')).toBe(true)
+    })
+
+    it('stepToCommandLines emits one guard line; empty condition → none', () => {
+      expect(stepToCommandLines(step({ kind: 'condition', condition: 'test -f package.json' }))).toEqual([
+        `if ! ( test -f package.json ); then echo '条件不成立,跳过后续步骤'; exit 0; fi`,
+      ])
+      expect(stepToCommandLines(step({ kind: 'condition', condition: '   ' }))).toEqual([])
+    })
+
+    it('flattens a multiline condition to a single line', () => {
+      expect(stepToCommandLines(step({ kind: 'condition', condition: '[ -d dist ]\n' }))).toEqual([
+        `if ! ( [ -d dist ] ); then echo '条件不成立,跳过后续步骤'; exit 0; fi`,
+      ])
+    })
+
+    it('lineToStep parses a guard line back to a condition step (round-trip)', () => {
+      const cond = '[ "$BRANCH" = "main" ] && [ -f deploy.sh ]'
+      const back = lineToStep(conditionGuardLine(cond))
+      expect(back.kind).toBe('condition')
+      expect(back.condition).toBe(cond)
+    })
+
+    it('round-trips a condition step through compile + parse', () => {
+      const steps: StepBlock[] = [
+        step({ kind: 'condition', condition: 'test -f package.json' }),
+        step({ kind: 'command', command: 'npm ci' }),
+      ]
+      const compiled = compileSteps(steps)
+      const parsed = parseSteps({ commands: compiled.commands })
+      expect(parsed.map((s) => s.kind)).toEqual(['condition', 'command'])
+      expect(parsed[0].condition).toBe('test -f package.json')
+      expect(parsed[1].command).toBe('npm ci')
+    })
+
+    it('a plain command is not misclassified as a condition', () => {
+      expect(lineToStep('echo hello').kind).toBe('command')
+      expect(lineToStep('if true; then echo hi; fi').kind).toBe('command')
+    })
+  })
+
   describe('configUsesTemplate', () => {
     it('detects commandTemplate / params', () => {
       expect(configUsesTemplate({ commandTemplate: 'cd {{dir}}' })).toBe(true)
@@ -178,6 +230,6 @@ describe('stepCompile', () => {
   })
 
   it('STEP_KIND_META covers every kind', () => {
-    expect(Object.keys(STEP_KIND_META).sort()).toEqual(['artifact', 'command', 'env', 'workDir'])
+    expect(Object.keys(STEP_KIND_META).sort()).toEqual(['artifact', 'command', 'condition', 'env', 'workDir'])
   })
 })

--- a/web/src/components/pipeline/stepCompile.ts
+++ b/web/src/components/pipeline/stepCompile.ts
@@ -13,6 +13,11 @@
  * 「切目录」步骤被编译成 `cd DIR` 命令行。因为所有命令同处一个 shell 脚本,
  * `export` / `cd` 对后续命令生效,顺序语义被忠实保留,且零后端改动。
  *
+ * 「条件守卫」(condition)步骤编译成**单行** `if ! ( <cond> ); then echo …; exit 0; fi`:
+ * 条件不成立则整段脚本提前**成功退出**,后续步骤全部跳过。这是 `set -e` **安全**的 ——
+ * 条件 `<cond>` 跑在 `if` 测试上下文里(set -e 对其豁免,即便条件命令非零退出也不会中断脚本),
+ * 命中则 `exit 0` 干净结束;且整条是单行,逐行反解析仍能原样还原条件,round-trip 不丢数据。
+ *
  * 编译(steps → config):把有序步骤列表展开为 `commands` 多行串,产物路径汇入
  * `artifactPath`;`image`/`workDir` 作为节点级字段单独保留(由调用方合并)。
  *
@@ -23,7 +28,7 @@
 
 // ─── 步骤模型 ──────────────────────────────────────────────────────────────────
 
-export type StepKind = 'command' | 'env' | 'workDir' | 'artifact'
+export type StepKind = 'command' | 'env' | 'workDir' | 'artifact' | 'condition'
 
 export interface StepBlock {
   /** 稳定的本地标识(列表 key / 拖拽用),不进 config */
@@ -39,6 +44,8 @@ export interface StepBlock {
   dir?: string
   /** artifact:产物路径(glob) */
   artifact?: string
+  /** condition:shell 条件表达式(不成立则跳过后续步骤) */
+  condition?: string
 }
 
 /** 编译产出:展开后的 config 片段(只含步骤拥有的键)。 */
@@ -61,11 +68,21 @@ export function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
+// 条件守卫单行模板:`if ! ( <cond> ); then echo '…'; exit 0; fi`(set -e 安全;cond 原样,不转义)。
+const COND_GUARD_PREFIX = 'if ! ( '
+const COND_GUARD_SUFFIX = " ); then echo '条件不成立,跳过后续步骤'; exit 0; fi"
+
+/** 把条件表达式包成单行 set -e 安全的守卫(不成立→提前成功退出)。 */
+export function conditionGuardLine(cond: string): string {
+  return `${COND_GUARD_PREFIX}${cond}${COND_GUARD_SUFFIX}`
+}
+
 /**
  * 把一个步骤编译成 0 条或多条命令行。
  * - command:原样多行(空步骤跳过)
  * - env:`export K=V`(K 合法才发;值做单引号转义)
  * - workDir:`cd DIR`(DIR 做单引号转义)
+ * - condition:`if ! ( <cond> ); then echo …; exit 0; fi`(单行守卫;cond 原样,空步骤跳过)
  * - artifact:不产生命令(进 artifactPath)
  */
 export function stepToCommandLines(step: StepBlock): string[] {
@@ -83,6 +100,11 @@ export function stepToCommandLines(step: StepBlock): string[] {
       const dir = (step.dir ?? '').trim()
       if (!dir) return []
       return [`cd ${shellQuote(dir)}`]
+    }
+    case 'condition': {
+      const cond = (step.condition ?? '').replace(/\r?\n/g, ' ').trim()
+      if (!cond) return []
+      return [conditionGuardLine(cond)]
     }
     case 'artifact':
       return []
@@ -113,6 +135,8 @@ export function compileSteps(steps: readonly StepBlock[]): CompiledSteps {
 
 const ENV_LINE = /^export\s+([A-Za-z_][A-Za-z0-9_]*)=(.*)$/
 const CD_LINE = /^cd\s+(.+)$/
+// 条件守卫:`if ! ( <cond> ); then echo …; exit 0; fi` → 抽回 <cond>(贪婪到最后一个 `); then echo`)。
+const COND_LINE = /^if ! \( (.+) \); then echo .*; exit 0; fi$/
 
 /**
  * 反单引号转义:把 shellQuote 产出的 '...'(内含 '\'' 续接)还原为原始字符串。
@@ -161,6 +185,10 @@ export function shellUnquote(token: string): string {
  */
 export function lineToStep(line: string): StepBlock {
   const trimmed = line.trim()
+  const cond = COND_LINE.exec(trimmed)
+  if (cond) {
+    return { id: nextStepId(), kind: 'condition', condition: cond[1].trim() }
+  }
   const env = ENV_LINE.exec(trimmed)
   if (env) {
     return { id: nextStepId(), kind: 'env', envKey: env[1], envValue: shellUnquote(env[2]) }
@@ -205,4 +233,5 @@ export const STEP_KIND_META: Record<StepKind, { label: string; accent: string }>
   env: { label: '设环境变量', accent: 'cyan' },
   workDir: { label: '切目录', accent: 'amber' },
   artifact: { label: '上传产物', accent: 'green' },
+  condition: { label: '条件守卫', accent: 'red' },
 }


### PR DESCRIPTION
## 背景

补齐 Tier 3 可视化步骤构建器的第 5 种步骤块「**条件守卫**」。此前因与后端「多行命令拼成一个 `set -e` 脚本经 `sh -c` 跑」的语义易冲突而搁置。

## 解法(`set -e` 安全)

编译为**单行**守卫:

```sh
if ! ( <cond> ); then echo '条件不成立,跳过后续步骤'; exit 0; fi
```

- 条件 `<cond>` 跑在 `if` 测试上下文 → `set -e` **对其豁免**(即便条件命令非零退出也不中断脚本);
- 不成立 → `exit 0` 让整段脚本提前**成功退出**,后续步骤全部跳过(「包裹后续」语义);
- 单行 → 逐行反解析能原样还原条件,round-trip 不丢数据;
- 条件表达式**自由**(参数不写死),原样入命令不转义。

## 改动(纯前端,零后端)

- `stepCompile.ts`:`StepKind` 加 `'condition'` + `StepBlock.condition`;`conditionGuardLine` 编译 + `COND_LINE` 反解析 + `STEP_KIND_META` 红色 accent。
- `StepBuilder.vue`:加步骤菜单项 + 条件编辑框 + 守卫语义说明 + 红色块样式。
- `stepCompile.test.ts`:6 新单测。

## 验证

- 前端 `lint`(0 error)/ `typecheck` / **233 测试** / `build` 全绿。
- **真 shell 证 `set -e` 安全**:条件假→跳过后续 `exit 0`;条件真→继续;**条件为失败命令(grep 非零)→ 不中断脚本**,由守卫按「不成立」处理。
- **真浏览器**:加步骤菜单含「条件守卫」、编辑框 + 说明渲染、编译进 config,0 console error。

🤖 Generated with [Claude Code](https://claude.com/claude-code)