### PR TITLE
fix(trigger): 手动/定时/串联触发按分支映射补解析环境(#56)

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -133,7 +133,10 @@ func main() {
 
 	// 装配运行服务(Story 3.1):本期桩 runner 跑占位步骤打通状态机;真实构建/部署=3-3/4-x。
 	// worker pool 在 aiSvc 装配后创建(以便注入 best-effort 自动诊断钩子,Story 7.2)。
-	runSvc := run.New(st.DB)
+	// 注入分支→环境解析器(#56):手动/定时/串联触发未显式带环境时,据项目分支映射补解析
+	// 环境 + 目标服务器,与 webhook 接收路径一致(否则 build_image 不知推哪个 registry、
+	// 部署节点 pull 不到镜像)。复用 trigger 包同一套 matchBranch glob。
+	runSvc := run.New(st.DB, run.WithEnvResolver(trigger.NewEnvironmentResolver(st.DB)))
 	// DORA 指标只读聚合(FR-8-15):同一 *service 实现暴露为 MetricsService,无新连接/新表。
 	doraMetricsSvc := run.NewMetricsService(runSvc)
 

--- a/internal/run/env_resolve_test.go
+++ b/internal/run/env_resolve_test.go
@@ -1,0 +1,115 @@
+package run
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// stubEnvResolver 是受控的 EnvResolver 测试替身:记录是否被调用 + 返回固定结果。
+type stubEnvResolver struct {
+	env     string
+	servers []string
+	called  bool
+	gotBr   string
+}
+
+func (r *stubEnvResolver) ResolveEnv(_ context.Context, _, branch string) (string, []string) {
+	r.called = true
+	r.gotBr = branch
+	return r.env, r.servers
+}
+
+// readResolved 直接读运行内部列(不进冻结 DTO)。
+func readResolved(t *testing.T, db *sql.DB, runID string) (env, targets string) {
+	t.Helper()
+	if err := db.QueryRow(
+		`SELECT resolved_environment, resolved_target_server_ids FROM pipeline_runs WHERE id = ?`, runID,
+	).Scan(&env, &targets); err != nil {
+		t.Fatalf("read resolved cols: %v", err)
+	}
+	return env, targets
+}
+
+// TestCreateResolvesEnvForManualTrigger 证 #56:手动触发未带环境时,Create 经注入的
+// EnvResolver 据分支补解析环境 + 目标服务器并落库。
+func TestCreateResolvesEnvForManualTrigger(t *testing.T) {
+	db := testDB(t)
+	res := &stubEnvResolver{env: "staging", servers: []string{"srv-1", "srv-2"}}
+	svc := New(db, WithEnvResolver(res))
+	projID := seedProject(t, db)
+
+	rn, err := svc.Create(context.Background(), projID, Trigger{Type: TriggerManual, Branch: "release/1.2"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !res.called || res.gotBr != "release/1.2" {
+		t.Fatalf("resolver 未按分支调用:called=%v br=%q", res.called, res.gotBr)
+	}
+	env, targets := readResolved(t, db, rn.ID)
+	if env != "staging" {
+		t.Errorf("resolved_environment = %q, want staging", env)
+	}
+	if targets != `["srv-1","srv-2"]` {
+		t.Errorf("resolved_target_server_ids = %q, want srv-1/srv-2", targets)
+	}
+}
+
+// TestCreateResolvesEnvUsesDefaultBranch 证补解析发生在默认分支回退之后:分支留空 →
+// 取项目默认分支(main)→ 据其解析环境。
+func TestCreateResolvesEnvUsesDefaultBranch(t *testing.T) {
+	db := testDB(t)
+	res := &stubEnvResolver{env: "prod"}
+	svc := New(db, WithEnvResolver(res))
+	projID := seedProject(t, db) // default_branch = main
+
+	rn, err := svc.Create(context.Background(), projID, Trigger{Type: TriggerManual})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if res.gotBr != "main" {
+		t.Errorf("resolver 应收到默认分支 main,实收 %q", res.gotBr)
+	}
+	if env, _ := readResolved(t, db, rn.ID); env != "prod" {
+		t.Errorf("resolved_environment = %q, want prod", env)
+	}
+}
+
+// TestCreateSkipsResolutionWhenEnvAlreadySet 证 webhook 路径(已显式带 ResolvedEnvironment)
+// 不被二次解析:resolver 不被调用,环境保持原值。
+func TestCreateSkipsResolutionWhenEnvAlreadySet(t *testing.T) {
+	db := testDB(t)
+	res := &stubEnvResolver{env: "should-not-be-used"}
+	svc := New(db, WithEnvResolver(res))
+	projID := seedProject(t, db)
+
+	rn, err := svc.Create(context.Background(), projID, Trigger{
+		Type:                TriggerWebhook,
+		Branch:              "main",
+		ResolvedEnvironment: "production",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if res.called {
+		t.Error("已带环境时不应调用 resolver(避免二次解析)")
+	}
+	if env, _ := readResolved(t, db, rn.ID); env != "production" {
+		t.Errorf("resolved_environment = %q, want production(原值不变)", env)
+	}
+}
+
+// TestCreateNoResolverKeepsEmptyEnv 证无 resolver(未注入)时行为不变:手动触发环境保持空。
+func TestCreateNoResolverKeepsEmptyEnv(t *testing.T) {
+	db := testDB(t)
+	svc := New(db) // 不注入 resolver
+	projID := seedProject(t, db)
+
+	rn, err := svc.Create(context.Background(), projID, Trigger{Type: TriggerManual, Branch: "main"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if env, targets := readResolved(t, db, rn.ID); env != "" || targets != "[]" {
+		t.Errorf("无 resolver 应保持空环境:env=%q targets=%q", env, targets)
+	}
+}

--- a/internal/run/service.go
+++ b/internal/run/service.go
@@ -123,6 +123,10 @@ type service struct {
 	// 返回非 nil 错误(队列满/已停机)时 Create 据此回滚并失败返回(不留挂死)。
 	enqueueMu sync.RWMutex
 	enqueue   func(runID string) error
+
+	// envResolver 可选:手动/定时/串联触发未显式带环境时,据项目分支映射补解析环境
+	// (与 webhook 路径对齐)。nil(纯单测 Service / 未注入)时 Create 不补解析,行为不变。
+	envResolver EnvResolver
 }
 
 // setEnqueue 由 WorkerPool 注入调度回调(Create 入库后调用)。
@@ -132,18 +136,38 @@ func (s *service) setEnqueue(fn func(runID string) error) {
 	s.enqueueMu.Unlock()
 }
 
-// New 构造运行 Service。db 经参数化 SQL 触库;事件总线用于 SSE 推送(不轮询 DB)。
-// 不做任何重活(无 init() 副作用,避免抬高空载内存)。
-func New(db *sql.DB) Service {
-	return newService(db)
+// EnvResolver 把(项目, 分支)解析为映射的环境名 + 目标服务器引用 id 列表。
+// 手动 / 定时 / 串联触发未显式带环境时,Create 经此按项目分支映射补解析,与 webhook 接收
+// 路径保持一致(否则 build_image 不知推哪个 registry、环境变量 / 目标机全落空)。
+// 无映射命中 → ("", nil),行为不变。trigger 包提供实现(同一套 matchBranch glob)。
+type EnvResolver interface {
+	ResolveEnv(ctx context.Context, projectID, branch string) (environment string, targetServerIDs []string)
 }
 
-func newService(db *sql.DB) *service {
-	return &service{
+// Option 配置运行 Service 的可选依赖。
+type Option func(*service)
+
+// WithEnvResolver 注入分支→环境解析器(供手动/定时/串联触发补解析环境;见 EnvResolver)。
+func WithEnvResolver(r EnvResolver) Option {
+	return func(s *service) { s.envResolver = r }
+}
+
+// New 构造运行 Service。db 经参数化 SQL 触库;事件总线用于 SSE 推送(不轮询 DB)。
+// 不做任何重活(无 init() 副作用,避免抬高空载内存)。
+func New(db *sql.DB, opts ...Option) Service {
+	return newService(db, opts...)
+}
+
+func newService(db *sql.DB, opts ...Option) *service {
+	s := &service{
 		db:      db,
 		bus:     newBus(),
 		cancels: make(map[string]context.CancelFunc),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
 }
 
 func (s *service) Create(ctx context.Context, projectID string, trigger Trigger) (*Run, error) {
@@ -161,6 +185,19 @@ func (s *service) Create(ctx context.Context, projectID string, trigger Trigger)
 		if qerr := s.db.QueryRowContext(ctx,
 			`SELECT default_branch FROM projects WHERE id = ?`, projectID).Scan(&defaultBranch); qerr == nil {
 			trigger.Branch = strings.TrimSpace(defaultBranch)
+		}
+	}
+
+	// 环境补解析(#56):手动 / 定时 / 串联触发未显式带环境时,据项目分支映射(与 webhook 同一套
+	// glob 匹配)解析出环境名 + 目标服务器。否则 resolveRegistry(settings, env="") → nil → build_image
+	// 不知推哪个 registry(部署节点 pull 不到镜像)、环境 envVars / targetServerIds 也全落空。
+	// webhook 路径已显式带 ResolvedEnvironment → 此处跳过(不二次解析,与既有行为字节级一致)。
+	if strings.TrimSpace(trigger.ResolvedEnvironment) == "" && s.envResolver != nil {
+		if env, servers := s.envResolver.ResolveEnv(ctx, projectID, trigger.Branch); env != "" {
+			trigger.ResolvedEnvironment = env
+			if len(trigger.ResolvedTargetServerIDs) == 0 {
+				trigger.ResolvedTargetServerIDs = servers
+			}
 		}
 	}
 

--- a/internal/trigger/envresolver.go
+++ b/internal/trigger/envresolver.go
@@ -1,0 +1,54 @@
+package trigger
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+)
+
+// EnvironmentResolver 把(项目, 分支)解析为映射的环境名 + 目标服务器引用 id 列表,
+// 复用与 webhook 接收路径**完全相同**的分支映射 + glob 匹配(matchBranch)。
+//
+// 用途(#56):手动 / 定时 / 串联触发经 run.Service.Create 创建运行时不走 webhook 接收器,
+// 此前恒不解析环境(ResolvedEnvironment 空)→ build_image 不知推哪个 registry、环境变量 /
+// 目标服务器全落空。注入本解析器后,这些触发也按项目分支映射补解析,与 webhook 一致。
+//
+// 只读 branch_mappings_json(不碰 webhook 签名密钥 / master key);实现 run.EnvResolver。
+type EnvironmentResolver struct {
+	db *sql.DB
+}
+
+// NewEnvironmentResolver 构造分支→环境解析器(db 经参数化 SQL 触库)。
+func NewEnvironmentResolver(db *sql.DB) *EnvironmentResolver {
+	return &EnvironmentResolver{db: db}
+}
+
+// ResolveEnv 返回 branch 在项目分支映射中首条命中的环境名 + 目标服务器 id 列表。
+// 无配置 / 空分支 / 无命中 / 解析失败 → ("", nil)(调用方据此保持「未解析」语义)。
+func (r *EnvironmentResolver) ResolveEnv(ctx context.Context, projectID, branch string) (string, []string) {
+	branch = strings.TrimSpace(branch)
+	projectID = strings.TrimSpace(projectID)
+	if r == nil || r.db == nil || branch == "" || projectID == "" {
+		return "", nil
+	}
+
+	var mappingsJSON string
+	err := r.db.QueryRowContext(ctx,
+		`SELECT branch_mappings_json FROM pipeline_triggers WHERE project_id = ?`, projectID,
+	).Scan(&mappingsJSON)
+	if err != nil || strings.TrimSpace(mappingsJSON) == "" {
+		// 无行(项目无触发配置)/ 空映射 / 查询错误 → 不解析(best-effort,绝不让创建运行失败)。
+		return "", nil
+	}
+
+	var mappings []BranchMapping
+	if jerr := json.Unmarshal([]byte(mappingsJSON), &mappings); jerr != nil {
+		return "", nil
+	}
+	m, ok := matchBranch(branch, mappings)
+	if !ok {
+		return "", nil
+	}
+	return m.Environment, m.TargetServerIDs
+}

--- a/internal/trigger/envresolver_test.go
+++ b/internal/trigger/envresolver_test.go
@@ -1,0 +1,66 @@
+package trigger
+
+import (
+	"context"
+	"testing"
+)
+
+// TestEnvironmentResolver 证分支→环境解析复用与 webhook 同一套 matchBranch glob:
+// 精确命中、release/* 跨 `/` 命中、无命中、无配置项目全覆盖。
+func TestEnvironmentResolver(t *testing.T) {
+	svc, db, _, projID := newSvc(t)
+	ctx := context.Background()
+
+	// 经 Save 落分支映射(与 webhook 配置同一存储)。
+	if _, err := svc.Save(ctx, projID, SaveInput{
+		UnmatchedPolicy: PolicyRecord,
+		BranchMappings: []BranchMapping{
+			{ID: "m1", BranchPattern: "main", Environment: "production", TargetServerIDs: []string{"prod-1"}},
+			{ID: "m2", BranchPattern: "release/*", Environment: "staging", TargetServerIDs: []string{"stg-1", "stg-2"}},
+		},
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	res := NewEnvironmentResolver(db)
+
+	t.Run("精确命中", func(t *testing.T) {
+		env, servers := res.ResolveEnv(ctx, projID, "main")
+		if env != "production" || len(servers) != 1 || servers[0] != "prod-1" {
+			t.Fatalf("env=%q servers=%v", env, servers)
+		}
+	})
+
+	t.Run("release/* 跨斜杠命中", func(t *testing.T) {
+		env, servers := res.ResolveEnv(ctx, projID, "release/1.2")
+		if env != "staging" || len(servers) != 2 {
+			t.Fatalf("env=%q servers=%v", env, servers)
+		}
+	})
+
+	t.Run("无命中分支", func(t *testing.T) {
+		if env, _ := res.ResolveEnv(ctx, projID, "feature/x"); env != "" {
+			t.Fatalf("无命中应返回空环境,得 %q", env)
+		}
+	})
+
+	t.Run("空分支", func(t *testing.T) {
+		if env, _ := res.ResolveEnv(ctx, projID, "  "); env != "" {
+			t.Fatalf("空分支应返回空环境,得 %q", env)
+		}
+	})
+
+	t.Run("无触发配置的项目", func(t *testing.T) {
+		other := seedProject(t, db) // 未 Save 任何映射
+		if env, _ := res.ResolveEnv(ctx, other, "main"); env != "" {
+			t.Fatalf("无配置项目应返回空环境,得 %q", env)
+		}
+	})
+
+	t.Run("nil 接收者安全", func(t *testing.T) {
+		var nilRes *EnvironmentResolver
+		if env, _ := nilRes.ResolveEnv(ctx, projID, "main"); env != "" {
+			t.Fatalf("nil resolver 应返回空,得 %q", env)
+		}
+	})
+}


### PR DESCRIPTION
## 背景

手动触发(及定时 `schedule` / 串联 `chain`)经 `run.Service.Create` 创建运行时**不走 webhook 接收器**(`internal/trigger/receiver.go` 才做分支映射解析),此前恒不解析环境,`ResolvedEnvironment` 一直为空。

后果:`resolveRegistry(settings, envName="")` → `nil` → `build_image` **不知推哪个 registry**(部署节点 pull 不到镜像),环境的 `envVars` / `targetServerIds` 也全落空 → **镜像构建 + 推 + 部署全链路只有 webhook 能跑通,浏览器手动触发跑不通**。

## 改动

- 新增 `trigger.EnvironmentResolver`(`internal/trigger/envresolver.go`):只读 `branch_mappings_json`,复用与 webhook 接收路径**完全相同**的 `matchBranch` glob,把(项目, 分支)解析为环境名 + 目标服务器 id。
- `run.Service` 加可选 `EnvResolver` 注入点(`WithEnvResolver` option)。`Create` 在**默认分支回退之后**、若 `ResolvedEnvironment` 为空且 resolver 已注入,则据分支映射补解析,填 `ResolvedEnvironment` + `ResolvedTargetServerIDs`。
- `main.go` 装配:`run.New(st.DB, run.WithEnvResolver(trigger.NewEnvironmentResolver(st.DB)))`。

### 不破坏既有行为

- **webhook 路径**已显式带 `ResolvedEnvironment` → `Create` 跳过补解析(不二次解析,字节级一致)。
- **未注入 resolver**(纯单测 `run.New(db)`)→ 行为不变,环境保持空。

## 验证

- 新测:`trigger` 侧覆盖精确命中 / `release/*` 跨斜杠 / 无命中 / 空分支 / 无配置项目 / nil 接收者;`run` 侧覆盖手动补解析、默认分支回退后解析、已带环境跳过、无 resolver 保持空(直读 `resolved_environment` 列断言)。
- `gofmt -l` 净 · `go vet ./...` · `go test ./...`(34 包)全绿 · 真二进制 boot 无 panic(worker/cron/vault/artifact/repocache 全启动)。

> 与 #57(部署节点透传镜像参数)配套:两者合入后,浏览器手动触发的「镜像构建 → 推 registry → 部署节点 pull 部署」全链路才端到端打通。

🤖 Generated with [Claude Code](https://claude.com/claude-code)