### PR TITLE
feat(deploy): 交互式分批部署 + 运行时续发/中止(P0)

### DIFF
--- a/internal/build/dag_stage_exec_test.go
+++ b/internal/build/dag_stage_exec_test.go
@@ -357,6 +357,12 @@ func (d *stubStageDeployer) Deploy(context.Context, deploy.DeployInput) ([]deplo
 func (d *stubStageDeployer) RetryFailed(context.Context, deploy.RetryInput) ([]deploy.TargetResult, error) {
 	panic("RetryFailed not expected")
 }
+func (d *stubStageDeployer) ContinueDeploy(context.Context, deploy.ContinueInput) ([]deploy.TargetResult, error) {
+	panic("ContinueDeploy not expected")
+}
+func (d *stubStageDeployer) AbortDeploy(context.Context, deploy.AbortInput) ([]deploy.TargetResult, error) {
+	panic("AbortDeploy not expected")
+}
 func (d *stubStageDeployer) DeployForStage(_ context.Context, _ string, serverIDs []string, cfg map[string]string, strategy string) ([]deploy.TargetResult, error) {
 	d.gotCfg = cfg
 	d.gotStrategy = strategy

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -40,6 +40,8 @@ var (
 	ErrNoFailedTargets = errors.New("deploy: run has no failed targets to retry")
 	// ErrRunNotDeployed 表示该 run 尚未部署过(无 deploy_targets),不可重试。
 	ErrRunNotDeployed = errors.New("deploy: run has not been deployed yet")
+	// ErrNoPendingTargets 表示该 run 当前无 pending 目标(分批部署续发/中止专用:无暂停中的批次)。
+	ErrNoPendingTargets = errors.New("deploy: run has no pending targets")
 )
 
 // truncateLen 是写入 message 的命令输出最大长度(防超大输出撑爆响应 / 内存)。
@@ -109,6 +111,15 @@ type Service interface {
 	// 定位类错误(run 不存在 / 非失败态 / 无失败目标 / 无产物 / 服务器不存在)上抛,供 HTTP 层 422/404。
 	// 执行失败不上抛:重试目标置 failed + 人读 message,整体仍 200。
 	RetryFailed(ctx context.Context, in RetryInput) ([]TargetResult, error)
+
+	// ContinueDeploy 续发交互式分批部署中**暂停**(pending)的其余目标(对齐 POST /runs/{id}/deploy/continue)。
+	// 复用上次产物 + 配置(由请求带回,同 RetryFailed),对 pending 机按 strategy(默认 rolling)续发 →
+	// 逐目标 upsert → 据全量重算 run 终态 → 返回全量最新 targets。无 pending → ErrNoPendingTargets。
+	ContinueDeploy(ctx context.Context, in ContinueInput) ([]TargetResult, error)
+
+	// AbortDeploy 中止交互式分批部署:把 pending(未部署)目标标记为「已中止,保留旧版本」(failed),
+	// **不触碰已部署批次** → 据全量重算 run 终态 → 返回全量最新 targets。无 pending → ErrNoPendingTargets。
+	AbortDeploy(ctx context.Context, in AbortInput) ([]TargetResult, error)
 
 	// DeployForStage 是「流水线 deploy_ssh 节点」用的中途部署:取该 run 已产出的首个可发布产物
 	// (dist/jar/archive)→ 按策略部署到目标机 → 持久化每机结果(填 run-detail targets)。
@@ -239,7 +250,15 @@ func (s *service) Deploy(ctx context.Context, in DeployInput) ([]TargetResult, e
 	// 4) 按**部署策略**执行(Story 8-8 / FR-8-8):rolling(默认,= 4-5 并行扇出)| canary | blue_green。
 	// 每机独立 goroutine + recover,有界信号量(cap 4)防同时打爆 N 台;单机 panic/失败不连累其它机;
 	// 结果按输入顺序独立收集。策略仅改机群编排(分批门控 / 统一切换),不改单机执行语义。
-	results := s.deployWithStrategy(ctx, servers, *artifact, in.Config, in.HealthCheck, NormalizeStrategy(in.Strategy))
+	strategy := NormalizeStrategy(in.Strategy)
+	var results []TargetResult
+	paused := false
+	if strategy == StrategyInteractive {
+		// 交互式分批:发首批 → 首批全过则其余登记 pending 并**暂停**(不置终态),否则中止其余。
+		results, paused = s.deployInteractiveFirstBatch(ctx, servers, *artifact, in.Config, in.HealthCheck)
+	} else {
+		results = s.deployWithStrategy(ctx, servers, *artifact, in.Config, in.HealthCheck, strategy)
+	}
 
 	// 5) 持久化每机结果(填 run-detail targets slot)。
 	dts := make([]run.DeployTarget, 0, len(results))
@@ -258,7 +277,11 @@ func (s *service) Deploy(ctx context.Context, in DeployInput) ([]TargetResult, e
 		return nil, err
 	}
 
-	// 6) 据结果置 run 终态:全成功 → success;有失败 → partial_failed;全失败 → failed。
+	// 6) 暂停态(交互式首批已过、其余 pending)→ 不置终态(run 保持成功,等续发/中止);
+	//    否则据结果置 run 终态:全成功 → success;有失败 → partial_failed;全失败 → failed。
+	if paused {
+		return results, nil
+	}
 	final := overallStatus(results)
 	if err := s.runs.SetDeployTerminal(ctx, in.RunID, final); err != nil {
 		return nil, err

--- a/internal/deploy/interactive.go
+++ b/internal/deploy/interactive.go
@@ -1,0 +1,228 @@
+package deploy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/huangchengsir/pipewright/internal/run"
+	"github.com/huangchengsir/pipewright/internal/target"
+)
+
+// interactive.go 实现「交互式分批部署」(P0 · 对标云效 firstBatchPause)+ 运行时续发/中止。
+//
+// 流程:Deploy(strategy=interactive) 发首批(同金丝雀子集)→ 首批全过则其余登记 pending 并**暂停**
+// (run 不置终态,保持成功);用户在运行详情按「继续部署」(ContinueDeploy 续发其余)或「中止」
+// (AbortDeploy 标记其余为已中止、保留旧版本、不动已部署批次)。首批失败 → 不暂停,直接中止其余
+// (= 金丝雀失败语义,安全:其余机仍跑旧版本)。
+//
+// 复用既有原语:canaryCount(首批量)、deployFanout(单批并行)、deployWithStrategy(续发)、
+// UpsertDeployTargets / overallStatusOfTargets(逐目标更新 + 全量重算终态)。无新表、无迁移。
+
+// ContinueInput 是一次「续发暂停中其余目标」请求(复用上次产物 + 配置,同 RetryInput 由前端带回)。
+type ContinueInput struct {
+	RunID       string
+	ArtifactID  string
+	Config      map[string]string
+	HealthCheck *HealthCheck
+	// Strategy 是续发其余批次的策略(默认 rolling;一般首批已验证,其余直接铺)。
+	Strategy string
+}
+
+// AbortInput 是一次「中止分批部署」请求(只需 RunID;标记 pending 为已中止,不动已部署批次)。
+type AbortInput struct {
+	RunID string
+}
+
+// pendingResult 合成「已登记、等待续发」的 pending 结果(交互式首批通过后,其余机的占位)。
+func pendingResult(srv *target.Server, msg string) TargetResult {
+	now := time.Now().UTC()
+	return TargetResult{
+		ServerID:   srv.ID,
+		ServerName: srv.Name,
+		Status:     run.TargetPending,
+		Message:    msg,
+		StartedAt:  now,
+	}
+}
+
+// deployInteractiveFirstBatch 发首批并决定是否暂停。返回 (按 servers 顺序对齐的结果, paused)。
+//   - 首批全过且有其余 → 其余登记 pending,paused=true(调用方不置终态)。
+//   - 首批未全过 → 中止其余(标 failed 人读),paused=false(调用方据结果置终态)。
+//   - 无其余(单机/全在首批)→ 直接返回首批结果,paused=false。
+func (s *service) deployInteractiveFirstBatch(ctx context.Context, servers []*target.Server, a run.Artifact, cfg map[string]string, hc *HealthCheck) ([]TargetResult, bool) {
+	total := len(servers)
+	if total == 0 {
+		return nil, false
+	}
+	n := canaryCount(cfg, total)
+	results := make([]TargetResult, total)
+
+	firstRes := s.deployFanout(ctx, servers[:n], a, cfg, hc)
+	copy(results[:n], firstRes)
+
+	rest := servers[n:]
+	if len(rest) == 0 {
+		return results, false // 无其余可分批 → 等同一次性部署,正常置终态。
+	}
+
+	if allSuccess(firstRes) {
+		for i, srv := range rest {
+			results[n+i] = pendingResult(srv, fmt.Sprintf("首批 %d 台已部署成功,待确认:点「继续部署」发布其余 %d 台,或「中止」保留旧版本", n, len(rest)))
+		}
+		return results, true // 暂停,等人确认。
+	}
+	// 首批未全过 → 中止其余(安全:其余机仍运行旧版本)。
+	for i, srv := range rest {
+		results[n+i] = abortedResult(srv, fmt.Sprintf("首批 %d 台未全部成功,已中止后续 %d 台(本机未部署,仍运行旧版本)", n, len(rest)))
+	}
+	return results, false
+}
+
+// ContinueDeploy 见接口注释:续发 pending 目标。
+func (s *service) ContinueDeploy(ctx context.Context, in ContinueInput) ([]TargetResult, error) {
+	rn, existing, pendingIDs, artifact, err := s.loadPending(ctx, in.RunID, in.ArtifactID)
+	if err != nil {
+		return nil, err
+	}
+	_ = rn
+
+	// 解析 pending 服务器(任一不存在 → 422,整次拒绝)。
+	servers := make([]*target.Server, 0, len(pendingIDs))
+	for _, sid := range pendingIDs {
+		srv, gerr := s.targets.Get(ctx, sid)
+		if gerr != nil {
+			if errors.Is(gerr, target.ErrNotFound) {
+				return nil, ErrServerNotFound
+			}
+			return nil, gerr
+		}
+		servers = append(servers, srv)
+	}
+
+	// 续发其余批次(默认 rolling;首批已验证,无需再金丝雀)。
+	strategy := NormalizeStrategy(in.Strategy)
+	if strategy == StrategyInteractive {
+		strategy = StrategyRolling // 续发不再二次暂停。
+	}
+	res := s.deployWithStrategy(ctx, servers, *artifact, in.Config, in.HealthCheck, strategy)
+
+	return s.upsertAndRecompute(ctx, in.RunID, res, existing)
+}
+
+// AbortDeploy 见接口注释:把 pending 标记为已中止(failed),不动已部署批次。
+func (s *service) AbortDeploy(ctx context.Context, in AbortInput) ([]TargetResult, error) {
+	existing, err := s.runs.ListDeployTargets(ctx, in.RunID)
+	if err != nil {
+		return nil, err
+	}
+	if len(existing) == 0 {
+		return nil, ErrRunNotDeployed
+	}
+	now := time.Now().UTC()
+	aborted := make([]TargetResult, 0)
+	for i := range existing {
+		if existing[i].Status != run.TargetPending {
+			continue
+		}
+		fin := now
+		aborted = append(aborted, TargetResult{
+			ServerID:   existing[i].ServerID,
+			ServerName: existing[i].ServerName,
+			Status:     run.TargetFailed,
+			Message:    "已中止分批部署:本机未部署,保留旧版本",
+			StartedAt:  existing[i].StartedAt,
+			FinishedAt: &fin,
+		})
+	}
+	if len(aborted) == 0 {
+		return nil, ErrNoPendingTargets
+	}
+	return s.upsertAndRecompute(ctx, in.RunID, aborted, existing)
+}
+
+// loadPending 校验 run + 取 pending 目标集合 + 定位产物(Continue 用)。
+func (s *service) loadPending(ctx context.Context, runID, artifactID string) (*run.Run, []run.DeployTarget, []string, *run.Artifact, error) {
+	rn, err := s.runs.Get(ctx, runID)
+	if err != nil {
+		if errors.Is(err, run.ErrNotFound) {
+			return nil, nil, nil, nil, ErrRunNotFound
+		}
+		return nil, nil, nil, nil, err
+	}
+	existing, err := s.runs.ListDeployTargets(ctx, runID)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	if len(existing) == 0 {
+		return nil, nil, nil, nil, ErrRunNotDeployed
+	}
+	pendingIDs := make([]string, 0)
+	for i := range existing {
+		if existing[i].Status == run.TargetPending {
+			pendingIDs = append(pendingIDs, existing[i].ServerID)
+		}
+	}
+	if len(pendingIDs) == 0 {
+		return nil, nil, nil, nil, ErrNoPendingTargets
+	}
+	arts, err := s.runs.ListArtifacts(ctx, runID)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	var artifact *run.Artifact
+	for i := range arts {
+		if arts[i].ID == artifactID {
+			a := arts[i]
+			artifact = &a
+			break
+		}
+	}
+	if artifact == nil {
+		return nil, nil, nil, nil, ErrArtifactNotFound
+	}
+	return rn, existing, pendingIDs, artifact, nil
+}
+
+// upsertAndRecompute 逐目标 upsert 本批结果 → 据全量最新目标重算 run 终态 → 返回全量 targets。
+// 若重算后仍有失败 → best-effort 触发 AI 诊断(不阻断)。
+func (s *service) upsertAndRecompute(ctx context.Context, runID string, batch []TargetResult, _ []run.DeployTarget) ([]TargetResult, error) {
+	dts := make([]run.DeployTarget, 0, len(batch))
+	for _, r := range batch {
+		dts = append(dts, run.DeployTarget{
+			RunID:      runID,
+			ServerID:   r.ServerID,
+			ServerName: r.ServerName,
+			Status:     r.Status,
+			Message:    r.Message,
+			StartedAt:  r.StartedAt,
+			FinishedAt: r.FinishedAt,
+		})
+	}
+	if err := s.runs.UpsertDeployTargets(ctx, runID, dts); err != nil {
+		return nil, err
+	}
+	all, err := s.runs.ListDeployTargets(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	final := overallStatusOfTargets(all)
+	if err := s.runs.SetDeployTerminal(ctx, runID, final); err != nil {
+		return nil, err
+	}
+	out := make([]TargetResult, 0, len(all))
+	for i := range all {
+		t := all[i]
+		out = append(out, TargetResult{
+			ServerID:   t.ServerID,
+			ServerName: t.ServerName,
+			Status:     t.Status,
+			Message:    t.Message,
+			StartedAt:  t.StartedAt,
+			FinishedAt: t.FinishedAt,
+		})
+	}
+	s.seedDiagnosisOnFailure(ctx, runID, final, out)
+	return out, nil
+}

--- a/internal/deploy/interactive_test.go
+++ b/internal/deploy/interactive_test.go
@@ -1,0 +1,193 @@
+package deploy
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// 交互式分批部署:首批成功 → 其余 pending + 暂停(run 不置失败终态),首批未触达其余机。
+func TestDeployInteractivePausesAfterFirstBatch(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	rec := &touchRecorder{}
+	tgt := &stubTarget{execFn: rec.exec}
+	s1 := seedServer(t, tgt, "web-1")
+	s2 := seedServer(t, tgt, "web-2")
+	s3 := seedServer(t, tgt, "web-3")
+	runID, artID := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactDist, "dist/shop.tar.gz")
+
+	svc := New(tgt, rsvc)
+	res, err := svc.Deploy(context.Background(), DeployInput{
+		RunID: runID, ArtifactID: artID,
+		ServerIDs: []string{s1.ID, s2.ID, s3.ID},
+		Strategy:  "interactive",
+	})
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if res[0].Status != run.TargetSuccess {
+		t.Fatalf("first batch status = %s, want success", res[0].Status)
+	}
+	for i := 1; i < 3; i++ {
+		if res[i].Status != run.TargetPending {
+			t.Fatalf("rest target %d status = %s, want pending", i, res[i].Status)
+		}
+	}
+	// 暂停态:其余机绝不应被执行任何部署命令。
+	if rec.touched[s2.ID] || rec.touched[s3.ID] {
+		t.Fatalf("暂停态其余机不应被部署;touched=%v", rec.touched)
+	}
+	// 暂停态:run 不置失败终态(保持成功,等续发/中止)。
+	rn, _ := rsvc.Get(context.Background(), runID)
+	if rn.Status != run.StatusSuccess {
+		t.Fatalf("暂停态 run 状态 = %s, want success", rn.Status)
+	}
+	// 持久化目标里有 pending。
+	targets, _ := rsvc.ListDeployTargets(context.Background(), runID)
+	pending := 0
+	for _, tg := range targets {
+		if tg.Status == run.TargetPending {
+			pending++
+		}
+	}
+	if pending != 2 {
+		t.Fatalf("want 2 pending targets, got %d", pending)
+	}
+}
+
+// 续发:暂停后 ContinueDeploy → 其余机被部署 → 全成功,run 终态 success。
+func TestContinueDeploy(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	rec := &touchRecorder{}
+	tgt := &stubTarget{execFn: rec.exec}
+	s1 := seedServer(t, tgt, "web-1")
+	s2 := seedServer(t, tgt, "web-2")
+	s3 := seedServer(t, tgt, "web-3")
+	runID, artID := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactDist, "dist/shop.tar.gz")
+	svc := New(tgt, rsvc)
+	if _, err := svc.Deploy(context.Background(), DeployInput{
+		RunID: runID, ArtifactID: artID, ServerIDs: []string{s1.ID, s2.ID, s3.ID}, Strategy: "interactive",
+	}); err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+
+	out, err := svc.ContinueDeploy(context.Background(), ContinueInput{RunID: runID, ArtifactID: artID})
+	if err != nil {
+		t.Fatalf("ContinueDeploy: %v", err)
+	}
+	if len(out) != 3 {
+		t.Fatalf("want 3 targets, got %d", len(out))
+	}
+	for _, r := range out {
+		if r.Status != run.TargetSuccess {
+			t.Fatalf("after continue, target %s status = %s, want success", r.ServerName, r.Status)
+		}
+	}
+	if !rec.touched[s2.ID] || !rec.touched[s3.ID] {
+		t.Fatalf("续发后其余机应被部署;touched=%v", rec.touched)
+	}
+}
+
+// 中止:暂停后 AbortDeploy → 其余机标记已中止(failed)、不触达;首批保留成功。
+func TestAbortDeploy(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	rec := &touchRecorder{}
+	tgt := &stubTarget{execFn: rec.exec}
+	s1 := seedServer(t, tgt, "web-1")
+	s2 := seedServer(t, tgt, "web-2")
+	s3 := seedServer(t, tgt, "web-3")
+	runID, artID := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactDist, "dist/shop.tar.gz")
+	svc := New(tgt, rsvc)
+	if _, err := svc.Deploy(context.Background(), DeployInput{
+		RunID: runID, ArtifactID: artID, ServerIDs: []string{s1.ID, s2.ID, s3.ID}, Strategy: "interactive",
+	}); err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+
+	out, err := svc.AbortDeploy(context.Background(), AbortInput{RunID: runID})
+	if err != nil {
+		t.Fatalf("AbortDeploy: %v", err)
+	}
+	var s1res, restFailed int
+	for _, r := range out {
+		if r.ServerID == s1.ID && r.Status == run.TargetSuccess {
+			s1res++
+		}
+		if (r.ServerID == s2.ID || r.ServerID == s3.ID) && r.Status == run.TargetFailed && strings.Contains(r.Message, "保留旧版本") {
+			restFailed++
+		}
+	}
+	if s1res != 1 {
+		t.Fatalf("首批应保留成功;out=%+v", out)
+	}
+	if restFailed != 2 {
+		t.Fatalf("其余应标记已中止(failed+保留旧版本);out=%+v", out)
+	}
+	// 中止绝不部署其余机。
+	if rec.touched[s2.ID] || rec.touched[s3.ID] {
+		t.Fatalf("中止时其余机不应被部署;touched=%v", rec.touched)
+	}
+}
+
+// 首批失败 → 不暂停,直接中止其余(failed,不触达);run 置失败终态。
+func TestDeployInteractiveFirstBatchFailAborts(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	s1ID := ""
+	rec := &touchRecorder{failOn: func(serverID string, cmd []string) bool {
+		return serverID == s1ID && cmd[0] == "mkdir"
+	}}
+	tgt := &stubTarget{execFn: rec.exec}
+	s1 := seedServer(t, tgt, "web-1")
+	s2 := seedServer(t, tgt, "web-2")
+	s3 := seedServer(t, tgt, "web-3")
+	s1ID = s1.ID
+	runID, artID := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactDist, "dist/shop.tar.gz")
+	svc := New(tgt, rsvc)
+	res, err := svc.Deploy(context.Background(), DeployInput{
+		RunID: runID, ArtifactID: artID, ServerIDs: []string{s1.ID, s2.ID, s3.ID}, Strategy: "interactive",
+	})
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if res[0].Status != run.TargetFailed {
+		t.Fatalf("first batch status = %s, want failed", res[0].Status)
+	}
+	for i := 1; i < 3; i++ {
+		if res[i].Status != run.TargetFailed {
+			t.Fatalf("rest target %d = %s, want failed(aborted), not pending", i, res[i].Status)
+		}
+	}
+	if rec.touched[s2.ID] || rec.touched[s3.ID] {
+		t.Fatalf("首批失败后其余不应被部署;touched=%v", rec.touched)
+	}
+}
+
+// 无 pending 时 Continue/Abort → ErrNoPendingTargets。
+func TestContinueAbortNoPending(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	rec := &touchRecorder{}
+	tgt := &stubTarget{execFn: rec.exec}
+	s1 := seedServer(t, tgt, "web-1")
+	runID, artID := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactDist, "dist/shop.tar.gz")
+	svc := New(tgt, rsvc)
+	// rolling 部署单机 → 无 pending。
+	if _, err := svc.Deploy(context.Background(), DeployInput{
+		RunID: runID, ArtifactID: artID, ServerIDs: []string{s1.ID}, Strategy: "rolling",
+	}); err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if _, err := svc.ContinueDeploy(context.Background(), ContinueInput{RunID: runID, ArtifactID: artID}); !errors.Is(err, ErrNoPendingTargets) {
+		t.Fatalf("ContinueDeploy want ErrNoPendingTargets, got %v", err)
+	}
+	if _, err := svc.AbortDeploy(context.Background(), AbortInput{RunID: runID}); !errors.Is(err, ErrNoPendingTargets) {
+		t.Fatalf("AbortDeploy want ErrNoPendingTargets, got %v", err)
+	}
+}

