### PR TITLE
fix(deploy): 部署节点透传镜像产物参数(#51 漏传修复)

### DIFF
--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -236,6 +236,14 @@ func (b *Builder) runDeployJob(ctx context.Context, rep dagrun.StageReporter, jb
 	if rc := cfgString(jb.Config, "restartCommand"); rc != "" {
 		cfg["restartCommand"] = rc
 	}
+	// 镜像产物部署参数(#51)透传:deploy.DeployForStage 经这些键挑镜像产物并组装
+	// `docker run`(artifactType=image 选镜像;containerName/ports/runArgs 驱动容器名与端口/运行参数)。
+	// 各值原样搬运(deploy 层 array 化、绝不拼 shell,守 AC-SEC-02);空值不入 cfg 保持默认。
+	for _, k := range []string{"artifactType", "containerName", "ports", "runArgs"} {
+		if v := cfgString(jb.Config, k); v != "" {
+			cfg[k] = v
+		}
+	}
 	strategy := cfgString(jb.Config, "strategy")
 	stratLabel := strategy
 	if stratLabel == "" {

--- a/internal/build/dag_stage_exec_test.go
+++ b/internal/build/dag_stage_exec_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/huangchengsir/pipewright/internal/deploy"
 	"github.com/huangchengsir/pipewright/internal/pipeline"
 	"github.com/huangchengsir/pipewright/internal/project"
 	"github.com/huangchengsir/pipewright/internal/run"
@@ -340,5 +341,64 @@ func TestScriptStepFromTemplatedJob(t *testing.T) {
 	}
 	if len(step.Commands) != 2 || step.Commands[0] != "cd web" {
 		t.Errorf("commands = %v", step.Commands)
+	}
+}
+
+// stubStageDeployer 捕获 DeployForStage 的入参(只为断言 cfg 透传)。
+type stubStageDeployer struct {
+	gotCfg      map[string]string
+	gotStrategy string
+	gotServers  []string
+}
+
+func (d *stubStageDeployer) Deploy(context.Context, deploy.DeployInput) ([]deploy.TargetResult, error) {
+	panic("Deploy not expected")
+}
+func (d *stubStageDeployer) RetryFailed(context.Context, deploy.RetryInput) ([]deploy.TargetResult, error) {
+	panic("RetryFailed not expected")
+}
+func (d *stubStageDeployer) DeployForStage(_ context.Context, _ string, serverIDs []string, cfg map[string]string, strategy string) ([]deploy.TargetResult, error) {
+	d.gotCfg = cfg
+	d.gotStrategy = strategy
+	d.gotServers = serverIDs
+	return []deploy.TargetResult{{ServerName: "srv", Status: run.TargetSuccess, Message: "ok"}}, nil
+}
+
+// TestRunDeployJobPassesImageParams 证 #55:部署节点把镜像产物参数
+// (artifactType/containerName/ports/runArgs)透传给 deploy.DeployForStage,
+// 使流水线部署节点能部署 #51 的镜像产物(而非只透传 releaseBase/restartCommand)。
+func TestRunDeployJobPassesImageParams(t *testing.T) {
+	dep := &stubStageDeployer{}
+	b := &Builder{deployer: dep}
+	rep := &fakeReporter{}
+	jb := pipeline.Job{ID: "d", Name: "部署", Type: "deploy_ssh", Config: map[string]any{
+		"serverId":      "srv-1",
+		"artifactType":  "image",
+		"containerName": "myapp",
+		"ports":         "8080:80,9000:9000",
+		"runArgs":       "-e KEY=v --restart always",
+		"strategy":      "blue_green",
+		"deployPath":    "/opt/app", // 文件态键仍应透传,不互斥
+	}}
+	if err := b.runDeployJob(context.Background(), rep, jb, "run-1"); err != nil {
+		t.Fatalf("runDeployJob err: %v", err)
+	}
+	for k, want := range map[string]string{
+		"artifactType":  "image",
+		"containerName": "myapp",
+		"ports":         "8080:80,9000:9000",
+		"runArgs":       "-e KEY=v --restart always",
+		"releaseBase":   "/opt/app",
+	} {
+		if got := dep.gotCfg[k]; got != want {
+			t.Errorf("cfg[%q] = %q, want %q(完整 cfg=%+v)", k, got, want, dep.gotCfg)
+		}
+	}
+	if dep.gotStrategy != "blue_green" {
+		t.Errorf("strategy = %q, want blue_green", dep.gotStrategy)
+	}
+	// 空键不应混入(保持默认行为)。
+	if _, ok := dep.gotCfg["restartCommand"]; ok {
+		t.Errorf("空 restartCommand 不应入 cfg:%+v", dep.gotCfg)
 	}
 }


### PR DESCRIPTION
## 背景

#51 给 `deploy.DeployForStage` 加了镜像产物部署能力(经 cfg 的 `artifactType`/`containerName`/`ports`/`runArgs` 键挑镜像产物并组装 `docker run`),但流水线 `deploy_ssh` 节点的 `runDeployJob`(`internal/build/dag_stage_exec.go`)组 cfg 时**只透传了 `releaseBase`(deployPath)+ `restartCommand`**,漏传这四个镜像键。

后果:**流水线部署节点用不上 #51 的镜像参数**,只有 HTTP `POST /api/runs/{id}/deploy` 路径能部署镜像产物。前端 deploy 节点已暴露这些字段(`jobConfigSchema.ts`),但点不到后端。

## 改动

- `runDeployJob` 把 `artifactType`/`containerName`/`ports`/`runArgs` 原样透传给 `DeployForStage`(空值不入 cfg,保持默认行为;array 化与不拼 shell 仍由 deploy 层负责,守 AC-SEC-02)。
- 补单测 `TestRunDeployJobPassesImageParams`:断言四键透传 + 文件态 `deployPath`→`releaseBase` 仍在 + 空 `restartCommand` 不混入 cfg。

## 验证

- `gofmt -l` 净 · `go build ./...` · `go vet ./internal/build/` · `go test ./internal/build/ ./internal/deploy/` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)