### PR TITLE
feat(buildcache): 构建依赖缓存(跨 run 持久化 · P0 引擎能力)

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/audit"
 	"github.com/huangchengsir/pipewright/internal/auth"
 	"github.com/huangchengsir/pipewright/internal/build"
+	"github.com/huangchengsir/pipewright/internal/buildcache"
 	"github.com/huangchengsir/pipewright/internal/chain"
 	"github.com/huangchengsir/pipewright/internal/config"
 	"github.com/huangchengsir/pipewright/internal/cron"
@@ -257,12 +258,36 @@ func main() {
 		}
 	}
 
+	// 构建依赖缓存(build cache · P0):script 类节点配了 cachePaths 时,执行前恢复依赖目录
+	// (node_modules/.m2/.gradle 等)到工作区、执行后保存回缓存库,按 key(分支 + lockfile hash)
+	// 寻址,跨 run 持久化提速。默认 DB 同级 cache/(PIPEWRIGHT_CACHE_DIR 可改);
+	// PIPEWRIGHT_NO_BUILD_CACHE=1 关。缓存问题绝不让构建失败(恢复失败=冷构建,保存失败=记日志)。
+	var cacheStore *buildcache.Store
+	if os.Getenv("PIPEWRIGHT_NO_BUILD_CACHE") != "1" {
+		cacheDir := strings.TrimSpace(os.Getenv("PIPEWRIGHT_CACHE_DIR"))
+		if cacheDir == "" {
+			cacheDir = filepath.Join(filepath.Dir(cfg.DBPath), "cache")
+		}
+		if cs, cerr := buildcache.New(cacheDir); cerr == nil {
+			cacheStore = cs
+			log.Printf("[buildcache] 构建依赖缓存已启用(配 cachePaths 的脚本节点跨 run 复用依赖):%s", cacheDir)
+		} else {
+			log.Printf("[buildcache] 警告:构建依赖缓存不可用(%v),脚本节点每次冷构建", cerr)
+		}
+	}
+
 	// 把代码缓存(若启用)做成 Builder 选项;未启用 → 无操作选项(保持默认直连克隆器)。
 	clonerOpt := func(*build.Builder) {}
 	var refsLister httpapi.RefsLister
 	if repoCache != nil {
 		clonerOpt = build.WithCloner(repoCache)
 		refsLister = repoCache
+	}
+
+	// 构建依赖缓存(若启用)做成 Builder 选项;未启用 → 无操作(避免 typed-nil 接口陷阱)。
+	buildCacheOpt := func(*build.Builder) {}
+	if cacheStore != nil {
+		buildCacheOpt = build.WithBuildCache(cacheStore)
 	}
 
 	// 部署服务(提前到 dag 装配前构造,供 deploy_ssh 流水线节点注入)。Story 4.6 诊断钩子复用 7-2。