--- a/internal/deploy/strategy.go
+++ b/internal/deploy/strategy.go
@@ -34,6 +34,10 @@ const (
 	StrategyCanary = "canary"
 	// StrategyBlueGreen 蓝绿:全机先就绪、统一切换、机群级失败回滚(release 类产物)。
 	StrategyBlueGreen = "blue_green"
+	// StrategyInteractive 交互式分批:先发首批(同金丝雀子集)→ **暂停等人确认**,
+	// 不自动铺其余(对标云效 firstBatchPause)。其余机登记为 pending,经 ContinueDeploy 续发
+	// 或 AbortDeploy 中止。首批失败 → 不暂停,直接中止其余(同金丝雀失败语义)。
+	StrategyInteractive = "interactive"
 )
 
 // NormalizeStrategy 归一策略串(大小写 / 连字符容错;空 / 未知 → rolling)。
@@ -43,6 +47,8 @@ func NormalizeStrategy(s string) string {
 		return StrategyCanary
 	case StrategyBlueGreen, "blue-green", "bluegreen", "blue green":
 		return StrategyBlueGreen
+	case StrategyInteractive, "interactive-batch", "batch":
+		return StrategyInteractive
 	default:
 		return StrategyRolling
 	}

--- a/internal/httpapi/deploy.go
+++ b/internal/httpapi/deploy.go
@@ -222,6 +222,82 @@ func makeRetryDeployHandler(svc deploy.Service, runSvc run.Service) http.Handler
 	}
 }
 
