### PR TITLE
feat(pipeline): 工作室节点实例「提升参数短清单」(类型化控件 · 纯前端)

### DIFF
--- a/web/src/components/pipeline/JobDrawer.studioShortlist.test.ts
+++ b/web/src/components/pipeline/JobDrawer.studioShortlist.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import JobDrawer from './JobDrawer.vue'
+import StudioInstanceParams from './StudioInstanceParams.vue'
+import StepBuilder from './StepBuilder.vue'
+import { encodeStudioMeta, STUDIO_META_KEY, type PromotedParam } from './studioCompile'
+import type { PipelineJob, PipelineStage } from '../../api/pipeline'
+
+const stage: PipelineStage = { id: 's1', name: '构建', kind: 'build', jobs: [] }
+
+function param(p: Partial<PromotedParam> & { key: string }): PromotedParam {
+  return { label: p.key, type: 'text', default: '', ...p }
+}
+
+/** A templated (studio) node carrying promoted params (dir=text, ver=select). */
+function studioJob(params: string): PipelineJob {
+  const meta = encodeStudioMeta([
+    param({ key: 'dir', label: '目录', type: 'text' }),
+    param({ key: 'ver', label: 'Go 版本', type: 'select', options: ['1.22', '1.21'] }),
+    param({ key: 'verbose', label: '详细日志', type: 'toggle' }),
+  ])
+  return {
+    id: 'j1',
+    name: '自定义构建',
+    type: 'templated',
+    summary: '',
+    config: {
+      image: 'golang:{{ver}}',
+      commandTemplate: 'cd {{dir}}\ngo build ./...',
+      params,
+      [STUDIO_META_KEY]: meta,
+    },
+  }
+}
+
+describe('JobDrawer — studio instance shortlist', () => {
+  it('renders the typed shortlist (not raw text) by default for a studio node', () => {
+    const wrapper = mount(JobDrawer, {
+      props: { job: studioJob('dir=web\nver=1.22\nverbose=false'), stage },
+    })
+    const shortlist = wrapper.findComponent(StudioInstanceParams)
+    expect(shortlist.exists()).toBe(true)
+    // definitions flow in from parsePromotedParams (label/type/options)
+    const defs = shortlist.props('params') as PromotedParam[]
+    expect(defs.map((d) => d.key)).toEqual(['dir', 'ver', 'verbose'])
+    expect(defs.find((d) => d.key === 'ver')!.type).toBe('select')
+    // current values seeded from params text
+    expect(shortlist.props('modelValue')).toEqual({ dir: 'web', ver: '1.22', verbose: 'false' })
+    // raw command-template textarea + step builder are NOT shown by default
+    expect(wrapper.findComponent(StepBuilder).exists()).toBe(false)
+    expect(wrapper.find('textarea').exists()).toBe(false)
+    // advanced "查看/编辑原始参数" entry is present (collapsed)
+    expect(wrapper.text()).toContain('查看/编辑原始参数')
+  })
+
+  it('writing a shortlist value flushes params text with only the value changed', async () => {
+    const wrapper = mount(JobDrawer, {
+      props: { job: studioJob('dir=web\nver=1.22\nverbose=false'), stage },
+    })
+    const shortlist = wrapper.findComponent(StudioInstanceParams)
+    shortlist.vm.$emit('update:modelValue', { dir: 'frontend', ver: '1.21', verbose: 'true' })
+    await wrapper.vm.$nextTick()
+
+    const events = wrapper.emitted('update')
+    expect(events).toBeTruthy()
+    const last = events!.at(-1)![0] as Partial<PipelineJob>
+    // params text rewritten (key order preserved), __studio meta + commandTemplate untouched
+    expect(last.config!.params).toBe('dir=frontend\nver=1.21\nverbose=true')
+    expect(last.config!.commandTemplate).toBe('cd {{dir}}\ngo build ./...')
+    expect(last.config![STUDIO_META_KEY]).toBe(studioJob('').config![STUDIO_META_KEY])
+  })
+
+  it('expanding 高级 reveals the raw typed form (commandTemplate textarea)', async () => {
+    const wrapper = mount(JobDrawer, {
+      props: { job: studioJob('dir=web\nver=1.22\nverbose=false'), stage },
+    })
+    expect(wrapper.find('textarea').exists()).toBe(false)
+    const toggle = wrapper.findAll('.advanced-toggle').find((b) => b.text().includes('查看/编辑原始参数'))
+    expect(toggle).toBeTruthy()
+    await toggle!.trigger('click')
+    // raw view now exposes the params / commandTemplate textareas
+    expect(wrapper.findAll('textarea').length).toBeGreaterThan(0)
+  })
+
+  it('round-trip: reload with edited params re-displays the new values', () => {
+    const wrapper = mount(JobDrawer, {
+      props: { job: studioJob('dir=web\nver=1.22\nverbose=false'), stage },
+    })
+    // simulate parent re-feeding the job with edited params (e.g. after save+reload)
+    wrapper.setProps({ job: studioJob('dir=app\nver=1.21\nverbose=true') })
+    return wrapper.vm.$nextTick().then(() => {
+      const shortlist = wrapper.findComponent(StudioInstanceParams)
+      expect(shortlist.props('modelValue')).toEqual({ dir: 'app', ver: '1.21', verbose: 'true' })
+    })
+  })
+
+  it('non-studio node is unaffected (no shortlist, normal typed form)', () => {
+    const job: PipelineJob = { id: 'j2', name: '通知', type: 'notify', summary: '', config: {} }
+    const wrapper = mount(JobDrawer, { props: { job, stage } })
+    expect(wrapper.findComponent(StudioInstanceParams).exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('实例参数')
+    expect(wrapper.text()).not.toContain('查看/编辑原始参数')
+  })
+
+  it('templated node with no promoted params keeps the original raw form (no empty shortlist)', () => {
+    const job: PipelineJob = {
+      id: 'j3',
+      name: '自定义',
+      type: 'templated',
+      summary: '',
+      config: { image: 'node:20', commandTemplate: 'npm run build' },
+    }
+    const wrapper = mount(JobDrawer, { props: { job, stage } })
+    expect(wrapper.findComponent(StudioInstanceParams).exists()).toBe(false)
+    // raw typed config section still rendered
+    expect(wrapper.text()).toContain('配置')
+  })
+})

--- a/web/src/components/pipeline/JobDrawer.vue
+++ b/web/src/components/pipeline/JobDrawer.vue
@@ -11,9 +11,17 @@ import {
   type JobField,
 } from './jobConfigSchema'
 import { configUsesTemplate } from './stepCompile'
+import {
+  isStudioNode,
+  parsePromotedParams,
+  promotedValues,
+  applyPromotedValues,
+  type PromotedParam,
+} from './studioCompile'
 import { createCustomNode } from '../../api/customNodes'
 import JobTypeIcon from './JobTypeIcon.vue'
 import StepBuilder from './StepBuilder.vue'
+import StudioInstanceParams from './StudioInstanceParams.vue'
 
 const props = defineProps<{
   job: PipelineJob
@@ -118,6 +126,39 @@ function onStepsUpdate(patch: { commands: string; artifactPath: string }): void 
     commands: patch.commands,
     artifactPath: patch.artifactPath,
   }
+  flush()
+}
+
+// ─── 工作室节点「实例参数短清单」 ─────────────────────────────────────────────
+// 把工作室(templated / 带 __studio)节点拖进流水线后,实例编辑默认只面对作者「提升」
+// 出来的少数参数(类型化控件),而非整段 commandTemplate/params 原始文本。提升参数的
+// 定义(label/type/options)来自 __studio 元信息,只读消费;短清单只编辑各参数的「值」,
+// 经 applyPromotedValues 写回 config.params 文本。原始视图收进可折叠「高级」入口兜底。
+
+/** 当前完整 config(typed + extras 合并),供 studio 解析提升参数定义/值。 */
+const liveConfig = computed<Record<string, string>>(() => currentConfig())
+
+/** 是否工作室节点(templated 或带 __studio)。 */
+const isStudio = computed<boolean>(() => isStudioNode(localType.value, liveConfig.value))
+
+/** 提升参数定义(只读):key/label/type/options + 当前值(default 字段)。 */
+const promotedParams = computed<PromotedParam[]>(() =>
+  isStudio.value ? parsePromotedParams(liveConfig.value) : [],
+)
+
+/** 该节点是否值得显示短清单(工作室节点且至少有一个提升参数)。 */
+const showShortlist = computed<boolean>(() => promotedParams.value.length > 0)
+
+/** 短清单当前值表(key → value),由 params 文本解析而来。 */
+const shortlistValues = computed<Record<string, string>>(() => promotedValues(liveConfig.value))
+
+/** 工作室实例:原始参数视图(image/params/commandTemplate 等)默认收起。 */
+const showStudioRaw = ref(false)
+
+/** 短清单改值 → 写回 params 文本(只动 value,不碰 __studio 定义)→ flush。 */
+function onShortlistUpdate(values: Record<string, string>): void {
+  const params = applyPromotedValues(promotedParams.value, values)
+  typedConfig.value = { ...typedConfig.value, params }
   flush()
 }
 