@@ -275,7 +300,7 @@ func main() {
 		var dagOpts []dagrun.Option
 		// 审批门 hook(Story 8-4):Gate 阶段阻塞等待人工批准/拒绝。
 		dagOpts = append(dagOpts, dagrun.WithGate(httpapi.NewApprovalGate(runSvc, approvalCoord, approvalStore)))
-		if b, berr := build.NewBuilder(projectSvc, pipelineSettingsSvc, credVault, build.WithArtifactStore(artStore), build.WithImageGC(os.Getenv("PIPEWRIGHT_NO_IMAGE_GC") != "1"), build.WithCommitRecorder(func(ctx context.Context, runID, commit string) { _ = runSvc.SetCommit(ctx, runID, commit) }), build.WithStageDeployer(deploySvc), build.WithStageNotifier(notifySvc), clonerOpt); berr == nil {
+		if b, berr := build.NewBuilder(projectSvc, pipelineSettingsSvc, credVault, build.WithArtifactStore(artStore), build.WithImageGC(os.Getenv("PIPEWRIGHT_NO_IMAGE_GC") != "1"), build.WithCommitRecorder(func(ctx context.Context, runID, commit string) { _ = runSvc.SetCommit(ctx, runID, commit) }), build.WithStageDeployer(deploySvc), build.WithStageNotifier(notifySvc), clonerOpt, buildCacheOpt); berr == nil {
 			// runSvc 作测试报告持久层注入(Story 8-6 / FR-8-6):script 步骤产报告 → 解析 →
 			// 落库 → 质量门禁裁决(不过则阶段失败,阻断下游部署)。
 			dagOpts = append(dagOpts, dagrun.WithStageExecutor(build.NewStageExecutorWithRunner(b, runSvc, runnerSvc, targetSvc)))

--- a/internal/build/buildcache.go
+++ b/internal/build/buildcache.go
@@ -1,0 +1,98 @@
+package build
+
+import (
+	"context"
+
+	"github.com/huangchengsir/pipewright/internal/buildcache"
+	"github.com/huangchengsir/pipewright/internal/dagrun"
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+)
+
+// buildcache.go 把「构建依赖缓存」(build cache · P0)接进 dag 阶段执行:script 类 job 执行前
+// 据 job.Config 恢复缓存目录到工作区、执行后保存回缓存库。缓存配置键(对齐前端 jobConfigSchema):
+//
+//   - cachePaths:多行,每行一个相对工作区根的目录(node_modules / .m2/repository / .gradle 等)。
+//     仅当配了 cachePaths 才启用缓存(空 → 跳过,零开销)。
+//   - cacheKey  :可选 key 模板;留空用默认推导(分支 + 工作区内 lockfile 们的内容 hash)。
+//     模板里的 {{参数}} 由 templateContext 渲染(与命令/产物路径一致)。
+//
+// 可靠性铁律:缓存问题绝不让构建失败 —— 恢复未命中/失败 = 冷构建;保存失败 = 只记日志。
+
+// jobCacheConfig 是从 job.Config 解析出的缓存配置。enabled=false 时调用方跳过缓存。
+type jobCacheConfig struct {
+	enabled bool
+	paths   []string // 相对工作区根的缓存路径(已 split 去空)
+	key     string   // 已渲染的 key 模板(空 = 用默认推导)
+}
+
+// parseCacheConfig 从 job.Config 解析缓存配置(cachePaths 多行 + 可选 cacheKey 模板,渲染 {{参数}})。
+// 没配 cachePaths → enabled=false(调用方跳过)。
+func parseCacheConfig(jb pipeline.Job) jobCacheConfig {
+	tplCtx := templateContext(jb.Config)
+	paths := splitCommands(renderTemplate(cfgString(jb.Config, "cachePaths"), tplCtx))
+	if len(paths) == 0 {
+		return jobCacheConfig{enabled: false}
+	}
+	return jobCacheConfig{
+		enabled: true,
+		paths:   paths,
+		key:     renderTemplate(cfgString(jb.Config, "cacheKey"), tplCtx),
+	}
+}
+
+// restoreJobCache 恢复 job 的缓存到工作区(best-effort:未命中/失败=冷构建,只记日志)。
+// 缓存库未注入或 job 未配 cachePaths → 无操作。branch 用于默认 key 推导。
+func (b *Builder) restoreJobCache(ctx context.Context, rep dagrun.StageReporter, jb pipeline.Job, branch, workspace string) {
+	if b.buildCache == nil {
+		return
+	}
+	cc := parseCacheConfig(jb)
+	if !cc.enabled {
+		return
+	}
+	key := buildcache.DeriveKey(branch, cc.key, workspace)
+	hit, err := b.buildCache.Restore(ctx, key, cc.paths, workspace)
+	if err != nil {
+		// 仅输入非法才到这(理论上不会);当冷构建处理。
+		_ = rep.Log(ctx, streamStdout, "缓存恢复跳过(配置无效),本次冷构建")
+		return
+	}
+	if hit {
+		_ = rep.Log(ctx, streamStdout, "已恢复构建缓存(暖构建):"+joinPaths(cc.paths))
+	} else {
+		_ = rep.Log(ctx, streamStdout, "未命中构建缓存(冷构建),构建后将保存:"+joinPaths(cc.paths))
+	}
+}
+
+// saveJobCache 把 job 的缓存路径保存回缓存库(best-effort:保存失败只记日志,不阻断构建)。
+// 缓存库未注入或 job 未配 cachePaths → 无操作。
+func (b *Builder) saveJobCache(ctx context.Context, rep dagrun.StageReporter, jb pipeline.Job, branch, workspace string) {
+	if b.buildCache == nil {
+		return
+	}
+	cc := parseCacheConfig(jb)
+	if !cc.enabled {
+		return
+	}
+	key := buildcache.DeriveKey(branch, cc.key, workspace)
+	if err := b.buildCache.Save(ctx, key, cc.paths, workspace); err != nil {
+		_ = rep.Log(ctx, streamStderr, "构建缓存保存失败(不影响本次构建结果):"+err.Error())
+		return
+	}
+	_ = rep.Log(ctx, streamStdout, "已保存构建缓存:"+joinPaths(cc.paths))
+}
+
+// joinPaths 把缓存路径列表拼成一行日志(逗号分隔)。
+func joinPaths(paths []string) string {
+	out := ""
+	for i, p := range paths {
+		if i > 0 {
+			out += ", "
+		}
+		out += p
+	}
+	return out
+}
+
+// 编译期断言:*buildcache.Store 满足 buildCacheStore(注入契约不漂移)。
+var _ buildCacheStore = (*buildcache.Store)(nil)

--- a/internal/build/buildcache_test.go
+++ b/internal/build/buildcache_test.go
@@ -1,0 +1,102 @@
+package build
+
+import (
+	"context"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// fakeCache 记录 Restore/Save 调用(验缓存被接进 dag 执行;不触真实磁盘)。
+type fakeCache struct {
+	restoreKeys []string
+	restorePath [][]string
+	saveKeys    []string
+	savePaths   [][]string
+	hit         bool // Restore 返回的命中标志
+}
+
+func (c *fakeCache) Restore(_ context.Context, key string, paths []string, _ string) (bool, error) {
+	c.restoreKeys = append(c.restoreKeys, key)
+	c.restorePath = append(c.restorePath, paths)
+	return c.hit, nil
+}
+
+func (c *fakeCache) Save(_ context.Context, key string, paths []string, _ string) error {
+	c.saveKeys = append(c.saveKeys, key)
+	c.savePaths = append(c.savePaths, paths)
+	return nil
+}
+
+// 配了 cachePaths 的 script job → 执行前 Restore、成功后 Save,各一次,key 非空且确定。
+func TestStageExecutorRestoresAndSavesCache(t *testing.T) {
+	drv := &recordingDriver{code: 0}
+	cache := &fakeCache{}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	b.buildCache = cache
+	exec := NewStageExecutor(b, nil)
+
+	jb := pipeline.Job{
+		Name: "build", Type: pipeline.StepTypeScript,
+		Config: map[string]any{"image": "node:20", "commands": "npm ci", "cachePaths": "node_modules\n.npm"},
+	}
+	r := &run.Run{ProjectID: "p1", Trigger: run.Trigger{Branch: "main"}}
+	if err := exec(context.Background(), r, scriptStage(jb), &fakeReporter{}); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+
+	if len(cache.restoreKeys) != 1 {
+		t.Fatalf("Restore called %d times, want 1", len(cache.restoreKeys))
+	}
+	if len(cache.saveKeys) != 1 {
+		t.Fatalf("Save called %d times, want 1", len(cache.saveKeys))
+	}
+	if cache.restoreKeys[0] == "" || cache.restoreKeys[0] != cache.saveKeys[0] {
+		t.Errorf("restore/save key mismatch or empty: %q vs %q", cache.restoreKeys[0], cache.saveKeys[0])
+	}
+	if len(cache.savePaths[0]) != 2 || cache.savePaths[0][0] != "node_modules" || cache.savePaths[0][1] != ".npm" {
+		t.Errorf("cache paths = %v, want [node_modules .npm]", cache.savePaths[0])
+	}
+}
+
+// 未配 cachePaths → 不碰缓存(零开销)。
+func TestStageExecutorSkipsCacheWhenUnconfigured(t *testing.T) {
+	drv := &recordingDriver{code: 0}
+	cache := &fakeCache{}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	b.buildCache = cache
+	exec := NewStageExecutor(b, nil)
+
+	if err := exec(context.Background(), &run.Run{ProjectID: "p1"},
+		scriptStage(scriptJob("unit", "busybox", "echo hi")), &fakeReporter{}); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if len(cache.restoreKeys) != 0 || len(cache.saveKeys) != 0 {
+		t.Errorf("cache touched without cachePaths: restore=%v save=%v", cache.restoreKeys, cache.saveKeys)
+	}
+}
+
+// 脚本失败 → 不保存缓存(避免缓存半截/坏依赖)。
+func TestStageExecutorNoSaveOnScriptFailure(t *testing.T) {
+	drv := &recordingDriver{code: 1} // 非零退出 → 步骤失败
+	cache := &fakeCache{}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	b.buildCache = cache
+	exec := NewStageExecutor(b, nil)
+
+	jb := pipeline.Job{
+		Name: "build", Type: pipeline.StepTypeScript,
+		Config: map[string]any{"image": "node:20", "commands": "false", "cachePaths": "node_modules"},
+	}
+	r := &run.Run{ProjectID: "p1", Trigger: run.Trigger{Branch: "main"}}
+	if err := exec(context.Background(), r, scriptStage(jb), &fakeReporter{}); err == nil {
+		t.Fatal("expected build failure")
+	}
+	if len(cache.restoreKeys) != 1 {
+		t.Errorf("Restore should still run before script: %v", cache.restoreKeys)
+	}
+	if len(cache.saveKeys) != 0 {
+		t.Errorf("Save must not run on script failure: %v", cache.saveKeys)
+	}
+}

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -61,6 +61,18 @@ type Builder struct {
 	// nil → 该类节点退化为占位日志(向后兼容;非-dag Builder.Run 路径不用)。
 	deployer deploy.Service
 	notifier notify.Service
+	// buildCache 是构建依赖缓存库(build cache · P0):非 nil 时 script 类 job 执行前后据 job.Config
+	// 的 cachePaths/cacheKey 恢复/保存依赖目录(node_modules/.m2/.gradle 等),跨 run 持久化提速。
+	// nil 则不缓存(向后兼容)。由 main 注入(WithBuildCache)。缓存问题绝不让构建失败(best-effort)。
+	buildCache buildCacheStore
+}
+
+// buildCacheStore 抽象「按 key 恢复/保存工作区缓存路径」的能力(便于 fake 单测注入)。
+// 实现是 *buildcache.Store。Restore 返回 (命中?, err);err 仅在输入非法时非 nil(缓存未命中
+// 不算错误,返回 false,nil)。Save 的 I/O 错误透出供日志,但调用方应忽略(不阻断构建)。
+type buildCacheStore interface {
+	Restore(ctx context.Context, key string, paths []string, workspace string) (bool, error)
+	Save(ctx context.Context, key string, paths []string, workspace string) error
 }
 
 // repoCloner 抽象「把仓库在 ref 上克隆到磁盘工作区」的能力(便于 fake 单测注入,
@@ -119,6 +131,16 @@ func WithStageDeployer(d deploy.Service) BuilderOption {
 // WithStageNotifier 注入通知服务,使 dag 里的 notify 节点真实发通知。
 func WithStageNotifier(n notify.Service) BuilderOption {
 	return func(b *Builder) { b.notifier = n }
+}
+
+// WithBuildCache 注入构建依赖缓存库(build cache · P0):script 类 job 配了 cachePaths 时,
+// 执行前恢复、执行后保存依赖目录到缓存库(跨 run 持久化提速)。nil 不改(不缓存,向后兼容)。
+func WithBuildCache(c buildCacheStore) BuilderOption {
+	return func(b *Builder) {
+		if c != nil {
+			b.buildCache = c
+		}
+	}
 }
 
 // NewBuilder 构造真实 Builder。driver 经 DetectDriver 探测(全无容器 CLI → ErrNoContainerCLI,

--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -171,9 +171,13 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 					return ErrBuildFailed
 				}
 				step.Env = append(runParamsAsEnv(r.Trigger.Params), step.Env...)
+				// 构建依赖缓存(build cache · P0):执行前恢复(暖构建)、成功后保存(best-effort,
+				// 缓存问题绝不让构建失败)。仅当 job 配了 cachePaths 才有动作;未注入缓存库 → 无操作。
+				b.restoreJobCache(ctx, rep, jb, r.Trigger.Branch, workspace)
 				if err := b.runScriptStep(ctx, sink, 0, step, workspace); err != nil {
 					return err // ErrBuildFailed / run.ErrCanceled
 				}
+				b.saveJobCache(ctx, rep, jb, r.Trigger.Branch, workspace)
 			}
 
 			commitTag := "latest"

--- a/internal/buildcache/cache.go
+++ b/internal/buildcache/cache.go
@@ -1,0 +1,280 @@
+// Package buildcache 是「构建依赖缓存」(build cache · P0 引擎能力)。
+//
+// 背景:Pipewright 的构建在隔离容器里跑(dag_stage_exec 每个 script 阶段独立克隆临时工作区 →
+// docker run --rm 挂载工作区跑命令)。临时工作区即用即销,故 node_modules/.m2/.gradle 这类
+// 依赖目录每次构建都要重新拉取,很慢。build cache 把指定缓存目录**跨 run 持久化**:
+// 构建前 Restore 到工作区、构建后 Save 回缓存库,按 key(分支 + lockfile hash)寻址。
+//
+// 设计:**键寻址**(key-addressed)磁盘库 —— 每个缓存 key 经 SHA-256 折成定长 hex,
+// 对应缓存库里一个 tar.gz 归档(<root>/<2 位前缀>/<keyhash>.tgz)。Save 经临时文件 + 原子
+// rename 落盘(key 已存在则覆盖,即最新一次构建的依赖快照胜出)。Restore 把归档解到工作区
+// 对应路径(归档内路径已相对工作区根,解包时严校防穿越)。
+//
+// **可靠性铁律**:缓存问题绝不让构建失败(best-effort)——Restore 失败 = 冷构建(返回 nil,
+// 调用方照常构建);Save 失败 = 只记日志(返回 nil)。所以本包的公有方法对「缓存未命中 /
+// 解包损坏 / 写盘失败」一律不返回致命错误,只在真正的「输入非法 / 内部 bug」时返回 error。
+//
+// 无外部依赖、无 init 副作用;root 由 main 注入(默认 DB 同级 cache/,
+// env PIPEWRIGHT_CACHE_DIR 可改;PIPEWRIGHT_NO_BUILD_CACHE=1 全关 → main 不注入)。
+package buildcache
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// 领域错误。
+var (
+	// ErrEmptyRoot 表示构造时缓存根目录为空。
+	ErrEmptyRoot = errors.New("buildcache: empty root")
+)
+
+// lockfileNames 是参与默认 key 推导的依赖锁文件名(命中工作区里这些文件就把其内容计入 hash)。
+// 锁文件变 → key 变 → 自动冷构建(依赖确实变了,旧缓存不应复用);锁文件不变 → 命中缓存。
+var lockfileNames = []string{
+	"package-lock.json",
+	"yarn.lock",
+	"pnpm-lock.yaml",
+	"npm-shrinkwrap.json",
+	"pom.xml",
+	"build.gradle",
+	"build.gradle.kts",
+	"gradle.lockfile",
+	"go.sum",
+	"Cargo.lock",
+	"composer.lock",
+	"Gemfile.lock",
+	"poetry.lock",
+	"requirements.txt",
+	"Pipfile.lock",
+}
+
+// Store 是键寻址磁盘缓存库。零依赖;Save 经临时文件 + 原子 rename(并发/中断不留半截归档)。
+type Store struct {
+	root string
+}
+
+// New 构造缓存库,root 不存在则创建(0700:缓存内容可能含构建中间产物,限本用户)。
+func New(root string) (*Store, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return nil, ErrEmptyRoot
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return nil, fmt.Errorf("buildcache: mkdir root: %w", err)
+	}
+	return &Store{root: root}, nil
+}
+
+// Restore 把 key 对应缓存归档解到 workspace 下的对应路径(归档内路径已相对工作区根)。
+// 返回 (true, nil) = 命中并恢复成功(暖构建);(false, nil) = 未命中或恢复失败(冷构建,
+// 不致命,调用方照常构建)。仅在 key/workspace 非法时返回 error。
+//
+// paths 仅用于日志/契约对齐(实际恢复哪些路径由归档内容决定,即上次 Save 的那批);
+// 传 nil 也能恢复整份归档。
+func (s *Store) Restore(ctx context.Context, key string, _ []string, workspace string) (bool, error) {
+	if s == nil {
+		return false, nil
+	}
+	if strings.TrimSpace(key) == "" {
+		return false, errors.New("buildcache: empty key")
+	}
+	if strings.TrimSpace(workspace) == "" {
+		return false, errors.New("buildcache: empty workspace")
+	}
+	archive := s.pathFor(key)
+	f, err := os.Open(archive)
+	if err != nil {
+		return false, nil // 未命中 → 冷构建(不致命)
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := extractTarGz(ctx, f, workspace); err != nil {
+		// 归档损坏 / 解包中途失败 → 当作未命中(冷构建);残留的半截解包由后续构建覆盖,best-effort。
+		return false, nil
+	}
+	return true, nil
+}
+
+// Save 把 workspace 下 paths 指定的目录/文件打包成 tar.gz 存进缓存库(key 已存在则覆盖)。
+// paths 为相对工作区根的路径(如 node_modules、.m2/repository);越界(.. / 绝对)路径被跳过。
+// 不存在的路径跳过(首次构建可能还没生成某缓存目录,正常)。
+//
+// 返回 nil = 成功或 best-effort 跳过(无可缓存内容也算成功);仅在 key/workspace 非法时返回 error。
+// 写盘失败由调用方决定如何记日志:本方法把 I/O 错误透出供日志,但调用方应忽略它(不阻断构建)。
+func (s *Store) Save(ctx context.Context, key string, paths []string, workspace string) error {
+	if s == nil {
+		return nil
+	}
+	if strings.TrimSpace(key) == "" {
+		return errors.New("buildcache: empty key")
+	}
+	if strings.TrimSpace(workspace) == "" {
+		return errors.New("buildcache: empty workspace")
+	}
+	clean := cleanRelPaths(paths)
+	if len(clean) == 0 {
+		return nil // 无合法缓存路径 → 无操作(不致命)
+	}
+
+	dest := s.pathFor(key)
+	if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+		return fmt.Errorf("buildcache: mkdir shard: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dest), ".save-*")
+	if err != nil {
+		return fmt.Errorf("buildcache: temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // 成功路径已 rename 走,Remove 无害
+
+	if err := writeTarGz(ctx, tmp, workspace, clean); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("buildcache: write archive: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("buildcache: close temp: %w", err)
+	}
+	// 原子覆盖(rename 覆盖同名,Save 同 key 即最新依赖快照胜出)。
+	if err := os.Rename(tmpName, dest); err != nil {
+		return fmt.Errorf("buildcache: commit: %w", err)
+	}
+	return nil
+}
+
+// Has 报告 key 是否已有缓存归档。
+func (s *Store) Has(key string) bool {
+	if s == nil || strings.TrimSpace(key) == "" {
+		return false
+	}
+	_, err := os.Stat(s.pathFor(key))
+	return err == nil
+}
+
+// pathFor 把缓存 key 折成分片归档路径:<root>/<keyhash 前 2 位>/<keyhash>.tgz。
+// key 经 SHA-256 → 64 位 hex,既杜绝路径穿越(key 任意字符都安全)又分片防单目录文件过多。
+func (s *Store) pathFor(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	h := hex.EncodeToString(sum[:])
+	return filepath.Join(s.root, h[:2], h+".tgz")
+}
+
+// DeriveKey 推导确定性缓存 key:分支 + 工作区内命中的 lockfile 们的内容 hash(+ 可选 user 模板)。
+//
+//   - userKey 非空:把它作为 key 主体(用户自定义模板;调用方应已渲染好占位),仍并入 branch 与
+//     lockfile hash 以保证「同模板不同分支/不同依赖」互不串缓存。
+//   - userKey 空:用默认推导 = branch + 排序去重后的 lockfile (名+内容hash) 拼接再整体 hash。
+//
+// 同输入恒等同输出(确定性);任一 lockfile 内容变 → key 变 → 自动冷构建。
+// 工作区不可读或无 lockfile 时降级为仅 branch(+userKey),仍是确定性的合法 key。
+func DeriveKey(branch, userKey, workspace string) string {
+	var sb strings.Builder
+	sb.WriteString("v1\x00") // 版本前缀:未来缓存格式变更可改版本失效旧缓存
+	sb.WriteString("branch=")
+	sb.WriteString(strings.TrimSpace(branch))
+	sb.WriteString("\x00")
+	if u := strings.TrimSpace(userKey); u != "" {
+		sb.WriteString("user=")
+		sb.WriteString(u)
+		sb.WriteString("\x00")
+	}
+	sb.WriteString("lock=")
+	sb.WriteString(lockfilesDigest(workspace))
+
+	sum := sha256.Sum256([]byte(sb.String()))
+	return hex.EncodeToString(sum[:])
+}
+
+// lockfilesDigest 算工作区内命中的 lockfile 们的确定性摘要(名 + 内容 hash,按名排序去重)。
+// 不递归扫整棵树(贵且不稳定):只看工作区根 + 一层常见子目录(frontend/backend/web/server/app/api)
+// 下的 lockfile,覆盖单体仓库常见前后端分目录布局。无命中 → 返回固定串(仍确定性)。
+func lockfilesDigest(workspace string) string {
+	ws := strings.TrimSpace(workspace)
+	if ws == "" {
+		return "none"
+	}
+	dirs := []string{"."}
+	dirs = append(dirs, "frontend", "backend", "web", "server", "app", "api")
+
+	type entry struct {
+		rel  string
+		hash string
+	}
+	var entries []entry
+	seen := map[string]bool{}
+	for _, d := range dirs {
+		for _, name := range lockfileNames {
+			rel := filepath.Join(d, name)
+			if seen[rel] {
+				continue
+			}
+			full := filepath.Join(ws, rel)
+			h, ok := fileContentHash(full)
+			if !ok {
+				continue
+			}
+			seen[rel] = true
+			entries = append(entries, entry{rel: filepath.ToSlash(rel), hash: h})
+		}
+	}
+	if len(entries) == 0 {
+		return "none"
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].rel < entries[j].rel })
+	var sb strings.Builder
+	for _, e := range entries {
+		sb.WriteString(e.rel)
+		sb.WriteString("=")
+		sb.WriteString(e.hash)
+		sb.WriteString(";")
+	}
+	return sb.String()
+}
+
+// fileContentHash 算文件内容的 sha256 hex(目录/不可读 → false)。
+func fileContentHash(path string) (string, bool) {
+	fi, err := os.Stat(path)
+	if err != nil || fi.IsDir() {
+		return "", false
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", false
+	}
+	return hex.EncodeToString(h.Sum(nil)), true
+}
+
+// cleanRelPaths 归一缓存路径:trim、去空、剔越界(绝对路径 / 含 .. 逃出工作区)、去重保序。
+func cleanRelPaths(paths []string) []string {
+	out := make([]string, 0, len(paths))
+	seen := map[string]bool{}
+	for _, p := range paths {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		clean := filepath.Clean(p)
+		if filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+			continue
+		}
+		if clean == "." || seen[clean] {
+			continue
+		}
+		seen[clean] = true
+		out = append(out, clean)
+	}
+	return out
+}

--- a/internal/buildcache/cache_test.go
+++ b/internal/buildcache/cache_test.go
@@ -1,0 +1,175 @@
+package buildcache
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeTree 在 base 下按 rel→content 建文件(含父目录)。
+func writeTree(t *testing.T, base string, files map[string]string) {
+	t.Helper()
+	for rel, content := range files {
+		full := filepath.Join(base, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+}
+
+func mustNew(t *testing.T) *Store {
+	t.Helper()
+	s, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return s
+}
+
+// Save 后到新工作区 Restore,内容应逐字节一致(round-trip)。
+func TestSaveRestoreRoundTrip(t *testing.T) {
+	s := mustNew(t)
+	ctx := context.Background()
+
+	src := t.TempDir()
+	writeTree(t, src, map[string]string{
+		"node_modules/dep/index.js": "module.exports = 1\n",
+		"node_modules/.bin/tool":    "#!/bin/sh\necho hi\n",
+		"keep/a.txt":                "alpha",
+		"untracked.txt":             "should-not-be-cached",
+	})
+
+	const key = "branch=main|lock=abc"
+	paths := []string{"node_modules", "keep"}
+	if err := s.Save(ctx, key, paths, src); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	dst := t.TempDir()
+	hit, err := s.Restore(ctx, key, paths, dst)
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if !hit {
+		t.Fatal("Restore: expected cache hit")
+	}
+
+	// 缓存的路径应恢复且内容一致。
+	for _, rel := range []string{"node_modules/dep/index.js", "node_modules/.bin/tool", "keep/a.txt"} {
+		got, rerr := os.ReadFile(filepath.Join(dst, rel))
+		if rerr != nil {
+			t.Errorf("restored %s missing: %v", rel, rerr)
+			continue
+		}
+		want, _ := os.ReadFile(filepath.Join(src, rel))
+		if string(got) != string(want) {
+			t.Errorf("%s = %q, want %q", rel, got, want)
+		}
+	}
+	// 未声明缓存的路径不应被恢复。
+	if _, err := os.Stat(filepath.Join(dst, "untracked.txt")); !os.IsNotExist(err) {
+		t.Errorf("untracked.txt should not be restored (err=%v)", err)
+	}
+}
+
+// 缺失 key → 冷恢复:返回 (false, nil),不报错,工作区不被改。
+func TestRestoreMiss(t *testing.T) {
+	s := mustNew(t)
+	dst := t.TempDir()
+	hit, err := s.Restore(context.Background(), "no-such-key", []string{"node_modules"}, dst)
+	if err != nil {
+		t.Fatalf("Restore miss returned error: %v", err)
+	}
+	if hit {
+		t.Fatal("Restore miss should report no hit")
+	}
+}
+
+// 同 key 再次 Save 覆盖:Restore 拿到最新内容。
+func TestSaveOverwrite(t *testing.T) {
+	s := mustNew(t)
+	ctx := context.Background()
+	const key = "k"
+
+	src1 := t.TempDir()
+	writeTree(t, src1, map[string]string{"cache/v.txt": "v1"})
+	if err := s.Save(ctx, key, []string{"cache"}, src1); err != nil {
+		t.Fatalf("Save v1: %v", err)
+	}
+
+	src2 := t.TempDir()
+	writeTree(t, src2, map[string]string{"cache/v.txt": "v2"})
+	if err := s.Save(ctx, key, []string{"cache"}, src2); err != nil {
+		t.Fatalf("Save v2: %v", err)
+	}
+
+	dst := t.TempDir()
+	if _, err := s.Restore(ctx, key, []string{"cache"}, dst); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	got, _ := os.ReadFile(filepath.Join(dst, "cache/v.txt"))
+	if string(got) != "v2" {
+		t.Errorf("after overwrite = %q, want v2", got)
+	}
+}
+
+// 不存在的缓存路径被跳过,不致命;无任何合法路径 → Save 无操作不报错。
+func TestSaveSkipsMissingAndEmpty(t *testing.T) {
+	s := mustNew(t)
+	ctx := context.Background()
+	src := t.TempDir()
+	writeTree(t, src, map[string]string{"node_modules/x": "y"})
+
+	// 一条存在、一条不存在 → 只缓存存在的那条,不报错。
+	if err := s.Save(ctx, "k1", []string{"node_modules", "does-not-exist"}, src); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if !s.Has("k1") {
+		t.Fatal("expected k1 archived")
+	}
+
+	// 全部为越界/空 → 无合法路径 → 无操作(不写归档,不报错)。
+	if err := s.Save(ctx, "k2", []string{"", "..", "/abs", "../escape"}, src); err != nil {
+		t.Fatalf("Save empty: %v", err)
+	}
+	if s.Has("k2") {
+		t.Fatal("k2 should not be archived (no valid paths)")
+	}
+}
+
+// 非法参数(空 key / 空 workspace)→ 返回 error(与 best-effort 的「未命中」区分开)。
+func TestInvalidArgs(t *testing.T) {
+	s := mustNew(t)
+	ctx := context.Background()
+	if _, err := s.Restore(ctx, "", nil, "/tmp"); err == nil {
+		t.Error("Restore empty key should error")
+	}
+	if _, err := s.Restore(ctx, "k", nil, ""); err == nil {
+		t.Error("Restore empty workspace should error")
+	}
+	if err := s.Save(ctx, "", []string{"x"}, "/tmp"); err == nil {
+		t.Error("Save empty key should error")
+	}
+	if err := s.Save(ctx, "k", []string{"x"}, ""); err == nil {
+		t.Error("Save empty workspace should error")
+	}
+}
+
+// nil Store 安全:Restore→(false,nil),Save→nil(main 未注入缓存库时调用方零分支)。
+func TestNilStoreSafe(t *testing.T) {
+	var s *Store
+	hit, err := s.Restore(context.Background(), "k", []string{"x"}, "/tmp")
+	if hit || err != nil {
+		t.Errorf("nil Restore = (%v,%v), want (false,nil)", hit, err)
+	}
+	if err := s.Save(context.Background(), "k", []string{"x"}, "/tmp"); err != nil {
+		t.Errorf("nil Save = %v, want nil", err)
+	}
+	if s.Has("k") {
+		t.Error("nil Has should be false")
+	}
+}

--- a/internal/buildcache/key_test.go
+++ b/internal/buildcache/key_test.go
@@ -1,0 +1,71 @@
+package buildcache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// 同输入恒等同输出(确定性);分支/lockfile/userKey 任一变 → key 变。
+func TestDeriveKeyDeterministic(t *testing.T) {
+	ws := t.TempDir()
+	writeTree(t, ws, map[string]string{"package-lock.json": `{"v":1}`})
+
+	k1 := DeriveKey("main", "", ws)
+	k2 := DeriveKey("main", "", ws)
+	if k1 != k2 {
+		t.Fatalf("non-deterministic: %s != %s", k1, k2)
+	}
+	if len(k1) != 64 {
+		t.Errorf("key not 64-hex: %q", k1)
+	}
+
+	// 分支变 → key 变。
+	if DeriveKey("dev", "", ws) == k1 {
+		t.Error("different branch should yield different key")
+	}
+	// userKey 变 → key 变。
+	if DeriveKey("main", "custom-v2", ws) == k1 {
+		t.Error("different userKey should yield different key")
+	}
+}
+
+// lockfile 内容变 → key 变(依赖确实变了,旧缓存不应复用);不变 → key 稳定。
+func TestDeriveKeyTracksLockfile(t *testing.T) {
+	ws := t.TempDir()
+	lock := filepath.Join(ws, "package-lock.json")
+
+	_ = os.WriteFile(lock, []byte(`{"deps":"a"}`), 0o644)
+	before := DeriveKey("main", "", ws)
+
+	_ = os.WriteFile(lock, []byte(`{"deps":"b"}`), 0o644)
+	after := DeriveKey("main", "", ws)
+
+	if before == after {
+		t.Error("lockfile content change should change key")
+	}
+}
+
+// 子目录 lockfile(单体仓库前后端分目录)也计入 key。
+func TestDeriveKeyScansSubdirs(t *testing.T) {
+	ws := t.TempDir()
+	base := DeriveKey("main", "", ws) // 无 lockfile
+
+	writeTree(t, ws, map[string]string{"frontend/package-lock.json": `{}`})
+	withFront := DeriveKey("main", "", ws)
+	if base == withFront {
+		t.Error("frontend/package-lock.json should affect key")
+	}
+}
+
+// 无 lockfile / 空工作区仍给确定性合法 key(降级为仅分支)。
+func TestDeriveKeyNoLockfile(t *testing.T) {
+	ws := t.TempDir()
+	k := DeriveKey("main", "", ws)
+	if len(k) != 64 {
+		t.Errorf("key not 64-hex: %q", k)
+	}
+	if k != DeriveKey("main", "", ws) {
+		t.Error("no-lockfile key not deterministic")
+	}
+}

--- a/internal/buildcache/tar.go
+++ b/internal/buildcache/tar.go
@@ -1,0 +1,182 @@
+package buildcache
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// tar.go 是缓存归档的 tar.gz 读写,带严格的解包防穿越(Zip Slip 防护)。
+//
+// 写:遍历 workspace 下指定 relPaths(目录递归),把每个文件/目录/符号链接以「相对工作区根」
+// 的路径名写进 tar.gz。读:把归档解到目标工作区,逐条校验解出路径仍落在工作区内(拒 ../、绝对路径)。
+
+// writeTarGz 把 workspace 下 relPaths(已 clean、相对工作区根)打包成 tar.gz 写入 w。
+// 目录递归;符号链接存为 symlink 头(不跟随,避免把链接目标整棵打进来)。relPaths 里不存在的
+// 路径跳过(首次构建某缓存目录可能还没生成)。ctx 取消即中止。
+func writeTarGz(ctx context.Context, w io.Writer, workspace string, relPaths []string) error {
+	gz := gzip.NewWriter(w)
+	tw := tar.NewWriter(gz)
+
+	for _, rel := range relPaths {
+		root := filepath.Join(workspace, rel)
+		if _, err := os.Lstat(root); err != nil {
+			continue // 不存在 → 跳过(best-effort)
+		}
+		walkErr := filepath.Walk(root, func(p string, fi os.FileInfo, err error) error {
+			if err != nil {
+				return nil // 单项不可读 → 跳过,不让整次打包失败
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+			name, rerr := filepath.Rel(workspace, p)
+			if rerr != nil {
+				return nil
+			}
+			name = filepath.ToSlash(name)
+
+			var link string
+			if fi.Mode()&os.ModeSymlink != 0 {
+				if l, lerr := os.Readlink(p); lerr == nil {
+					link = l
+				}
+			}
+			hdr, herr := tar.FileInfoHeader(fi, link)
+			if herr != nil {
+				return nil
+			}
+			hdr.Name = name
+			if fi.IsDir() {
+				hdr.Name += "/"
+			}
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+			if fi.Mode().IsRegular() {
+				f, oerr := os.Open(p)
+				if oerr != nil {
+					return nil // 打开失败 → 头已写,内容空;不致命
+				}
+				_, cerr := io.Copy(tw, f)
+				_ = f.Close()
+				if cerr != nil {
+					return cerr
+				}
+			}
+			return nil
+		})
+		if walkErr != nil {
+			_ = tw.Close()
+			_ = gz.Close()
+			return walkErr
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		_ = gz.Close()
+		return err
+	}
+	return gz.Close()
+}
+
+// extractTarGz 把 r 的 tar.gz 解到 dest 工作区。每条目录条目严校解出路径仍在 dest 内(防穿越)。
+// 符号链接解为 symlink(其 target 不在解包时跟随;仅恢复链接本身,与打包对称)。ctx 取消即中止。
+func extractTarGz(ctx context.Context, r io.Reader, dest string) error {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = gz.Close() }()
+	tr := tar.NewReader(gz)
+
+	destAbs, err := filepath.Abs(dest)
+	if err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		target, terr := safeJoin(destAbs, hdr.Name)
+		if terr != nil {
+			return terr // 穿越 → 整次解包失败(Restore 调用方当未命中处理)
+		}
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, fileMode(hdr.Mode, 0o755)); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			if err := writeFileFromTar(tr, target, fileMode(hdr.Mode, 0o644)); err != nil {
+				return err
+			}
+		case tar.TypeSymlink:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			_ = os.Remove(target) // 覆盖已存在的同名链接
+			// symlink target 不校验(容器内才解引用;此处仅恢复链接本身,与打包对称)。
+			if err := os.Symlink(hdr.Linkname, target); err != nil {
+				return err
+			}
+		default:
+			// 其它类型(块设备/管道等)缓存场景不该出现,跳过。
+		}
+	}
+	return nil
+}
+
+// writeFileFromTar 把 tar 当前条目内容写到 target(覆盖)。
+func writeFileFromTar(tr io.Reader, target string, mode os.FileMode) error {
+	f, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(f, tr); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// safeJoin 把归档内条目名拼到 destAbs 下,并校验结果仍在 destAbs 内(防 ../ / 绝对路径穿越)。
+func safeJoin(destAbs, name string) (string, error) {
+	clean := filepath.Clean("/" + filepath.FromSlash(name)) // 锚到根后 Clean,吞掉前导 ../
+	joined := filepath.Join(destAbs, clean)
+	rel, err := filepath.Rel(destAbs, joined)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("buildcache: archive entry escapes workspace: %q", name)
+	}
+	return joined, nil
+}
+
+// fileMode 把 tar 头里的 mode(int64)转 os.FileMode,非法/为 0 时用 fallback。
+func fileMode(mode int64, fallback os.FileMode) os.FileMode {
+	m := os.FileMode(mode).Perm()
+	if m == 0 {
+		return fallback
+	}
+	return m
+}

--- a/internal/buildcache/tar_test.go
+++ b/internal/buildcache/tar_test.go
@@ -1,0 +1,84 @@
+package buildcache
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// 恶意归档含 ../ 逃逸条目 → extractTarGz 拒绝(防 Zip Slip),且不在工作区外写文件。
+func TestExtractRejectsTraversal(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	body := []byte("pwned")
+	hdr := &tar.Header{Name: "../escape.txt", Mode: 0o644, Size: int64(len(body)), Typeflag: tar.TypeReg}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	_ = tw.Close()
+	_ = gz.Close()
+
+	dest := filepath.Join(t.TempDir(), "ws")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// 防穿越:前导 ../ 被锚到工作区根后中和,绝不写到工作区外(无论解包成功与否)。
+	_ = extractTarGz(context.Background(), bytes.NewReader(buf.Bytes()), dest)
+	if _, serr := os.Stat(filepath.Join(filepath.Dir(dest), "escape.txt")); !os.IsNotExist(serr) {
+		t.Errorf("escape file written outside workspace (err=%v)", serr)
+	}
+	// 条目应落在工作区内(中和为 dest/escape.txt),内容完整。
+	if got, rerr := os.ReadFile(filepath.Join(dest, "escape.txt")); rerr != nil || string(got) != "pwned" {
+		t.Errorf("entry not neutralized into workspace: got=%q err=%v", got, rerr)
+	}
+}
+
+// 显式绝对路径条目(/etc/x)也被锚回工作区内,不写到真实绝对路径。
+func TestExtractNeutralizesAbsolutePath(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	body := []byte("data")
+	_ = tw.WriteHeader(&tar.Header{Name: "/abs/file.txt", Mode: 0o644, Size: int64(len(body)), Typeflag: tar.TypeReg})
+	_, _ = tw.Write(body)
+	_ = tw.Close()
+	_ = gz.Close()
+
+	dest := filepath.Join(t.TempDir(), "ws")
+	_ = os.MkdirAll(dest, 0o755)
+	if err := extractTarGz(context.Background(), bytes.NewReader(buf.Bytes()), dest); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if _, rerr := os.Stat(filepath.Join(dest, "abs", "file.txt")); rerr != nil {
+		t.Errorf("absolute entry not anchored into workspace: %v", rerr)
+	}
+}
+
+// Restore 遇损坏归档 → 当未命中处理(false,nil),不让构建失败。
+func TestRestoreCorruptArchiveTreatedAsMiss(t *testing.T) {
+	s := mustNew(t)
+	const key = "k"
+	// 直接往 key 的归档路径写一段非 gzip 垃圾。
+	dest := s.pathFor(key)
+	if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte("not a gzip"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hit, err := s.Restore(context.Background(), key, []string{"node_modules"}, t.TempDir())
+	if err != nil {
+		t.Fatalf("corrupt archive should not error: %v", err)
+	}
+	if hit {
+		t.Fatal("corrupt archive should be reported as miss")
+	}
+}

--- a/web/src/components/pipeline/jobConfigSchema.test.ts
+++ b/web/src/components/pipeline/jobConfigSchema.test.ts
@@ -130,4 +130,32 @@ describe('jobConfigSchema', () => {
       expect(extras.map(([k]) => k)).toEqual(['a', 'b'])
     })
   })
+
+  describe('build cache fields (build cache · P0)', () => {
+    // 脚本类节点(后端 isScriptJob 路径)都暴露 cachePaths/cacheKey 表单字段。
+    const SCRIPT_CLASS = ['script', 'custom', 'build_frontend', 'build_backend', 'templated']
+
+    it('script-class types expose cachePaths/cacheKey fields', () => {
+      for (const t of SCRIPT_CLASS) {
+        const keys = JOB_TYPE_SPECS[t].fields.map((f) => f.key)
+        expect(keys, `${t} should offer cachePaths`).toContain('cachePaths')
+        expect(keys, `${t} should offer cacheKey`).toContain('cacheKey')
+      }
+    })
+
+    it('owns cache keys (not dropped as raw extras)', () => {
+      for (const t of SCRIPT_CLASS) {
+        const keys = schemaKeys(t)
+        expect(keys.has('cachePaths'), `${t} owns cachePaths`).toBe(true)
+        expect(keys.has('cacheKey'), `${t} owns cacheKey`).toBe(true)
+        const { extras } = splitConfig(t, { cachePaths: 'node_modules', cacheKey: 'k' })
+        expect(extras.length, `${t} keeps cache keys typed, not extras`).toBe(0)
+      }
+    })
+
+    it('non-script types do not gain cache fields', () => {
+      const keys = JOB_TYPE_SPECS.git_source.fields.map((f) => f.key)
+      expect(keys).not.toContain('cachePaths')
+    })
+  })
 })