+// continueDeployRequest 是 POST /api/runs/{id}/deploy/continue 请求体(交互式分批续发其余 pending)。
+// 同 retry:不持久化原始产物/配置,故前端(已持有上次部署表单)随请求带回 artifactId + 配置。
+type continueDeployRequest struct {
+	ArtifactID   string            `json:"artifactId"`
+	DeployConfig map[string]string `json:"deployConfig"`
+	HealthCheck  *healthCheckDTO   `json:"healthCheck"`
+	Strategy     string            `json:"strategy"`
+}
+
+// makeContinueDeployHandler 返回 POST /api/runs/{id}/deploy/continue handler(认证 + CSRF)。
+// 续发交互式分批部署中暂停(pending)的其余目标。run/产物/服务器定位类错误 → 404/422;
+// 执行失败不 500(目标置 failed,整体 200)。
+func makeContinueDeployHandler(svc deploy.Service, runSvc run.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil || runSvc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "部署服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+		var req continueDeployRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		results, err := svc.ContinueDeploy(r.Context(), deploy.ContinueInput{
+			RunID:       id,
+			ArtifactID:  req.ArtifactID,
+			Config:      req.DeployConfig,
+			HealthCheck: toHealthCheck(req.HealthCheck),
+			Strategy:    req.Strategy,
+		})
+		if err != nil {
+			writeDeployError(w, err)
+			return
+		}
+		targets, lerr := runSvc.ListDeployTargets(r.Context(), id)
+		if lerr != nil {
+			out := make([]targetDTO, 0, len(results))
+			for i := range results {
+				out = append(out, targetResultToDTO(results[i]))
+			}
+			writeJSON(w, http.StatusOK, deployResponse{Targets: out})
+			return
+		}
+		writeJSON(w, http.StatusOK, deployResponse{Targets: toTargetDTOs(targets)})
+	}
+}
+
+// makeAbortDeployHandler 返回 POST /api/runs/{id}/deploy/abort handler(认证 + CSRF)。
+// 中止交互式分批部署:pending 目标标记为已中止(保留旧版本),不触碰已部署批次。
+func makeAbortDeployHandler(svc deploy.Service, runSvc run.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil || runSvc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "部署服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		results, err := svc.AbortDeploy(r.Context(), deploy.AbortInput{RunID: id})
+		if err != nil {
+			writeDeployError(w, err)
+			return
+		}
+		targets, lerr := runSvc.ListDeployTargets(r.Context(), id)
+		if lerr != nil {
+			out := make([]targetDTO, 0, len(results))
+			for i := range results {
+				out = append(out, targetResultToDTO(results[i]))
+			}
+			writeJSON(w, http.StatusOK, deployResponse{Targets: out})
+			return
+		}
+		writeJSON(w, http.StatusOK, deployResponse{Targets: toTargetDTOs(targets)})
+	}
+}
+
 // writeDeployError 把部署定位类错误映射为契约错误码 / 状态码(绝不回显明文 / 私钥 / 口令 / 栈)。
 // 执行类失败由 deploy.Deploy 内化为每机 failed,不走此路径(整体 200)。
 func writeDeployError(w http.ResponseWriter, err error) {
@@ -240,6 +316,8 @@ func writeDeployError(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusUnprocessableEntity, "no_failed_targets", "该运行没有可重试的失败目标")
 	case errors.Is(err, deploy.ErrRunNotDeployed):
 		writeError(w, http.StatusUnprocessableEntity, "run_not_deployed", "该运行尚未部署过,无可重试目标")
+	case errors.Is(err, deploy.ErrNoPendingTargets):
+		writeError(w, http.StatusUnprocessableEntity, "no_pending_targets", "该运行没有暂停待续发的目标")
 	default:
 		writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
 	}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -467,6 +467,10 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		// → 重算 run 终态 → 返回全量最新 targets。run 非失败 / 无失败目标 → 422;不存在 → 404。
 		// 重试执行失败不 500(被重试目标 status=failed)。比 /deploy 多一段,不会被吞。
 		ar.Post("/runs/{id}/deploy/retry", makeRetryDeployHandler(o.deployer, rs))
