### PR TITLE
feat(build): 步骤输出→下游变量($PIPEWRIGHT_ENV · P1)

### DIFF
--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -162,6 +162,8 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 				b.recordCommit(ctx, r.ID, resolved.CommitShort)
 			}
 
+			// 步骤输出→下游变量(P1):同阶段 job 间经 $PIPEWRIGHT_ENV 文件传值,carriedEnv 累积注入后续 job。
+			var carriedEnv []pipeline.BuildVar
 			for _, jb := range scriptJobs {
 				if canceled(ctx) {
 					return run.ErrCanceled
@@ -171,7 +173,10 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 					_ = rep.Log(ctx, streamStderr, fmt.Sprintf("script job「%s」配置无效:%v", jb.Name, verr))
 					return ErrBuildFailed
 				}
-				step.Env = append(runParamsAsEnv(r.Trigger.Params), step.Env...)
+				// 注入顺序:运行参数 → 上游 job 输出(carriedEnv)→ job 自身 env(后者覆盖同名)→ PIPEWRIGHT_ENV(系统,末位防覆盖)。
+				base := append(runParamsAsEnv(r.Trigger.Params), carriedEnv...)
+				step.Env = append(base, step.Env...)
+				step.Env = append(step.Env, pipewrightEnvVar())
 				// 构建依赖缓存(#61):执行前恢复(暖构建)、成功后保存(best-effort,缓存问题绝不让构建失败)。
 				// 任务级 timeout/retry(#63):零值时 runScriptStepWithOpts 退化为单次无超时执行(旧行为)。
 				b.restoreJobCache(ctx, rep, jb, r.Trigger.Branch, workspace)
@@ -179,6 +184,8 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 					return err // ErrBuildFailed / run.ErrCanceled
 				}
 				b.saveJobCache(ctx, rep, jb, r.Trigger.Branch, workspace)
+				// 捕获本 job 写入 $PIPEWRIGHT_ENV 的变量,供后续同阶段 job 引用。
+				carriedEnv = append(carriedEnv, captureStageEnv(ctx, rep, workspace)...)
 			}
 
 			commitTag := "latest"