--- a/web/src/components/pipeline/jobConfigSchema.ts
+++ b/web/src/components/pipeline/jobConfigSchema.ts
@@ -155,6 +155,22 @@ const SCRIPT_FIELDS: JobField[] = [
     placeholder: 'frontend/dist\nbackend/target/app.jar',
     hint: '可选,每行一条。相对工作区根:目录→dist、*.jar→jar、其它文件→archive。一个节点可出多件;填了才归档进制品库并在运行详情可下载/部署。镜像产物请用「构建」节点(build_image),不在这里',
   },
+  {
+    key: 'cachePaths',
+    label: '依赖缓存目录',
+    kind: 'textarea',
+    monospace: true,
+    placeholder: 'node_modules\n.m2/repository',
+    hint: '可选,每行一条,相对工作区根。配了才启用缓存:构建前恢复、构建后保存,跨多次运行复用依赖(免重复拉 node_modules/.m2/.gradle 等)。缓存问题绝不影响构建结果',
+  },
+  {
+    key: 'cacheKey',
+    label: '缓存 Key(可选)',
+    kind: 'text',
+    monospace: true,
+    placeholder: '留空=按分支+lockfile 自动',
+    hint: '可选缓存键模板。留空则自动按「分支 + 工作区内 lockfile(package-lock/pom.xml/go.sum 等)内容」推导:依赖变则自动冷构建。支持 {{参数}}',
+  },
 ]
 
 // SSH 部署节点的字段(deploy_ssh 与 deploy_frontend 模板共用)。