@@ -310,11 +351,39 @@ async function confirmSave(): Promise<void> {
       </div>
     </div>
 
+    <!-- 工作室节点「实例参数短清单」:只展示作者提升的参数,类型化控件,default 预填。 -->
+    <div v-if="showShortlist" class="drawer-section">
+      <div class="drawer-section-label">实例参数</div>
+      <p class="shortlist-hint">
+        该自定义节点提升了以下参数;按需调整,其余命令模板已由节点作者固定。
+      </p>
+      <StudioInstanceParams
+        :params="promotedParams"
+        :model-value="shortlistValues"
+        @update:model-value="onShortlistUpdate"
+      />
+    </div>
+
+    <!-- 工作室实例:原始命令模板/参数视图收进可折叠「高级」入口(默认收起)。 -->
+    <div v-if="showShortlist && spec" class="drawer-section drawer-studio-raw-toggle">
+      <button
+        class="advanced-toggle"
+        :class="{ 'advanced-toggle--open': showStudioRaw }"
+        :aria-expanded="showStudioRaw"
+        @click="showStudioRaw = !showStudioRaw"
+      >
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true">
+          <path d="M9 18l6-6-6-6"/>
+        </svg>
+        高级 · 查看/编辑原始参数
+      </button>
+    </div>
+
     <!-- Typed config section (per-type form) -->
-    <div v-if="spec" class="drawer-section">
+    <div v-if="spec && (!showShortlist || showStudioRaw)" class="drawer-section">
       <div class="drawer-section-head">
         <div class="drawer-section-label">{{ spec.label }}配置</div>
-        <div v-if="canUseStepBuilder" class="view-switch" role="tablist" aria-label="配置视图">
+        <div v-if="canUseStepBuilder && !showShortlist" class="view-switch" role="tablist" aria-label="配置视图">
           <button
             class="view-tab"
             :class="{ 'view-tab--active': viewMode === 'steps' }"
@@ -586,6 +655,18 @@ async function confirmSave(): Promise<void> {
 
 .step-builder-field {
   margin-top: 4px;
+}
+
+.shortlist-hint {
+  margin: 0 0 12px;
+  font-size: 0.73rem;
+  line-height: 1.45;
+  color: var(--color-faint);
+}
+
+.drawer-studio-raw-toggle {
+  padding-top: 0;
+  margin-top: -4px;
 }
 
 .kv-empty {

--- a/web/src/components/pipeline/StudioInstanceParams.vue
+++ b/web/src/components/pipeline/StudioInstanceParams.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+/**
+ * StudioInstanceParams — 工作室节点实例的「提升参数短清单」类型化控件。
+ *
+ * 把一个工作室(templated)节点拖进流水线后,实例编辑只需面对作者「提升」出来的
+ * 少数参数,而非整段 commandTemplate/params 原始文本(n8n promote 参数 / Node-RED
+ * Subflow properties 范式)。据每个提升参数的 type 渲染控件:
+ *   select → 下拉、toggle → 开关、number → 数字框、text → 输入框,以当前值预填。
+ *
+ * 数据契约(与「运行参数」TypedRunParams 区分):
+ *   - 定义(key/label/type/options)由调用方经 `parsePromotedParams` 提供,**只读消费**,
+ *     本组件绝不改它 —— 故 `__studio` 元信息不被实例编辑破坏。
+ *   - 当前值经 v-model 以 Record<string,string> 回传;调用方用 `applyPromotedValues`
+ *     写回 config.params 文本。本组件不直接碰 config。
+ */
+import { ref, watch } from 'vue'
+import type { PromotedParam } from './studioCompile'
+
+const props = defineProps<{
+  /** 提升参数定义(只读):提供控件类型/标签/候选项与初始值。 */
+  params: PromotedParam[]
+  /** 当前实例值表(key → value);缺失的 key 由 param.default 兜底。 */
+  modelValue: Record<string, string>
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: Record<string, string>): void
+}>()
+
+/** 以 default 兜底 + 已有 modelValue 覆盖,建立本地值表。 */
+function seed(): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const p of props.params) {
+    const provided = props.modelValue[p.key]
+    out[p.key] = provided != null && provided !== '' ? provided : p.default
+  }
+  return out
+}
+
+const values = ref<Record<string, string>>(seed())
+
+// 切节点 / 参数定义变化时重新播种(不 commit:避免把回显当成一次编辑写回)。
+watch(
+  () => props.params,
+  () => {
+    values.value = seed()
+  },
+)
+
+function setVal(key: string, v: string): void {
+  values.value = { ...values.value, [key]: v }
+  emit('update:modelValue', { ...values.value })
+}
+
+function toggleBool(key: string): void {
+  setVal(key, values.value[key] === 'true' ? 'false' : 'true')
+}
+</script>
+
+<template>
+  <div class="studio-instance">
+    <div v-for="p in params" :key="p.key" class="si-field">
+      <label class="si-label" :for="`si-${p.key}`">
+        {{ p.label || p.key }}
+        <code class="si-key">{{ p.key }}</code>
+      </label>
+
+      <!-- 枚举 → 下拉 -->
+      <select
+        v-if="p.type === 'select'"
+        :id="`si-${p.key}`"
+        class="si-input"
+        :value="values[p.key]"
+        :aria-label="p.label || p.key"
+        @change="setVal(p.key, ($event.target as HTMLSelectElement).value)"
+      >
+        <option v-for="opt in p.options ?? []" :key="opt" :value="opt">{{ opt }}</option>
+      </select>
+
+      <!-- 布尔 → 开关 -->
+      <button
+        v-else-if="p.type === 'toggle'"
+        :id="`si-${p.key}`"
+        type="button"
+        class="si-toggle"
+        :class="{ 'si-toggle--on': values[p.key] === 'true' }"
+        role="switch"
+        :aria-checked="values[p.key] === 'true'"
+        :aria-label="p.label || p.key"
+        @click="toggleBool(p.key)"
+      >
+        <span class="si-toggle-knob" />
+        <span class="si-toggle-text">{{ values[p.key] === 'true' ? 'true' : 'false' }}</span>
+      </button>
+
+      <!-- 数字 / 文本 -->
+      <input
+        v-else
+        :id="`si-${p.key}`"
+        class="si-input"
+        :type="p.type === 'number' ? 'number' : 'text'"
+        :value="values[p.key]"
+        :placeholder="p.default"
+        :aria-label="p.label || p.key"
+        autocomplete="off"
+        @input="setVal(p.key, ($event.target as HTMLInputElement).value)"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.studio-instance { display: flex; flex-direction: column; gap: 12px; }
+.si-field { display: flex; flex-direction: column; gap: 5px; }
+.si-label {
+  font-size: 0.8rem; font-weight: 600; color: var(--color-text);
+  display: flex; align-items: center; gap: 6px;
+}
+.si-key {
+  font-family: var(--font-mono, ui-monospace, monospace); font-size: 0.7rem;
+  color: var(--color-faint); background: var(--color-inset);
+  padding: 0 4px; border-radius: 4px; font-weight: 400;
+}
+.si-input {
+  height: 34px; padding: 0 10px;
+  border: 1px solid var(--color-border-strong); border-radius: var(--rounded-md);
+  background: var(--color-card); color: var(--color-text);
+  font: inherit; font-size: 0.85rem; outline: none; width: 100%;
+}
+.si-input:focus { border-color: var(--color-primary); box-shadow: 0 0 0 2px var(--color-primary-soft); }
+.si-toggle {
+  display: inline-flex; align-items: center; gap: 9px;
+  height: 34px; padding: 0 12px 0 4px; width: fit-content;
+  border: 1px solid var(--color-border-strong); border-radius: var(--rounded-full, 999px);
+  background: var(--color-inset); cursor: pointer; color: var(--color-dim);
+  font: inherit; font-size: 0.8rem; transition: background-color var(--duration-fast);
+}
+.si-toggle--on { background: var(--color-primary-soft); color: var(--color-primary); border-color: var(--color-primary); }
+.si-toggle-knob {
+  width: 24px; height: 24px; border-radius: 50%;
+  background: var(--color-card); border: 1px solid var(--color-border-strong);
+  transition: transform var(--duration-fast); flex: none;
+}
+.si-toggle--on .si-toggle-knob { transform: translateX(2px); border-color: var(--color-primary); }
+.si-toggle-text { font-family: var(--font-mono, ui-monospace, monospace); }
+</style>