--- a/internal/build/stage_env.go
+++ b/internal/build/stage_env.go
@@ -1,0 +1,82 @@
+package build
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/huangchengsir/pipewright/internal/dagrun"
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+)
+
+// stage_env.go 实现「步骤输出 → 下游变量」(P1 · 对标云效 $FLOW_ENV / GitHub $GITHUB_ENV)。
+//
+// 同一阶段内多个 script job 共享克隆工作区。约定:job 容器内向 `$PIPEWRIGHT_ENV` 指向的文件
+// 追加 `KEY=VALUE` 行,执行后由执行器捕获并注入**后续同阶段 job** 的环境变量,实现 job 间
+// 传值(如 build job 算出版本号 → deploy/通知 job 引用)。
+//
+// 文件位于工作区根(挂载进容器),宿主可读;每个 job 执行后即捕获并清空,故各 job 的写入隔离、
+// 捕获结果在内存累积(后写覆盖同名键,与环境变量语义一致)。绝不改单机执行语义、无新依赖。
+
+// pipewrightEnvFileName 是阶段内「步骤输出环境」文件名(工作区根相对)。
+const pipewrightEnvFileName = ".pipewright_env"
+
+// pipewrightEnvVar 返回注入容器的 `PIPEWRIGHT_ENV=<容器内路径>` 变量;job 内向该路径写 KEY=VALUE。
+func pipewrightEnvVar() pipeline.BuildVar {
+	return pipeline.BuildVar{
+		Key:   "PIPEWRIGHT_ENV",
+		Value: joinContainerPath(scriptWorkspaceMount, pipewrightEnvFileName),
+	}
+}
+
+// captureStageEnv 读取并清空工作区根的步骤输出文件,解析 KEY=VALUE 行为 BuildVar(明文,非 secret)。
+// 文件不存在 / 空 → 返回 nil(无输出)。读失败 / 行非法宽松跳过(绝不阻断构建)。
+func captureStageEnv(ctx context.Context, rep dagrun.StageReporter, workspace string) []pipeline.BuildVar {
+	path := filepath.Join(workspace, pipewrightEnvFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil // 不存在 = 本 job 无输出(常态)
+	}
+	_ = os.Remove(path) // 即捕即清,隔离各 job 的写入
+	var out []pipeline.BuildVar
+	for _, line := range strings.Split(strings.ReplaceAll(string(data), "\r", ""), "\n") {
+		t := strings.TrimSpace(line)
+		if t == "" || strings.HasPrefix(t, "#") {
+			continue
+		}
+		i := strings.IndexByte(t, '=')
+		if i <= 0 {
+			continue // 无 = 或 = 在首位 → 非法,跳过
+		}
+		key := strings.TrimSpace(t[:i])
+		if !isEnvKey(key) {
+			continue
+		}
+		out = append(out, pipeline.BuildVar{Key: key, Value: t[i+1:]})
+	}
+	if len(out) > 0 && rep != nil {
+		keys := make([]string, 0, len(out))
+		for _, v := range out {
+			keys = append(keys, v.Key) // 仅记键名,绝不回显值(可能含敏感数据)
+		}
+		_ = rep.Log(ctx, streamStdout, "· 捕获步骤输出变量供下游 job 使用:"+strings.Join(keys, ", "))
+	}
+	return out
+}
+
+// isEnvKey 校验环境变量名合法(字母/下划线开头,仅字母数字下划线)。
+func isEnvKey(k string) bool {
+	if k == "" {
+		return false
+	}
+	for i, r := range k {
+		switch {
+		case r == '_' || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z'):
+		case i > 0 && r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/build/stage_env_test.go
+++ b/internal/build/stage_env_test.go
@@ -1,0 +1,106 @@
+package build
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+func TestCaptureStageEnv(t *testing.T) {
+	ws := t.TempDir()
+	body := "VERSION=1.2.3\n# comment\n\nBAD LINE NO EQ\n=novalue\nTAG=v9\n9bad=x\n"
+	if err := os.WriteFile(filepath.Join(ws, pipewrightEnvFileName), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := captureStageEnv(context.Background(), nil, ws)
+	want := map[string]string{"VERSION": "1.2.3", "TAG": "v9"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d vars %+v, want %d", len(got), got, len(want))
+	}
+	for _, v := range got {
+		if v.Value != want[v.Key] {
+			t.Errorf("%s=%q, want %q", v.Key, v.Value, want[v.Key])
+		}
+		if v.Secret {
+			t.Errorf("captured var %s should be plain, not secret", v.Key)
+		}
+	}
+	// 即捕即清:文件应被移除。
+	if _, err := os.Stat(filepath.Join(ws, pipewrightEnvFileName)); !os.IsNotExist(err) {
+		t.Error("env file should be removed after capture")
+	}
+}
+
+func TestCaptureStageEnvNoFile(t *testing.T) {
+	if got := captureStageEnv(context.Background(), nil, t.TempDir()); got != nil {
+		t.Fatalf("no file → nil, got %+v", got)
+	}
+}
+
+func TestPipewrightEnvVar(t *testing.T) {
+	v := pipewrightEnvVar()
+	if v.Key != "PIPEWRIGHT_ENV" || !strings.HasPrefix(v.Value, scriptWorkspaceMount) || v.Secret {
+		t.Fatalf("unexpected PIPEWRIGHT_ENV var: %+v", v)
+	}
+}
+
+// envEmitDriver:job1(首调)向工作区写 .pipewright_env(模拟 job 产出),job2(次调)记录收到的 env。
+type envEmitDriver struct {
+	calls   int
+	job2Env []string
+}
+
+func (d *envEmitDriver) Binary() string { return "fake" }
+func (d *envEmitDriver) RunToolchain(_ context.Context, _, hostDir, _ string, env []string, _ []string, _ pipeline.Resource, _ func(string, string)) (int, error) {
+	d.calls++
+	if d.calls == 1 {
+		_ = os.WriteFile(filepath.Join(hostDir, pipewrightEnvFileName), []byte("VERSION=1.2.3\n"), 0o644)
+	} else {
+		d.job2Env = append([]string(nil), env...)
+	}
+	return 0, nil
+}
+func (d *envEmitDriver) Build(context.Context, string, string, string, []string, []string, func(string, string)) (int, error) {
+	panic("Build not expected")
+}
+func (d *envEmitDriver) Tag(context.Context, string, string, func(string, string)) (int, error) {
+	panic("Tag not expected")
+}
+func (d *envEmitDriver) Login(context.Context, string, string, string, func(string, string)) (int, error) {
+	panic("Login not expected")
+}
+func (d *envEmitDriver) Push(context.Context, string, func(string, string)) (int, error) {
+	panic("Push not expected")
+}
+func (d *envEmitDriver) InspectImage(context.Context, string) (string, int64, error) {
+	panic("InspectImage not expected")
+}
+
+// 证步骤输出跨 job 传递:job1 写 VERSION → job2 的容器 env 收到 VERSION=1.2.3。
+func TestStageEnvCarriesToDownstreamJob(t *testing.T) {
+	drv := &envEmitDriver{}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b, nil)
+	stage := scriptStage(
+		scriptJob("build", "busybox", "echo build"),
+		scriptJob("deploy", "busybox", "echo deploy"),
+	)
+	if err := exec(context.Background(), &run.Run{ProjectID: "p1"}, stage, &fakeReporter{}); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if drv.calls != 2 {
+		t.Fatalf("want 2 job runs, got %d", drv.calls)
+	}
+	joined := strings.Join(drv.job2Env, " ")
+	if !strings.Contains(joined, "VERSION=1.2.3") {
+		t.Errorf("下游 job 未收到上游输出 VERSION;job2 env=%v", drv.job2Env)
+	}
+	if !strings.Contains(joined, "PIPEWRIGHT_ENV=") {
+		t.Errorf("job 未注入 PIPEWRIGHT_ENV;job2 env=%v", drv.job2Env)
+	}
+}


### PR DESCRIPTION
## 背景
对标**云效 $FLOW_ENV / GitHub $GITHUB_ENV**(benchmark P1「步骤输出→下游变量」)。同一阶段内 script job 共享克隆工作区:job 容器向 `$PIPEWRIGHT_ENV` 指向的文件追加 `KEY=VALUE`,执行后由执行器捕获并注入**后续同阶段 job** 的环境变量(如 build job 算出版本号 → deploy/通知 job 引用)。

## 改动
- `stage_env.go`:`pipewrightEnvVar`(注入 `PIPEWRIGHT_ENV=<容器内工作区路径>`)+ `captureStageEnv`(读工作区根 `.pipewright_env` → 解析 `KEY=VALUE` → **即捕即清**,各 job 写入隔离;键名校验、非法行宽松跳过、**日志仅记键名不回显值**)。
- `dag_stage_exec.go` script job 循环:`carriedEnv` 累积上游输出,注入顺序 = 运行参数 → 上游输出 → job 自身 env(覆盖同名)→ `PIPEWRIGHT_ENV`(系统末位防覆盖);每 job 执行后捕获其输出。

**不改单机执行语义、无新依赖、无迁移**;无输出文件 = 常态(零开销)。

## 验证
- `captureStageEnv` 解析/清理/无文件 + `pipewrightEnvVar` + **集成测试**(fake driver:job1 写 `VERSION` → job2 容器 env 收到 `VERSION=1.2.3` + `PIPEWRIGHT_ENV` 注入)。
- `go test ./internal/build/` 绿;gofmt/vet/build 净。

## 诚实边界
跨阶段(不同工作区)传值不覆盖(仅同阶段 job 间);secret 输出由用户自负(按明文注入)。

> 本轮 P1 多路并发的一支:另有 matrix / 环境一等公民 / 工作室实例短清单(agent)在并行。**services 旁挂容器 / post-finally 块** 因需重构执行器(run-on-failure)+ 扩 Driver 容器网络生命周期,留作下一焦点(不鲁莽塞进本批)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)