+		// 交互式分批部署(P0 · 对标云效 firstBatchPause):续发暂停中的其余 pending / 中止保留旧版本。
+		// 认证 + CSRF。比 /deploy 多一段,不会被吞。dep 为 nil → 503。
+		ar.Post("/runs/{id}/deploy/continue", makeContinueDeployHandler(o.deployer, rs))
+		ar.Post("/runs/{id}/deploy/abort", makeAbortDeployHandler(o.deployer, rs))
 
 		// AI 失败诊断(Story 7.2):显式(重)诊断。认证 + CSRF(写方法)。
 		// 取 run 失败日志 → 脱敏 → ai.Diagnose → 持久化 → 返回 diagnosis 子 DTO。

--- a/web/src/api/runs.ts
+++ b/web/src/api/runs.ts
@@ -428,7 +428,9 @@ export interface HealthCheckInput {
 // gate on its health, then the rest (abort the rest if the canary fails).
 // 'blue_green' = stage every target, then cut over all at once; if any cutover
 // fails, roll back the whole fleet (release-mode artifacts: dist/jar).
-export type DeployStrategy = 'rolling' | 'canary' | 'blue_green'
+// 'interactive' = 交互式分批(对标云效 firstBatchPause):先发首批(同金丝雀子集)→ 暂停等人确认,
+// 其余登记 pending,经 continueDeploy 续发或 abortDeploy 中止。首批量经 deployConfig.canaryCount。
+export type DeployStrategy = 'rolling' | 'canary' | 'blue_green' | 'interactive'
 
 export interface DeployRunInput {
   artifactId: string
@@ -474,6 +476,29 @@ export function retryFailedDeploy(
   input: RetryFailedDeployInput,
 ): Promise<DeployRunResponse> {
   return http.post<DeployRunResponse>(`/api/runs/${id}/deploy/retry`, input)
+}
+
+// ─── Interactive batch deploy: continue / abort (P0) ──────────────────────────
+//
+// POST /api/runs/{id}/deploy/continue  body { artifactId, deployConfig?, healthCheck?, strategy? }
+//   续发交互式分批部署中暂停(pending)的其余目标。复用上次产物 + 配置(前端带回)。
+// POST /api/runs/{id}/deploy/abort     (no body)
+//   中止:pending 目标标记为「已中止,保留旧版本」,不触碰已部署批次。
+// 二者均返回该 run 全量最新 targets;404 run_not_found;422 无 pending 目标。
+
+export interface ContinueDeployInput {
+  artifactId: string
+  deployConfig?: Record<string, string>
+  healthCheck?: HealthCheckInput
+  strategy?: DeployStrategy
+}
+
+export function continueDeploy(id: string, input: ContinueDeployInput): Promise<DeployRunResponse> {
+  return http.post<DeployRunResponse>(`/api/runs/${id}/deploy/continue`, input)
+}
+
+export function abortDeploy(id: string): Promise<DeployRunResponse> {
+  return http.post<DeployRunResponse>(`/api/runs/${id}/deploy/abort`, {})
 }
 
 // ─── SSE subscription ────────────────────────────────────────────────────────

--- a/web/src/views/RunDetail.vue
+++ b/web/src/views/RunDetail.vue
@@ -22,6 +22,8 @@ import {
   diagnoseRun,
   deployRun,
   retryFailedDeploy,
+  continueDeploy,
+  abortDeploy,
   listApprovals,
   approveStage,
   rejectStage,
@@ -164,6 +166,7 @@ const deployStrategyOptions: ReadonlyArray<{ value: DeployStrategy; label: strin
   { value: 'rolling', label: '滚动', desc: '全机并行,各自成败' },
   { value: 'canary', label: '金丝雀', desc: '先发小批,通过再铺' },
   { value: 'blue_green', label: '蓝绿', desc: '统一切换,失败全退' },
+  { value: 'interactive', label: '交互式分批', desc: '先发首批,暂停等人确认' },
 ]
 
 // buildDeployConfig 据高级选项收敛 deployConfig;空字段不传(后端取默认)。
@@ -174,8 +177,8 @@ function buildDeployConfig(): Record<string, string> | undefined {
   const keep = clampInt(keepReleases.value, 1, 50, 1)
   // 仅在非默认(1)时下发,避免无谓字段。
   if (keep !== 1) cfg.keepReleases = String(keep)
-  // 金丝雀批量:仅 canary 策略且 >1 时下发(默认 1 台)。
-  if (deployStrategy.value === 'canary') {
+  // 首批量:canary / interactive 策略且 >1 时下发(默认 1 台)。
+  if (deployStrategy.value === 'canary' || deployStrategy.value === 'interactive') {
     const n = clampInt(canaryCount.value, 1, 100, 1)
     if (n > 1) cfg.canaryCount = String(n)
   }
@@ -319,6 +322,53 @@ async function handleRetryFailed(): Promise<void> {
     }
   } finally {
     retrying.value = false
+  }
+}
+
+// ─── 交互式分批部署:续发 / 中止(P0)─────────────────────────────────────────
+const batchBusy = ref(false)
+const batchError = ref('')
+
+// 是否有暂停待确认的批次(pending 目标存在)。
+const hasPendingTargets = computed(() =>
+  (run.value?.targets ?? []).some((t) => t.status === 'pending'),
+)
+const pendingCount = computed(() => (run.value?.targets ?? []).filter((t) => t.status === 'pending').length)
+
+async function handleContinueDeploy(): Promise<void> {
+  if (!run.value || batchBusy.value) return
+  const artifactId = selectedArtifactId.value || run.value.artifacts[0]?.id || ''
+  if (!artifactId) {
+    batchError.value = '无可用产物,无法续发'
+    return
+  }
+  batchBusy.value = true
+  batchError.value = ''
+  try {
+    const res = await continueDeploy(run.value.id, {
+      artifactId,
+      deployConfig: buildDeployConfig(),
+      healthCheck: buildHealthCheck(),
+    })
+    run.value = { ...run.value, targets: res.targets, status: deriveStatus(res.targets) }
+  } catch (err) {
+    batchError.value = err instanceof HttpError ? (err.apiError?.message ?? `续发失败(${err.status})`) : '续发请求失败,请稍后重试'
+  } finally {
+    batchBusy.value = false
+  }
+}
+
+async function handleAbortDeploy(): Promise<void> {
+  if (!run.value || batchBusy.value) return
+  batchBusy.value = true
+  batchError.value = ''
+  try {
+    const res = await abortDeploy(run.value.id)
+    run.value = { ...run.value, targets: res.targets, status: deriveStatus(res.targets) }
+  } catch (err) {
+    batchError.value = err instanceof HttpError ? (err.apiError?.message ?? `中止失败(${err.status})`) : '中止请求失败,请稍后重试'
+  } finally {
+    batchBusy.value = false
   }
 }
 
@@ -758,6 +808,25 @@ function nodeClass(status: StepStatus): string {
               :retry-error="retryError"
               @retry="handleRetryFailed"
             />
+
+            <!-- 交互式分批部署:暂停态(有 pending 目标)→ 继续 / 中止(P0)-->
+            <div v-if="hasPendingTargets" class="batch-pause" role="status">
+              <div class="batch-pause-head">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                  <rect x="6" y="5" width="4" height="14" rx="1" /><rect x="14" y="5" width="4" height="14" rx="1" />
+                </svg>
+                <span>分批部署已暂停:首批已发布,其余 <strong>{{ pendingCount }}</strong> 台待确认</span>
+              </div>
+              <p v-if="batchError" class="batch-pause-err" role="alert">{{ batchError }}</p>
+              <div class="batch-pause-actions">
+                <button class="batch-btn batch-btn--go" :disabled="batchBusy" @click="handleContinueDeploy">
+                  {{ batchBusy ? '处理中…' : '继续部署其余' }}
+                </button>
+                <button class="batch-btn batch-btn--abort" :disabled="batchBusy" @click="handleAbortDeploy">
+                  中止(保留旧版本)
+                </button>
+              </div>
+            </div>
 
             <!-- 部署入口:仅在有产物时可用 -->
             <div v-if="run.artifacts.length > 0" class="deploy-entry">
@@ -2278,4 +2347,37 @@ function nodeClass(status: StepStatus): string {
 .strat-opt-desc { font-size: 0.68rem; color: var(--color-faint); line-height: 1.35; }
 .strat-canary { margin-top: 10px; }
 .strat-canary-hint { margin-left: 8px; }
+
+/* ─── 交互式分批部署:暂停态 banner(P0)─────────────────────────────────── */
+.batch-pause {
+  margin-top: 12px;
+  border: 1px solid var(--color-amber, #b8860b);
+  background: var(--color-amber-soft, #fbf3df);
+  border-radius: var(--rounded-lg, 12px);
+  padding: 13px 15px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.batch-pause-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: var(--color-text);
+}
+.batch-pause-head svg { color: var(--color-amber, #b8860b); flex: none; }
+.batch-pause-head strong { color: var(--color-amber, #b8860b); }
+.batch-pause-err { margin: 0; font-size: 0.78rem; color: var(--color-danger, #dc2626); }
+.batch-pause-actions { display: flex; gap: 9px; }
+.batch-btn {
+  height: 32px; padding: 0 14px; border-radius: var(--rounded-md);
+  font: inherit; font-size: 0.8rem; font-weight: 600; cursor: pointer;
+  border: 1px solid var(--color-border-strong); background: var(--color-card); color: var(--color-text);
+  transition: background-color var(--duration-fast), transform var(--duration-fast);
+}
+.batch-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.batch-btn--go { background: var(--color-primary); border-color: var(--color-primary); color: #fff; }
+.batch-btn--go:hover:not(:disabled) { background: var(--color-primary-press, var(--color-primary)); transform: translateY(-1px); }
+.batch-btn--abort:hover:not(:disabled) { border-color: var(--color-danger, #dc2626); color: var(--color-danger, #dc2626); }
 </style>


### PR DESCRIPTION
## 背景

对标**云效 firstBatchPause**(benchmark P0,差异化最高 —— 安全可控部署是 Pipewright 替 Kamal/Portainer 的核心价值)。`strategy=interactive`:先发首批(同金丝雀子集)→ 首批全过则其余登记 `pending` 并**暂停**(run 不置终态,保持成功)→ 用户在运行详情按「继续部署其余」(续发)或「中止」(保留旧版本,不动已部署批次)。首批失败 → 不暂停,直接中止其余(= 金丝雀失败语义,安全:其余机仍跑旧版本)。

这也覆盖**运行时重跑/跳过**:重跑 = 既有 `RetryFailed`(失败目标),跳过 = `AbortDeploy`(中止其余 pending)。

> 仅在机群编排层叠加暂停/续发,**不改单机执行语义;无新表、无迁移**(复用 `deploy_targets` 的 `pending` 状态 + `UpsertDeployTargets`/`overallStatusOfTargets`)。

## 后端
- `strategy.go`:`StrategyInteractive` + `NormalizeStrategy`。
- `deploy.go` `Deploy`:interactive 分支走 `deployInteractiveFirstBatch`,**暂停态不置终态**。
- `interactive.go`:`deployInteractiveFirstBatch` + `ContinueDeploy`(续发 pending,产物/配置由前端带回同 RetryFailed)+ `AbortDeploy`(pending→failed「保留旧版本」)+ `upsertAndRecompute`;`ErrNoPendingTargets`。
- `httpapi`:`POST /runs/{id}/deploy/{continue,abort}` + 路由 + 错误映射。

## 前端
- `runs.ts`:`DeployStrategy` 加 `'interactive'`;`continueDeploy`/`abortDeploy`。
- `RunDetail.vue`:策略选项加「交互式分批」(首批量复用 canaryCount);**暂停态 banner + 「继续部署其余」/「中止(保留旧版本)」**按钮。

## 验证
- `interactive_test.go` 5 例(暂停后其余 pending + 不触达 + run 保持成功 / 续发全部署 / 中止 failed+保留旧版本+不触达 / 首批失败直接中止不暂停 / 无 pending→`ErrNoPendingTargets`)。
- **go test 34 包 + vitest 255 + typecheck/lint(0 err)/build 全绿**;真二进制 boot 新路由无 panic。

## 诚实边界
① 续发/中止是 deploy-target 粒度的运行时重跑/跳过;DAG 阶段级 mid-run 重跑/跳过是另一引擎关注点,留后续。② 真 docker-in-docker 分批部署 e2e 仍无(harness 限制),单测 + 既有金丝雀 CentOS e2e 设施覆盖编排;真多机分批 e2e 待。

🤖 Generated with [Claude Code](https://claude.com/claude-code)