### PR TITLE
feat(pipeline): 类型化运行参数(枚举/布尔/数字 · P0)

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -125,6 +125,7 @@ func main() {
 	// 装配项目级并发上限配置服务(FR-8-10 并发/队列控制):每项目一份 max_concurrent。
 	// 注入 worker pool 做准入(下方);经 /api/projects/{id}/concurrency 读写。
 	concurrencySvc := run.NewConcurrencyService(st.DB)
+	parameterSvc := run.NewParameterService(st.DB)
 
 	// 装配流水线串联配置服务(FR-8-11):每项目一份「成功后触发的下游目标」列表。
 	// 串联终态钩子(下方,与通知钩子同槽组合)在 run 落 success 时据此创建下游运行;
@@ -404,7 +405,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithRefs(refsLister), httpapi.WithArtifactStore(artStore), httpapi.WithServers(targetSvc), httpapi.WithRunnerConfig(runnerSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithChain(chainSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc), httpapi.WithPromotion(promotionStore), httpapi.WithDoraMetrics(doraMetricsSvc), httpapi.WithTemplates(templateSvc), httpapi.WithVariableGroups(varGroupSvc), httpapi.WithCustomNodes(customNodeSvc)),
+		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithRefs(refsLister), httpapi.WithArtifactStore(artStore), httpapi.WithServers(targetSvc), httpapi.WithRunnerConfig(runnerSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithChain(chainSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc), httpapi.WithParameters(parameterSvc), httpapi.WithPromotion(promotionStore), httpapi.WithDoraMetrics(doraMetricsSvc), httpapi.WithTemplates(templateSvc), httpapi.WithVariableGroups(varGroupSvc), httpapi.WithCustomNodes(customNodeSvc)),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		// WriteTimeout 置 0:SSE 长连接(/api/runs/{id}/events)不可被写超时切断;

--- a/internal/httpapi/parameters.go
+++ b/internal/httpapi/parameters.go
@@ -1,0 +1,92 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// parameters.go 暴露项目级「类型化运行参数定义」端点(P0 typed params)。
+//
+// GET /api/projects/{id}/parameters → { parameters: ParamDef[] }
+// PUT /api/projects/{id}/parameters → 同上(需 CSRF)。校验在 run.ParameterService。
+//
+// 手动触发弹窗据此渲染类型化控件并校验;无定义则前端回退自由 KV。执行期仍以 key=value 注入。
+
+type paramDefDTO struct {
+	Key      string   `json:"key"`
+	Label    string   `json:"label"`
+	Type     string   `json:"type"`
+	Default  string   `json:"default"`
+	Options  []string `json:"options,omitempty"`
+	Required bool     `json:"required"`
+}
+
+type parametersDTO struct {
+	Parameters []paramDefDTO `json:"parameters"`
+}
+
+func toParametersDTO(c *run.ParametersConfig) parametersDTO {
+	defs := make([]paramDefDTO, 0, len(c.Defs))
+	for _, d := range c.Defs {
+		defs = append(defs, paramDefDTO{
+			Key: d.Key, Label: d.Label, Type: d.Type, Default: d.Default,
+			Options: d.Options, Required: d.Required,
+		})
+	}
+	return parametersDTO{Parameters: defs}
+}
+
+func writeParametersError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, run.ErrParamProjectNotFound):
+		writeError(w, http.StatusNotFound, "project_not_found", "项目不存在")
+	case errors.Is(err, run.ErrInvalidParamDef):
+		// 校验错误体已含人读原因(键/类型/枚举/默认值)。
+		writeError(w, http.StatusUnprocessableEntity, "invalid_parameter", err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+	}
+}
+
+func makeGetParametersHandler(svc run.ParameterService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "参数配置服务未初始化")
+			return
+		}
+		cfg, err := svc.Get(r.Context(), chi.URLParam(r, "id"))
+		if err != nil {
+			writeParametersError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, toParametersDTO(cfg))
+	}
+}
+
+func makeSaveParametersHandler(svc run.ParameterService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "参数配置服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+		var req struct {
+			Parameters []run.ParamDef `json:"parameters"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		cfg, err := svc.Save(r.Context(), id, req.Parameters)
+		if err != nil {
+			writeParametersError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, toParametersDTO(cfg))
+	}
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -59,6 +59,7 @@ type options struct {
 	cron             cron.Service
 	chain            chain.Service
 	concurrency      run.ConcurrencyService
+	parameters       run.ParameterService
 	pipelines        pipeline.Service
 	pipelineSettings pipeline.SettingsService
 	runs             run.Service
@@ -166,6 +167,12 @@ func WithChain(s chain.Service) Option {
 // 不传则该端点返回 503(服务未初始化)。GET 过 auth;PUT 过 auth + CSRF。
 func WithConcurrency(s run.ConcurrencyService) Option {
 	return func(o *options) { o.concurrency = s }
+}
+
+// WithParameters 注入项目级类型化运行参数定义服务,挂载 /api/projects/{id}/parameters 路由(P0 typed params)。
+// 不传则该端点返回 503;手动触发亦据此校验提供的参数(无定义则透传,向后兼容)。
+func WithParameters(s run.ParameterService) Option {
+	return func(o *options) { o.parameters = s }
 }
 
 // WithTriggers 注入触发配置服务,挂载 /api/projects/{id}/trigger* 路由。
@@ -387,6 +394,10 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		ar.Get("/projects/{id}/concurrency", makeGetConcurrencyHandler(o.concurrency))
 		ar.Put("/projects/{id}/concurrency", makeSaveConcurrencyHandler(o.concurrency))
 
+		// 项目级类型化运行参数定义(P0 typed params)。o.parameters 为 nil → handler 返回 503。GET 过 auth;PUT 过 auth + CSRF。
+		ar.Get("/projects/{id}/parameters", makeGetParametersHandler(o.parameters))
+		ar.Put("/projects/{id}/parameters", makeSaveParametersHandler(o.parameters))
+
 		// 流水线串联(FR-8-11):上游成功后触发下游流水线。o.chain 为 nil → handler 返回 503。
 		// GET 过 auth;PUT 为写方法,过 auth + CSRF。
 		ar.Get("/projects/{id}/chain", makeGetChainHandler(o.chain))
@@ -481,7 +492,8 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		ar.Post("/runs/{id}/diagnosis/feedback", makeSubmitDiagnosisFeedbackHandler(rs, o.feedback, o.secretSource))
 
 		// 手动触发创建运行(Story 3.2):认证 + CSRF;actor=admin;返 201 run-detail DTO。
-		ar.Post("/projects/{id}/runs", makeManualRunHandler(rs, aud))
+		// o.parameters 非 nil 时,据项目参数定义校验 + 强转 + 填默认(typed params,P0);无定义则透传。
+		ar.Post("/projects/{id}/runs", makeManualRunHandler(rs, o.parameters, aud))
 
 		// 账户设置(Story 1.7):改口令 / 会话列表 / 撤销会话。ac 为 nil 时 handler 返回 503。
 		// 改口令、撤销会话为写方法,过 auth + CSRF;列表为 GET,过 auth。

--- a/internal/httpapi/webhooks.go
+++ b/internal/httpapi/webhooks.go
@@ -107,7 +107,7 @@ func makeWebhookHandler(rc *trigger.Receiver) http.HandlerFunc {
 // makeManualRunHandler 返回 POST /api/projects/{id}/runs handler(认证 + CSRF;手动触发）。
 // body {branch, commit?};actor=admin;成功 → 201 冻结 run-detail DTO。
 // 成功后追加 run_trigger_manual 审计(detail 记分支/commit/运行 id)。
-func makeManualRunHandler(svc run.Service, aud audit.Recorder) http.HandlerFunc {
+func makeManualRunHandler(svc run.Service, params run.ParameterService, aud audit.Recorder) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if svc == nil {
 			writeError(w, http.StatusServiceUnavailable, "internal", "运行服务未初始化")
@@ -128,13 +128,27 @@ func makeManualRunHandler(svc run.Service, aud audit.Recorder) http.HandlerFunc 
 		branch := strings.TrimSpace(req.Branch)
 		commit := strings.TrimSpace(req.Commit)
 		// 参数化运行(Story 8-11):trim key、剔空 key;明文构建参数(注入 script 步骤容器环境)。
-		params := normalizeRunParams(req.Params)
+		runParams := normalizeRunParams(req.Params)
+		// 类型化参数(P0):有项目参数定义时校验 + 强转 + 填默认;无定义则透传(向后兼容)。
+		// 非法值(必填缺失 / 枚举越界 / 类型不符)→ 422,不创建运行。
+		if params != nil {
+			resolved, perr := params.Resolve(r.Context(), id, runParams)
+			if perr != nil {
+				if errors.Is(perr, run.ErrInvalidParamValue) {
+					writeError(w, http.StatusUnprocessableEntity, "invalid_parameter", perr.Error())
+					return
+				}
+				writeError(w, http.StatusInternalServerError, "internal", "参数校验失败")
+				return
+			}
+			runParams = resolved
+		}
 		rn, err := svc.Create(r.Context(), id, run.Trigger{
 			Type:   run.TriggerManual,
 			Branch: branch,
 			Commit: commit,
 			Actor:  "admin",
-			Params: params,
+			Params: runParams,
 		})
 		if err != nil {
 			writeRunError(w, err)
@@ -145,7 +159,7 @@ func makeManualRunHandler(svc run.Service, aud audit.Recorder) http.HandlerFunc 
 			Action:     audit.ActionRunTriggerManual,
 			TargetType: audit.TargetRun,
 			TargetID:   rn.ID,
-			Detail:     map[string]any{"projectId": id, "branch": branch, "commit": commit, "paramCount": len(params)},
+			Detail:     map[string]any{"projectId": id, "branch": branch, "commit": commit, "paramCount": len(runParams)},
 			IP:         clientIP(r),
 		})
 		// 刚创建(queued)的运行尚无产物/无部署;nil → []/null。产物在成功路径由 worker emit、部署经 deploy 端点。

--- a/internal/run/parameters.go
+++ b/internal/run/parameters.go
@@ -1,0 +1,268 @@
+package run
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// parameters.go 实现项目级「类型化运行参数」定义(P0 · 对标 Jenkins parameters / 云效 variables type)。
+//
+// 每项目一份参数定义数组(key/label/type/default/options/required)。手动触发弹窗据此渲染
+// 类型化控件(枚举→下拉、布尔→开关、数字→数字框)并在提交时校验;执行期仍以 key=value
+// (map[string]string)注入容器,故这仅是「触发期定义 + 校验层」,不改执行语义(Story 8-11)。
+//
+// 无定义(空数组)→ Resolve 透传调用方所给参数,与现有自由 KV 行为字节级一致(向后兼容)。
+
+// 参数类型枚举(JSON/DB 存小写串)。
+const (
+	ParamTypeString  = "string"
+	ParamTypeChoice  = "choice"
+	ParamTypeBoolean = "boolean"
+	ParamTypeNumber  = "number"
+)
+
+// maxParamDefs 是单项目参数定义条数上界(防误填巨量)。
+const maxParamDefs = 64
+
+// 参数键命名:env-var 安全(参数以 PW_<KEY> 注入容器环境),字母/下划线开头。
+var paramKeyRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// 领域错误(错误体不含敏感数据)。
+var (
+	// ErrParamProjectNotFound 表示引用的项目不存在。
+	ErrParamProjectNotFound = errors.New("run: parameter project not found")
+	// ErrInvalidParamDef 表示参数定义非法(键/类型/枚举/默认值校验失败)。
+	ErrInvalidParamDef = errors.New("run: invalid parameter definition")
+	// ErrInvalidParamValue 表示触发时提供的参数值不满足定义(必填缺失 / 枚举越界 / 类型不符)。
+	ErrInvalidParamValue = errors.New("run: invalid parameter value")
+)
+
+// ParamDef 是一条参数定义。Default/Options 均为字符串(执行期注入字符串环境变量);
+// boolean 的合法值为 "true"/"false",number 为可解析数值。
+type ParamDef struct {
+	Key      string   `json:"key"`
+	Label    string   `json:"label"`
+	Type     string   `json:"type"`
+	Default  string   `json:"default"`
+	Options  []string `json:"options,omitempty"`
+	Required bool     `json:"required"`
+}
+
+// ParametersConfig 是项目参数定义领域模型。
+type ParametersConfig struct {
+	Defs      []ParamDef
+	UpdatedAt time.Time
+}
+
+// ParameterService 定义项目参数定义领域接口(HTTP 读写 + 触发期解析校验)。
+type ParameterService interface {
+	// Get 返回项目参数定义;无配置 → 空 Defs(非错误)。
+	Get(ctx context.Context, projectID string) (*ParametersConfig, error)
+	// Save 校验参数定义(键合法/唯一、类型枚举、choice 有 options、默认值符合类型)→ upsert → 回读。
+	// 项目不存在 → ErrParamProjectNotFound;定义非法 → ErrInvalidParamDef(附人读原因)。
+	Save(ctx context.Context, projectID string, defs []ParamDef) (*ParametersConfig, error)
+	// Resolve 据项目定义把「触发时提供的参数」校验 + 强转 + 填默认,返回执行期注入用的 key=value。
+	// 无定义 → 原样透传 provided(向后兼容)。非法值 → ErrInvalidParamValue(附人读原因)。
+	// 定义非空时:仅保留已定义的键(丢弃未定义键),缺省值由 default 填充。
+	Resolve(ctx context.Context, projectID string, provided map[string]string) (map[string]string, error)
+}
+
+type parameterService struct {
+	db *sql.DB
+}
+
+// NewParameterService 构造项目参数定义 Service(参数化 SQL 触库;无 init 副作用、不驻留)。
+func NewParameterService(db *sql.DB) ParameterService { return &parameterService{db: db} }
+
+func (s *parameterService) Get(ctx context.Context, projectID string) (*ParametersConfig, error) {
+	var (
+		defsJSON string
+		updated  string
+	)
+	err := s.db.QueryRowContext(ctx,
+		`SELECT defs_json, updated_at FROM project_parameters WHERE project_id = ?`,
+		strings.TrimSpace(projectID),
+	).Scan(&defsJSON, &updated)
+	if errors.Is(err, sql.ErrNoRows) {
+		return &ParametersConfig{Defs: []ParamDef{}}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("run: load parameters: %w", err)
+	}
+	defs := []ParamDef{}
+	if strings.TrimSpace(defsJSON) != "" {
+		if uerr := json.Unmarshal([]byte(defsJSON), &defs); uerr != nil {
+			return nil, fmt.Errorf("run: parse parameter defs: %w", uerr)
+		}
+	}
+	if defs == nil {
+		defs = []ParamDef{}
+	}
+	t, _ := time.Parse(time.RFC3339, updated)
+	return &ParametersConfig{Defs: defs, UpdatedAt: t}, nil
+}
+
+func (s *parameterService) Save(ctx context.Context, projectID string, defs []ParamDef) (*ParametersConfig, error) {
+	projectID = strings.TrimSpace(projectID)
+	normalized, err := normalizeParamDefs(defs)
+	if err != nil {
+		return nil, err
+	}
+	blob, err := json.Marshal(normalized)
+	if err != nil {
+		return nil, fmt.Errorf("run: marshal parameter defs: %w", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO project_parameters (project_id, defs_json, created_at, updated_at)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(project_id) DO UPDATE SET
+		   defs_json  = excluded.defs_json,
+		   updated_at = excluded.updated_at`,
+		projectID, string(blob), now, now,
+	)
+	if err != nil {
+		if isForeignKeyErr(err) {
+			return nil, ErrParamProjectNotFound
+		}
+		return nil, fmt.Errorf("run: upsert parameters: %w", err)
+	}
+	return s.Get(ctx, projectID)
+}
+
+func (s *parameterService) Resolve(ctx context.Context, projectID string, provided map[string]string) (map[string]string, error) {
+	cfg, err := s.Get(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	return ResolveParams(cfg.Defs, provided)
+}
+
+// normalizeParamDefs 校验 + 规范化定义列表:键合法/唯一、类型枚举、choice 有 options、默认值符合类型。
+// label 留空 → 回退 key。
+func normalizeParamDefs(defs []ParamDef) ([]ParamDef, error) {
+	if len(defs) > maxParamDefs {
+		return nil, fmt.Errorf("%w: 参数定义不能超过 %d 条", ErrInvalidParamDef, maxParamDefs)
+	}
+	out := make([]ParamDef, 0, len(defs))
+	seen := make(map[string]struct{}, len(defs))
+	for _, d := range defs {
+		key := strings.TrimSpace(d.Key)
+		if !paramKeyRe.MatchString(key) {
+			return nil, fmt.Errorf("%w: 参数键「%s」非法(须字母/下划线开头,仅含字母数字下划线)", ErrInvalidParamDef, d.Key)
+		}
+		if _, dup := seen[key]; dup {
+			return nil, fmt.Errorf("%w: 参数键「%s」重复", ErrInvalidParamDef, key)
+		}
+		seen[key] = struct{}{}
+
+		typ := strings.TrimSpace(d.Type)
+		if typ == "" {
+			typ = ParamTypeString
+		}
+		opts := trimOptions(d.Options)
+		switch typ {
+		case ParamTypeString, ParamTypeNumber, ParamTypeBoolean:
+			opts = nil // 非枚举类型不带 options
+		case ParamTypeChoice:
+			if len(opts) == 0 {
+				return nil, fmt.Errorf("%w: 枚举参数「%s」必须至少有一个选项", ErrInvalidParamDef, key)
+			}
+		default:
+			return nil, fmt.Errorf("%w: 参数「%s」类型「%s」未知", ErrInvalidParamDef, key, typ)
+		}
+
+		def := strings.TrimSpace(d.Default)
+		if err := validateParamValue(key, typ, opts, def); err != nil {
+			return nil, fmt.Errorf("%w: 参数「%s」默认值不合法:%v", ErrInvalidParamDef, key, err)
+		}
+
+		label := strings.TrimSpace(d.Label)
+		if label == "" {
+			label = key
+		}
+		out = append(out, ParamDef{Key: key, Label: label, Type: typ, Default: d.Default, Options: opts, Required: d.Required})
+	}
+	return out, nil
+}
+
+func trimOptions(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, o := range in {
+		if t := strings.TrimSpace(o); t != "" {
+			out = append(out, t)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// validateParamValue 校验单个值是否满足类型/枚举(空值由调用方据 required 处理,这里只查非空值的合法性)。
+func validateParamValue(key, typ string, options []string, value string) error {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return nil // 空值合法性(必填)由 ResolveParams 单独判
+	}
+	switch typ {
+	case ParamTypeNumber:
+		if _, err := strconv.ParseFloat(v, 64); err != nil {
+			return fmt.Errorf("「%s」不是数字", value)
+		}
+	case ParamTypeBoolean:
+		if v != "true" && v != "false" {
+			return fmt.Errorf("布尔值须为 true/false,得「%s」", value)
+		}
+	case ParamTypeChoice:
+		for _, o := range options {
+			if o == v {
+				return nil
+			}
+		}
+		return fmt.Errorf("「%s」不在可选项 %v 中", value, options)
+	}
+	return nil
+}
+
+// ResolveParams 是 Resolve 的纯函数核心(供 Service 与测试复用)。
+// 无定义 → 透传 provided(向后兼容,nil 安全)。有定义:逐项取「提供值(非空)否则默认值」,
+// 校验必填/枚举/类型,仅保留已定义键。
+func ResolveParams(defs []ParamDef, provided map[string]string) (map[string]string, error) {
+	if len(defs) == 0 {
+		if provided == nil {
+			return nil, nil
+		}
+		out := make(map[string]string, len(provided))
+		for k, v := range provided {
+			out[k] = v
+		}
+		return out, nil
+	}
+	out := make(map[string]string, len(defs))
+	for _, d := range defs {
+		v, ok := provided[d.Key]
+		if !ok || strings.TrimSpace(v) == "" {
+			v = d.Default
+		}
+		if strings.TrimSpace(v) == "" {
+			if d.Required {
+				return nil, fmt.Errorf("%w: 参数「%s」为必填", ErrInvalidParamValue, d.Label)
+			}
+			out[d.Key] = ""
+			continue
+		}
+		if err := validateParamValue(d.Key, d.Type, d.Options, v); err != nil {
+			return nil, fmt.Errorf("%w: 参数「%s」%v", ErrInvalidParamValue, d.Label, err)
+		}
+		out[d.Key] = v
+	}
+	return out, nil
+}

--- a/internal/run/parameters_test.go
+++ b/internal/run/parameters_test.go
@@ -1,0 +1,159 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestParameterServiceSaveAndGet(t *testing.T) {
+	db := testDB(t)
+	svc := NewParameterService(db)
+	projID := seedProject(t, db)
+
+	defs := []ParamDef{
+		{Key: "env", Label: "环境", Type: ParamTypeChoice, Default: "prod", Options: []string{"prod", "staging"}},
+		{Key: "ver", Type: ParamTypeString, Default: "1.0"},
+		{Key: "force", Type: ParamTypeBoolean, Default: "false"},
+		{Key: "count", Type: ParamTypeNumber, Default: "3"},
+	}
+	cfg, err := svc.Save(context.Background(), projID, defs)
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if len(cfg.Defs) != 4 {
+		t.Fatalf("want 4 defs, got %d", len(cfg.Defs))
+	}
+	// label 缺省回退 key。
+	if cfg.Defs[1].Label != "ver" {
+		t.Errorf("label fallback = %q, want ver", cfg.Defs[1].Label)
+	}
+	// 非枚举类型不带 options。
+	if cfg.Defs[2].Options != nil {
+		t.Errorf("boolean should drop options, got %v", cfg.Defs[2].Options)
+	}
+
+	got, err := svc.Get(context.Background(), projID)
+	if err != nil || len(got.Defs) != 4 {
+		t.Fatalf("Get round-trip: %v / %d", err, len(got.Defs))
+	}
+}
+
+func TestParameterServiceGetEmpty(t *testing.T) {
+	db := testDB(t)
+	svc := NewParameterService(db)
+	projID := seedProject(t, db)
+	got, err := svc.Get(context.Background(), projID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Defs == nil || len(got.Defs) != 0 {
+		t.Fatalf("unconfigured project should yield empty defs, got %v", got.Defs)
+	}
+}
+
+func TestParameterServiceSaveValidation(t *testing.T) {
+	db := testDB(t)
+	svc := NewParameterService(db)
+	projID := seedProject(t, db)
+
+	cases := []struct {
+		name string
+		defs []ParamDef
+	}{
+		{"bad key", []ParamDef{{Key: "1bad", Type: ParamTypeString}}},
+		{"empty key", []ParamDef{{Key: "  ", Type: ParamTypeString}}},
+		{"dup key", []ParamDef{{Key: "a", Type: ParamTypeString}, {Key: "a", Type: ParamTypeString}}},
+		{"unknown type", []ParamDef{{Key: "a", Type: "weird"}}},
+		{"choice no options", []ParamDef{{Key: "a", Type: ParamTypeChoice}}},
+		{"choice default not in options", []ParamDef{{Key: "a", Type: ParamTypeChoice, Default: "z", Options: []string{"x", "y"}}}},
+		{"number bad default", []ParamDef{{Key: "a", Type: ParamTypeNumber, Default: "NaNxx"}}},
+		{"boolean bad default", []ParamDef{{Key: "a", Type: ParamTypeBoolean, Default: "yes"}}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := svc.Save(context.Background(), projID, c.defs); !errors.Is(err, ErrInvalidParamDef) {
+				t.Fatalf("want ErrInvalidParamDef, got %v", err)
+			}
+		})
+	}
+}
+
+func TestParameterServiceSaveProjectNotFound(t *testing.T) {
+	db := testDB(t)
+	svc := NewParameterService(db)
+	if _, err := svc.Save(context.Background(), "nope", []ParamDef{{Key: "a", Type: ParamTypeString}}); !errors.Is(err, ErrParamProjectNotFound) {
+		t.Fatalf("want ErrParamProjectNotFound, got %v", err)
+	}
+}
+
+func TestResolveParams(t *testing.T) {
+	defs := []ParamDef{
+		{Key: "env", Type: ParamTypeChoice, Default: "prod", Options: []string{"prod", "staging"}},
+		{Key: "ver", Type: ParamTypeString, Default: "1.0"},
+		{Key: "force", Type: ParamTypeBoolean, Default: "false"},
+		{Key: "count", Type: ParamTypeNumber, Default: "3"},
+		{Key: "token", Type: ParamTypeString, Required: true},
+	}
+
+	t.Run("fills defaults + keeps provided, drops undefined", func(t *testing.T) {
+		got, err := ResolveParams(defs, map[string]string{"env": "staging", "token": "abc", "GHOST": "x"})
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		want := map[string]string{"env": "staging", "ver": "1.0", "force": "false", "count": "3", "token": "abc"}
+		if len(got) != len(want) {
+			t.Fatalf("got %v want %v", got, want)
+		}
+		for k, v := range want {
+			if got[k] != v {
+				t.Errorf("%s = %q want %q", k, got[k], v)
+			}
+		}
+		if _, ok := got["GHOST"]; ok {
+			t.Error("undefined key should be dropped")
+		}
+	})
+
+	t.Run("required missing → error", func(t *testing.T) {
+		if _, err := ResolveParams(defs, map[string]string{"env": "prod"}); !errors.Is(err, ErrInvalidParamValue) {
+			t.Fatalf("want ErrInvalidParamValue, got %v", err)
+		}
+	})
+
+	t.Run("choice out of range → error", func(t *testing.T) {
+		if _, err := ResolveParams(defs, map[string]string{"env": "dev", "token": "x"}); !errors.Is(err, ErrInvalidParamValue) {
+			t.Fatalf("want ErrInvalidParamValue, got %v", err)
+		}
+	})
+
+	t.Run("number/boolean type mismatch → error", func(t *testing.T) {
+		if _, err := ResolveParams(defs, map[string]string{"token": "x", "count": "abc"}); !errors.Is(err, ErrInvalidParamValue) {
+			t.Fatalf("want number err, got %v", err)
+		}
+		if _, err := ResolveParams(defs, map[string]string{"token": "x", "force": "maybe"}); !errors.Is(err, ErrInvalidParamValue) {
+			t.Fatalf("want boolean err, got %v", err)
+		}
+	})
+
+	t.Run("no defs → passthrough (backward compat)", func(t *testing.T) {
+		in := map[string]string{"anything": "goes", "x": "y"}
+		got, err := ResolveParams(nil, in)
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		if len(got) != 2 || got["anything"] != "goes" || got["x"] != "y" {
+			t.Fatalf("passthrough failed: %v", got)
+		}
+	})
+
+	t.Run("provided empty falls back to default", func(t *testing.T) {
+		got, err := ResolveParams(defs, map[string]string{"env": "  ", "token": "x"})
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		if got["env"] != "prod" {
+			t.Errorf("empty provided should fall back to default, got %q", got["env"])
+		}
+	})
+}

--- a/internal/store/migrations/0034_project_parameters.sql
+++ b/internal/store/migrations/0034_project_parameters.sql
@@ -1,0 +1,16 @@
+-- 0034 project_parameters:项目级「类型化运行参数」定义(P0 · 对标 Jenkins parameters / 云效 variables type)。
+-- 每项目至多一行(project_id 既是主键也是外键)。defs_json 存一份参数定义数组:
+--   [{ key, label, type(string|choice|boolean|number), default, options[], required }]
+-- 手动触发弹窗据此渲染类型化控件并校验;运行执行仍以 key=value(map[string]string)注入,
+-- 故仅是「触发期的定义 + 校验层」,不改执行语义。无定义 → 触发回退自由 KV(向后兼容)。
+-- 不存敏感信息(secret 仍走 vault 引用,绝不作明文参数);删项目级联删参数定义。
+--   project_id : FK → projects.id;PK;ON DELETE CASCADE
+--   defs_json  : 参数定义数组 JSON(空数组 = 未配置 = 自由 KV)
+
+CREATE TABLE IF NOT EXISTS project_parameters (
+    project_id TEXT PRIMARY KEY,
+    defs_json  TEXT NOT NULL DEFAULT '[]',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);

--- a/web/src/api/parameters.test.ts
+++ b/web/src/api/parameters.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { validateParamValues, type ParamDef } from './parameters'
+
+const defs: ParamDef[] = [
+  { key: 'env', label: '环境', type: 'choice', default: 'prod', options: ['prod', 'staging'], required: false },
+  { key: 'ver', label: '版本', type: 'string', default: '1.0', required: false },
+  { key: 'force', label: '强制', type: 'boolean', default: 'false', required: false },
+  { key: 'count', label: '数量', type: 'number', default: '3', required: false },
+  { key: 'token', label: '令牌', type: 'string', default: '', required: true },
+]
+
+describe('validateParamValues', () => {
+  it('passes when required filled + values valid (defaults count)', () => {
+    expect(validateParamValues(defs, { token: 'abc' })).toBe('')
+  })
+
+  it('flags missing required', () => {
+    expect(validateParamValues(defs, {})).toContain('令牌')
+  })
+
+  it('flags number type mismatch', () => {
+    expect(validateParamValues(defs, { token: 'x', count: 'abc' })).toContain('数量')
+  })
+
+  it('flags boolean type mismatch', () => {
+    expect(validateParamValues(defs, { token: 'x', force: 'maybe' })).toContain('强制')
+  })
+
+  it('flags choice out of range', () => {
+    expect(validateParamValues(defs, { token: 'x', env: 'dev' })).toContain('环境')
+  })
+
+  it('empty provided falls back to default (valid)', () => {
+    expect(validateParamValues(defs, { token: 'x', env: '' })).toBe('')
+  })
+
+  it('no defs → always valid', () => {
+    expect(validateParamValues([], { anything: 'x' })).toBe('')
+  })
+})

--- a/web/src/api/parameters.ts
+++ b/web/src/api/parameters.ts
@@ -1,0 +1,63 @@
+/**
+ * Parameters API — 项目级「类型化运行参数定义」(P0 typed params).
+ *
+ * GET /api/projects/{id}/parameters → { parameters: ParamDef[] }
+ * PUT /api/projects/{id}/parameters → 同上 (needs CSRF)
+ *
+ * 手动触发弹窗据此渲染类型化控件(枚举→下拉、布尔→开关、数字→数字框)并校验;
+ * 无定义则回退自由 KV(向后兼容)。执行期仍以 key=value 注入容器(同 Story 8-11)。
+ * secret 绝不作明文参数 —— 仍走 vault 引用。
+ */
+
+import { http } from './http'
+
+export type ParamType = 'string' | 'choice' | 'boolean' | 'number'
+
+export interface ParamDef {
+  key: string
+  label: string
+  type: ParamType
+  default: string
+  options?: string[]
+  required: boolean
+}
+
+interface ParametersResponse {
+  parameters: ParamDef[]
+}
+
+export async function getParameters(projectId: string): Promise<ParamDef[]> {
+  const res = await http.get<ParametersResponse>(`/api/projects/${projectId}/parameters`)
+  return res.parameters ?? []
+}
+
+export async function saveParameters(projectId: string, parameters: ParamDef[]): Promise<ParamDef[]> {
+  const res = await http.put<ParametersResponse>(`/api/projects/${projectId}/parameters`, { parameters })
+  return res.parameters ?? []
+}
+
+export const PARAM_TYPE_OPTIONS: ReadonlyArray<{ value: ParamType; label: string }> = [
+  { value: 'string', label: '文本' },
+  { value: 'choice', label: '枚举' },
+  { value: 'boolean', label: '布尔' },
+  { value: 'number', label: '数字' },
+]
+
+/**
+ * 客户端校验「触发时填的值」是否满足定义(与后端 ResolveParams 同规则),返回首个错误信息或 ''。
+ * 用于触发弹窗提交前的即时反馈;后端仍会再校验一次(422)。
+ */
+export function validateParamValues(defs: readonly ParamDef[], values: Record<string, string>): string {
+  for (const d of defs) {
+    const raw = values[d.key]
+    const v = (raw ?? '').trim() !== '' ? raw : d.default
+    if ((v ?? '').trim() === '') {
+      if (d.required) return `参数「${d.label}」为必填`
+      continue
+    }
+    if (d.type === 'number' && Number.isNaN(Number(v))) return `参数「${d.label}」须为数字`
+    if (d.type === 'boolean' && v !== 'true' && v !== 'false') return `参数「${d.label}」须为 true/false`
+    if (d.type === 'choice' && !(d.options ?? []).includes(v)) return `参数「${d.label}」不在可选项中`
+  }
+  return ''
+}

--- a/web/src/components/ParametersPanel.vue
+++ b/web/src/components/ParametersPanel.vue
@@ -1,0 +1,264 @@
+<script setup lang="ts">
+/**
+ * ParametersPanel — 项目级「类型化运行参数定义」编辑器(P0 typed params)。
+ *
+ * 自包含卡片,自管载入/保存 /api/projects/{id}/parameters。定义一组参数
+ * (key/label/type/default/options/required);手动触发弹窗据此渲染类型化控件并校验。
+ * 无定义 = 触发回退自由 KV(向后兼容)。嵌于 TriggersPanel(ConcurrencyPanel 之后)。
+ */
+import { ref, onMounted, watch } from 'vue'
+import {
+  getParameters,
+  saveParameters,
+  PARAM_TYPE_OPTIONS,
+  type ParamDef,
+  type ParamType,
+} from '../api/parameters'
+import { HttpError } from '../api/http'
+
+const props = defineProps<{
+  projectId: string
+}>()
+
+interface Row extends ParamDef {
+  rid: number
+  optionsText: string
+}
+
+type LoadState = 'idle' | 'loading' | 'error'
+const loadState = ref<LoadState>('idle')
+const loadError = ref('')
+const rows = ref<Row[]>([])
+const saveSubmitting = ref(false)
+const saveBanner = ref('')
+const saveSuccess = ref(false)
+
+let ridSeq = 0
+function toRow(d: ParamDef): Row {
+  return {
+    rid: ++ridSeq,
+    key: d.key,
+    label: d.label,
+    type: d.type,
+    default: d.default,
+    options: d.options ?? [],
+    optionsText: (d.options ?? []).join(', '),
+    required: d.required,
+  }
+}
+
+async function load(): Promise<void> {
+  loadState.value = 'loading'
+  loadError.value = ''
+  try {
+    rows.value = (await getParameters(props.projectId)).map(toRow)
+    loadState.value = 'idle'
+  } catch (err) {
+    loadState.value = 'error'
+    loadError.value = err instanceof HttpError ? err.message : '加载参数定义失败'
+  }
+}
+
+function addRow(): void {
+  rows.value.push(toRow({ key: '', label: '', type: 'string', default: '', options: [], required: false }))
+  clearBanner()
+}
+function removeRow(rid: number): void {
+  rows.value = rows.value.filter((r) => r.rid !== rid)
+  clearBanner()
+}
+function clearBanner(): void {
+  saveBanner.value = ''
+  saveSuccess.value = false
+}
+function onTypeChange(row: Row): void {
+  if (row.type !== 'choice') row.optionsText = ''
+  clearBanner()
+}
+
+async function handleSave(): Promise<void> {
+  clearBanner()
+  const defs: ParamDef[] = rows.value.map((r) => ({
+    key: r.key.trim(),
+    label: r.label.trim(),
+    type: r.type as ParamType,
+    default: r.default,
+    options:
+      r.type === 'choice'
+        ? r.optionsText.split(',').map((s) => s.trim()).filter((s) => s !== '')
+        : undefined,
+    required: r.required,
+  }))
+  saveSubmitting.value = true
+  try {
+    rows.value = (await saveParameters(props.projectId, defs)).map(toRow)
+    saveSuccess.value = true
+    saveBanner.value = '参数定义已保存'
+  } catch (err) {
+    saveSuccess.value = false
+    saveBanner.value =
+      err instanceof HttpError
+        ? (err.apiError?.message ?? `保存失败(${err.status})`)
+        : '保存失败,请重试'
+  } finally {
+    saveSubmitting.value = false
+  }
+}
+
+onMounted(load)
+watch(() => props.projectId, load)
+</script>
+
+<template>
+  <section class="config-card" aria-labelledby="param-heading">
+    <div class="card-head">
+      <span class="card-icon" aria-hidden="true">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9">
+          <path d="M4 7h16M4 12h16M4 17h10" />
+        </svg>
+      </span>
+      <h2 id="param-heading" class="card-title">运行参数</h2>
+      <span class="card-sub">手动触发时按类型填写的参数;无定义则触发用自由键值对</span>
+    </div>
+
+    <div class="card-body card-body--pad">
+      <p v-if="loadState === 'loading'" class="muted">加载中…</p>
+      <p v-else-if="loadState === 'error'" class="err" role="alert">{{ loadError }}</p>
+
+      <template v-else>
+        <p v-if="rows.length === 0" class="muted empty">
+          还没有定义参数。点下方「+ 添加参数」后,手动触发弹窗会渲染对应的类型化控件(枚举下拉 / 布尔开关 / 数字框)。
+        </p>
+
+        <div v-for="row in rows" :key="row.rid" class="param-def">
+          <button class="def-del" aria-label="移除参数" @click="removeRow(row.rid)">✕</button>
+          <div class="def-grid">
+            <label class="def-fld">
+              <span class="def-lbl">键(KEY)</span>
+              <input v-model="row.key" class="def-input is-mono" placeholder="env" autocomplete="off" @input="clearBanner" />
+            </label>
+            <label class="def-fld">
+              <span class="def-lbl">显示标签</span>
+              <input v-model="row.label" class="def-input" placeholder="部署环境" autocomplete="off" @input="clearBanner" />
+            </label>
+            <label class="def-fld def-fld--type">
+              <span class="def-lbl">类型</span>
+              <select v-model="row.type" class="def-input" @change="onTypeChange(row)">
+                <option v-for="opt in PARAM_TYPE_OPTIONS" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+              </select>
+            </label>
+          </div>
+          <div class="def-grid">
+            <label v-if="row.type === 'boolean'" class="def-fld">
+              <span class="def-lbl">默认值</span>
+              <select v-model="row.default" class="def-input" @change="clearBanner">
+                <option value="false">false</option>
+                <option value="true">true</option>
+              </select>
+            </label>
+            <label v-else class="def-fld">
+              <span class="def-lbl">默认值</span>
+              <input
+                v-model="row.default"
+                class="def-input"
+                :type="row.type === 'number' ? 'number' : 'text'"
+                placeholder="prod"
+                autocomplete="off"
+                @input="clearBanner"
+              />
+            </label>
+            <label v-if="row.type === 'choice'" class="def-fld def-fld--grow">
+              <span class="def-lbl">选项(逗号分隔)</span>
+              <input v-model="row.optionsText" class="def-input is-mono" placeholder="prod, staging, dev" autocomplete="off" @input="clearBanner" />
+            </label>
+            <label class="def-req">
+              <input v-model="row.required" type="checkbox" @change="clearBanner" />
+              <span>必填</span>
+            </label>
+          </div>
+        </div>
+
+        <button class="link-add" @click="addRow">+ 添加参数</button>
+
+        <p v-if="saveBanner" class="banner" :class="saveSuccess ? 'banner--ok' : 'banner--err'" role="status">{{ saveBanner }}</p>
+
+        <div class="save-row">
+          <button class="btn-primary" :disabled="saveSubmitting" :aria-busy="saveSubmitting" @click="handleSave">
+            <span v-if="saveSubmitting" class="spinner" aria-hidden="true" />
+            {{ saveSubmitting ? '保存中…' : '保存参数定义' }}
+          </button>
+        </div>
+      </template>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.config-card { border: 1px solid var(--color-border); border-radius: var(--rounded-lg, 12px); background: var(--color-card); overflow: hidden; }
+.card-head { display: flex; align-items: center; gap: 9px; padding: 14px 16px; border-bottom: 1px solid var(--color-border); }
+.card-icon { display: grid; place-items: center; width: 26px; height: 26px; border-radius: var(--rounded-md); background: var(--color-primary-soft); color: var(--color-primary); flex: none; }
+.card-title { font-size: 0.92rem; font-weight: 650; color: var(--color-text); }
+.card-sub { font-size: 0.76rem; color: var(--color-faint); flex: 1; min-width: 0; }
+.card-body--pad { padding: 16px; display: flex; flex-direction: column; gap: 12px; }
+
+.muted { margin: 0; font-size: 0.82rem; color: var(--color-faint); }
+.muted.empty { line-height: 1.55; }
+.err { margin: 0; font-size: 0.82rem; color: var(--color-danger, #dc2626); }
+
+.param-def {
+  position: relative;
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-primary);
+  border-radius: var(--rounded-md);
+  background: var(--color-inset);
+  padding: 11px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+.def-del {
+  position: absolute; top: 8px; right: 8px;
+  width: 22px; height: 22px; border: none; background: none;
+  color: var(--color-faint); cursor: pointer; border-radius: 5px;
+}
+.def-del:hover { color: var(--color-danger, #dc2626); background: var(--color-card); }
+.def-grid { display: grid; grid-template-columns: 1fr 1fr auto; gap: 9px; align-items: end; }
+.def-fld { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.def-fld--type { width: 96px; }
+.def-fld--grow { grid-column: 2 / 4; }
+.def-lbl { font-size: 0.7rem; font-weight: 600; color: var(--color-faint); }
+.def-input {
+  height: 32px; padding: 0 9px;
+  border: 1px solid var(--color-border-strong); border-radius: var(--rounded-md);
+  background: var(--color-card); color: var(--color-text);
+  font: inherit; font-size: 0.82rem; outline: none; width: 100%;
+}
+.def-input:focus { border-color: var(--color-primary); box-shadow: 0 0 0 2px var(--color-primary-soft); }
+.is-mono { font-family: var(--font-mono, ui-monospace, monospace); font-size: 0.78rem; }
+.def-req { display: inline-flex; align-items: center; gap: 6px; font-size: 0.78rem; color: var(--color-dim); height: 32px; white-space: nowrap; }
+
+.link-add {
+  align-self: flex-start; background: none; border: none;
+  color: var(--color-primary); font: inherit; font-size: 0.8rem; font-weight: 600; cursor: pointer; padding: 0;
+}
+.link-add:hover { text-decoration: underline; }
+
+.banner { margin: 0; font-size: 0.8rem; font-weight: 500; }
+.banner--ok { color: var(--color-success, #16a34a); }
+.banner--err { color: var(--color-danger, #dc2626); }
+
+.save-row { display: flex; justify-content: flex-end; }
+.btn-primary {
+  display: inline-flex; align-items: center; gap: 7px; height: 34px; padding: 0 16px;
+  border: none; background: var(--color-primary); color: #fff;
+  font-family: var(--font-sans); font-size: 0.83rem; font-weight: 600;
+  border-radius: var(--rounded); cursor: pointer;
+  box-shadow: 0 5px 16px var(--color-primary-soft);
+  transition: background-color var(--duration-fast), transform var(--duration-fast); white-space: nowrap;
+}
+.btn-primary:hover:not(:disabled) { background: var(--color-primary-press); transform: translateY(-1px); }
+.btn-primary:disabled { opacity: 0.45; cursor: not-allowed; transform: none; box-shadow: none; }
+.spinner { display: inline-block; width: 13px; height: 13px; border: 2px solid rgba(255,255,255,0.35); border-top-color: #fff; border-radius: var(--rounded-full); animation: spin 0.7s linear infinite; flex-shrink: 0; }
+@keyframes spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) { .spinner { animation: none; border-top-color: currentColor; } }
+</style>

--- a/web/src/components/TriggersPanel.vue
+++ b/web/src/components/TriggersPanel.vue
@@ -21,6 +21,7 @@ import { HttpError } from '../api/http'
 import CronPanel from './CronPanel.vue'
 import EnvironmentsPanel from './EnvironmentsPanel.vue'
 import ConcurrencyPanel from './ConcurrencyPanel.vue'
+import ParametersPanel from './ParametersPanel.vue'
 import ChainPanel from './ChainPanel.vue'
 import RunnerPanel from './RunnerPanel.vue'
 
@@ -526,6 +527,9 @@ const displayWebhookUrl = computed(() => {
 
       <!-- ═══ Environment promotion chain · Story 8-7 / FR-8-7 ════════════ -->
       <EnvironmentsPanel :project-id="props.projectId" />
+
+      <!-- ═══ Typed run parameters · P0 ════════════════════════════════════ -->
+      <ParametersPanel :project-id="props.projectId" />
 
       <!-- ═══ Concurrency limit · Story 8-10 / FR-8-10 ═════════════════════ -->
       <ConcurrencyPanel :project-id="props.projectId" />

--- a/web/src/components/TypedRunParams.vue
+++ b/web/src/components/TypedRunParams.vue
@@ -1,0 +1,134 @@
+<script setup lang="ts">
+/**
+ * TypedRunParams — 手动触发弹窗的「类型化参数」输入(P0 typed params)。
+ *
+ * 据项目参数定义渲染对应控件:枚举→下拉、布尔→开关、数字→数字框、文本→输入框,
+ * 各以 default 预填。值经 v-model 以 Record<string,string> 回传(执行期注入容器环境)。
+ * 当项目无参数定义时,调用方改用 RunParamsEditor(自由 KV);本组件只在有定义时渲染。
+ */
+import { ref, watch } from 'vue'
+import type { ParamDef } from '../api/parameters'
+
+const props = defineProps<{
+  defs: ParamDef[]
+  modelValue: Record<string, string>
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: Record<string, string>): void
+}>()
+
+/** 以 default 预填 + 已有 modelValue 覆盖,建立本地值表。 */
+function seed(): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const d of props.defs) {
+    const provided = props.modelValue[d.key]
+    out[d.key] = provided != null && provided !== '' ? provided : d.default
+  }
+  return out
+}
+
+const values = ref<Record<string, string>>(seed())
+
+// defs 变化(切项目/重开弹窗)时重新播种。
+watch(
+  () => props.defs,
+  () => {
+    values.value = seed()
+    commit()
+  },
+)
+
+function commit(): void {
+  emit('update:modelValue', { ...values.value })
+}
+
+function setVal(key: string, v: string): void {
+  values.value = { ...values.value, [key]: v }
+  commit()
+}
+
+function toggleBool(key: string): void {
+  setVal(key, values.value[key] === 'true' ? 'false' : 'true')
+}
+</script>
+
+<template>
+  <div class="typed-params">
+    <div v-for="d in defs" :key="d.key" class="tp-field">
+      <label class="tp-label" :for="`tp-${d.key}`">
+        {{ d.label }}
+        <span v-if="d.required" class="tp-req" aria-label="必填">*</span>
+        <code class="tp-key">{{ d.key }}</code>
+      </label>
+
+      <!-- 枚举 → 下拉 -->
+      <select
+        v-if="d.type === 'choice'"
+        :id="`tp-${d.key}`"
+        class="tp-input"
+        :value="values[d.key]"
+        @change="setVal(d.key, ($event.target as HTMLSelectElement).value)"
+      >
+        <option v-for="opt in d.options ?? []" :key="opt" :value="opt">{{ opt }}</option>
+      </select>
+
+      <!-- 布尔 → 开关 -->
+      <button
+        v-else-if="d.type === 'boolean'"
+        :id="`tp-${d.key}`"
+        type="button"
+        class="tp-toggle"
+        :class="{ 'tp-toggle--on': values[d.key] === 'true' }"
+        role="switch"
+        :aria-checked="values[d.key] === 'true'"
+        @click="toggleBool(d.key)"
+      >
+        <span class="tp-toggle-knob" />
+        <span class="tp-toggle-text">{{ values[d.key] === 'true' ? 'true' : 'false' }}</span>
+      </button>
+
+      <!-- 数字 / 文本 -->
+      <input
+        v-else
+        :id="`tp-${d.key}`"
+        class="tp-input"
+        :type="d.type === 'number' ? 'number' : 'text'"
+        :value="values[d.key]"
+        :placeholder="d.default"
+        autocomplete="off"
+        @input="setVal(d.key, ($event.target as HTMLInputElement).value)"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.typed-params { display: flex; flex-direction: column; gap: 12px; }
+.tp-field { display: flex; flex-direction: column; gap: 5px; }
+.tp-label { font-size: 0.8rem; font-weight: 600; color: var(--color-text); display: flex; align-items: center; gap: 6px; }
+.tp-req { color: var(--color-danger, #dc2626); }
+.tp-key { font-family: var(--font-mono, ui-monospace, monospace); font-size: 0.7rem; color: var(--color-faint); background: var(--color-inset); padding: 0 4px; border-radius: 4px; font-weight: 400; }
+.tp-input {
+  height: 34px; padding: 0 10px;
+  border: 1px solid var(--color-border-strong); border-radius: var(--rounded-md);
+  background: var(--color-card); color: var(--color-text);
+  font: inherit; font-size: 0.85rem; outline: none; width: 100%;
+}
+.tp-input:focus { border-color: var(--color-primary); box-shadow: 0 0 0 2px var(--color-primary-soft); }
+.tp-toggle {
+  display: inline-flex; align-items: center; gap: 9px;
+  height: 34px; padding: 0 12px 0 4px; width: fit-content;
+  border: 1px solid var(--color-border-strong); border-radius: var(--rounded-full, 999px);
+  background: var(--color-inset); cursor: pointer; color: var(--color-dim);
+  font: inherit; font-size: 0.8rem; transition: background-color var(--duration-fast);
+}
+.tp-toggle--on { background: var(--color-primary-soft); color: var(--color-primary); border-color: var(--color-primary); }
+.tp-toggle-knob {
+  width: 24px; height: 24px; border-radius: 50%;
+  background: var(--color-card); border: 1px solid var(--color-border-strong);
+  transition: transform var(--duration-fast); flex: none;
+}
+.tp-toggle--on .tp-toggle-knob { transform: translateX(2px); border-color: var(--color-primary); }
+.tp-toggle-text { font-family: var(--font-mono, ui-monospace, monospace); }
+</style>

--- a/web/src/views/Projects.vue
+++ b/web/src/views/Projects.vue
@@ -16,6 +16,8 @@ import { listCredentials, type Credential } from '../api/credentials'
 import { triggerManual, type RunDetail, type TriggerManualInput } from '../api/runs'
 import { listRefs, listCommits, type GitRef, type GitCommit } from '../api/refs'
 import RunParamsEditor from '../components/RunParamsEditor.vue'
+import TypedRunParams from '../components/TypedRunParams.vue'
+import { getParameters, validateParamValues, type ParamDef } from '../api/parameters'
 import { HttpError } from '../api/http'
 
 // ─── router ───────────────────────────────────────────────────────────────────
@@ -382,6 +384,7 @@ const triggerModalOpen   = ref(false)
 const triggerProject     = ref<Project | null>(null)
 const triggerForm        = ref({ branch: '', commit: '' })
 const triggerParams      = ref<Record<string, string>>({})
+const triggerDefs        = ref<ParamDef[]>([])
 const triggerBranchError = ref('')
 const triggerBanner      = ref('')
 const triggerSubmitting  = ref(false)
@@ -390,11 +393,22 @@ function openTriggerModal(p: Project): void {
   triggerProject.value     = p
   triggerForm.value        = { branch: p.defaultBranch || '', commit: '' }
   triggerParams.value      = {}
+  triggerDefs.value        = []
   triggerBranchError.value = ''
   triggerBanner.value      = ''
   triggerSubmitting.value  = false
   triggerModalOpen.value   = true
   void loadBranchOptions(p.id)
+  void loadTriggerDefs(p.id)
+}
+
+// 类型化运行参数定义(P0):有定义 → 弹窗渲染类型化控件;无 → 回退自由 KV。失败静默(降级)。
+async function loadTriggerDefs(projectId: string): Promise<void> {
+  try {
+    triggerDefs.value = await getParameters(projectId)
+  } catch {
+    triggerDefs.value = []
+  }
 }
 
 // 代码管理区(Story 8-18):拉取真实分支/commit 供下拉建议(datalist);未启用/失败 → 静默回退手填。
@@ -443,6 +457,16 @@ async function handleTriggerSubmit(): Promise<void> {
   const branch = triggerForm.value.branch.trim()
 
   if (!triggerProject.value) return
+
+  // 类型化参数:提交前客户端即时校验(后端仍会再校验一次 422)。
+  if (triggerDefs.value.length) {
+    const verr = validateParamValues(triggerDefs.value, triggerParams.value)
+    if (verr) {
+      triggerBanner.value = verr
+      return
+    }
+  }
+
   triggerSubmitting.value = true
 
   try {
@@ -918,13 +942,20 @@ const STATUS_CONFIG: Record<RunStatus, StatusConfig> = {
             </datalist>
           </div>
 
-          <!-- Parameters (optional · Story 8-11) -->
+          <!-- Parameters · 有类型化定义(P0)→ 渲染类型化控件;无 → 自由 KV(Story 8-11) -->
           <div class="field">
             <label class="field-label">
               参数
-              <span class="field-hint-inline">（可选,注入流水线为环境变量）</span>
+              <span class="field-hint-inline">{{ triggerDefs.length ? '（按定义填写,注入流水线为环境变量）' : '（可选,注入流水线为环境变量）' }}</span>
             </label>
+            <TypedRunParams
+              v-if="triggerDefs.length"
+              :key="`typed-${triggerProject.id}`"
+              :defs="triggerDefs"
+              v-model="triggerParams"
+            />
             <RunParamsEditor
+              v-else
               :key="triggerProject.id"
               v-model="triggerParams"
               :disabled="triggerSubmitting"

--- a/web/src/views/Runs.vue
+++ b/web/src/views/Runs.vue
@@ -3,6 +3,8 @@ import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { listRuns, triggerManual, type RunListItem, type RunStatus, type RunDetail, type ListRunsParams, type TriggerManualInput } from '../api/runs'
 import RunParamsEditor from '../components/RunParamsEditor.vue'
+import TypedRunParams from '../components/TypedRunParams.vue'
+import { getParameters, validateParamValues, type ParamDef } from '../api/parameters'
 import { listProjects, type Project } from '../api/projects'
 import { HttpError } from '../api/http'
 
@@ -74,6 +76,7 @@ const projects            = ref<Project[]>([])
 const projectsLoading     = ref(false)
 const triggerForm         = ref({ projectId: '', branch: '', commit: '' })
 const triggerParams       = ref<Record<string, string>>({})
+const triggerDefs         = ref<ParamDef[]>([])
 const triggerBranchError  = ref('')
 const triggerProjectError = ref('')
 const triggerBanner       = ref('')
@@ -98,6 +101,7 @@ async function loadProjectsForTrigger(): Promise<void> {
 function openTriggerModal(): void {
   triggerForm.value        = { projectId: '', branch: '', commit: '' }
   triggerParams.value       = {}
+  triggerDefs.value         = []
   triggerBranchError.value  = ''
   triggerProjectError.value = ''
   triggerBanner.value       = ''
@@ -118,6 +122,17 @@ function onProjectSelect(): void {
   if (proj && !triggerForm.value.branch) {
     triggerForm.value.branch = proj.defaultBranch || ''
   }
+  // 切项目 → 重载类型化参数定义(P0);清空已填值。失败静默回退自由 KV。
+  triggerParams.value = {}
+  triggerDefs.value = []
+  const pid = triggerForm.value.projectId
+  if (pid) {
+    void getParameters(pid)
+      .then((defs) => {
+        if (triggerForm.value.projectId === pid) triggerDefs.value = defs
+      })
+      .catch(() => {})
+  }
 }
 
 async function handleTriggerSubmit(): Promise<void> {
@@ -136,6 +151,14 @@ async function handleTriggerSubmit(): Promise<void> {
     ok = false
   }
   if (!ok) return
+
+  if (triggerDefs.value.length) {
+    const verr = validateParamValues(triggerDefs.value, triggerParams.value)
+    if (verr) {
+      triggerBanner.value = verr
+      return
+    }
+  }
 
   triggerSubmitting.value = true
   try {
@@ -604,13 +627,19 @@ function isFailedStatus(status: RunStatus): boolean {
             />
           </div>
 
-          <!-- Parameters (optional · Story 8-11) -->
+          <!-- Parameters · 有类型化定义(P0)→ 类型化控件;无 → 自由 KV(Story 8-11) -->
           <div class="field">
             <label class="field-label">
               参数
-              <span class="field-hint-inline">（可选,注入流水线为环境变量）</span>
+              <span class="field-hint-inline">{{ triggerDefs.length ? '（按定义填写,注入流水线为环境变量）' : '（可选,注入流水线为环境变量）' }}</span>
             </label>
-            <RunParamsEditor v-model="triggerParams" :disabled="triggerSubmitting" />
+            <TypedRunParams
+              v-if="triggerDefs.length"
+              :key="`typed-${triggerForm.projectId}`"
+              :defs="triggerDefs"
+              v-model="triggerParams"
+            />
+            <RunParamsEditor v-else v-model="triggerParams" :disabled="triggerSubmitting" />
           </div>
 
           <!-- Footer -->


### PR DESCRIPTION
## 背景

对标 **Jenkins parameters / 云效 variables type**(benchmark P0「手动触发弹窗最高频痛点」)。此前手动触发只有自由 KV(`map[string]string`),没有类型/默认/必填/枚举。本次补**项目级类型化参数定义** + **类型化触发弹窗**。

> 仅在「触发期」加定义 + 校验层,**执行期仍以 key=value 注入容器,不改执行语义**(Story 8-11)。无定义 → 透传自由 KV(向后兼容,字节级一致)。

## 后端

- 迁移 `0034_project_parameters`(每项目一行 `defs_json`)。
- `run.ParameterService`:`Get/Save/Resolve`。`ParamDef{key,label,type(string|choice|boolean|number),default,options,required}`。
  - `Save` 校验:键合法/唯一、类型枚举、choice 必有 options、默认值符合类型。
  - `Resolve`:据定义校验 + 强转 + 填默认,仅保留已定义键;**无定义 → 透传**。
- `GET/PUT /api/projects/{id}/parameters`;**手动触发 handler 接 `Resolve`**,非法值(必填缺失/枚举越界/类型不符)→ **422 不创建运行**。`main` 装配 `WithParameters`。

## 前端

- `api/parameters.ts`(`getParameters/saveParameters` + 客户端校验 `validateParamValues`)。
- `ParametersPanel.vue` 定义编辑器(嵌 `TriggersPanel`)。
- `TypedRunParams.vue` 类型化触发控件(枚举→下拉、布尔→开关、数字→数字框、文本→输入框,`default` 预填);`Projects.vue` / `Runs.vue` 触发弹窗:**有定义→类型化控件,无→回退 `RunParamsEditor`**。

## 验证

- `run/parameters_test.go`(Save 校验 8 例 + Resolve 必填/枚举/类型/默认/透传)+ `parameters.test.ts`(客户端校验)。
- 全包 **go test 34 包绿** · **vitest 255 绿** · typecheck/lint(0 err)/build 绿。
- **真二进制 + 浏览器 e2e**:定义参数(`env` 枚举 + `token` 必填)→ 保存 → 持久化 → 触发弹窗渲染下拉 + 必填控件 → 空必填阻断(客户端 banner + 后端 422「参数『令牌』为必填」)→ 填值 → 运行创建,`params_json={"env":"staging","token":"abc123"}`(仅已定义键)。**0 console error**。

## 诚实边界

非手动触发(webhook/cron/chain)暂不自动填默认(本期仅手动触发校验 + 填默认)。可作小后续:经注入 resolver 到 `run.Service.Create`(同 #56 EnvResolver 套路)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)