@@ -518,6 +534,22 @@ export const JOB_TYPE_SPECS: Record<string, JobTypeSpec> = {
         monospace: true,
         placeholder: '.',
         hint: '可选,相对克隆工作区根',
+      },
+      {
+        key: 'cachePaths',
+        label: '依赖缓存目录',
+        kind: 'textarea',
+        monospace: true,
+        placeholder: '{{dir}}/node_modules',
+        hint: '可选,每行一条,相对工作区根,支持 {{参数}}。配了才启用缓存:构建前恢复、构建后保存,跨运行复用依赖。缓存问题绝不影响构建结果',
+      },
+      {
+        key: 'cacheKey',
+        label: '缓存 Key(可选)',
+        kind: 'text',
+        monospace: true,
+        placeholder: '留空=按分支+lockfile 自动',
+        hint: '可选缓存键模板,支持 {{参数}}。留空则自动按分支 + lockfile 内容推导(依赖变则自动冷构建)',
       },
     ],
     defaultConfig: {


### PR DESCRIPTION
## 背景

Pipewright 构建在隔离容器里跑(`dag_stage_exec.go`:每个 script 阶段独立克隆临时工作区 → `docker run --rm` 挂载工作区跑命令)。临时工作区即用即销,故 `node_modules`/`.m2`/`.gradle` 这类依赖目录**每次构建都要重新拉取**,很慢。

build cache 把指定缓存目录**跨 run 持久化**:构建前恢复到工作区、构建后保存回缓存库,按 key(分支 + lockfile hash)寻址。

## 改动

**新包 `internal/buildcache`**(键寻址磁盘缓存库,参考 `artifactstore` 风格)
- `Save(ctx, key, paths, ws)`:把工作区指定路径打 tar.gz 存进缓存库(临时文件 + 原子 rename;key 已存在则覆盖 = 最新依赖快照胜出)。
- `Restore(ctx, key, paths, ws)`:把缓存归档解到工作区(命中返回 `true`)。
- `DeriveKey(branch, userKey, ws)`:确定性 key 推导 = 分支 + 工作区内 lockfile(`package-lock.json`/`pom.xml`/`go.sum`/`Cargo.lock` 等,含一层常见子目录)内容 hash;lockfile 变 → key 变 → 自动冷构建。
- **防穿越**:归档内路径锚回工作区根(Zip Slip 防护),绝不写到工作区外。
- **可靠性铁律**:缓存问题绝不让构建失败 —— 恢复未命中/归档损坏 = 冷构建(`false, nil`);保存失败 = 只记日志。仅在输入非法(空 key/空 workspace)时返回 error。

**接进构建执行**(`internal/build`)
- `Builder` 加 `buildCache` 字段 + `WithBuildCache(...)` option(对齐 `WithArtifactStore`,nil-safe)。
- dag script job:执行**前** `Restore`、成功**后** `Save`;脚本失败则不保存(避免缓存半截/坏依赖)。仅当 job 配了 `cachePaths` 才启用,否则零开销。

**装配**(`cmd/pipewright/main.go`)
- 缓存根默认 DB 同级 `cache/`;`PIPEWRIGHT_CACHE_DIR` 覆盖;`PIPEWRIGHT_NO_BUILD_CACHE=1` 关。
- 经 `buildCacheOpt`(条件构造,规避 typed-nil 接口陷阱)注入 dag Builder。

**前端**(`jobConfigSchema.ts`)
- script 类节点(`SCRIPT_FIELDS` 覆盖 script/custom/build_frontend/build_backend + `templated`)加 `cachePaths`(textarea)+ `cacheKey`(text)字段,中文标签/提示。
- 不破坏 2-2 冻结契约:config 仍 `Record<string,string>`,新键纳入各 type 的 schema(不被当 raw extras 丢弃);后端零强 schema。

## 验证(全绿)

后端:
- `gofmt -l`(空)· `go vet ./...`(干净)· `go build ./...`(通过)
- `go test ./...` 全通过;`internal/buildcache` 覆盖 round-trip / 覆盖写 / 缺失 key 冷恢复 / 防穿越 / 损坏归档当未命中 / nil-store 安全 / DeriveKey 确定性 + lockfile 跟踪;`internal/build` 覆盖「配 cachePaths → Restore+Save 各一次、key 一致」「未配 → 不碰缓存」「脚本失败 → 不保存」。

前端(`web/`):
- `npm run typecheck`(0 错)· `npm run lint`(0 error,仅既有 warning)· `npx vitest run`(255 + 新增 cache 字段用例全过)· `npm run build`(通过,已 `git restore web/dist/index.html`)。

## 诚实边界

- 仅接进 **dag runner**(`PIPEWRIGHT_RUNNER=dag`)的 script job 路径(build cache 的实际工作区/script 执行就在那)。非-dag 的 `Builder.Run` 自定义脚本步骤未接缓存(无 job.Config 缓存键的概念,且后续将统一到 dag)。
- key 默认只扫工作区根 + 一层常见子目录(frontend/backend/web/server/app/api)的 lockfile,深层 monorepo 子包需用 `cacheKey` 自定义或后续增强。
- 缓存按 key 覆盖,**无淘汰/容量上限**(磁盘增长由运维侧 GC,与 artifactstore 一致);LRU/TTL 留后续。
- 符号链接按 symlink 头打包/恢复(不跟随),容器内解引用;链接 target 不校验(与打包对称)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)