--- a/web/src/components/pipeline/studioCompile.test.ts
+++ b/web/src/components/pipeline/studioCompile.test.ts
@@ -11,6 +11,8 @@ import {
   compileStudioConfig,
   isStudioNode,
   emptyStudioModel,
+  promotedValues,
+  applyPromotedValues,
 } from './studioCompile'
 
 function param(p: Partial<PromotedParam> & { key: string }): PromotedParam {
@@ -132,5 +134,65 @@ describe('studioCompile', () => {
 
   it('emptyStudioModel is a blank studio', () => {
     expect(emptyStudioModel()).toEqual({ image: '', params: [], stepConfig: { commands: '', artifactPath: '' } })
+  })
+
+  describe('instance shortlist values (promotedValues / applyPromotedValues)', () => {
+    it('reads current values keyed by param key from params text', () => {
+      const meta = encodeStudioMeta([
+        param({ key: 'node', label: '镜像', type: 'select', options: ['20', '18'] }),
+        param({ key: 'flag', label: '开关', type: 'toggle' }),
+      ])
+      const config = { params: 'node=18\nflag=true', [STUDIO_META_KEY]: meta }
+      expect(promotedValues(config)).toEqual({ node: '18', flag: 'true' })
+    })
+
+    it('reads values even without __studio (type=text fallback)', () => {
+      expect(promotedValues({ params: 'dir=web\nenv=prod' })).toEqual({ dir: 'web', env: 'prod' })
+    })
+
+    it('writes edited values back into params text, preserving key order', () => {
+      const params = [
+        param({ key: 'node', label: '镜像', type: 'select', default: '20', options: ['20', '18'] }),
+        param({ key: 'dir', label: '目录', default: 'web' }),
+      ]
+      const next = applyPromotedValues(params, { node: '18', dir: 'frontend' })
+      expect(next).toBe('node=18\ndir=frontend')
+    })
+
+    it('missing key in values keeps its existing default', () => {
+      const params = [param({ key: 'a', default: '1' }), param({ key: 'b', default: '2' })]
+      expect(applyPromotedValues(params, { a: '9' })).toBe('a=9\nb=2')
+    })
+
+    it('round-trips: read → edit → write → re-read across all types', () => {
+      const meta = encodeStudioMeta([
+        param({ key: 'ver', label: 'Go', type: 'select', options: ['1.22', '1.21'] }),
+        param({ key: 'count', label: '并发', type: 'number' }),
+        param({ key: 'verbose', label: '详细', type: 'toggle' }),
+        param({ key: 'note', label: '备注', type: 'text' }),
+      ])
+      const config = {
+        params: 'ver=1.22\ncount=4\nverbose=false\nnote=hi',
+        [STUDIO_META_KEY]: meta,
+      }
+      const defs = parsePromotedParams(config)
+      const edited = { ver: '1.21', count: '8', verbose: 'true', note: 'bye' }
+      const newParams = applyPromotedValues(defs, edited)
+      // re-read from the new params text + same __studio meta
+      const back = promotedValues({ params: newParams, [STUDIO_META_KEY]: meta })
+      expect(back).toEqual(edited)
+      // __studio definitions untouched by the value edit
+      expect(parsePromotedParams({ params: newParams, [STUDIO_META_KEY]: meta }).map((p) => ({
+        key: p.key,
+        label: p.label,
+        type: p.type,
+        options: p.options,
+      }))).toEqual([
+        { key: 'ver', label: 'Go', type: 'select', options: ['1.22', '1.21'] },
+        { key: 'count', label: '并发', type: 'number', options: undefined },
+        { key: 'verbose', label: '详细', type: 'toggle', options: undefined },
+        { key: 'note', label: '备注', type: 'text', options: undefined },
+      ])
+    })
   })
 })

--- a/web/src/components/pipeline/studioCompile.ts
+++ b/web/src/components/pipeline/studioCompile.ts
@@ -150,6 +150,38 @@ export function parsePromotedParams(config: Record<string, unknown>): PromotedPa
   })
 }
 
