### PR TITLE
feat: 任务级 timeout/retry/资源规格 + 路径过滤触发(monorepo)(P0 引擎能力)

### DIFF
--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -385,7 +385,7 @@ func (b *Builder) build(ctx context.Context, sink run.StepSink, ordinal int, pro
 		}
 		env := append(buildArgs, secretArgs...) // 工具链构建经 -e 注入(secret 回显只列 key)
 		buildCmd := toolchainBuildCmd(cfg.ArtifactType)
-		code, err := b.driver.RunToolchain(ctx, image, workspace, "/src", env, buildCmd, onLine)
+		code, err := b.driver.RunToolchain(ctx, image, workspace, "/src", env, buildCmd, pipeline.Resource{}, onLine)
 		if err != nil && code < 0 {
 			return "", nil, fmt.Errorf("构建器无法启动")
 		}

--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/huangchengsir/pipewright/internal/dagrun"
@@ -171,7 +172,8 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 					return ErrBuildFailed
 				}
 				step.Env = append(runParamsAsEnv(r.Trigger.Params), step.Env...)
-				if err := b.runScriptStep(ctx, sink, 0, step, workspace); err != nil {
+				// 任务级 timeout/retry(P0):零值时 runScriptStepWithOpts 退化为单次无超时执行(旧行为)。
+				if err := b.runScriptStepWithOpts(ctx, sink, 0, step, workspace); err != nil {
 					return err // ErrBuildFailed / run.ErrCanceled
 				}
 			}
@@ -486,7 +488,37 @@ func scriptStepFromJob(jb pipeline.Job) (pipeline.PipelineStep, error) {
 		Image:    image,
 		Commands: cmds,
 		WorkDir:  renderTemplate(cfgString(jb.Config, "workDir"), ctx),
+		// 任务级 timeout/retry/资源规格(P0 引擎能力):从 job.Config 自由 KV 读取(非负;非法/缺失→零值=旧行为)。
+		TimeoutSeconds: cfgNonNegInt(jb.Config, "timeoutSeconds"),
+		Retries:        cfgNonNegInt(jb.Config, "retries"),
+		Resource: pipeline.Resource{
+			CPU:    cfgString(jb.Config, "cpu"),
+			Memory: cfgString(jb.Config, "memory"),
+		},
 	}, nil
