### PR TITLE
feat(library): 自定义节点工作室(低代码组合 → templated 节点)

### DIFF
--- a/web/src/components/pipeline/CustomNodeStudio.vue
+++ b/web/src/components/pipeline/CustomNodeStudio.vue
@@ -1,0 +1,599 @@
+<script setup lang="ts">
+/**
+ * CustomNodeStudio — 复用库「自定义节点工作室」(低代码组合 · Tier 3 收口)。
+ *
+ * 把可视化步骤(复用 StepBuilder)+ 提升参数(promoted params)+ 节点表面(名称/说明)
+ * 拼成一个可复用、可配置的自定义节点,编译成 `templated` 节点 config 存库 —— 后端零改。
+ * 见 studioCompile.ts 的转换契约。
+ *
+ * 受控组件:父级持有 open / saving / banner;本组件持有表单态,保存时把
+ * { name, description, summary, config } emit 出去,由父级调 createCustomNode / updateCustomNode。
+ */
+import { ref, computed, watch } from 'vue'
+import StepBuilder from './StepBuilder.vue'
+import {
+  type PromotedParam,
+  type PromotedParamType,
+  type StudioModel,
+  compileStudioConfig,
+  parseStudioConfig,
+  emptyStudioModel,
+} from './studioCompile'
+
+interface StudioNode {
+  id: string
+  name: string
+  description: string
+  summary: string
+  nodeType: string
+  config: Record<string, unknown>
+}
+
+const props = defineProps<{
+  open: boolean
+  /** 编辑既有节点;null = 新建。 */
+  node: StudioNode | null
+  saving: boolean
+  banner: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'save', payload: { id: string | null; name: string; description: string; summary: string; config: Record<string, string> }): void
+}>()
+
+const name = ref('')
+const description = ref('')
+const summary = ref('')
+const image = ref('')
+const params = ref<PromotedParam[]>([])
+const stepConfig = ref<{ commands: string; artifactPath: string }>({ commands: '', artifactPath: '' })
+const localError = ref('')
+
+/** 每次打开 +1,作 StepBuilder 的 key 强制按当前 config 干净反解析。 */
+const instanceKey = ref(0)
+
+const isEdit = computed(() => props.node !== null)
+const title = computed(() => (isEdit.value ? '编辑工作室节点' : '新建工作室节点'))
+
+const PARAM_TYPE_OPTIONS: ReadonlyArray<{ value: PromotedParamType; label: string }> = [
+  { value: 'text', label: '文本' },
+  { value: 'select', label: '枚举' },
+  { value: 'number', label: '数字' },
+  { value: 'toggle', label: '布尔' },
+]
+
+// 含字面 {{ }} 的示例文案放常量里(避免模板内 {{ '{{x}}' }} 触发 vue 解析错误)。
+const ex = {
+  imgLabelHint: '可用 {{param}}',
+  imgPlaceholder: 'node:20 或 node:{{ver}}',
+  summaryPlaceholder: '用 {{node}} 镜像构建 {{dir}} 并产出 dist',
+  keyRef: '{{key}}',
+  braceL: '{{',
+  braceR: '}}',
+}
+
+function hydrate(): void {
+  localError.value = ''
+  if (props.node) {
+    name.value = props.node.name
+    description.value = props.node.description
+    summary.value = props.node.summary
+    const model = parseStudioConfig(props.node.config)
+    image.value = model.image
+    params.value = model.params.map((p) => ({ ...p }))
+    stepConfig.value = { ...model.stepConfig }
+  } else {
+    name.value = ''
+    description.value = ''
+    summary.value = ''
+    const m = emptyStudioModel()
+    image.value = m.image
+    params.value = []
+    stepConfig.value = { ...m.stepConfig }
+  }
+  instanceKey.value += 1
+}
+
+watch(
+  () => [props.open, props.node] as const,
+  ([open]) => {
+    if (open) hydrate()
+  },
+  { immediate: true },
+)
+
+/** StepBuilder 回传编译片段(commands + artifactPath)。 */
+function onStepsUpdate(patch: { commands: string; artifactPath: string }): void {
+  stepConfig.value = { commands: patch.commands, artifactPath: patch.artifactPath }
+}
+
+// ─── 提升参数编辑 ──────────────────────────────────────────────────────────────
+function addParam(): void {
+  params.value = [...params.value, { key: `param${params.value.length + 1}`, label: '新参数', type: 'text', default: '' }]
+}
+function removeParam(idx: number): void {
+  params.value = params.value.filter((_, i) => i !== idx)
+}
+function patchParam(idx: number, patch: Partial<PromotedParam>): void {
+  params.value = params.value.map((p, i) => (i === idx ? { ...p, ...patch } : p))
+}
+function optionsText(p: PromotedParam): string {
+  return (p.options ?? []).join(', ')
+}
+function setOptions(idx: number, raw: string): void {
+  const options = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s !== '')
+  patchParam(idx, { options })
+}
+
+// ─── 实时编译预览 ──────────────────────────────────────────────────────────────
+const model = computed<StudioModel>(() => ({
+  image: image.value,
+  params: params.value,
+  stepConfig: stepConfig.value,
+}))
+const compiled = computed(() => compileStudioConfig(model.value))
+const previewLines = computed<Array<{ k: string; v: string }>>(() => {
+  const c = compiled.value
+  const order = ['image', 'commandTemplate', 'artifactPath', 'params']
+  return order.filter((k) => c[k] != null && c[k] !== '').map((k) => ({ k, v: c[k] }))
+})
+
+/** 步骤里引用了但未声明的 {{param}}(轻量校验提示)。 */
+const undeclaredRefs = computed<string[]>(() => {
+  const declared = new Set(params.value.map((p) => p.key.trim()).filter(Boolean))
+  const text = `${image.value}\n${stepConfig.value.commands}\n${stepConfig.value.artifactPath}`
+  const refs = new Set<string>()
+  for (const m of text.matchAll(/\{\{\s*([a-zA-Z_]\w*)\s*\}\}/g)) {
+    if (!declared.has(m[1])) refs.add(m[1])
+  }
+  return [...refs]
+})
+const undeclaredRefsText = computed(() => undeclaredRefs.value.map((r) => `${ex.braceL}${r}${ex.braceR}`).join(' '))
+
+function highlight(value: string): string {
+  const esc = value.replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' })[c] ?? c)
+  return esc.replace(/\{\{\s*([a-zA-Z_]\w*)\s*\}\}/g, '<span class="tok">{{$1}}</span>')
+}
+
+const stepBuilderConfig = computed(() => ({
+  commands: stepConfig.value.commands,
+  artifactPath: stepConfig.value.artifactPath,
+}))
+
+function onSave(): void {
+  localError.value = ''
+  const trimmed = name.value.trim()
+  if (!trimmed) {
+    localError.value = '节点名称不能为空'
+    return
+  }
+  if (!stepConfig.value.commands.trim()) {
+    localError.value = '至少要有一个会产生命令的步骤'
+    return
+  }
+  emit('save', {
+    id: props.node?.id ?? null,
+    name: trimmed,
+    description: description.value.trim(),
+    summary: summary.value.trim(),
+    config: compiled.value,
+  })
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="open" class="studio-scrim" @click.self="emit('close')">
+      <div class="studio" role="dialog" aria-modal="true" :aria-label="title">
+        <header class="studio-head">
+          <div>
+            <h2 class="studio-title">{{ title }}</h2>
+            <p class="studio-sub">低代码组合步骤 + 提升参数 → 可复用 <code>templated</code> 节点(后端零改)</p>
+          </div>
+          <button class="studio-close" aria-label="关闭" @click="emit('close')">✕</button>
+        </header>
+
+        <div v-if="banner || localError" class="studio-banner">{{ banner || localError }}</div>
+
+        <div class="studio-meta">
+          <label class="fld fld--grow">
+            <span class="fld-label">节点名称</span>
+            <input v-model="name" class="fld-input" placeholder="如 构建并打包前端" autocomplete="off" />
+          </label>
+          <label class="fld fld--img">
+            <span class="fld-label">运行镜像({{ ex.imgLabelHint }})</span>
+            <input v-model="image" class="fld-input is-mono" :placeholder="ex.imgPlaceholder" autocomplete="off" />
+          </label>
+        </div>
+        <label class="fld">
+          <span class="fld-label">一句话说明(可选,实例卡片展示)</span>
+          <input v-model="summary" class="fld-input" :placeholder="ex.summaryPlaceholder" autocomplete="off" />
+        </label>
+
+        <div class="studio-body">
+          <section class="studio-col">
+            <h3 class="col-head">步骤组合</h3>
+            <StepBuilder :key="instanceKey" :config="stepBuilderConfig" @update="onStepsUpdate" />
+          </section>
+
+          <section class="studio-col">
+            <div class="col-head-row">
+              <h3 class="col-head">提升参数</h3>
+              <button class="link-add" @click="addParam">＋ 提升参数</button>
+            </div>
+            <p class="col-hint">步骤里以 <span class="tok">{{ ex.keyRef }}</span> 引用;实例复用时只配这几项。</p>
+
+            <div v-if="params.length === 0" class="param-empty">还没有提升参数。整段脚本写死也行,提升后才可在实例里改。</div>
+
+            <div v-for="(p, idx) in params" :key="idx" class="param-row">
+              <button class="param-del" aria-label="移除参数" @click="removeParam(idx)">✕</button>
+              <div class="param-key-line">
+                <span class="param-brace">{{ ex.braceL }}</span>
+                <input
+                  :value="p.key"
+                  class="fld-input is-mono param-key"
+                  placeholder="key"
+                  @input="patchParam(idx, { key: ($event.target as HTMLInputElement).value })"
+                />
+                <span class="param-brace">{{ ex.braceR }}</span>
+              </div>
+              <input
+                :value="p.label"
+                class="fld-input param-label"
+                placeholder="显示标签"
+                @input="patchParam(idx, { label: ($event.target as HTMLInputElement).value })"
+              />
+              <div class="param-row2">
+                <input
+                  :value="p.default"
+                  class="fld-input is-mono"
+                  placeholder="默认值"
+                  @input="patchParam(idx, { default: ($event.target as HTMLInputElement).value })"
+                />
+                <select
+                  :value="p.type"
+                  class="fld-input param-type"
+                  @change="patchParam(idx, { type: ($event.target as HTMLSelectElement).value as PromotedParamType })"
+                >
+                  <option v-for="opt in PARAM_TYPE_OPTIONS" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+                </select>
+              </div>
+              <input
+                v-if="p.type === 'select'"
+                :value="optionsText(p)"
+                class="fld-input is-mono param-options"
+                placeholder="逗号分隔选项,如 20, 18, 22"
+                @input="setOptions(idx, ($event.target as HTMLInputElement).value)"
+              />
+            </div>
+          </section>
+        </div>
+
+        <details class="studio-preview" open>
+          <summary>编译产出 · templated 节点 config(后端原样跑)</summary>
+          <div v-if="undeclaredRefs.length" class="preview-warn">
+            ⚠ 步骤引用了未提升的参数:{{ undeclaredRefsText }}(将原样保留,实例改不动)
+          </div>
+          <pre class="preview-code"><template v-for="line in previewLines" :key="line.k"><span class="pk">{{ line.k }}</span>: <span v-html="highlight(line.v)"></span>
+</template></pre>
+        </details>
+
+        <footer class="studio-foot">
+          <button class="btn-ghost" :disabled="saving" @click="emit('close')">取消</button>
+          <button class="btn-primary" :disabled="saving" @click="onSave">{{ saving ? '保存中…' : '保存到复用库' }}</button>
+        </footer>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.studio-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: color-mix(in oklab, var(--color-text) 38%, transparent);
+  backdrop-filter: blur(2px);
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.studio {
+  width: min(960px, 96vw);
+  max-height: 92vh;
+  overflow: auto;
+  background: var(--color-bg, #fff);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-lg, 16px);
+  box-shadow: 0 24px 60px rgba(20, 26, 34, 0.22);
+  padding: 20px 22px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 13px;
+}
+
+.studio-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+.studio-title {
+  margin: 0;
+  font-size: 1.12rem;
+  font-weight: 700;
+}
+.studio-sub {
+  margin: 3px 0 0;
+  font-size: 0.76rem;
+  color: var(--color-faint);
+}
+.studio-sub code {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  padding: 0 3px;
+  border-radius: 3px;
+  background: var(--color-inset);
+}
+.studio-close {
+  flex: none;
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: none;
+  color: var(--color-faint);
+  cursor: pointer;
+}
+.studio-close:hover {
+  color: var(--color-text);
+  border-color: var(--color-border-strong);
+}
+
+.studio-banner {
+  background: var(--color-red-soft);
+  color: var(--color-red);
+  border: 1px solid color-mix(in oklab, var(--color-red) 30%, transparent);
+  border-radius: var(--rounded-md);
+  padding: 8px 11px;
+  font-size: 0.8rem;
+}
+
+.studio-meta {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 11px;
+}
+.fld {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.fld-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--color-faint);
+}
+.fld-input {
+  width: 100%;
+  height: 32px;
+  padding: 0 10px;
+  background: var(--color-inset);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded-md);
+  color: var(--color-text);
+  font: inherit;
+  font-size: 0.82rem;
+}
+.fld-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px var(--color-primary-soft);
+}
+.is-mono {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+}
+
+.studio-body {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  align-items: start;
+}
+.studio-col {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+.col-head {
+  margin: 0;
+  font-size: 0.74rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--color-faint);
+}
+.col-head-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.col-hint {
+  margin: -2px 0 2px;
+  font-size: 0.7rem;
+  color: var(--color-faint);
+}
+.link-add {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  font: inherit;
+  font-size: 0.76rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+.link-add:hover {
+  text-decoration: underline;
+}
+
+.param-empty {
+  font-size: 0.74rem;
+  color: var(--color-faint);
+  font-style: italic;
+  padding: 6px 0;
+}
+.param-row {
+  position: relative;
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-amber);
+  border-radius: var(--rounded-md);
+  background: var(--color-amber-soft, var(--color-inset));
+  padding: 9px 10px;
+  margin-bottom: 9px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.param-del {
+  position: absolute;
+  top: 7px;
+  right: 7px;
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: none;
+  color: var(--color-faint);
+  cursor: pointer;
+  border-radius: 4px;
+}
+.param-del:hover {
+  color: var(--color-red);
+  background: var(--color-red-soft);
+}
+.param-key-line {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.param-brace {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  color: var(--color-amber);
+}
+.param-key {
+  height: 28px;
+  max-width: 180px;
+}
+.param-label {
+  height: 28px;
+}
+.param-row2 {
+  display: grid;
+  grid-template-columns: 1fr 92px;
+  gap: 7px;
+}
+.param-row2 .fld-input,
+.param-options {
+  height: 28px;
+}
+.param-type {
+  cursor: pointer;
+}
+
+.tok {
+  background: var(--color-amber-soft, #fbf3df);
+  color: var(--color-amber);
+  border-radius: 3px;
+  padding: 0 3px;
+  font-weight: 700;
+}
+
+.studio-preview {
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-md);
+  background: var(--color-inset);
+  padding: 4px 12px 10px;
+}
+.studio-preview > summary {
+  cursor: pointer;
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: var(--color-dim);
+  padding: 8px 0;
+}
+.preview-warn {
+  font-size: 0.72rem;
+  color: var(--color-amber);
+  margin-bottom: 6px;
+}
+.preview-code {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--color-text);
+}
+.preview-code .pk {
+  color: var(--color-primary);
+  font-weight: 700;
+}
+
+.studio-foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding-top: 4px;
+  border-top: 1px solid var(--color-border);
+  margin-top: 2px;
+  padding-top: 13px;
+}
+.btn-ghost,
+.btn-primary {
+  height: 34px;
+  padding: 0 16px;
+  border-radius: var(--rounded-md);
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.btn-ghost {
+  background: none;
+  border: 1px solid var(--color-border-strong);
+  color: var(--color-text);
+}
+.btn-ghost:hover {
+  border-color: var(--color-primary);
+}
+.btn-primary {
+  background: var(--color-primary);
+  border: 1px solid var(--color-primary);
+  color: #fff;
+}
+.btn-primary:hover {
+  background: var(--color-primary-strong, var(--color-primary));
+  filter: brightness(0.96);
+}
+.btn-primary:disabled,
+.btn-ghost:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+@media (max-width: 760px) {
+  .studio-meta,
+  .studio-body {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/web/src/components/pipeline/studioCompile.test.ts
+++ b/web/src/components/pipeline/studioCompile.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest'
+import {
+  type PromotedParam,
+  type StudioModel,
+  STUDIO_META_KEY,
+  paramsToText,
+  parseParamsText,
+  encodeStudioMeta,
+  parsePromotedParams,
+  parseStudioConfig,
+  compileStudioConfig,
+  isStudioNode,
+  emptyStudioModel,
+} from './studioCompile'
+
+function param(p: Partial<PromotedParam> & { key: string }): PromotedParam {
+  return { label: p.key, type: 'text', default: '', ...p }
+}
+
+describe('studioCompile', () => {
+  describe('paramsToText / parseParamsText', () => {
+    it('compiles key=default lines, skips empty keys', () => {
+      const params = [param({ key: 'dir', default: 'web' }), param({ key: '', default: 'x' }), param({ key: 'env', default: 'prod' })]
+      expect(paramsToText(params)).toBe('dir=web\nenv=prod')
+    })
+
+    it('parses lines back, skips blanks and # comments', () => {
+      const got = parseParamsText('dir=web\n\n# comment\nenv=prod')
+      expect(got).toEqual([
+        { key: 'dir', label: 'dir', type: 'text', default: 'web' },
+        { key: 'env', label: 'env', type: 'text', default: 'prod' },
+      ])
+    })
+
+    it('default may contain = (only first = splits)', () => {
+      expect(parseParamsText('flags=-a=1 -b=2')).toEqual([
+        { key: 'flags', label: 'flags', type: 'text', default: '-a=1 -b=2' },
+      ])
+    })
+  })
+
+  describe('compileStudioConfig → templated config', () => {
+    it('maps steps.commands → commandTemplate, params → params text, stores __studio', () => {
+      const model: StudioModel = {
+        image: 'node:{{node}}',
+        params: [
+          param({ key: 'node', label: '构建镜像', type: 'select', default: '20', options: ['20', '18'] }),
+          param({ key: 'dir', label: '目录', default: 'web' }),
+        ],
+        stepConfig: { commands: 'cd {{dir}}\nnpm ci', artifactPath: '{{dir}}/dist' },
+      }
+      const cfg = compileStudioConfig(model)
+      expect(cfg.image).toBe('node:{{node}}')
+      expect(cfg.commandTemplate).toBe('cd {{dir}}\nnpm ci')
+      expect(cfg.artifactPath).toBe('{{dir}}/dist')
+      expect(cfg.params).toBe('node=20\ndir=web')
+      // __studio carries label/type/options (not defaults).
+      const meta = JSON.parse(cfg[STUDIO_META_KEY])
+      expect(meta.v).toBe(1)
+      expect(meta.params).toEqual([
+        { key: 'node', label: '构建镜像', type: 'select', options: ['20', '18'] },
+        { key: 'dir', label: '目录', type: 'text' },
+      ])
+    })
+
+    it('omits empty fields and __studio when no params', () => {
+      const cfg = compileStudioConfig({ image: '  ', params: [], stepConfig: { commands: 'echo hi', artifactPath: '' } })
+      expect(cfg).toEqual({ commandTemplate: 'echo hi' })
+      expect(cfg[STUDIO_META_KEY]).toBeUndefined()
+    })
+  })
+
+  describe('round-trip compile → parse', () => {
+    it('preserves image, params (incl. type/label/options), and steps', () => {
+      const model: StudioModel = {
+        image: 'golang:{{ver}}',
+        params: [
+          param({ key: 'ver', label: 'Go 版本', type: 'select', default: '1.22', options: ['1.22', '1.21'] }),
+          param({ key: 'flags', label: '编译参数', default: '-trimpath' }),
+        ],
+        stepConfig: { commands: 'go build {{flags}} ./...', artifactPath: 'bin/app' },
+      }
+      const back = parseStudioConfig(compileStudioConfig(model))
+      expect(back.image).toBe('golang:{{ver}}')
+      expect(back.stepConfig).toEqual({ commands: 'go build {{flags}} ./...', artifactPath: 'bin/app' })
+      expect(back.params).toEqual(model.params)
+    })
+  })
+
+  describe('parsePromotedParams fallback (no/broken __studio)', () => {
+    it('falls back to params text with type=text when __studio missing', () => {
+      expect(parsePromotedParams({ params: 'dir=web\nenv=prod' })).toEqual([
+        { key: 'dir', label: 'dir', type: 'text', default: 'web' },
+        { key: 'env', label: 'env', type: 'text', default: 'prod' },
+      ])
+    })
+
+    it('ignores corrupt __studio JSON, still recovers params from text', () => {
+      const got = parsePromotedParams({ params: 'dir=web', [STUDIO_META_KEY]: '{not json' })
+      expect(got).toEqual([{ key: 'dir', label: 'dir', type: 'text', default: 'web' }])
+    })
+
+    it('meta only enriches keys present in params text (no phantom params)', () => {
+      const meta = encodeStudioMeta([param({ key: 'gone', label: 'X', type: 'number', default: '1' })])
+      // params text has only "dir"; meta references "gone" → ignored.
+      expect(parsePromotedParams({ params: 'dir=web', [STUDIO_META_KEY]: meta })).toEqual([
+        { key: 'dir', label: 'dir', type: 'text', default: 'web' },
+      ])
+    })
+  })
+
+  describe('parseStudioConfig compat', () => {
+    it('reads legacy commands when commandTemplate absent', () => {
+      expect(parseStudioConfig({ commands: 'make build' }).stepConfig.commands).toBe('make build')
+    })
+    it('prefers commandTemplate over commands', () => {
+      expect(parseStudioConfig({ commandTemplate: 'a', commands: 'b' }).stepConfig.commands).toBe('a')
+    })
+  })
+
+  describe('isStudioNode', () => {
+    it('true for templated nodeType', () => {
+      expect(isStudioNode('templated', {})).toBe(true)
+    })
+    it('true for any node carrying __studio', () => {
+      expect(isStudioNode('script', { [STUDIO_META_KEY]: '{"v":1,"params":[]}' })).toBe(true)
+    })
+    it('false for plain non-studio nodes', () => {
+      expect(isStudioNode('build_image', { dockerfile: 'Dockerfile' })).toBe(false)
+    })
+  })
+
+  it('emptyStudioModel is a blank studio', () => {
+    expect(emptyStudioModel()).toEqual({ image: '', params: [], stepConfig: { commands: '', artifactPath: '' } })
+  })
+})

--- a/web/src/components/pipeline/studioCompile.ts
+++ b/web/src/components/pipeline/studioCompile.ts
@@ -1,0 +1,193 @@
+/**
+ * studioCompile — 自定义节点工作室的「模型 ↔ templated 节点 config」纯函数转换层。
+ *
+ * 工作室把三样东西拼成一个可复用、可配置的自定义节点:
+ *   ① 步骤组合(复用 stepCompile / StepBuilder,产出 commands + artifactPath)
+ *   ② 提升参数(promoted params:key/label/type/default,步骤里以 {{key}} 引用)
+ *   ③ 节点表面(名称/说明,由调用方持有)
+ *
+ * 编译产出落在**已有的 `templated` 节点类型**上 —— 后端零改(`internal/build/dag_stage_exec.go`
+ * 的 templateContext/renderTemplate 已会读 `params` 当渲染上下文 + 渲染 `commandTemplate`/`artifactPath`
+ * 里的 {{key}})。故工作室 = 纯前端编译,延续 Tier 3「StepBuilder 编译进 config 零后端改动」哲学。
+ *
+ * 关键:`commandTemplate` 与步骤构建器的 `commands` 是同一段脚本文本,只是 templated 节点
+ * 存在 `commandTemplate` 键下并对其中 {{param}} 做渲染。故工作室在边界处把 commands ↔ commandTemplate
+ * 互译,StepBuilder 始终以 `commands` 形态工作({{param}} 对它只是不透明文本)。
+ *
+ * `__studio` 是工作室私有结构(JSON 串),仅存提升参数的**额外元信息**(label/type/options)——
+ * key 与 default 以 `params` 文本为唯一真源,避免双源漂移。后端忽略此键;删了它节点照常跑,
+ * 只是回库重开时降级为「按 params 文本反解析(type 全 text)」。
+ */
+
+import { type StepBlock } from './stepCompile'
+
+export type PromotedParamType = 'text' | 'select' | 'number' | 'toggle'
+
+export interface PromotedParam {
+  /** 模板占位名:步骤里 {{key}} 引用、实例编辑时可覆盖。 */
+  key: string
+  /** 实例编辑时的显示标签。 */
+  label: string
+  type: PromotedParamType
+  /** 默认值(落入 params 文本,既是默认也是渲染上下文)。 */
+  default: string
+  /** select 类型的候选项。 */
+  options?: string[]
+}
+
+/** 工作室模型:步骤部分以 StepBuilder 的 config 形状(commands + artifactPath)承载。 */
+export interface StudioModel {
+  image: string
+  params: PromotedParam[]
+  stepConfig: { commands: string; artifactPath: string }
+}
+
+/** config 键名:工作室私有元信息(后端忽略,仅前端无损回开用)。 */
+export const STUDIO_META_KEY = '__studio'
+
+const PARAM_TYPES: readonly PromotedParamType[] = ['text', 'select', 'number', 'toggle']
+
+function configString(config: Record<string, unknown>, key: string): string {
+  const v = config[key]
+  if (typeof v === 'string') return v
+  return v == null ? '' : String(v)
+}
+
+/**
+ * 提升参数 → `params` 配置字段(每行 `key=default`)。
+ * 后端 templateContext 读它:既作渲染上下文(`{{key}}` → default),也是实例未覆盖时的默认值。
+ */
+export function paramsToText(params: readonly PromotedParam[]): string {
+  return params
+    .map((p) => ({ k: p.key.trim(), v: p.default ?? '' }))
+    .filter((x) => x.k !== '')
+    .map((x) => `${x.k}=${x.v}`)
+    .join('\n')
+}
+
+/** `params` 文本 → 基础提升参数(仅 key+default,type 兜底 text)。无 __studio 时的回退。 */
+export function parseParamsText(text: string): PromotedParam[] {
+  const out: PromotedParam[] = []
+  for (const line of (text ?? '').replace(/\r/g, '').split('\n')) {
+    const t = line.trim()
+    if (t === '' || t.startsWith('#')) continue
+    const i = t.indexOf('=')
+    const key = (i >= 0 ? t.slice(0, i) : t).trim()
+    if (key === '') continue
+    out.push({ key, label: key, type: 'text', default: i >= 0 ? t.slice(i + 1) : '' })
+  }
+  return out
+}
+
+/** 把提升参数的额外元信息(label/type/options)编码进 __studio(不存 default,以 params 文本为准)。 */
+export function encodeStudioMeta(params: readonly PromotedParam[]): string {
+  const meta = params
+    .filter((p) => p.key.trim() !== '')
+    .map((p) => {
+      const m: { key: string; label: string; type: PromotedParamType; options?: string[] } = {
+        key: p.key.trim(),
+        label: p.label,
+        type: p.type,
+      }
+      if (p.type === 'select' && p.options && p.options.length > 0) m.options = p.options
+      return m
+    })
+  return JSON.stringify({ v: 1, params: meta })
+}
+
+interface DecodedMeta {
+  key: string
+  label?: string
+  type?: PromotedParamType
+  options?: string[]
+}
+
+/** 解码 __studio;非法/缺失 → null(调用方回退 parseParamsText,绝不报错丢数据)。 */
+function decodeStudioMeta(raw: unknown): DecodedMeta[] | null {
+  if (typeof raw !== 'string' || raw.trim() === '') return null
+  let obj: unknown
+  try {
+    obj = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  const params = (obj as { params?: unknown })?.params
+  if (!Array.isArray(params)) return null
+  const out: DecodedMeta[] = []
+  for (const p of params) {
+    if (!p || typeof p !== 'object') continue
+    const key = (p as { key?: unknown }).key
+    if (typeof key !== 'string' || key.trim() === '') continue
+    const type = (p as { type?: unknown }).type
+    const label = (p as { label?: unknown }).label
+    const options = (p as { options?: unknown }).options
+    out.push({
+      key: key.trim(),
+      label: typeof label === 'string' ? label : undefined,
+      type: PARAM_TYPES.includes(type as PromotedParamType) ? (type as PromotedParamType) : undefined,
+      options: Array.isArray(options) ? options.filter((o): o is string => typeof o === 'string') : undefined,
+    })
+  }
+  return out
+}
+
+/** 合并 params 文本(key+default 真源)与 __studio 元信息(label/type/options)→ 提升参数列表。 */
+export function parsePromotedParams(config: Record<string, unknown>): PromotedParam[] {
+  const base = parseParamsText(configString(config, 'params'))
+  const meta = decodeStudioMeta(config[STUDIO_META_KEY])
+  if (!meta) return base
+  const byKey = new Map(meta.map((m) => [m.key, m]))
+  return base.map((p) => {
+    const m = byKey.get(p.key)
+    if (!m) return p
+    const merged: PromotedParam = {
+      ...p,
+      label: m.label ?? p.label,
+      type: m.type ?? p.type,
+    }
+    if (m.options) merged.options = m.options
+    return merged
+  })
+}
+
+/** 反解析 templated 节点 config → 工作室模型(commandTemplate 优先,兼容旧 commands)。 */
+export function parseStudioConfig(config: Record<string, unknown>): StudioModel {
+  const commands = configString(config, 'commandTemplate') || configString(config, 'commands')
+  return {
+    image: configString(config, 'image'),
+    params: parsePromotedParams(config),
+    stepConfig: { commands, artifactPath: configString(config, 'artifactPath') },
+  }
+}
+
+/** 工作室模型 → templated 节点 config(后端原样跑;空值不入 config;__studio 仅供回开)。 */
+export function compileStudioConfig(model: StudioModel): Record<string, string> {
+  const config: Record<string, string> = {}
+  const image = model.image.trim()
+  if (image) config.image = model.image
+  if (model.stepConfig.commands.trim()) config.commandTemplate = model.stepConfig.commands
+  if (model.stepConfig.artifactPath.trim()) config.artifactPath = model.stepConfig.artifactPath
+  const params = paramsToText(model.params)
+  if (params) config.params = params
+  if (model.params.some((p) => p.key.trim() !== '')) {
+    config[STUDIO_META_KEY] = encodeStudioMeta(model.params)
+  }
+  return config
+}
+
+/**
+ * 判断一个自定义节点是否「工作室可编辑」:带 __studio 元信息,或本就是 templated 类型
+ * (它的 config 形状=工作室产出)。其余类型仍走原始 KV 编辑器。
+ */
+export function isStudioNode(nodeType: string, config: Record<string, unknown>): boolean {
+  if (typeof config[STUDIO_META_KEY] === 'string') return true
+  return nodeType.trim() === 'templated'
+}
+
+/** 新建工作室节点的初始模型(一个空命令步骤起手 + 无提升参数)。 */
+export function emptyStudioModel(): StudioModel {
+  return { image: '', params: [], stepConfig: { commands: '', artifactPath: '' } }
+}
+
+// 供测试/调用方引用步骤类型(避免重复 import 路径)。
+export type { StepBlock }

--- a/web/src/views/Library.vue
+++ b/web/src/views/Library.vue
@@ -27,11 +27,14 @@ import {
 import { listCredentials, type Credential } from '../api/credentials'
 import {
   listCustomNodes,
+  createCustomNode,
   updateCustomNode,
   deleteCustomNode,
   type CustomNode,
 } from '../api/customNodes'
 import { jobTypeLabel } from '../components/pipeline/jobConfigSchema'
+import CustomNodeStudio from '../components/pipeline/CustomNodeStudio.vue'
+import { isStudioNode } from '../components/pipeline/studioCompile'
 
 type Tab = 'templates' | 'variableGroups' | 'customNodes'
 type LoadState = 'idle' | 'loading' | 'error'
@@ -275,7 +278,26 @@ const cnEditorSaving = ref(false)
 
 const cnEditorTypeLabel = computed(() => jobTypeLabel(cnEditorNodeType.value))
 
+// ─── 自定义节点工作室(低代码组合 → templated 节点)──────────────────────────────
+const studioOpen = ref(false)
+const studioNode = ref<CustomNode | null>(null)
+const studioSaving = ref(false)
+const studioBanner = ref('')
+
+function openCreateStudio(): void {
+  studioNode.value = null
+  studioBanner.value = ''
+  studioOpen.value = true
+}
+
+/** 工作室节点(templated 或带 __studio)走工作室;其余类型走原始 KV 编辑器。 */
 function openEditCustomNode(n: CustomNode): void {
+  if (isStudioNode(n.nodeType, n.config ?? {})) {
+    studioNode.value = n
+    studioBanner.value = ''
+    studioOpen.value = true
+    return
+  }
   cnEditingId.value = n.id
   cnEditorName.value = n.name
   cnEditorDescription.value = n.description
@@ -287,6 +309,41 @@ function openEditCustomNode(n: CustomNode): void {
   }))
   cnEditorBanner.value = ''
   cnEditorOpen.value = true
+}
+
+async function saveStudioNode(payload: {
+  id: string | null
+  name: string
+  description: string
+  summary: string
+  config: Record<string, string>
+}): Promise<void> {
+  studioBanner.value = ''
+  studioSaving.value = true
+  try {
+    const input = {
+      name: payload.name,
+      description: payload.description,
+      nodeType: 'templated',
+      summary: payload.summary,
+      config: payload.config,
+    }
+    if (payload.id) {
+      await updateCustomNode(payload.id, input)
+      message.success(`已更新自定义节点「${payload.name}」`)
+    } else {
+      await createCustomNode(input)
+      message.success(`已创建自定义节点「${payload.name}」`)
+    }
+    studioOpen.value = false
+    await loadCustomNodes()
+  } catch (err: unknown) {
+    studioBanner.value = err instanceof HttpError
+      ? err.apiError?.message ?? `保存失败(${err.status})`
+      : '保存失败'
+  } finally {
+    studioSaving.value = false
+  }
 }
 
 function addCnRow(): void {
@@ -383,6 +440,13 @@ onMounted(() => {
         @click="openCreateGroup"
       >
         + 新建变量组
+      </button>
+      <button
+        v-if="tab === 'customNodes'"
+        class="btn-primary"
+        @click="openCreateStudio"
+      >
+        + 新建工作室节点
       </button>
     </header>
 
@@ -528,9 +592,10 @@ onMounted(() => {
         <div class="empty-icon">◇</div>
         <p class="empty-label">还没有自定义节点</p>
         <p class="empty-hint">
-          在项目流水线编辑器里把任意节点(尤其是自定义/模板节点)配好参数后,点「存为自定义节点」
-          即可沉淀到这里,之后在任意流水线的节点选择器里一键复用,免去重复填参。
+          点右上「新建工作室节点」用低代码方式组合步骤 + 提升参数,沉淀成可复用节点;
+          或在流水线编辑器里把任意节点配好参数后点「存为自定义节点」。之后在任意流水线的节点选择器一键复用。
         </p>
+        <button class="btn-primary" @click="openCreateStudio">+ 新建工作室节点</button>
       </div>
 
       <ul v-else class="card-grid" role="list">
@@ -730,6 +795,16 @@ onMounted(() => {
         </footer>
       </div>
     </div>
+
+    <!-- ─── 自定义节点工作室(低代码组合) ─── -->
+    <CustomNodeStudio
+      :open="studioOpen"
+      :node="studioNode"
+      :saving="studioSaving"
+      :banner="studioBanner"
+      @close="studioOpen = false"
+      @save="saveStudioNode"
+    />
   </section>
 </template>
 


### PR DESCRIPTION
## 背景

复用库三层中,**自定义节点低代码组合**此前缺位:`StepBuilder`(Tier 3 可视化步骤)只活在流水线画布的节点抽屉;复用库的自定义节点编辑只有裸 KV 行;无法在库里从零用低代码组合,且自定义节点没有「参数化表面」——复用时只能整体套用快照,改不动其中变量。

对标 **Node-RED Subflow / n8n composite node** 的 *promote-params* 范式补齐:一个可复用节点 = 内部步骤序列 + 把若干变量「提升」到节点表面,复用时只配提升的那几项。

> 配套调研/方案:`_bmad-output/planning-artifacts/custom-node-studio-plan.md`、`pipeline-capability-benchmark.md`(本 PR 不含,planning 文档单独处理)。

## 实现(纯前端,后端零改)

- **`studioCompile.ts`** — 提升参数模型(`key/label/type/default/options`)+ 编译/反解析纯函数。编译落在**已有的 `templated` 节点**上:`commandTemplate`(步骤)/ `params`(提升参数默认值,既是默认也是后端 `templateContext` 的渲染上下文)/ `image` / `artifactPath`。后端 `renderTemplate` 已渲染 `{{param}}`,故**零改**。`__studio` 私有 JSON 仅存 `label/type/options`(`default` 以 `params` 文本为唯一真源,避免双源漂移);后端忽略,删了照常跑,只是回开降级为按 `params` 文本反解析(type 全 text)。
- **`CustomNodeStudio.vue`** — 三段式工作室模态:复用 `StepBuilder`(边界处 `commands ↔ commandTemplate` 互译)+ 提升参数编辑 + 实时编译预览 + 未声明 `{{param}}` 告警。
- **`Library.vue`** — 「+ 新建工作室节点」入口;`templated` / 带 `__studio` 的节点编辑走工作室,其余类型仍走原始 KV 编辑器。

## 验证

- `studioCompile.test.ts` 15 例(编译 / round-trip / `__studio` 损坏回退 / 无 phantom 参数 / `isStudioNode`)。
- 全包 **vitest 248 绿** · typecheck 净 · lint 0 error · build 绿。
- **真二进制 + 浏览器 e2e**:登录 → 复用库 → 新建工作室节点 → 低代码步骤 + 提升参数 → 实时编译预览 → 存库(真 `POST /api/custom-nodes`,CSRF 自动)→ 列表出现 → 重开,`label/type` 经 `__studio` **无损回显**,**0 console error**。

## 诚实边界

实例抽屉「只露提升参数短清单」为快进项:当前 `templated` 节点的 `params` 字段已可在抽屉编辑(功能可用,非短清单形态)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)