+/**
+ * 实例编辑专用:读出每个提升参数的「当前值」(key → value)。
+ *
+ * 当前值以 `params` 文本里 `key=value` 的 value 为唯一真源 —— `parsePromotedParams`
+ * 把它解析进 `default` 字段;在实例语境下它就是「实例已填的值 / 未填则模板默认」。
+ * 供节点抽屉的短清单控件初始绑定。
+ */
+export function promotedValues(config: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const p of parsePromotedParams(config)) out[p.key] = p.default
+  return out
+}
+
+/**
+ * 实例编辑专用:把短清单控件改后的值写回 `params` 文本。
+ *
+ * 以提升参数定义(key/顺序)为骨架,仅替换各参数的 value;`values` 缺失的 key
+ * 沿用其原 default。**只动 value,不碰 key/label/type/options**,故 `__studio`
+ * 元信息不被实例编辑破坏;产出直接覆盖 config.params,回开短清单回显新值。
+ */
+export function applyPromotedValues(
+  params: readonly PromotedParam[],
+  values: Record<string, string>,
+): string {
+  return paramsToText(
+    params.map((p) => {
+      const next = values[p.key]
+      return next === undefined ? p : { ...p, default: next }
+    }),
+  )
+}
+
 /** 反解析 templated 节点 config → 工作室模型(commandTemplate 优先,兼容旧 commands)。 */
 export function parseStudioConfig(config: Record<string, unknown>): StudioModel {
   const commands = configString(config, 'commandTemplate') || configString(config, 'commands')


### PR DESCRIPTION
## 背景

PR #59 做了「自定义节点工作室」:用低代码组合步骤 + **提升参数(promoted params)**,编译成 `templated` 节点存库。提升参数的元信息(key/label/type/options)存在 config 的 `__studio` JSON 键(`STUDIO_META_KEY`)。

**本次补缺口**:把这种工作室节点拖进流水线后,节点抽屉(`JobDrawer.vue`)编辑实例时,默认**只展示提升参数的「短清单」类型化控件**(枚举→下拉、布尔→开关、数字→数字框、文本→输入,default 预填),而不是让用户面对整段 commandTemplate/params 原始文本。这就是 n8n「promote 参数→实例短清单」/ Node-RED Subflow properties 的范式。

## 改动(纯前端,无后端改动)

- **`StudioInstanceParams.vue`(新)**:据 `PromotedParam[]` 渲染类型化短清单控件。参数定义(label/type/options)**只读消费**,仅经 v-model 以 `Record<string,string>` 回传当前值 —— 绝不改 `__studio` 元信息。控件样式对齐既有 `TypedRunParams.vue`,但数据源是 promoted params。
- **`studioCompile.ts`(最小只读附加)**:
  - `promotedValues(config)` — 读出每个提升参数当前值(`key → value`,源自 params 文本)。
  - `applyPromotedValues(params, values)` — 把改后的值写回 params 文本,**只替换 value,保 key/顺序**,不碰 `__studio`。
  - 既有 `parsePromotedParams` / `isStudioNode` / `paramsToText` 语义不变,仅复用。
- **`JobDrawer.vue`**:
  - `isStudioNode(localType, config)` 为真且**有提升参数**时,默认渲染「实例参数」短清单。
  - 保留老的原始 typed 视图(image/params/commandTemplate/artifactPath 等),收进可折叠「**高级 · 查看/编辑原始参数**」入口兜底,默认收起。
  - 短清单改值 → `applyPromotedValues` 写回 `config.params` 文本 → `flush()` 落库(config 仍 `Record<string,string>`,不破 2-2 冻结契约)。
  - **非工作室节点行为完全不变**;templated 但无提升参数的节点继续走原始视图(不显示空短清单)。

## round-trip

实例改提升参数值 → 写回 params 文本 → 保存 → reload 后短清单回显新值;`__studio` 元信息(label/type/options)只读消费、不被实例编辑破坏。已用单测覆盖(含各类型 select/number/toggle/text 往返)。

## 验证(绿)

\`\`\`
npm run typecheck   # vue-tsc 0 error
npm run lint        # 0 error(仅 10 条 pre-existing warning,均在未触碰文件)
npx vitest run      # 27 files / 269 tests passed(新增 studioCompile 值往返 + JobDrawer 短清单 12 用例)
npm run build       # built in ~24s(已 git restore web/dist/index.html)
\`\`\`

## 诚实边界

- 仅做了 vitest 组件级验证(`@vue/test-utils` mount,断言 props/emit/DOM)。**未跑 Playwright** 真实例视觉验证(可选项,本轮未做)。
- 短清单值与 params 文本的真源仍是文本里的 `key=value` —— 若用户经「高级」原始视图手改 params 文本同时改了短清单,以最后一次 flush 为准(典型单向编辑,无并发冲突场景)。
- `applyPromotedValues` 仅对**有定义的提升参数**写回;params 文本里若存在 `__studio` 未覆盖的额外行,经 `parsePromotedParams` 仍会被当 type=text 提升参数纳入短清单(符合预期:params 文本是 key 真源)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)