+}
+
+// cfgNonNegInt 从自由 KV config 取非负整数(支持 JSON number 与字符串两种存法;
+// 缺失/非法/负数 → 0,即「不限/不重试」的旧行为,向后兼容)。
+func cfgNonNegInt(cfg map[string]any, key string) int {
+	if cfg == nil {
+		return 0
+	}
+	switch v := cfg[key].(type) {
+	case float64: // encoding/json 把数字反序列化为 float64
+		if v > 0 {
+			return int(v)
+		}
+	case int:
+		if v > 0 {
+			return v
+		}
+	case string:
+		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 0
 }
 
 // runParamsAsEnv 把运行参数(明文 K=V)转为非 secret BuildVar(注入容器环境)。键序确定性不保证(map),

--- a/internal/build/dag_stage_exec_test.go
+++ b/internal/build/dag_stage_exec_test.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -39,16 +40,18 @@ type recordingDriver struct {
 	gotCmd    []string
 	gotWork   string
 	gotEnv    []string
+	gotRes    pipeline.Resource
 	callCount int
 }
 
 func (d *recordingDriver) Binary() string { return "fake" }
-func (d *recordingDriver) RunToolchain(_ context.Context, image, _, workdir string, env []string, cmd []string, onLine func(stream, line string)) (int, error) {
+func (d *recordingDriver) RunToolchain(_ context.Context, image, _, workdir string, env []string, cmd []string, res pipeline.Resource, onLine func(stream, line string)) (int, error) {
 	d.callCount++
 	d.gotImage = image
 	d.gotCmd = cmd
 	d.gotWork = workdir
 	d.gotEnv = env
+	d.gotRes = res
 	for _, l := range d.emit {
 		onLine("stdout", l)
 	}
@@ -174,6 +177,116 @@ func TestStageExecutorInjectsRunParams(t *testing.T) {
 	}
 }
 
+// scriptJobWithConfig 构造一条带额外 config 键的 script job(timeout/retry/cpu/memory 等)。
+func scriptJobWithConfig(name, image, commands string, extra map[string]any) pipeline.Job {
+	cfg := map[string]any{"image": image, "commands": commands}
+	for k, v := range extra {
+		cfg[k] = v
+	}
+	return pipeline.Job{Name: name, Type: pipeline.StepTypeScript, Config: cfg}
+}
+
+// TestStageExecutorPassesResourceToDriver:job.Config 的 cpu/memory 应透传进 RunToolchain。
+func TestStageExecutorPassesResourceToDriver(t *testing.T) {
+	drv := &recordingDriver{code: 0}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b, nil)
+	job := scriptJobWithConfig("unit", "busybox", "echo hi", map[string]any{"cpu": "1.5", "memory": "512m"})
+	if err := exec(context.Background(), &run.Run{ProjectID: "p1"}, scriptStage(job), &fakeReporter{}); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if drv.gotRes.CPU != "1.5" || drv.gotRes.Memory != "512m" {
+		t.Errorf("resource not passed to driver: %+v", drv.gotRes)
+	}
+}
+
+// flakyDriver 在前 failUntil 次返回非零退出,其后返回 0;记录被调次数。可注入每次调用的阻塞时长(供超时测试)。
+type flakyDriver struct {
+	failUntil int // 前 failUntil 次返回非零(模拟失败)
+	calls     int
+	block     time.Duration // 每次调用阻塞时长(>0 时配合超时 ctx 测试)
+}
+
+func (d *flakyDriver) Binary() string { return "fake" }
+func (d *flakyDriver) RunToolchain(ctx context.Context, _, _, _ string, _ []string, _ []string, _ pipeline.Resource, _ func(string, string)) (int, error) {
+	d.calls++
+	if d.block > 0 {
+		select {
+		case <-time.After(d.block):
+		case <-ctx.Done():
+			return -1, ctx.Err() // 被(超时)取消:无法完成,exitCode<0
+		}
+	}
+	if d.calls <= d.failUntil {
+		return 1, nil // 非零退出 → ErrBuildFailed
+	}
+	return 0, nil
+}
+func (d *flakyDriver) Build(context.Context, string, string, string, []string, []string, func(string, string)) (int, error) {
+	panic("Build not expected")
+}
+func (d *flakyDriver) Tag(context.Context, string, string, func(string, string)) (int, error) {
+	panic("Tag not expected")
+}
+func (d *flakyDriver) Login(context.Context, string, string, string, func(string, string)) (int, error) {
+	panic("Login not expected")
+}
+func (d *flakyDriver) Push(context.Context, string, func(string, string)) (int, error) {
+	panic("Push not expected")
+}
+func (d *flakyDriver) InspectImage(context.Context, string) (string, int64, error) {
+	panic("InspectImage not expected")
+}
+
+// TestStageExecutorRetriesToSuccess:retries=2、前 2 次失败 → 第 3 次成功,共 3 次尝试,阶段成功。
+func TestStageExecutorRetriesToSuccess(t *testing.T) {
+	drv := &flakyDriver{failUntil: 2}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b, nil)
+	job := scriptJobWithConfig("unit", "busybox", "flaky", map[string]any{"retries": 2})
+	if err := exec(context.Background(), &run.Run{ProjectID: "p1"}, scriptStage(job), &fakeReporter{}); err != nil {
+		t.Fatalf("exec should succeed after retries: %v", err)
+	}
+	if drv.calls != 3 {
+		t.Errorf("attempts = %d, want 3 (1 + 2 retries)", drv.calls)
+	}
+}
+
+// TestStageExecutorRetriesExhausted:retries=1、始终失败 → 共 2 次尝试后判失败(ErrBuildFailed)。
+func TestStageExecutorRetriesExhausted(t *testing.T) {
+	drv := &flakyDriver{failUntil: 99}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b, nil)
+	job := scriptJobWithConfig("unit", "busybox", "always-fail", map[string]any{"retries": 1})
+	err := exec(context.Background(), &run.Run{ProjectID: "p1"}, scriptStage(job), &fakeReporter{})
+	if !errors.Is(err, ErrBuildFailed) {
+		t.Fatalf("err = %v, want ErrBuildFailed", err)
+	}
+	if drv.calls != 2 {
+		t.Errorf("attempts = %d, want 2 (1 + 1 retry)", drv.calls)
+	}
+}
+
+// TestStageExecutorTimeoutTriggersFailure:timeoutSeconds=1、容器阻塞 10s → 超时取消、判失败(非取消整次运行)。
+func TestStageExecutorTimeoutTriggersFailure(t *testing.T) {
+	drv := &flakyDriver{block: 10 * time.Second}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b, nil)
+	rep := &fakeReporter{}
+	job := scriptJobWithConfig("unit", "busybox", "sleep 10", map[string]any{"timeoutSeconds": 1})
+	start := time.Now()
+	err := exec(context.Background(), &run.Run{ProjectID: "p1"}, scriptStage(job), rep)
+	if !errors.Is(err, ErrBuildFailed) {
+		t.Fatalf("timeout should yield ErrBuildFailed (not run-canceled), got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("timeout did not kick in promptly: %v", elapsed)
+	}
+	if !strings.Contains(strings.Join(rep.logs, "\n"), "超时") {
+		t.Errorf("expected honest timeout log, got %v", rep.logs)
+	}
+}
+
 func TestStageExecutorNonScriptPlaceholder(t *testing.T) {
 	drv := &recordingDriver{}
 	b := newDAGTestBuilder(drv, &markerCloner{})
@@ -201,7 +314,7 @@ type imgDriver struct {
 }
 
 func (d *imgDriver) Binary() string { return "fake" }
-func (d *imgDriver) RunToolchain(context.Context, string, string, string, []string, []string, func(string, string)) (int, error) {
+func (d *imgDriver) RunToolchain(context.Context, string, string, string, []string, []string, pipeline.Resource, func(string, string)) (int, error) {
 	return 0, nil
 }
 func (d *imgDriver) Build(_ context.Context, _, dockerfile, _ string, _, _ []string, _ func(string, string)) (int, error) {

--- a/internal/build/driver.go
+++ b/internal/build/driver.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"os/exec"
 	"strings"
+
+	"github.com/huangchengsir/pipewright/internal/pipeline"
 )
 
 // 领域错误。错误体绝不含明文凭据/master key。
@@ -132,7 +134,8 @@ type Driver interface {
 	Build(ctx context.Context, contextDir, dockerfile, localTag string, buildArgs, secretArgs []string, onLine func(stream, line string)) (int, error)
 	// RunToolchain 模型 B:用工具链镜像挂载工作区跑构建命令产 jar/dist。
 	// image=工具链镜像:版本;workdir=容器内挂载点;hostDir=宿主工作区;cmd=构建命令 array。
-	RunToolchain(ctx context.Context, image, hostDir, workdir string, env []string, cmd []string, onLine func(stream, line string)) (int, error)
+	// res 为可选容器资源规格(cpu/memory → docker run --cpus/--memory);零值=不限(向后兼容)。
+	RunToolchain(ctx context.Context, image, hostDir, workdir string, env []string, cmd []string, res pipeline.Resource, onLine func(stream, line string)) (int, error)
 	// Tag 给 localTag 打远端 remoteTag(推送前)。
 	Tag(ctx context.Context, localTag, remoteTag string, onLine func(stream, line string)) (int, error)
 	// Login 经 --password-stdin 登录仓库(password 经 stdin,**绝不**进 argv/日志)。

--- a/internal/build/remote_stage_exec.go
+++ b/internal/build/remote_stage_exec.go
@@ -148,7 +148,9 @@ func (b *Builder) runScriptOnDriver(ctx context.Context, driver Driver, onLine f
 	script := "set -e\n" + strings.Join(step.Commands, "\n")
 	cmd := []string{"sh", "-c", script}
 
-	code, err := driver.RunToolchain(ctx, step.Image, remoteWS, workdir, env, cmd, onLine)
+	// 资源规格透传给远程 docker run(--cpus/--memory);远程 docker 不支持时由其自身报错(诚实边界)。
+	// 远程模式本期不套 timeout/retry(留后续增量)。
+	code, err := driver.RunToolchain(ctx, step.Image, remoteWS, workdir, env, cmd, step.Resource, onLine)
 	if err != nil && code < 0 {
 		if errors.Is(ctx.Err(), context.Canceled) {
 			return run.ErrCanceled

--- a/internal/build/remote_test.go
+++ b/internal/build/remote_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/huangchengsir/pipewright/internal/pipeline"
 	"github.com/huangchengsir/pipewright/internal/target"
 )
 
@@ -122,13 +123,17 @@ func TestNewRemoteDriverUsesRemoteCommander(t *testing.T) {
 	if drv.Binary() != "docker" {
 		t.Fatalf("默认 Binary = %q, want docker", drv.Binary())
 	}
-	// 触发一次 RunToolchain:应经远程机执行 `docker run ...`(命令打到 srv-1)。
-	_, err := drv.RunToolchain(context.Background(), "node:20", "/ws", "/src", nil, []string{"sh", "-c", "npm ci"}, func(string, string) {})
+	// 触发一次 RunToolchain:应经远程机执行 `docker run ...`(命令打到 srv-1);
+	// 资源规格(cpu/memory)应透传为 --cpus/--memory 投到远程 docker。
+	_, err := drv.RunToolchain(context.Background(), "node:20", "/ws", "/src", nil, []string{"sh", "-c", "npm ci"}, pipeline.Resource{CPU: "2", Memory: "1g"}, func(string, string) {})
 	if err != nil {
 		t.Fatalf("RunToolchain err: %v", err)
 	}
 	if f.gotServerID != "srv-1" || len(f.gotCmds) == 0 || f.gotCmds[0][0] != "docker" {
 		t.Fatalf("远程工具链命令未经 srv-1/docker 投递:server=%q cmds=%v", f.gotServerID, f.gotCmds)
+	}
+	if !cmdContainsPair(f.gotCmds[0], "--cpus", "2") || !cmdContainsPair(f.gotCmds[0], "--memory", "1g") {
+		t.Fatalf("远程 docker run 未透传资源规格:%v", f.gotCmds[0])
 	}
 
 	// podman:Binary 与命令前缀应随之变化。
@@ -136,4 +141,14 @@ func TestNewRemoteDriverUsesRemoteCommander(t *testing.T) {
 	if drv2.Binary() != "podman" {
 		t.Fatalf("Binary = %q, want podman", drv2.Binary())
 	}
+}
+
+// cmdContainsPair 判断 args 中存在相邻的 (flag, value) 对。
+func cmdContainsPair(args []string, flag, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/build/script_steps.go
+++ b/internal/build/script_steps.go
@@ -3,7 +3,9 @@ package build
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
+	"time"
 
 	"github.com/huangchengsir/pipewright/internal/pipeline"
 	"github.com/huangchengsir/pipewright/internal/run"
@@ -68,7 +70,7 @@ func (b *Builder) runScriptStep(ctx context.Context, sink run.StepSink, ordinal 
 	script := "set -e\n" + strings.Join(step.Commands, "\n")
 	cmd := []string{"sh", "-c", script}
 
-	code, err := b.driver.RunToolchain(ctx, step.Image, workspace, workdir, env, cmd, onLine)
+	code, err := b.driver.RunToolchain(ctx, step.Image, workspace, workdir, env, cmd, step.Resource, onLine)
 	if err != nil && code < 0 {
 		// 容器无法启动(镜像拉取失败/CLI 不可用等);ctx 取消时 code<0 但 ctx.Err 命中,由调用方归一。
 		if errors.Is(ctx.Err(), context.Canceled) {
@@ -83,6 +85,61 @@ func (b *Builder) runScriptStep(ctx context.Context, sink run.StepSink, ordinal 
 		return ErrBuildFailed
 	}
 	return nil
+}
+
+// runScriptStepWithOpts 在 runScriptStep 之上叠加「任务级超时 + 失败重试」(P0 引擎能力)。
+//
+// 超时(step.TimeoutSeconds>0):用 context.WithTimeout 套住每次尝试;超时即取消子 ctx → kill 容器,
+// 该步判失败(ErrBuildFailed)。注意:用 context.Cause 区分「本步超时」与「上层取消(用户取消/上层超时)」——
+//   - 上层 ctx 已取消(parent.Err()!=nil)→ run.ErrCanceled,不重试(尊重取消语义)。
+//   - 仅本步超时(子 ctx 超时但 parent 未取消)→ 记一行诚实日志,按 ErrBuildFailed 走重试逻辑。
+//
+// 重试(step.Retries>0):整步非零退出/容器启动失败时重跑,达上限(共 1+Retries 次尝试)才判失败。
+// run.ErrCanceled(取消)绝不重试。每次重试前再查一次 parent ctx。
+func (b *Builder) runScriptStepWithOpts(ctx context.Context, sink run.StepSink, ordinal int, step pipeline.PipelineStep, workspace string) error {
+	onLine := b.lineSink(sink, ordinal)
+	attempts := step.Retries + 1
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		if ctx.Err() != nil {
+			return run.ErrCanceled
+		}
+		if attempt > 1 {
+			onLine("stdout", fmt.Sprintf("· 步骤「%s」失败,第 %d/%d 次重试…", step.Name, attempt-1, step.Retries))
+		}
+
+		// 每次尝试套一层可选超时子 ctx(>0 才套;=0 直接用 parent)。
+		attemptCtx := ctx
+		cancel := context.CancelFunc(func() {})
+		if step.TimeoutSeconds > 0 {
+			attemptCtx, cancel = context.WithTimeout(ctx, time.Duration(step.TimeoutSeconds)*time.Second)
+		}
+		err := b.runScriptStep(attemptCtx, sink, ordinal, step, workspace)
+		timedOut := step.TimeoutSeconds > 0 && errors.Is(attemptCtx.Err(), context.DeadlineExceeded)
+		cancel()
+
+		// 上层取消优先:用户取消 / 上层超时 → 立即终止,不重试。
+		if ctx.Err() != nil {
+			return run.ErrCanceled
+		}
+		if errors.Is(err, run.ErrCanceled) && !timedOut {
+			// runScriptStep 因子 ctx 取消返回 Canceled,但若那是本步超时所致(timedOut),
+			// 不算运行取消,转成可重试的步失败;否则尊重取消。
+			return run.ErrCanceled
+		}
+		if err == nil {
+			return nil
+		}
+		if timedOut {
+			onLine("stderr", fmt.Sprintf("步骤「%s」执行超时(>%ds),已终止本次尝试", step.Name, step.TimeoutSeconds))
+		}
+		lastErr = ErrBuildFailed // 归一为构建失败(供上层置 failed)
+	}
+	return lastErr
 }
 
 // joinContainerPath 把容器内挂载点与用户给的相对子目录拼成容器内绝对路径,去掉前导/尾随斜杠与

--- a/internal/build/shell_driver.go
+++ b/internal/build/shell_driver.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/huangchengsir/pipewright/internal/pipeline"
 )
 
 // shellDriver 是默认 Driver:shell 到探测出的容器 CLI(bin),所有命令经 Commander 以 array 执行。
@@ -55,10 +57,20 @@ func (d *shellDriver) Build(ctx context.Context, contextDir, dockerfile, localTa
 	return d.cmdr.Stream(ctx, d.bin, args, "", onLine)
 }
 
-func (d *shellDriver) RunToolchain(ctx context.Context, image, hostDir, workdir string, env []string, cmd []string, onLine func(stream, line string)) (int, error) {
-	// docker run --rm -v hostDir:workdir -w workdir [-e K=V...] image cmd...
+func (d *shellDriver) RunToolchain(ctx context.Context, image, hostDir, workdir string, env []string, cmd []string, res pipeline.Resource, onLine func(stream, line string)) (int, error) {
+	// docker run --rm -v hostDir:workdir -w workdir [--cpus N] [--memory M] [-e K=V...] image cmd...
 	args := []string{"run", "--rm", "-v", hostDir + ":" + workdir, "-w", workdir}
 	display := []string{"run", "--rm", "-v", hostDir + ":" + workdir, "-w", workdir}
+	// 资源规格(可选):cpu→--cpus、memory→--memory。值原样作 array 实参(不拼 shell;非法值由 docker 拒绝)。
+	// 资源 flag 非 secret,回显与真实参数一致。
+	if cpu := strings.TrimSpace(res.CPU); cpu != "" {
+		args = append(args, "--cpus", cpu)
+		display = append(display, "--cpus", cpu)
+	}
+	if mem := strings.TrimSpace(res.Memory); mem != "" {
+		args = append(args, "--memory", mem)
+		display = append(display, "--memory", mem)
+	}
 	for _, kv := range env {
 		args = append(args, "-e", kv)
 		display = append(display, "-e", maskKV(kv)) // 环境变量可能含 secret:回显只列 key

--- a/internal/httpapi/triggers.go
+++ b/internal/httpapi/triggers.go
@@ -21,6 +21,8 @@ type triggerDTO struct {
 	Events              eventsDTO          `json:"events"`
 	BranchMappings      []branchMappingDTO `json:"branchMappings"`
 	UnmatchedPolicy     string             `json:"unmatchedPolicy"`
+	// PathFilters 为路径过滤 glob 列表(monorepo · P0);空 = 不启用(放行一切)。
+	PathFilters []string `json:"pathFilters"`
 }
 
 type eventsDTO struct {
@@ -52,6 +54,10 @@ func toTriggerDTO(c *trigger.Config) triggerDTO {
 			TargetServerIDs: ids,
 		})
 	}
+	filters := c.PathFilters
+	if filters == nil {
+		filters = []string{}
+	}
 	return triggerDTO{
 		WebhookURL:          webhookURLPrefix + c.WebhookToken,
 		WebhookSecretMasked: c.WebhookSecretMasked,
@@ -63,6 +69,7 @@ func toTriggerDTO(c *trigger.Config) triggerDTO {
 		},
 		BranchMappings:  mappings,
 		UnmatchedPolicy: c.UnmatchedPolicy,
+		PathFilters:     filters,
 	}
 }
 
@@ -79,6 +86,8 @@ func writeTriggerError(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusUnprocessableEntity, "invalid_branch_pattern", "分支模式不能为空且需为合法通配(如 main、release/*)")
 	case errors.Is(err, trigger.ErrInvalidPolicy):
 		writeError(w, http.StatusUnprocessableEntity, "invalid_unmatched_policy", "未匹配策略只能为 record 或 ignore")
+	case errors.Is(err, trigger.ErrInvalidPathFilter):
+		writeError(w, http.StatusUnprocessableEntity, "invalid_path_filter", "路径过滤 glob 不能含空白(如 backend/**、*.go)")
 	default:
 		writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
 	}
@@ -125,7 +134,8 @@ func makeSaveTriggerHandler(svc trigger.Service) http.HandlerFunc {
 				Environment     string   `json:"environment"`
 				TargetServerIDs []string `json:"targetServerIds"`
 			} `json:"branchMappings"`
-			UnmatchedPolicy string `json:"unmatchedPolicy"`
+			UnmatchedPolicy string   `json:"unmatchedPolicy"`
+			PathFilters     []string `json:"pathFilters"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
@@ -150,6 +160,7 @@ func makeSaveTriggerHandler(svc trigger.Service) http.HandlerFunc {
 			},
 			BranchMappings:  mappings,
 			UnmatchedPolicy: req.UnmatchedPolicy,
+			PathFilters:     req.PathFilters,
 		})
 		if err != nil {
 			writeTriggerError(w, err)

--- a/internal/pipeline/settings.go
+++ b/internal/pipeline/settings.go
@@ -147,6 +147,31 @@ type PipelineStep struct {
 	Commands []string   `json:"commands"`          // 多行命令(顺序执行),script 必填且至少一条非空
 	Env      []BuildVar `json:"env,omitempty"`     // 步骤级环境变量(非 secret 明文 + secret 引用 CredentialID)
 	WorkDir  string     `json:"workDir,omitempty"` // 容器内相对工作目录(相对克隆工作区根;空=工作区根)
+	// TimeoutSeconds 是该步整步执行超时(秒);>0 时执行侧以 context.WithTimeout 套,超时即 kill 容器并判失败。
+	// 零值=不限(沿用旧行为,向后兼容)。
+	TimeoutSeconds int `json:"timeoutSeconds,omitempty"`
+	// Retries 是失败重试次数(整步非零退出时重跑;达上限才判失败)。零值=不重试(旧行为)。
+	// ctx 取消(用户取消 / 上层超时)不触发重试。
+	Retries int `json:"retries,omitempty"`
+	// Resource 是该步容器资源规格(cpu/memory),透传给容器运行(docker run --cpus/--memory)。
+	// 零值=不限(沿用旧行为)。
+	Resource Resource `json:"resource,omitempty"`
+}
+
+// Resource 是一条 script 步骤的容器资源规格(轻量,对齐云效 instanceType 思路)。
+//   - CPU:docker run --cpus 取值(如 "1" / "0.5"),空=不限。
+//   - Memory:docker run --memory 取值(如 "512m" / "2g"),空=不限。
+//
+// 远程 runner(SSH 投递 docker run)同样透传这两个 flag;若远程 docker 版本不支持则由其自身报错,
+// 平台不强求生效(诚实边界)。值原样作为 docker flag 实参(array,不拼 shell;非法值由 docker 拒绝)。
+type Resource struct {
+	CPU    string `json:"cpu,omitempty"`
+	Memory string `json:"memory,omitempty"`
+}
+
+// IsZero 判断资源规格是否为空(两字段都未配)。
+func (r Resource) IsZero() bool {
+	return strings.TrimSpace(r.CPU) == "" && strings.TrimSpace(r.Memory) == ""
 }
 
 // Settings 是构建/部署配置领域模型(冻结 DTO 外层形状)。
@@ -511,14 +536,26 @@ func (s *settingsService) normalizeSteps(in []PipelineStep) ([]PipelineStep, err
 			return nil, err
 		}
 
+		// 任务级 timeout/retry/资源规格(P0):负值钳为 0(=不限/不重试,旧行为);资源串 trim。
+		timeout := st.TimeoutSeconds
+		if timeout < 0 {
+			timeout = 0
+		}
+		retries := st.Retries
+		if retries < 0 {
+			retries = 0
+		}
 		out = append(out, PipelineStep{
-			ID:       id,
-			Name:     name,
-			Type:     stepType,
-			Image:    image,
-			Commands: cmds,
-			Env:      env,
-			WorkDir:  strings.TrimSpace(st.WorkDir),
+			ID:             id,
+			Name:           name,
+			Type:           stepType,
+			Image:          image,
+			Commands:       cmds,
+			Env:            env,
+			WorkDir:        strings.TrimSpace(st.WorkDir),
+			TimeoutSeconds: timeout,
+			Retries:        retries,
+			Resource:       Resource{CPU: strings.TrimSpace(st.Resource.CPU), Memory: strings.TrimSpace(st.Resource.Memory)},
 		})
 	}
 	return out, nil
@@ -711,13 +748,16 @@ type storedEnvironment struct {
 }
 
 type storedStep struct {
-	ID       string      `json:"id"`
-	Name     string      `json:"name"`
-	Type     string      `json:"type"`
-	Image    string      `json:"image"`
-	Commands []string    `json:"commands"`
-	Env      []storedVar `json:"env,omitempty"`
-	WorkDir  string      `json:"workDir,omitempty"`
+	ID             string      `json:"id"`
+	Name           string      `json:"name"`
+	Type           string      `json:"type"`
+	Image          string      `json:"image"`
+	Commands       []string    `json:"commands"`
+	Env            []storedVar `json:"env,omitempty"`
+	WorkDir        string      `json:"workDir,omitempty"`
+	TimeoutSeconds int         `json:"timeoutSeconds,omitempty"`
+	Retries        int         `json:"retries,omitempty"`
+	Resource       Resource    `json:"resource,omitempty"`
 }
 
 func toStoredVars(in []BuildVar) []storedVar {
@@ -780,13 +820,16 @@ func toStoredSteps(in []PipelineStep) []storedStep {
 			cmds = []string{}
 		}
 		out = append(out, storedStep{
-			ID:       st.ID,
-			Name:     st.Name,
-			Type:     st.Type,
-			Image:    st.Image,
-			Commands: cmds,
-			Env:      toStoredVars(st.Env),
-			WorkDir:  st.WorkDir,
+			ID:             st.ID,
+			Name:           st.Name,
+			Type:           st.Type,
+			Image:          st.Image,
+			Commands:       cmds,
+			Env:            toStoredVars(st.Env),
+			WorkDir:        st.WorkDir,
+			TimeoutSeconds: st.TimeoutSeconds,
+			Retries:        st.Retries,
+			Resource:       st.Resource,
 		})
 	}
 	return out

--- a/internal/pipeline/steps_test.go
+++ b/internal/pipeline/steps_test.go
@@ -56,6 +56,47 @@ func TestSettingsStepRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSettingsStepOptsRoundTrip 验证任务级 timeout/retry/资源规格往返(存读一致;负值钳为 0)。
+func TestSettingsStepOptsRoundTrip(t *testing.T) {
+	svc, _, _, _, projID := newSettingsSvc(t)
+	ctx := context.Background()
+
+	in := SettingsInput{
+		Steps: []PipelineStep{
+			{
+				Name:           "build",
+				Image:          "node:20",
+				Commands:       []string{"npm run build"},
+				TimeoutSeconds: 600,
+				Retries:        2,
+				Resource:       Resource{CPU: "1.5", Memory: "1g"},
+			},
+			{
+				Name:           "neg",
+				Image:          "node:20",
+				Commands:       []string{"echo hi"},
+				TimeoutSeconds: -5, // 负值应钳为 0
+				Retries:        -1,
+			},
+		},
+	}
+	st, err := svc.Save(ctx, projID, in)
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	s0 := st.Steps[0]
+	if s0.TimeoutSeconds != 600 || s0.Retries != 2 {
+		t.Fatalf("timeout/retry round-trip failed: %+v", s0)
+	}
+	if s0.Resource.CPU != "1.5" || s0.Resource.Memory != "1g" {
+		t.Fatalf("resource round-trip failed: %+v", s0.Resource)
+	}
+	s1 := st.Steps[1]
+	if s1.TimeoutSeconds != 0 || s1.Retries != 0 {
+		t.Fatalf("negative timeout/retry should clamp to 0: %+v", s1)
+	}
+}
+
 func TestSettingsStepEmptyNameRejected(t *testing.T) {
 	svc, _, _, _, projID := newSettingsSvc(t)
 	_, err := svc.Save(context.Background(), projID, SettingsInput{

--- a/internal/store/migrations/0036_trigger_path_filters.sql
+++ b/internal/store/migrations/0036_trigger_path_filters.sql
@@ -1,0 +1,5 @@
+-- 0036 trigger_path_filters:路径过滤触发(monorepo · P0 引擎能力)。
+-- 给触发配置加一组 glob(如 backend/**):仅当本次 push 改动的文件匹配任一 glob 才触发,
+-- 不匹配则忽略(IgnoredReason=path_no_match);拿不到改动文件列表时放行不拦(诚实降级)。
+-- 以 JSON 数组存于 pipeline_triggers 新列(非敏感);空数组 [] = 不启用路径过滤(放行一切,向后兼容)。
+ALTER TABLE pipeline_triggers ADD COLUMN path_filters_json TEXT NOT NULL DEFAULT '[]';

--- a/internal/trigger/path_filter_test.go
+++ b/internal/trigger/path_filter_test.go
@@ -1,0 +1,168 @@
+package trigger
+
+import (
+	"context"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/vault"
+)
+
+// ─── pathGlobMatch 单元 ─────────────────────────────────────────────────────
+
+func TestPathGlobMatch(t *testing.T) {
+	cases := []struct {
+		pat, name string
+		want      bool
+	}{
+		{"backend/**", "backend/app/main.go", true},
+		{"backend/**", "backend/main.go", true},
+		{"backend/**", "frontend/index.ts", false},
+		{"**/*.go", "backend/app/main.go", true},
+		{"**/*.go", "backend/app/main.ts", false},
+		{"*.md", "README.md", true},
+		{"*.md", "docs/README.md", false}, // `*` 不跨 /
+		{"docs/*.md", "docs/guide.md", true},
+		{"docs/*.md", "docs/sub/guide.md", false},
+		{"backend/**/*.go", "backend/a/b/c.go", true},
+		{"backend/**/*.go", "backend/a/b/c.txt", false},
+		{"Makefile", "Makefile", true},
+		{"Makefile", "src/Makefile", false},
+		{"**", "anything/at/all", true},
+	}
+	for _, c := range cases {
+		if got := pathGlobMatch(c.pat, c.name); got != c.want {
+			t.Errorf("pathGlobMatch(%q, %q) = %v, want %v", c.pat, c.name, got, c.want)
+		}
+	}
+}
+
+func TestMatchPathFiltersAnyHit(t *testing.T) {
+	filters := []string{"backend/**", "shared/**"}
+	// 一个文件命中即放行。
+	if !matchPathFilters(filters, []string{"frontend/x.ts", "backend/y.go"}) {
+		t.Error("expected match when one file hits backend/**")
+	}
+	if matchPathFilters(filters, []string{"frontend/x.ts", "docs/y.md"}) {
+		t.Error("expected no match when no file hits any filter")
+	}
+}
+
+// ─── changedFiles 解析 ──────────────────────────────────────────────────────
+
+func TestChangedFilesUnionAndDedup(t *testing.T) {
+	commits := []pushCommit{
+		{Added: []string{"a.go"}, Modified: []string{"b.go"}, Removed: []string{"c.go"}},
+		{Modified: []string{"b.go", " "}, Added: []string{"d.go"}}, // b.go 去重、空白剔除
+	}
+	got := changedFiles(commits)
+	want := map[string]bool{"a.go": true, "b.go": true, "c.go": true, "d.go": true}
+	if len(got) != len(want) {
+		t.Fatalf("changed files = %v, want 4 unique", got)
+	}
+	for _, f := range got {
+		if !want[f] {
+			t.Errorf("unexpected changed file %q", f)
+		}
+	}
+	if changedFiles(nil) != nil {
+		t.Error("nil commits should yield nil changed files (degrade to allow)")
+	}
+}
+
+// ─── 端到端:配置 round-trip + 接收器行为 ──────────────────────────────────
+
+// newReceiverWithPaths 装配一个配了 push 事件 + main→prod 映射 + 给定路径过滤的接收器。
+func newReceiverWithPaths(t *testing.T, pathFilters []string) (*Receiver, *fakeRunCreator, string, string) {
+	t.Helper()
+	db, _ := testDB(t)
+	v := vault.New(db, testMasterKey())
+	svc := New(db, v)
+	projID := seedProject(t, db)
+
+	ctx := context.Background()
+	cfg, err := svc.Get(ctx, projID)
+	if err != nil {
+		t.Fatalf("get config: %v", err)
+	}
+	token := cfg.WebhookToken
+	reset, err := svc.ResetSecret(ctx, projID)
+	if err != nil {
+		t.Fatalf("reset secret: %v", err)
+	}
+
+	saved, err := svc.Save(ctx, projID, SaveInput{
+		Events:          Events{Push: true},
+		BranchMappings:  []BranchMapping{{BranchPattern: "main", Environment: "prod"}},
+		UnmatchedPolicy: PolicyIgnore,
+		PathFilters:     pathFilters,
+	})
+	if err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	// 配置 round-trip:存读一致。
+	if len(saved.PathFilters) != len(pathFilters) {
+		t.Fatalf("path filters round-trip mismatch: got %v want %v", saved.PathFilters, pathFilters)
+	}
+
+	fake := &fakeRunCreator{}
+	return NewReceiver(db, v, fake), fake, token, reset.Secret
+}
+
+// pushBodyWithFiles 构造带 commits 改动文件的 push payload。
+func pushBodyWithFiles(branch, commit string, files ...string) []byte {
+	body := `{"ref":"refs/heads/` + branch + `","after":"` + commit + `","commits":[{"added":[`
+	for i, f := range files {
+		if i > 0 {
+			body += ","
+		}
+		body += `"` + f + `"`
+	}
+	body += `],"modified":[],"removed":[]}]}`
+	return []byte(body)
+}
+
+func TestWebhookPathFilterHitTriggers(t *testing.T) {
+	rc, fake, token, secret := newReceiverWithPaths(t, []string{"backend/**"})
+	res, err := rc.Handle(context.Background(), Delivery{
+		Token: token, Event: eventPush, TokenHdr: secret, DeliveryID: "d-hit",
+		RawBody: pushBodyWithFiles("main", "abc", "backend/app/main.go", "README.md"),
+	})
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if !res.Accepted || fake.count() != 1 {
+		t.Fatalf("path filter hit should create run, got %+v / count=%d", res, fake.count())
+	}
+}
+
+func TestWebhookPathFilterMissIgnored(t *testing.T) {
+	rc, fake, token, secret := newReceiverWithPaths(t, []string{"backend/**"})
+	res, err := rc.Handle(context.Background(), Delivery{
+		Token: token, Event: eventPush, TokenHdr: secret, DeliveryID: "d-miss",
+		RawBody: pushBodyWithFiles("main", "abc", "frontend/index.ts", "docs/guide.md"),
+	})
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if res.Accepted || res.Ignored != IgnoredPathNoMatch {
+		t.Fatalf("path filter miss should ignore (path_no_match), got %+v", res)
+	}
+	if fake.count() != 0 {
+		t.Fatalf("no run should be created on path miss, count=%d", fake.count())
+	}
+}
+
+func TestWebhookPathFilterNoFilesAllows(t *testing.T) {
+	// 配了过滤但 payload 拿不到改动文件(无 commits)→ 诚实降级放行。
+	rc, fake, token, secret := newReceiverWithPaths(t, []string{"backend/**"})
+	res, err := rc.Handle(context.Background(), Delivery{
+		Token: token, Event: eventPush, TokenHdr: secret, DeliveryID: "d-nofiles",
+		RawBody: pushBody("main", "abc"), // 无 commits 字段
+	})
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if !res.Accepted || fake.count() != 1 {
+		t.Fatalf("missing changed-files should degrade to allow, got %+v / count=%d", res, fake.count())
+	}
+}

--- a/internal/trigger/receiver.go
+++ b/internal/trigger/receiver.go
@@ -50,6 +50,8 @@ const (
 	IgnoredNoBranchMatch      = "no_branch_match"
 	IgnoredDuplicate          = "duplicate"
 	IgnoredUnmatchedIgnored   = "unmatched_ignored"
+	// IgnoredPathNoMatch:配了路径过滤,但本次 push 改动文件不匹配任一 glob(monorepo · P0)。
+	IgnoredPathNoMatch = "path_no_match"
 	// IgnoredUnmatchedRecorded:未匹配但策略=record——本期记录一次「已记录未部署」,不创建可执行运行。
 	IgnoredUnmatchedRecorded = "unmatched_recorded"
 )
@@ -176,6 +178,13 @@ func (rc *Receiver) Handle(ctx context.Context, d Delivery) (*Result, error) {
 		return &Result{Accepted: false, Ignored: reason}, nil
 	}
 
+	// 路径过滤(monorepo · P0):配了 glob 且**拿得到**改动文件时,文件不匹配任一 glob → 忽略。
+	// 拿不到改动文件列表(非 push 事件 / 畸形 payload / 无 commits)→ 放行不拦(诚实降级,见 matchPathFilters)。
+	if len(cfg.PathFilters) > 0 && len(parsed.ChangedFiles) > 0 && !matchPathFilters(cfg.PathFilters, parsed.ChangedFiles) {
+		rc.setOutcome(ctx, recID, IgnoredPathNoMatch)
+		return &Result{Accepted: false, Ignored: IgnoredPathNoMatch}, nil
+	}
+
 	runID, err := rc.runner.CreateWebhookRun(ctx, cfg.ProjectID, RunRequest{
 		Branch:                  parsed.Branch,
 		Commit:                  parsed.Commit,
@@ -231,16 +240,17 @@ func (rc *Receiver) loadForVerify(ctx context.Context, token string) (*Config, [
 		return nil, nil, ErrTokenNotFound
 	}
 	var (
-		cfg          Config
-		sealed       []byte
-		eventsJSON   string
-		mappingsJSON string
+		cfg             Config
+		sealed          []byte
+		eventsJSON      string
+		mappingsJSON    string
+		pathFiltersJSON string
 	)
 	err := rc.db.QueryRowContext(ctx,
 		`SELECT project_id, webhook_token, webhook_secret_ciphertext, events_json,
-		        branch_mappings_json, unmatched_policy
+		        branch_mappings_json, unmatched_policy, path_filters_json
 		 FROM pipeline_triggers WHERE webhook_token = ?`, token,
-	).Scan(&cfg.ProjectID, &cfg.WebhookToken, &sealed, &eventsJSON, &mappingsJSON, &cfg.UnmatchedPolicy)
+	).Scan(&cfg.ProjectID, &cfg.WebhookToken, &sealed, &eventsJSON, &mappingsJSON, &cfg.UnmatchedPolicy, &pathFiltersJSON)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil, ErrTokenNotFound
@@ -255,6 +265,12 @@ func (rc *Receiver) loadForVerify(ctx context.Context, token string) (*Config, [
 	if strings.TrimSpace(mappingsJSON) != "" {
 		if err := json.Unmarshal([]byte(mappingsJSON), &cfg.BranchMappings); err != nil {
 			return nil, nil, fmt.Errorf("trigger: parse branch mappings: %w", err)
+		}
+	}
+	cfg.PathFilters = []string{}
+	if strings.TrimSpace(pathFiltersJSON) != "" {
+		if err := json.Unmarshal([]byte(pathFiltersJSON), &cfg.PathFilters); err != nil {
+			return nil, nil, fmt.Errorf("trigger: parse path filters: %w", err)
 		}
 	}
 
@@ -395,16 +411,28 @@ func eventSubscribed(event string, ev Events) bool {
 }
 
 // parsedPayload 是从 Gitee payload 解析出的关注字段。
+//
+// ChangedFiles 为本次 push 改动的文件路径并集(commits[].{added,modified,removed} 去重);
+// 仅 push 事件有意义,其余事件 / 拿不到时为空(空 → 路径过滤放行,诚实降级)。
 type parsedPayload struct {
-	Branch string
-	Commit string
+	Branch       string
+	Commit       string
+	ChangedFiles []string
+}
+
+// pushCommit 是 push 事件 commits[] 元素里本包关心的改动文件三类(GitHub/Gitee 同形)。
+type pushCommit struct {
+	Added    []string `json:"added"`
+	Modified []string `json:"modified"`
+	Removed  []string `json:"removed"`
 }
 
 // giteePayload 是 Gitee push/tag/MR/release webhook 的部分字段(只取所需,容忍多余字段)。
 type giteePayload struct {
-	Ref         string `json:"ref"`
-	After       string `json:"after"`
-	CheckoutSHA string `json:"checkout_sha"`
+	Ref         string       `json:"ref"`
+	After       string       `json:"after"`
+	CheckoutSHA string       `json:"checkout_sha"`
+	Commits     []pushCommit `json:"commits"`
 	HeadCommit  struct {
 		ID string `json:"id"`
 	} `json:"head_commit"`
@@ -456,7 +484,36 @@ func parsePayload(body []byte) parsedPayload {
 	if commit == "" {
 		commit = strings.TrimSpace(p.Release.TargetCommitish)
 	}
-	return parsedPayload{Branch: branch, Commit: commit}
+	return parsedPayload{Branch: branch, Commit: commit, ChangedFiles: changedFiles(p.Commits)}
+}
+
+// changedFiles 把 push 事件 commits[].{added,modified,removed} 汇成去重的文件路径并集
+// (保留首次出现序;trim 后剔空)。无 commits / 全空 → nil(路径过滤据此放行,诚实降级)。
+func changedFiles(commits []pushCommit) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0, 8)
+	add := func(paths []string) {
+		for _, f := range paths {
+			f = strings.TrimSpace(f)
+			if f == "" {
+				continue
+			}
+			if _, dup := seen[f]; dup {
+				continue
+			}
+			seen[f] = struct{}{}
+			out = append(out, f)
+		}
+	}
+	for _, c := range commits {
+		add(c.Added)
+		add(c.Modified)
+		add(c.Removed)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // refToBranch 从 refs/heads/main 或 refs/tags/v1 取末段分支/标签名;非 ref 形式原样返回。
@@ -526,6 +583,69 @@ func globMatch(pattern, s string) bool {
 		return strings.HasSuffix(s, last)
 	}
 	return true
+}
+
+// ---- 路径过滤(monorepo · P0)-------------------------------------------
+
+// matchPathFilters 判断「本次改动文件」是否匹配任一路径过滤 glob(任一文件命中任一 glob 即放行)。
+// 调用方已保证 filters 与 files 均非空(空文件列表走放行降级,不进此函数)。
+func matchPathFilters(filters, files []string) bool {
+	for _, pat := range filters {
+		pat = strings.TrimSpace(pat)
+		if pat == "" {
+			continue
+		}
+		for _, f := range files {
+			if pathGlobMatch(pat, strings.TrimSpace(f)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// pathGlobMatch 是支持 `**` 的路径 glob 匹配(按路径段递归):
+//   - `**` 匹配任意数量的路径段(含零段,跨 `/`),如 `backend/**` 命中 `backend/a/b.go`、`**/*.go` 命中 `a/b.go`。
+//   - `*`  匹配同一路径段内任意字符(不跨 `/`),如 `*.md` 命中 `README.md` 但不命中 `docs/x.md`。
+//   - 其余按段精确匹配(段内仍走 path.Match 支持 `*`/`?`)。
+//
+// 语义对齐常见 CI(GitLab rules:changes / GitHub paths)。pattern/name 均以 `/` 切段后比较。
+func pathGlobMatch(pattern, name string) bool {
+	if pattern == "" || name == "" {
+		return false
+	}
+	return segMatch(strings.Split(pattern, "/"), strings.Split(name, "/"))
+}
+
+// segMatch 按段做带 `**` 的 glob 匹配:`**` 段可吞 0..n 个 name 段(递归回溯);
+// 普通段用 path.Match 段内匹配(`*`/`?` 不跨 `/`)。
+func segMatch(pat, name []string) bool {
+	for len(pat) > 0 {
+		if pat[0] == "**" {
+			// 折叠连续的 `**`。
+			for len(pat) > 1 && pat[1] == "**" {
+				pat = pat[1:]
+			}
+			if len(pat) == 1 {
+				return true // 末尾 `**` 吞掉所有剩余段(含零段)。
+			}
+			// `**` 吞 0..len(name) 段,逐一尝试让后续模式从某位置起匹配。
+			for i := 0; i <= len(name); i++ {
+				if segMatch(pat[1:], name[i:]) {
+					return true
+				}
+			}
+			return false
+		}
+		if len(name) == 0 {
+			return false
+		}
+		if ok, err := path.Match(pat[0], name[0]); err != nil || !ok {
+			return false
+		}
+		pat, name = pat[1:], name[1:]
+	}
+	return len(name) == 0
 }
 
 // ---- helpers ------------------------------------------------------------

--- a/internal/trigger/trigger.go
+++ b/internal/trigger/trigger.go
@@ -51,6 +51,8 @@ var (
 	ErrInvalidBranchPattern = errors.New("trigger: invalid branch pattern")
 	// ErrInvalidPolicy 表示未匹配策略枚举非法。
 	ErrInvalidPolicy = errors.New("trigger: invalid unmatched policy")
+	// ErrInvalidPathFilter 表示路径过滤 glob 非空校验失败(去空白后为空)。
+	ErrInvalidPathFilter = errors.New("trigger: invalid path filter")
 )
 
 // Events 是触发事件开关(手动触发常开,不建模为字段)。
@@ -75,6 +77,9 @@ type BranchMapping struct {
 }
 
 // Config 是触发配置领域模型。WebhookSecretMasked 为掩码;明文绝不在此模型常驻。
+//
+// PathFilters 为路径过滤 glob 列表(monorepo · P0):非空时仅当本次 push 改动文件匹配任一 glob 才触发;
+// 空列表 = 不启用(放行一切,向后兼容)。glob 支持 `*`(单段)与 `**`(跨 `/`)。
 type Config struct {
 	ProjectID           string
 	WebhookToken        string
@@ -82,6 +87,7 @@ type Config struct {
 	Events              Events
 	BranchMappings      []BranchMapping
 	UnmatchedPolicy     string
+	PathFilters         []string
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
 }
@@ -91,6 +97,7 @@ type SaveInput struct {
 	Events          Events
 	BranchMappings  []BranchMapping
 	UnmatchedPolicy string
+	PathFilters     []string
 }
 
 // ResetResult 是重置密钥的结果:完整明文仅此一次返回,同时给掩码。
@@ -153,6 +160,10 @@ func (s *service) Save(ctx context.Context, projectID string, in SaveInput) (*Co
 	if err != nil {
 		return nil, err
 	}
+	pathFilters, err := normalizePathFilters(in.PathFilters)
+	if err != nil {
+		return nil, err
+	}
 
 	eventsJSON, err := json.Marshal(in.Events)
 	if err != nil {
@@ -162,13 +173,17 @@ func (s *service) Save(ctx context.Context, projectID string, in SaveInput) (*Co
 	if err != nil {
 		return nil, fmt.Errorf("trigger: marshal branch mappings: %w", err)
 	}
+	pathFiltersJSON, err := json.Marshal(pathFilters)
+	if err != nil {
+		return nil, fmt.Errorf("trigger: marshal path filters: %w", err)
+	}
 
 	nowStr := time.Now().UTC().Format(time.RFC3339)
 	_, err = s.db.ExecContext(ctx,
 		`UPDATE pipeline_triggers
-		 SET events_json = ?, branch_mappings_json = ?, unmatched_policy = ?, updated_at = ?
+		 SET events_json = ?, branch_mappings_json = ?, unmatched_policy = ?, path_filters_json = ?, updated_at = ?
 		 WHERE project_id = ?`,
-		string(eventsJSON), string(mappingsJSON), policy, nowStr, projectID,
+		string(eventsJSON), string(mappingsJSON), policy, string(pathFiltersJSON), nowStr, projectID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("trigger: update config: %w", err)
@@ -205,20 +220,21 @@ func (s *service) ResetSecret(ctx context.Context, projectID string) (*ResetResu
 // 永不返回密钥明文;掩码由密文解密后即时计算并即弃明文。
 func (s *service) load(ctx context.Context, projectID string) (*Config, string, error) {
 	var (
-		cfg          Config
-		sealed       []byte
-		eventsJSON   string
-		mappingsJSON string
-		createdStr   string
-		updatedStr   string
+		cfg             Config
+		sealed          []byte
+		eventsJSON      string
+		mappingsJSON    string
+		pathFiltersJSON string
+		createdStr      string
+		updatedStr      string
 	)
 	cfg.ProjectID = projectID
 	err := s.db.QueryRowContext(ctx,
 		`SELECT webhook_token, webhook_secret_ciphertext, events_json, branch_mappings_json,
-		        unmatched_policy, created_at, updated_at
+		        unmatched_policy, path_filters_json, created_at, updated_at
 		 FROM pipeline_triggers WHERE project_id = ?`, projectID,
 	).Scan(&cfg.WebhookToken, &sealed, &eventsJSON, &mappingsJSON,
-		&cfg.UnmatchedPolicy, &createdStr, &updatedStr)
+		&cfg.UnmatchedPolicy, &pathFiltersJSON, &createdStr, &updatedStr)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, "", ErrNotFound
@@ -236,6 +252,15 @@ func (s *service) load(ctx context.Context, projectID string) (*Config, string, 
 		}
 		if cfg.BranchMappings == nil {
 			cfg.BranchMappings = []BranchMapping{}
+		}
+	}
+	cfg.PathFilters = []string{}
+	if strings.TrimSpace(pathFiltersJSON) != "" {
+		if err := json.Unmarshal([]byte(pathFiltersJSON), &cfg.PathFilters); err != nil {
+			return nil, "", fmt.Errorf("trigger: parse path filters: %w", err)
+		}
+		if cfg.PathFilters == nil {
+			cfg.PathFilters = []string{}
 		}
 	}
 
@@ -309,6 +334,7 @@ func (s *service) createDefault(ctx context.Context, projectID string) (*Config,
 		Events:              Events{},
 		BranchMappings:      []BranchMapping{},
 		UnmatchedPolicy:     PolicyRecord,
+		PathFilters:         []string{},
 		CreatedAt:           now,
 		UpdatedAt:           now,
 	}, nil
@@ -436,6 +462,31 @@ func normalizeMappings(in []BranchMapping) ([]BranchMapping, error) {
 			Environment:     strings.TrimSpace(m.Environment),
 			TargetServerIDs: ids,
 		})
+	}
+	return out, nil
+}
+
+// normalizePathFilters 校验并规范化路径过滤 glob 列表(monorepo · P0):
+//   - 每条 trim、剔空、去重(保留首次出现序)。
+//   - 含空白的非法 glob → ErrInvalidPathFilter(与分支模式一致:glob 不应含空白)。
+//
+// 返回非 nil 切片(空列表 = 不启用路径过滤,放行一切)。
+func normalizePathFilters(in []string) ([]string, error) {
+	out := make([]string, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for _, raw := range in {
+		p := strings.TrimSpace(raw)
+		if p == "" {
+			continue // 空行直接剔除(前端多行文本框常见尾随空行)
+		}
+		if strings.ContainsAny(p, " \t\n\r") {
+			return nil, fmt.Errorf("%w: path filter %q must not contain whitespace", ErrInvalidPathFilter, p)
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
 	}
 	return out, nil
 }

--- a/internal/trigger/trigger_test.go
+++ b/internal/trigger/trigger_test.go
@@ -3,6 +3,7 @@ package trigger
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -152,6 +153,49 @@ func TestSaveRoundTrip(t *testing.T) {
 	}
 	if len(got.BranchMappings) != 2 || got.BranchMappings[0].Environment != "生产" {
 		t.Fatalf("回读映射不符: %+v", got.BranchMappings)
+	}
+}
+
+// TestSavePathFiltersRoundTrip 验证路径过滤 glob 往返:trim、剔空、去重、保序;回读一致。
+func TestSavePathFiltersRoundTrip(t *testing.T) {
+	svc, _, _, projID := newSvc(t)
+	in := SaveInput{
+		Events:          Events{Push: true},
+		UnmatchedPolicy: PolicyRecord,
+		PathFilters:     []string{" backend/** ", "frontend/**", "backend/**", "  ", "*.go"},
+	}
+	saved, err := svc.Save(context.Background(), projID, in)
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	want := []string{"backend/**", "frontend/**", "*.go"}
+	if len(saved.PathFilters) != len(want) {
+		t.Fatalf("path filters = %v, want %v", saved.PathFilters, want)
+	}
+	for i, p := range want {
+		if saved.PathFilters[i] != p {
+			t.Fatalf("path filter[%d] = %q, want %q (order/trim/dedup)", i, saved.PathFilters[i], p)
+		}
+	}
+	got, err := svc.Get(context.Background(), projID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(got.PathFilters) != len(want) {
+		t.Fatalf("回读路径过滤不符: %v", got.PathFilters)
+	}
+}
+
+// TestSaveInvalidPathFilter:含空白的 glob 被拒(ErrInvalidPathFilter)。
+func TestSaveInvalidPathFilter(t *testing.T) {
+	svc, _, _, projID := newSvc(t)
+	_, err := svc.Save(context.Background(), projID, SaveInput{
+		Events:          Events{Push: true},
+		UnmatchedPolicy: PolicyRecord,
+		PathFilters:     []string{"back end/**"},
+	})
+	if !errors.Is(err, ErrInvalidPathFilter) {
+		t.Fatalf("err = %v, want ErrInvalidPathFilter", err)
 	}
 }
 

--- a/web/src/api/triggers.ts
+++ b/web/src/api/triggers.ts
@@ -49,6 +49,8 @@ export interface TriggerConfig {
   events: TriggerEvents
   branchMappings: BranchMapping[]
   unmatchedPolicy: UnmatchedPolicy
+  /** 路径过滤 glob 列表(monorepo · P0);空 = 不启用(放行一切)。 */
+  pathFilters: string[]
 }
 
 export interface SaveTriggerInput {
@@ -59,6 +61,7 @@ export interface SaveTriggerInput {
     targetServerIds: string[]
   }>
   unmatchedPolicy: UnmatchedPolicy
+  pathFilters: string[]
 }
 
 export interface SecretResetResult {

--- a/web/src/components/TriggersPanel.vue
+++ b/web/src/components/TriggersPanel.vue
@@ -61,6 +61,24 @@ let _keySeq = 0
 const mappings = ref<MappingRow[]>([])
 const unmatchedPolicy = ref<UnmatchedPolicy>('record')
 
+// 路径过滤(monorepo · P0):多行 glob 文本框;每行一条,空行忽略。
+// 仅当本次 push 改动文件匹配任一 glob 才触发(拿不到改动文件列表时放行,诚实降级)。
+const pathFiltersText = ref('')
+
+/** 解析多行 glob 文本为去空、trim 后的数组(去重保序)。 */
+function parsePathFilters(text: string): string[] {
+  const out: string[] = []
+  const seen = new Set<string>()
+  for (const raw of text.split('\n')) {
+    const p = raw.trim()
+    if (p && !seen.has(p)) {
+      seen.add(p)
+      out.push(p)
+    }
+  }
+  return out
+}
+
 // ─── Copy state ───────────────────────────────────────────────────────────────
 
 type CopyTarget = 'url' | 'secret'
@@ -207,6 +225,7 @@ async function handleSave(): Promise<void> {
         targetServerIds: r.targetServerIds,
       })),
       unmatchedPolicy: unmatchedPolicy.value,
+      pathFilters: parsePathFilters(pathFiltersText.value),
     })
     applyConfig(updated)
     showSaveSuccess()
@@ -237,6 +256,7 @@ function applyConfig(config: TriggerConfig): void {
   eventPullRequest.value      = config.events.pullRequest
   eventRelease.value          = config.events.release ?? false
   unmatchedPolicy.value       = config.unmatchedPolicy
+  pathFiltersText.value       = (config.pathFilters ?? []).join('\n')
   mappings.value = config.branchMappings.map((m) => ({
     _key: ++_keySeq,
     id: m.id,
@@ -522,6 +542,32 @@ const displayWebhookUrl = computed(() => {
         </div>
       </section>
 
+      <!-- ═══ Section 5: Path filter (monorepo · P0) ══════════════════════ -->
+      <section class="config-card" aria-labelledby="tp-paths-heading">
+        <div class="card-head">
+          <span class="card-icon" aria-hidden="true">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9">
+              <path d="M3 7l3-3h5l2 2h8v12a2 2 0 0 1-2 2H3z"/>
+            </svg>
+          </span>
+          <h2 id="tp-paths-heading" class="card-title">路径过滤(monorepo)</h2>
+          <span class="card-sub">仅当本次推送改动的文件匹配以下任一 glob 才触发</span>
+        </div>
+        <div class="card-body card-body--pad">
+          <textarea
+            v-model="pathFiltersText"
+            class="map-input map-input--mono path-filters-input"
+            rows="4"
+            placeholder="backend/**&#10;shared/**&#10;*.go"
+            aria-label="路径过滤 glob(每行一条)"
+          ></textarea>
+          <p class="policy-desc">
+            每行一条 glob:<code>**</code> 跨目录、<code>*</code> 单层(如 <code>backend/**</code>、<code>**/*.go</code>)。
+            留空 = 不启用(任意改动都触发)。匹配不中的推送将被忽略;无法获取改动文件列表时放行不拦。
+          </p>
+        </div>
+      </section>
+
       <!-- ═══ Scheduled (cron) trigger · Story 8-6 ════════════════════════ -->
       <CronPanel :project-id="props.projectId" />
 
@@ -685,6 +731,8 @@ const displayWebhookUrl = computed(() => {
 .seg-btn:hover:not(.seg-btn--active) { color: var(--color-text); background: oklch(100% 0 0 / 0.04); }
 .seg-btn--active { background: var(--color-card); color: var(--color-text); box-shadow: var(--shadow); }
 .policy-desc { margin-top: 12px; font-size: 0.8rem; color: var(--color-faint); line-height: 1.6; }
+.policy-desc code { font-family: var(--font-mono); font-size: 0.78em; padding: 1px 4px; border-radius: 4px; background: var(--color-inset); color: var(--color-dim); }
+.path-filters-input { height: auto; min-height: 92px; padding: 8px 10px; line-height: 1.5; resize: vertical; }
 
 /* ─── Save bar ────────────────────────────────── */
 .save-bar { display: flex; justify-content: flex-start; padding-bottom: 8px; }

--- a/web/src/components/pipeline/jobConfigSchema.ts
+++ b/web/src/components/pipeline/jobConfigSchema.ts
@@ -122,6 +122,41 @@ const probeIs = (v: string) => (c: Record<string, string>) =>
 
 // ─── Per-type specs ──────────────────────────────────────────────────────────────
 
+// 任务级执行选项(P0 引擎能力):超时 / 重试 / 资源规格。脚本类节点共用。
+// 全部可选;留空 = 旧行为(不限超时、不重试、不限资源)。timeout/retry 为非负整数。
+const EXEC_OPTION_FIELDS: JobField[] = [
+  {
+    key: 'timeoutSeconds',
+    label: '超时(秒)',
+    kind: 'number',
+    placeholder: '0',
+    hint: '本步执行超时;超时即终止容器并判失败。留空 / 0 = 不限',
+  },
+  {
+    key: 'retries',
+    label: '失败重试次数',
+    kind: 'number',
+    placeholder: '0',
+    hint: '非零退出时重跑,达上限才判失败;用户取消不重试。留空 / 0 = 不重试',
+  },
+  {
+    key: 'cpu',
+    label: 'CPU 限额',
+    kind: 'text',
+    monospace: true,
+    placeholder: '1',
+    hint: '透传 docker --cpus(如 1、0.5);留空 = 不限。远程 runner 视其 docker 支持而定',
+  },
+  {
+    key: 'memory',
+    label: '内存限额',
+    kind: 'text',
+    monospace: true,
+    placeholder: '512m',
+    hint: '透传 docker --memory(如 512m、2g);留空 = 不限',
+  },
+]
+
 const SCRIPT_FIELDS: JobField[] = [
   {
     key: 'image',
@@ -155,6 +190,7 @@ const SCRIPT_FIELDS: JobField[] = [
     placeholder: 'frontend/dist\nbackend/target/app.jar',
     hint: '可选,每行一条。相对工作区根:目录→dist、*.jar→jar、其它文件→archive。一个节点可出多件;填了才归档进制品库并在运行详情可下载/部署。镜像产物请用「构建」节点(build_image),不在这里',
   },
+  ...EXEC_OPTION_FIELDS,
 ]
 
 // SSH 部署节点的字段(deploy_ssh 与 deploy_frontend 模板共用)。
@@ -519,6 +555,7 @@ export const JOB_TYPE_SPECS: Record<string, JobTypeSpec> = {
         placeholder: '.',
         hint: '可选,相对克隆工作区根',
       },
+      ...EXEC_OPTION_FIELDS,
     ],
     defaultConfig: {
       image: 'node:20',


### PR DESCRIPTION
## 背景

两块 P0 引擎能力,两个独立提交,放同一 PR。

## 改动

### ① 任务级 timeout / retry / 资源规格(commit `feat(pipeline): 任务级 timeout/retry/资源规格`)
- **模型**:脚本类 job 加可选 `TimeoutSeconds` / `Retries` / `Resource{cpu,memory}`,存 `spec_json`(job.config),**无迁移**,零值=旧行为(向后兼容)。
- **执行**:`runScriptStepWithOpts` 包住 `runScriptStep`——
  - timeout>0 → `context.WithTimeout` 套每次尝试,超时即终止容器并判失败;用 `context.Cause` 区分「本步超时」与「上层取消(用户取消/上层超时)」,**上层取消不重试**。
  - retries>0 → 整步非零退出/容器启动失败时重跑,达上限(1+Retries)才判失败;取消绝不重试。
  - resource → 透传 `Driver.RunToolchain` → `docker run --cpus/--memory`。
- **Resource 透传**:本地与远程(SSH)driver 都是同一 `shellDriver`,故两路都真实加 flag;远程模式资源透传生效(远程 docker 不支持则其自身报错),**远程暂不套 timeout/retry**(诚实边界)。
- **settings 级步骤**同步支持(`normalizeSteps` + `storedStep` 持久化新字段)。
- **前端**:`jobConfigSchema.ts` 给脚本类 / 自定义节点加 4 个可选字段(超时秒 / 重试 / CPU / 内存,中文标签),走 JobDrawer 既有 number/text 渲染,存 config 字符串。

### ② 路径过滤触发(monorepo)(commit `feat(trigger): 路径过滤触发(monorepo)`)
- **存储**:`pipeline_triggers` 加列 `path_filters_json`(迁移 **0036**),JSON 数组,空=不启用。
- **解析**:从 push payload `commits[].{added,modified,removed}` 汇成去重改动文件并集(GitHub/Gitee push 同形);拿不到时=空 → **放行降级**。
- **匹配**:`pathGlobMatch` 按路径段递归,支持 `**`(跨 `/`)与 `*`(单层不跨 `/`),对齐 GitLab `rules:changes` / GitHub `paths`;任一文件命中任一 glob 即放行,否则忽略(新增 `IgnoredReason=path_no_match`)。
- **校验**:`normalizePathFilters` trim/剔空/去重/保序;含空白 glob → `ErrInvalidPathFilter`(422)。
- **前端**:`TriggersPanel.vue` 加「路径过滤(monorepo)」多行 glob 输入 + 中文说明;API DTO 加 `pathFilters`。

## 验证(全绿)

后端:
- `gofmt -l` 空、`go vet ./...` 干净、`go build ./...` 干净、`go test ./...` 全过(新增 timeout/retry/resource、路径匹配命中/不中/放行、配置 round-trip 等测试)。

前端(`web/`):
- `npm run typecheck` 干净、`npm run lint` 0 error(仅无关文件预存 warning)、`npx vitest run` 255 passed、`npm run build` 成功(已 `git restore web/dist/index.html`,未碰 favicon.svg/headed-demo.mjs)。

## 诚实边界与踩坑

- **特性①**
  - timeout/retry 仅作用于**脚本类容器执行**(script/custom/build_frontend/build_backend/templated);非脚本节点(build_image/deploy/notify)不套。
  - **远程 runner 不套 timeout/retry**(仅透传 resource),留后续增量。
  - resource 值原样作 docker flag 实参(array,不拼 shell);非法值由 docker 自身拒绝,平台不预校验、不强求生效。
  - `RunToolchain` 接口签名加了 `pipeline.Resource` 参数(shellDriver + 2 个测试 fake + builder 模型B调用 + 远程执行器随之更新);与并发 agent 同动 `dag_stage_exec.go`/`jobConfigSchema.ts` 时均为既有插入点最小附加,未重排。
- **特性②**
  - 仅 push 事件携带改动文件;tag/MR/release **无文件列表 → 放行**(不拦),与「拿不到即放行」一致。
  - 中间含通配的 `**` 片段做了宽松字面退化(`segMatch` 仅在普通段用 `path.Match`),路径过滤以「命中即放行、宁宽勿漏触发」为准。
  - 路径过滤在分支匹配**之后**判;未匹配分支仍走原 unmatched 策略,不受影响。

不自行 merge。