### PR TITLE
feat(pipeline): 矩阵构建 matrix(阶段声明轴 → 并行 cell 笛卡尔积 · P1)

### DIFF
--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -490,6 +490,7 @@ func scriptStepFromJob(jb pipeline.Job) (pipeline.PipelineStep, error) {
 		Type:     pipeline.StepTypeScript,
 		Image:    image,
 		Commands: cmds,
+		Env:      matrixEnvVars(jb.Config), // 矩阵 cell 注入的 axis 环境变量(MATRIX_<AXIS>),空时 nil
 		WorkDir:  renderTemplate(cfgString(jb.Config, "workDir"), ctx),
 		// 任务级 timeout/retry/资源规格(P0 引擎能力):从 job.Config 自由 KV 读取(非负;非法/缺失→零值=旧行为)。
 		TimeoutSeconds: cfgNonNegInt(jb.Config, "timeoutSeconds"),
@@ -522,6 +523,41 @@ func cfgNonNegInt(cfg map[string]any, key string) int {
 		}
 	}
 	return 0
+}
+
+// matrixEnvVars 读取矩阵展开(dagrun.ExpandMatrix)注入 job.Config 的 cell 环境变量,转为非 secret
+// BuildVar(`MATRIX_<AXIS>=<值>`,容器内命令可 `$MATRIX_GO` 引用)。键 "__matrixEnv" 由调度层合成、
+// 非用户配置;值通常是 map[string]string(内存构造),JSON 回环时为 map[string]any,两者皆容错。
+// 普通(非矩阵)job 无此键 → 返回 nil(零行为变化)。
+func matrixEnvVars(cfg map[string]any) []pipeline.BuildVar {
+	if cfg == nil {
+		return nil
+	}
+	raw, ok := cfg["__matrixEnv"]
+	if !ok {
+		return nil
+	}
+	collect := func(k, v string) pipeline.BuildVar {
+		return pipeline.BuildVar{Key: k, Value: v, Secret: false}
+	}
+	switch m := raw.(type) {
+	case map[string]string:
+		out := make([]pipeline.BuildVar, 0, len(m))
+		for k, v := range m {
+			out = append(out, collect(k, v))
+		}
+		return out
+	case map[string]any:
+		out := make([]pipeline.BuildVar, 0, len(m))
+		for k, v := range m {
+			if s, ok := v.(string); ok {
+				out = append(out, collect(k, s))
+			}
+		}
+		return out
+	default:
+		return nil
+	}
 }
 
 // runParamsAsEnv 把运行参数(明文 K=V)转为非 secret BuildVar(注入容器环境)。键序确定性不保证(map),

--- a/internal/dagrun/dagrun.go
+++ b/internal/dagrun/dagrun.go
@@ -133,7 +133,10 @@ func (r *Runner) Run(ctx context.Context, rn *run.Run, sink run.StepSink) error 
 	if err != nil {
 		return fmt.Errorf("dagrun: load pipeline spec: %w", err)
 	}
-	stages := cfg.Spec.Stages
+	// 矩阵展开(P1):把声明了 Matrix 的阶段在纯调度层展开成笛卡尔积的并行 cell 子阶段,
+	// 并重映射 needs(下游等所有 cell)。无 matrix 阶段时原样返回。展开后阶段集作为后续
+	// 建图 / stageByID / 上报 / 执行的权威集——不改 dag 的并发与失败语义。
+	stages := ExpandMatrix(cfg.Spec.Stages)
 	if len(stages) == 0 {
 		// 无阶段:声明零步,直接成功(与既有空流水线语义一致)。
 		_ = sink.Plan(ctx, nil)

--- a/internal/dagrun/matrix.go
+++ b/internal/dagrun/matrix.go
@@ -1,0 +1,206 @@
+package dagrun
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+)
+
+// matrix.go 是矩阵构建(P1)的纯调度层展开:把一个声明了 Matrix 的阶段展开成笛卡尔积的多个并行
+// cell 子阶段。对标 GHA matrix / GitLab parallel:matrix / Jenkins matrix。
+//
+// 设计(不改 dag/dagrun 的并发与失败语义):
+//   - 展开发生在 BuildGraph 之前(ExpandMatrix),产出一份「展开后的阶段列表」,既喂给 BuildGraph
+//     建图,也作为 Run 里 stageByID 的权威阶段集——下游调度、上报、执行全走展开后的 cell。
+//   - 每个 cell = 原阶段的副本:同 Kind/When/Gate/AllowFailure,jobs 深拷贝并把 axis 值以
+//     `MATRIX_<AXIS>` 注入各 script 类 job 的 Config["__matrixEnv"](执行器既有 scriptStepFromJob 消费)。
+//   - cell id 形如 `<stageID>__<sortedAxisKey>`,确定性可复现(轴名字典序)。
+//   - needs 重映射:下游若 need 一个 matrix 阶段 M,则改为 need M 的**全部 cell**(下游等所有 cell 完成);
+//     cell 自身的 needs 同样把指向 matrix 上游的引用展开为该上游的全部 cell。
+//   - cell 间并行 / 各自成败 / 失败按 allowFailure+needs 传播,全部复用既有 dag.Schedule(零改并发语义)。
+//   - 空 Matrix → 阶段原样保留(行为不变)。
+//
+// matrixEnvConfigKey 是注入 cell job.Config 的内部键:值为 map[string]string(axis 环境变量),
+// 由 build.scriptStepFromJob 读取并并入 step.Env。下划线前缀标记「调度层合成、非用户配置」。
+const matrixEnvConfigKey = "__matrixEnv"
+
+// ExpandMatrix 把阶段列表里所有声明了 Matrix 的阶段展开为并行 cell 子阶段,并重映射 needs。
+// 无任何 matrix 阶段时原样返回(零开销)。假定 stages 已通过 pipeline 校验(轴/cell 数上限等)。
+func ExpandMatrix(stages []pipeline.Stage) []pipeline.Stage {
+	hasMatrix := false
+	for _, st := range stages {
+		if len(st.Matrix) > 0 {
+			hasMatrix = true
+			break
+		}
+	}
+	if !hasMatrix {
+		return stages
+	}
+
+	// 原 stageID → 展开后承接其「下游依赖」的 ID 列表:
+	//   非 matrix 阶段 → [自身 id];matrix 阶段 → [全部 cell id]。
+	expandedIDs := make(map[string][]string, len(stages))
+	for _, st := range stages {
+		if len(st.Matrix) == 0 {
+			expandedIDs[st.ID] = []string{st.ID}
+			continue
+		}
+		ids := make([]string, 0)
+		for _, cell := range cartesian(st.Matrix) {
+			ids = append(ids, cellID(st.ID, cell))
+		}
+		expandedIDs[st.ID] = ids
+	}
+
+	remapNeeds := func(needs []string) []string {
+		if len(needs) == 0 {
+			return nil
+		}
+		out := make([]string, 0, len(needs))
+		for _, n := range needs {
+			if ids, ok := expandedIDs[n]; ok {
+				out = append(out, ids...)
+			} else {
+				out = append(out, n) // 未知依赖:原样保留(dag.New 会兜底报错)
+			}
+		}
+		return out
+	}
+
+	out := make([]pipeline.Stage, 0, len(stages))
+	for _, st := range stages {
+		if len(st.Matrix) == 0 {
+			cp := st
+			cp.Needs = remapNeeds(st.Needs)
+			out = append(out, cp)
+			continue
+		}
+		needs := remapNeeds(st.Needs)
+		for _, cell := range cartesian(st.Matrix) {
+			out = append(out, buildCell(st, cell, needs))
+		}
+	}
+	return out
+}
+
+// buildCell 构造一个 cell 子阶段:复制原阶段元信息,jobs 深拷贝并注入 axis 环境变量。
+func buildCell(st pipeline.Stage, cell map[string]string, needs []string) pipeline.Stage {
+	env := make(map[string]string, len(cell))
+	for axis, val := range cell {
+		env[pipeline.MatrixEnvKey(axis)] = val
+	}
+	jobs := make([]pipeline.Job, 0, len(st.Jobs))
+	for _, jb := range st.Jobs {
+		jobs = append(jobs, cloneJobWithMatrixEnv(jb, env, cellSuffixFromCell(cell)))
+	}
+	return pipeline.Stage{
+		ID:           cellID(st.ID, cell),
+		Name:         st.Name + " " + cellLabel(cell),
+		Kind:         st.Kind,
+		Needs:        needs,
+		AllowFailure: st.AllowFailure,
+		When:         st.When,
+		Gate:         st.Gate,
+		// Matrix 故意清空:cell 已是展开后的具体实例,不可再被二次展开。
+		Jobs: jobs,
+	}
+}
+
+// cellLabel 返回供展示的 cell 标签,如 `[go=1.21, os=linux]`(轴字典序)。
+func cellLabel(cell map[string]string) string {
+	axes := make([]string, 0, len(cell))
+	for a := range cell {
+		axes = append(axes, a)
+	}
+	sort.Strings(axes)
+	parts := make([]string, 0, len(axes))
+	for _, a := range axes {
+		parts = append(parts, fmt.Sprintf("%s=%s", a, cell[a]))
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+// cloneJobWithMatrixEnv 深拷贝 job(含 Config 浅拷贝足够——只新增键),写入 __matrixEnv,
+// 并给 job id 追加 cell 后缀以保证全局唯一(同阶段多 cell 的同名 job 不撞 id)。
+func cloneJobWithMatrixEnv(jb pipeline.Job, env map[string]string, suffix string) pipeline.Job {
+	cfg := make(map[string]any, len(jb.Config)+1)
+	for k, v := range jb.Config {
+		cfg[k] = v
+	}
+	// 拷贝一份 env,避免多 job 共享同一 map 引用。
+	envCopy := make(map[string]string, len(env))
+	for k, v := range env {
+		envCopy[k] = v
+	}
+	cfg[matrixEnvConfigKey] = envCopy
+	jb.Config = cfg
+	if suffix != "" {
+		jb.ID = jb.ID + "__" + suffix
+	}
+	return jb
+}
+
+// cartesian 返回矩阵所有轴的笛卡尔积(每个 cell = axis→值 的一种取值组合)。
+// 轴序按字典序固定(MatrixAxisOrder),保证 cell 顺序与命名可复现。
+func cartesian(matrix map[string][]string) []map[string]string {
+	axes := pipeline.MatrixAxisOrder(matrix)
+	cells := []map[string]string{{}}
+	for _, axis := range axes {
+		vals := matrix[axis]
+		next := make([]map[string]string, 0, len(cells)*len(vals))
+		for _, base := range cells {
+			for _, v := range vals {
+				nc := make(map[string]string, len(base)+1)
+				for k, ov := range base {
+					nc[k] = ov
+				}
+				nc[axis] = v
+				next = append(next, nc)
+			}
+		}
+		cells = next
+	}
+	return cells
+}
+
+// cellID 返回 cell 子阶段的全局唯一 id(`<原阶段id>__<cellSuffix>`)。
+func cellID(stageID string, cell map[string]string) string {
+	return stageID + "__" + cellSuffixFromCell(cell)
+}
+
+// cellSuffixFromCell 不依赖原 matrix(cell 自身即含全部轴),按轴名字典序连接。
+func cellSuffixFromCell(cell map[string]string) string {
+	axes := make([]string, 0, len(cell))
+	for a := range cell {
+		axes = append(axes, a)
+	}
+	sort.Strings(axes)
+	parts := make([]string, 0, len(axes))
+	for _, a := range axes {
+		parts = append(parts, sanitizeIDPart(a)+"-"+sanitizeIDPart(cell[a]))
+	}
+	return strings.Join(parts, "_")
+}
+
+// sanitizeIDPart 把任意轴值清洗成可安全嵌入 id 的片段(非字母/数字/下划线/连字符/点 → `-`)。
+// 允许点(.):版本值常含点(如 1.21),保留更可读。
+func sanitizeIDPart(s string) string {
+	s = strings.TrimSpace(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' || r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	if b.Len() == 0 {
+		return "x"
+	}
+	return b.String()
+}

--- a/internal/dagrun/matrix_test.go
+++ b/internal/dagrun/matrix_test.go
@@ -1,0 +1,219 @@
+package dagrun
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// errStageFail 是矩阵测试里用的「阶段失败」哨兵。
+var errStageFail = errors.New("matrix cell boom")
+
+// stageIDs 取展开后阶段的 id 集合(排序,便于断言)。
+func stageIDs(stages []pipeline.Stage) []string {
+	out := make([]string, 0, len(stages))
+	for _, st := range stages {
+		out = append(out, st.ID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestExpandMatrixNoMatrixUnchanged(t *testing.T) {
+	in := []pipeline.Stage{
+		{ID: "src", Name: "源"},
+		{ID: "build", Name: "构建", Needs: []string{"src"}},
+	}
+	out := ExpandMatrix(in)
+	if len(out) != 2 {
+		t.Fatalf("空 matrix 应原样保留,得 %d 阶段", len(out))
+	}
+	if out[1].ID != "build" || !equal(out[1].Needs, []string{"src"}) {
+		t.Errorf("无 matrix 阶段不应被改写: %+v", out[1])
+	}
+}
+
+func TestExpandMatrix2x1ToTwoCells(t *testing.T) {
+	in := []pipeline.Stage{
+		{ID: "src", Name: "源"},
+		{
+			ID:   "test",
+			Name: "测试",
+			Kind: pipeline.KindBuild,
+			Matrix: map[string][]string{
+				"go": {"1.21", "1.22"},
+				"os": {"linux"},
+			},
+			Needs: []string{"src"},
+			Jobs:  []pipeline.Job{{ID: "j1", Name: "run", Type: "script", Config: map[string]any{"image": "golang"}}},
+		},
+	}
+	out := ExpandMatrix(in)
+	// src + 2 个 cell。
+	if len(out) != 3 {
+		t.Fatalf("2×1 应展开成 src+2 cell = 3,得 %d", len(out))
+	}
+	got := stageIDs(out)
+	want := []string{"src", "test__go-1.21_os-linux", "test__go-1.22_os-linux"}
+	if !equal(got, want) {
+		t.Fatalf("cell id 集 = %v, want %v", got, want)
+	}
+	// 每个 cell:needs 对齐(指向 src)、Matrix 清空、job 注入 MATRIX_GO/MATRIX_OS。
+	for _, st := range out {
+		if st.ID == "src" {
+			continue
+		}
+		if !equal(st.Needs, []string{"src"}) {
+			t.Errorf("cell %s needs 应对齐 [src],得 %v", st.ID, st.Needs)
+		}
+		if len(st.Matrix) != 0 {
+			t.Errorf("cell %s Matrix 应清空,得 %v", st.ID, st.Matrix)
+		}
+		if len(st.Jobs) != 1 {
+			t.Fatalf("cell %s 应含 1 job", st.ID)
+		}
+		env, _ := st.Jobs[0].Config["__matrixEnv"].(map[string]string)
+		if env["MATRIX_OS"] != "linux" {
+			t.Errorf("cell %s 应注入 MATRIX_OS=linux,得 %v", st.ID, env)
+		}
+		if env["MATRIX_GO"] == "" {
+			t.Errorf("cell %s 应注入 MATRIX_GO,得 %v", st.ID, env)
+		}
+		// 镜像等原 config 应保留。
+		if st.Jobs[0].Config["image"] != "golang" {
+			t.Errorf("cell %s 应保留原 config image", st.ID)
+		}
+		// job id 追加 cell 后缀,保证全局唯一。
+		if !strings.HasPrefix(st.Jobs[0].ID, "j1__") {
+			t.Errorf("cell %s job id 应带 cell 后缀,得 %q", st.ID, st.Jobs[0].ID)
+		}
+	}
+}
+
+func TestExpandMatrixDownstreamNeedsAllCells(t *testing.T) {
+	in := []pipeline.Stage{
+		{ID: "src", Name: "源"},
+		{
+			ID:     "build",
+			Name:   "构建",
+			Matrix: map[string][]string{"go": {"1.21", "1.22"}},
+			Needs:  []string{"src"},
+		},
+		{ID: "deploy", Name: "部署", Needs: []string{"build"}},
+	}
+	out := ExpandMatrix(in)
+	var deploy *pipeline.Stage
+	for i := range out {
+		if out[i].ID == "deploy" {
+			deploy = &out[i]
+		}
+	}
+	if deploy == nil {
+		t.Fatal("未找到 deploy 阶段")
+	}
+	needs := append([]string(nil), deploy.Needs...)
+	sort.Strings(needs)
+	want := []string{"build__go-1.21", "build__go-1.22"}
+	if !equal(needs, want) {
+		t.Errorf("下游 deploy.needs 应展开为所有 cell,得 %v want %v", needs, want)
+	}
+}
+
+func TestExpandMatrixCartesian2x2(t *testing.T) {
+	in := []pipeline.Stage{
+		{ID: "src", Name: "源"},
+		{
+			ID:     "m",
+			Name:   "矩阵",
+			Matrix: map[string][]string{"a": {"1", "2"}, "b": {"x", "y"}},
+		},
+	}
+	out := ExpandMatrix(in)
+	// src + 2×2 = 5。
+	if len(out) != 5 {
+		t.Fatalf("2×2 应展开 4 cell,总 5 阶段,得 %d", len(out))
+	}
+}
+
+// ─── Run 级:cell 间并行 + cell 失败按既有 needs/allowFailure 传播 ────────────────
+
+func TestRunnerMatrixCellFailureBlocksDownstream(t *testing.T) {
+	cfg := cfgWith(
+		pipeline.Stage{ID: "src", Name: "源"},
+		pipeline.Stage{
+			ID:     "build",
+			Name:   "构建",
+			Matrix: map[string][]string{"go": {"1.21", "1.22"}},
+			Needs:  []string{"src"},
+		},
+		pipeline.Stage{ID: "deploy", Name: "部署", Needs: []string{"build"}},
+	)
+	ld := &fakeLoader{cfg: cfg}
+
+	// 执行器:cell go-1.22 失败,其余成功。
+	var mu sync.Mutex
+	ran := map[string]bool{}
+	exec := func(_ context.Context, _ *run.Run, stage pipeline.Stage, _ StageReporter) error {
+		mu.Lock()
+		ran[stage.ID] = true
+		mu.Unlock()
+		if strings.Contains(stage.ID, "go-1.22") {
+			return errStageFail
+		}
+		return nil
+	}
+	r := New(ld, WithStageExecutor(exec))
+	err := r.Run(context.Background(), &run.Run{ProjectID: "p"}, newFakeSink())
+	if err == nil {
+		t.Fatal("有 cell 失败,整体应失败")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	// 成功的 cell 应执行;失败 cell 也执行过;deploy 因上游 cell 失败应被跳过(未执行)。
+	if !ran["build__go-1.21"] || !ran["build__go-1.22"] {
+		t.Errorf("两个 cell 都应被调度执行,得 %v", ran)
+	}
+	if ran["deploy"] {
+		t.Error("上游 cell 失败,deploy 不应执行")
+	}
+}
+
+func TestRunnerMatrixAllowFailureCellDoesNotBlock(t *testing.T) {
+	cfg := cfgWith(
+		pipeline.Stage{ID: "src", Name: "源"},
+		pipeline.Stage{
+			ID:           "build",
+			Name:         "构建",
+			Matrix:       map[string][]string{"go": {"1.21", "1.22"}},
+			Needs:        []string{"src"},
+			AllowFailure: true,
+		},
+		pipeline.Stage{ID: "deploy", Name: "部署", Needs: []string{"build"}},
+	)
+	ld := &fakeLoader{cfg: cfg}
+	var mu sync.Mutex
+	ran := map[string]bool{}
+	exec := func(_ context.Context, _ *run.Run, stage pipeline.Stage, _ StageReporter) error {
+		mu.Lock()
+		ran[stage.ID] = true
+		mu.Unlock()
+		if strings.Contains(stage.ID, "go-1.22") {
+			return errStageFail
+		}
+		return nil
+	}
+	r := New(ld, WithStageExecutor(exec))
+	_ = r.Run(context.Background(), &run.Run{ProjectID: "p"}, newFakeSink())
+	mu.Lock()
+	defer mu.Unlock()
+	// AllowFailure cell 失败不阻断下游:deploy 仍执行。
+	if !ran["deploy"] {
+		t.Errorf("allowFailure cell 失败不应阻断 deploy,得 %v", ran)
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -81,8 +81,13 @@ type Stage struct {
 	When         When     `json:"when,omitempty"`
 	// Gate 为 true 时,进入该阶段前需人工审批(Story 8-4):运行阻塞、状态置 waiting_approval,
 	// 批准→继续,拒绝→该阶段失败(运行终止)。
-	Gate bool  `json:"gate,omitempty"`
-	Jobs []Job `json:"jobs"`
+	Gate bool `json:"gate,omitempty"`
+	// Matrix 声明矩阵构建轴(P1,对标 GHA matrix / GitLab parallel:matrix):
+	// 多维 axisName→值列表,调度时展开成笛卡尔积的多个并行 cell(各跑该阶段 jobs 副本),
+	// axis 值以 `MATRIX_<AXIS>`(大写)注入 cell 各 script job 的容器环境供命令引用。
+	// 空(nil / 无轴)= 行为不变(单 stage)。校验/展开见 stage_matrix.go 与 dagrun.ExpandMatrix。
+	Matrix map[string][]string `json:"matrix,omitempty"`
+	Jobs   []Job               `json:"jobs"`
 }
 
 // Spec 是流水线编排声明式配置(阶段集合)。
@@ -357,7 +362,13 @@ func normalizeSpec(in Spec) (Spec, error) {
 		// Needs 规范化:trim、去空、去重、剔除自指(自指交由 dag 校验报错以给明确信息)。
 		needs := normalizeNeeds(st.Needs)
 
-		out.Stages = append(out.Stages, Stage{ID: stageID, Name: name, Kind: kind, Needs: needs, AllowFailure: st.AllowFailure, When: normalizeWhen(st.When), Gate: st.Gate, Jobs: jobs})
+		// Matrix 规范化 + 校验(轴名合法 / 值非空 / 维度·cell 数上限):空 → nil(行为不变)。
+		matrix, merr := normalizeMatrix(st.Matrix)
+		if merr != nil {
+			return Spec{}, merr
+		}
+
+		out.Stages = append(out.Stages, Stage{ID: stageID, Name: name, Kind: kind, Needs: needs, AllowFailure: st.AllowFailure, When: normalizeWhen(st.When), Gate: st.Gate, Matrix: matrix, Jobs: jobs})
 	}
 
 	// 源阶段不变式:流水线必须恰有一个 source 阶段(引用项目仓库)。前端不渲染删源阶段的入口,

--- a/internal/pipeline/stage_matrix.go
+++ b/internal/pipeline/stage_matrix.go
@@ -1,0 +1,108 @@
+package pipeline
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// stage_matrix.go 是矩阵构建(P1,对标 GHA matrix / GitLab parallel:matrix / Jenkins matrix)的领域规则:
+// 一个阶段可声明多维 axes(axisName→值列表),调度时展开成笛卡尔积的多个并行 cell(各跑该阶段 jobs)。
+//
+// 本文件只管「校验 + 规范化 + 命名」:
+//   - 轴名合法(标识符:字母/数字/下划线,首字符非数字)、轴名唯一(map 天然)、值非空且去重;
+//   - 维度数 ≤ MatrixMaxAxes、cell 数(笛卡尔积) ≤ MatrixMaxCells —— 防组合爆炸;
+//   - axis 值注入容器的环境变量键 = `MATRIX_<大写轴名>`(MatrixEnvKey)。
+//
+// 真正的「1 stage → N cell stage」展开在调度层(dagrun.ExpandMatrix),不改 dag/dagrun 的并发与失败语义。
+
+const (
+	// MatrixMaxAxes 是单阶段矩阵维度(轴)数上限。
+	MatrixMaxAxes = 8
+	// MatrixMaxCells 是单阶段矩阵展开后的 cell(笛卡尔积)数上限,防组合爆炸。
+	MatrixMaxCells = 50
+	// MatrixEnvPrefix 是注入 cell 容器的 axis 环境变量前缀(键 = 前缀 + 大写轴名)。
+	MatrixEnvPrefix = "MATRIX_"
+)
+
+// MatrixEnvKey 返回 axis 注入容器的环境变量键(`MATRIX_<大写轴名>`)。
+// 轴名已在校验期保证为合法标识符,故大写即安全的 env 键。
+func MatrixEnvKey(axis string) string {
+	return MatrixEnvPrefix + strings.ToUpper(strings.TrimSpace(axis))
+}
+
+// normalizeMatrix 校验并规范化阶段矩阵声明。
+//   - 空(nil / 全空轴)→ 返回 nil(阶段行为不变,不展开);
+//   - 轴名非法 / 值全空 / 维度超限 / cell 数超限 → ErrInvalidStage(附简短原因)。
+//
+// 规范化:trim 轴名与值、剔空值、同轴内去重(保留首现序)。
+func normalizeMatrix(in map[string][]string) (map[string][]string, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	out := make(map[string][]string, len(in))
+	for rawAxis, rawVals := range in {
+		axis := strings.TrimSpace(rawAxis)
+		if axis == "" {
+			// 空轴名 + 空值:整体视作未声明,跳过;非空值却无轴名:报错(防静默丢值)。
+			if len(dedupTrim(rawVals)) == 0 {
+				continue
+			}
+			return nil, fmt.Errorf("%w: matrix axis name must not be empty", ErrInvalidStage)
+		}
+		if !isValidMatrixAxis(axis) {
+			return nil, fmt.Errorf("%w: invalid matrix axis name %q (须为标识符:字母/下划线起,后接字母/数字/下划线)", ErrInvalidStage, axis)
+		}
+		vals := dedupTrim(rawVals)
+		if len(vals) == 0 {
+			return nil, fmt.Errorf("%w: matrix axis %q must have at least one value", ErrInvalidStage, axis)
+		}
+		out[axis] = vals
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	if len(out) > MatrixMaxAxes {
+		return nil, fmt.Errorf("%w: matrix has %d axes, exceeds limit %d", ErrInvalidStage, len(out), MatrixMaxAxes)
+	}
+	cells := 1
+	for _, vals := range out {
+		cells *= len(vals)
+	}
+	if cells > MatrixMaxCells {
+		return nil, fmt.Errorf("%w: matrix expands to %d cells, exceeds limit %d", ErrInvalidStage, cells, MatrixMaxCells)
+	}
+	return out, nil
+}
+
+// isValidMatrixAxis 报告轴名是否为合法标识符(首字符字母/下划线,后接字母/数字/下划线)。
+func isValidMatrixAxis(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		isLetter := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_'
+		isDigit := r >= '0' && r <= '9'
+		if i == 0 {
+			if !isLetter {
+				return false
+			}
+			continue
+		}
+		if !isLetter && !isDigit {
+			return false
+		}
+	}
+	return true
+}
+
+// MatrixAxisOrder 返回矩阵轴名的确定性序(字典序),供展开 cell 时稳定笛卡尔积与命名。
+// map 迭代序不确定,展开必须经此取序以保证 cell id / 注入 env 的可复现性。
+func MatrixAxisOrder(matrix map[string][]string) []string {
+	axes := make([]string, 0, len(matrix))
+	for a := range matrix {
+		axes = append(axes, a)
+	}
+	sort.Strings(axes)
+	return axes
+}

--- a/internal/pipeline/stage_matrix_test.go
+++ b/internal/pipeline/stage_matrix_test.go
@@ -1,0 +1,123 @@
+package pipeline
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeMatrixEmptyReturnsNil(t *testing.T) {
+	for _, in := range []map[string][]string{nil, {}, {"  ": {"  ", ""}}} {
+		got, err := normalizeMatrix(in)
+		if err != nil {
+			t.Fatalf("空 matrix 不应报错: %v (in=%v)", err, in)
+		}
+		if got != nil {
+			t.Errorf("空 matrix 应规范化为 nil,得 %v", got)
+		}
+	}
+}
+
+func TestNormalizeMatrixTrimsAndDedups(t *testing.T) {
+	got, err := normalizeMatrix(map[string][]string{
+		"go": {" 1.21 ", "1.22", "1.21", ""},
+		"os": {"linux"},
+	})
+	if err != nil {
+		t.Fatalf("normalizeMatrix: %v", err)
+	}
+	if len(got["go"]) != 2 || got["go"][0] != "1.21" || got["go"][1] != "1.22" {
+		t.Errorf("go 轴应 trim+去重保序 [1.21 1.22],得 %v", got["go"])
+	}
+	if len(got["os"]) != 1 || got["os"][0] != "linux" {
+		t.Errorf("os 轴 = %v", got["os"])
+	}
+}
+
+func TestNormalizeMatrixInvalidAxisName(t *testing.T) {
+	for _, bad := range []string{"1go", "go-version", "go.v", "go version"} {
+		_, err := normalizeMatrix(map[string][]string{bad: {"x"}})
+		if !errors.Is(err, ErrInvalidStage) {
+			t.Errorf("非法轴名 %q 应报 ErrInvalidStage,得 %v", bad, err)
+		}
+	}
+}
+
+func TestNormalizeMatrixEmptyValuesError(t *testing.T) {
+	_, err := normalizeMatrix(map[string][]string{"go": {"  ", ""}})
+	if !errors.Is(err, ErrInvalidStage) {
+		t.Errorf("轴值全空应报 ErrInvalidStage,得 %v", err)
+	}
+}
+
+func TestNormalizeMatrixTooManyAxes(t *testing.T) {
+	m := map[string][]string{}
+	for i := 0; i <= MatrixMaxAxes; i++ {
+		m[string(rune('a'+i))] = []string{"v"}
+	}
+	_, err := normalizeMatrix(m)
+	if !errors.Is(err, ErrInvalidStage) {
+		t.Errorf("超维度上限应报 ErrInvalidStage,得 %v", err)
+	}
+}
+
+func TestNormalizeMatrixCellExplosionCapped(t *testing.T) {
+	// 51 cell(单轴 51 值)> 上限 50 → 报错。
+	vals := make([]string, 51)
+	for i := range vals {
+		vals[i] = string(rune('A')) + strings.Repeat("x", i+1)
+	}
+	_, err := normalizeMatrix(map[string][]string{"v": vals})
+	if !errors.Is(err, ErrInvalidStage) {
+		t.Errorf("cell 数超上限应报 ErrInvalidStage,得 %v", err)
+	}
+
+	// 多轴乘积爆炸:8×8 = 64 > 50。
+	_, err = normalizeMatrix(map[string][]string{
+		"a": {"1", "2", "3", "4", "5", "6", "7", "8"},
+		"b": {"1", "2", "3", "4", "5", "6", "7", "8"},
+	})
+	if !errors.Is(err, ErrInvalidStage) {
+		t.Errorf("乘积爆炸应报 ErrInvalidStage,得 %v", err)
+	}
+}
+
+func TestNormalizeMatrixCellAtLimitOK(t *testing.T) {
+	// 恰 50 cell 应放行。
+	vals := make([]string, MatrixMaxCells)
+	for i := range vals {
+		vals[i] = "v" + strings.Repeat("a", i)
+	}
+	if _, err := normalizeMatrix(map[string][]string{"v": vals}); err != nil {
+		t.Errorf("恰上限 %d cell 应放行,得 %v", MatrixMaxCells, err)
+	}
+}
+
+func TestMatrixEnvKey(t *testing.T) {
+	if got := MatrixEnvKey(" go "); got != "MATRIX_GO" {
+		t.Errorf("MatrixEnvKey(go) = %q, want MATRIX_GO", got)
+	}
+}
+
+func TestNormalizeSpecPropagatesMatrix(t *testing.T) {
+	out, err := NormalizeSpec(Spec{Stages: []Stage{
+		{Name: "源", Kind: KindSource, Jobs: []Job{{Name: "s", Type: "git_source"}}},
+		{Name: "测试", Kind: KindBuild, Matrix: map[string][]string{"go": {"1.21", "1.22"}}, Jobs: []Job{}},
+	}})
+	if err != nil {
+		t.Fatalf("NormalizeSpec: %v", err)
+	}
+	if len(out.Stages[1].Matrix["go"]) != 2 {
+		t.Errorf("matrix 应贯穿规范化,得 %v", out.Stages[1].Matrix)
+	}
+}
+
+func TestNormalizeSpecRejectsBadMatrix(t *testing.T) {
+	_, err := NormalizeSpec(Spec{Stages: []Stage{
+		{Name: "源", Kind: KindSource, Jobs: []Job{{Name: "s", Type: "git_source"}}},
+		{Name: "测试", Kind: KindBuild, Matrix: map[string][]string{"1bad": {"x"}}, Jobs: []Job{}},
+	}})
+	if !errors.Is(err, ErrInvalidStage) {
+		t.Errorf("非法轴名经 Save 校验应报 ErrInvalidStage,得 %v", err)
+	}
+}

--- a/internal/pipelineyaml/pipelineyaml.go
+++ b/internal/pipelineyaml/pipelineyaml.go
@@ -57,14 +57,15 @@ type doc struct {
 }
 
 type stageNode struct {
-	ID           string    `yaml:"id,omitempty"`
-	Name         string    `yaml:"name"`
-	Kind         string    `yaml:"kind"`
-	Needs        []string  `yaml:"needs,omitempty"`
-	AllowFailure bool      `yaml:"allowFailure,omitempty"`
-	Gate         bool      `yaml:"gate,omitempty"`
-	When         *whenNode `yaml:"when,omitempty"`
-	Jobs         []jobNode `yaml:"jobs,omitempty"`
+	ID           string              `yaml:"id,omitempty"`
+	Name         string              `yaml:"name"`
+	Kind         string              `yaml:"kind"`
+	Needs        []string            `yaml:"needs,omitempty"`
+	AllowFailure bool                `yaml:"allowFailure,omitempty"`
+	Gate         bool                `yaml:"gate,omitempty"`
+	When         *whenNode           `yaml:"when,omitempty"`
+	Matrix       map[string][]string `yaml:"matrix,omitempty"`
+	Jobs         []jobNode           `yaml:"jobs,omitempty"`
 }
 
 type whenNode struct {
@@ -143,6 +144,7 @@ func Parse(data []byte) (pipeline.Config, error) {
 			AllowFailure: sn.AllowFailure,
 			When:         when,
 			Gate:         sn.Gate,
+			Matrix:       sn.Matrix,
 			Jobs:         jobs,
 		})
 	}
@@ -173,6 +175,7 @@ func Marshal(spec pipeline.Spec) ([]byte, error) {
 			Needs:        nonEmpty(st.Needs),
 			AllowFailure: st.AllowFailure,
 			Gate:         st.Gate,
+			Matrix:       st.Matrix,
 		}
 		if !st.When.IsEmpty() {
 			sn.When = &whenNode{Branches: nonEmpty(st.When.Branches), Events: nonEmpty(st.When.Events)}

--- a/internal/pipelineyaml/pipelineyaml_test.go
+++ b/internal/pipelineyaml/pipelineyaml_test.go
@@ -358,3 +358,49 @@ func TestParseAutoFillsStageID(t *testing.T) {
 		t.Fatalf("缺省任务 id 应被补全")
 	}
 }
+
+func TestParseMatrixAxes(t *testing.T) {
+	doc := `stages:
+  - name: src
+    kind: source
+    jobs: [{name: a, type: git_source}]
+  - name: test
+    kind: build
+    matrix:
+      go: ["1.21", "1.22"]
+      os: [linux]
+    jobs:
+      - name: run
+        type: script
+        script:
+          image: golang
+          commands: [go test ./...]
+`
+	cfg, err := Parse([]byte(doc))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	st := cfg.Spec.Stages[1]
+	if len(st.Matrix["go"]) != 2 || st.Matrix["os"][0] != "linux" {
+		t.Fatalf("matrix 轴应解析: %+v", st.Matrix)
+	}
+}
+
+func TestParseMatrixCellCap(t *testing.T) {
+	// 8×8 = 64 cell > 50 上限 → 经领域校验报错。
+	doc := `stages:
+  - name: src
+    kind: source
+    jobs: [{name: a, type: git_source}]
+  - name: big
+    kind: build
+    matrix:
+      a: ["1","2","3","4","5","6","7","8"]
+      b: ["1","2","3","4","5","6","7","8"]
+    jobs: []
+`
+	_, err := Parse([]byte(doc))
+	if !errors.Is(err, ErrParse) || !errors.Is(err, pipeline.ErrInvalidStage) {
+		t.Fatalf("cell 爆炸应回 ErrParse∧ErrInvalidStage, got %v", err)
+	}
+}

--- a/web/src/api/pipeline.ts
+++ b/web/src/api/pipeline.ts
@@ -46,6 +46,12 @@ export interface PipelineStage {
   when?: StageWhen
   /** Require manual approval before entering this stage (Epic 8 · 8-4). */
   gate?: boolean
+  /**
+   * Matrix build axes (P1): axisName → value list. Scheduler expands to the
+   * cartesian product of parallel cells, each running this stage's jobs with
+   * `MATRIX_<AXIS>` injected as container env. Empty = no expansion (single stage).
+   */
+  matrix?: Record<string, string[]>
   jobs: PipelineJob[]
 }
 
@@ -69,6 +75,7 @@ export interface SavePipelineInput {
     allowFailure?: boolean
     when?: StageWhen
     gate?: boolean
+    matrix?: Record<string, string[]>
     jobs: Array<{
       id?: string
       name: string

--- a/web/src/components/pipeline/PipelineCanvas.vue
+++ b/web/src/components/pipeline/PipelineCanvas.vue
@@ -317,6 +317,7 @@ function handleDrawerUpdate(patch: Partial<PipelineJob>): void {
             @update-allow-failure="(v) => updateStage(stage.id, { allowFailure: v })"
             @update-when="(when) => updateStage(stage.id, { when })"
             @update-gate="(v) => updateStage(stage.id, { gate: v })"
+            @update-matrix="(matrix) => updateStage(stage.id, { matrix })"
           />
         </template>
 

--- a/web/src/components/pipeline/StageColumn.vue
+++ b/web/src/components/pipeline/StageColumn.vue
@@ -12,6 +12,11 @@ import {
   normalizeWhen,
   hasWhen,
   whenSummary,
+  parseMatrix,
+  matrixToText,
+  hasMatrix,
+  matrixSummary,
+  matrixError,
   type WhenEvent,
 } from './stageSettings'
 
@@ -33,6 +38,7 @@ const emit = defineEmits<{
   (e: 'update-allow-failure', value: boolean): void
   (e: 'update-when', when: StageWhen | undefined): void
   (e: 'update-gate', value: boolean): void
+  (e: 'update-matrix', matrix: Record<string, string[]> | undefined): void
 }>()
 
 function stageLabel(index: number): string {
@@ -69,10 +75,28 @@ const branchText = computed<string>(() => branchesToText(props.stage.when?.branc
 
 const currentEvents = computed<string[]>(() => props.stage.when?.events ?? [])
 
-/** Active when settings or gate → highlight the settings button. */
-const hasStageRules = computed(() => hasWhen(props.stage.when) || props.stage.gate === true)
+/** Active when settings, gate, or matrix → highlight the settings button. */
+const hasStageRules = computed(
+  () => hasWhen(props.stage.when) || props.stage.gate === true || hasMatrix(props.stage.matrix),
+)
 
 const whenChip = computed(() => whenSummary(props.stage.when))
+
+// ─── Matrix build axes (P1) ───────────────────────────────────────────────────
+
+/** Editable matrix text (one `axis: a, b` per line), parsed → map only on commit. */
+const matrixText = computed<string>(() => matrixToText(props.stage.matrix))
+
+/** Chip summary for the matrix (empty when none). */
+const matrixChip = computed(() => matrixSummary(props.stage.matrix))
+
+/** Client-side validation message for the current matrix (null = ok/empty). */
+const matrixWarn = computed(() => matrixError(props.stage.matrix))
+
+/** Commit edited matrix text → parsed axes map (or undefined when empty). */
+function commitMatrix(text: string): void {
+  emit('update-matrix', parseMatrix(text))
+}
 
 /** Commit a new branch-glob set, preserving the current events. */
 function commitBranches(text: string): void {
@@ -182,6 +206,10 @@ function resetDrag(): void {
         <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
         审批门
       </span>
+      <span v-if="matrixChip" class="stage-rule-chip stage-rule-chip--matrix" title="矩阵展开:并行多个 cell">
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+        {{ matrixChip }}
+      </span>
     </div>
 
     <!-- Dependency editor popover -->
@@ -244,6 +272,20 @@ function resetDrag(): void {
         <span>进入本阶段前需人工审批</span>
       </label>
       <p class="deps-hint">开启后运行将暂停在此,等待批准/拒绝</p>
+
+      <div class="deps-divider"></div>
+      <div class="deps-popover-title">矩阵构建(matrix)</div>
+      <label class="settings-field-label" :for="`matrix-${stage.id}`">轴(每行一个:<code>名称: 值1, 值2</code>)</label>
+      <textarea
+        :id="`matrix-${stage.id}`"
+        class="settings-input settings-textarea"
+        rows="3"
+        :value="matrixText"
+        placeholder="go: 1.21, 1.22&#10;os: linux"
+        @change="commitMatrix(($event.target as HTMLTextAreaElement).value)"
+      ></textarea>
+      <p v-if="matrixWarn" class="settings-warn" role="alert">{{ matrixWarn }}</p>
+      <p class="deps-hint">展开成并行 cell(笛卡尔积),各注入 <code>MATRIX_&lt;轴名&gt;</code> 环境变量;空 = 不展开</p>
     </div>
 
     <!-- Job cards -->
@@ -401,6 +443,7 @@ function resetDrag(): void {
 .stage-rule-chip svg { flex: none; }
 .stage-rule-chip--when { background: var(--color-primary-soft); color: var(--color-primary); }
 .stage-rule-chip--gate { background: var(--color-amber-soft, rgba(217, 119, 6, 0.14)); color: var(--color-amber, #b45309); }
+.stage-rule-chip--matrix { background: var(--color-violet-soft, rgba(124, 58, 237, 0.13)); color: var(--color-violet, #6d28d9); }
 
 /* ─── Settings popover fields ─────────────────────────────────────────────── */
 .settings-popover { width: 232px; }
@@ -427,6 +470,8 @@ function resetDrag(): void {
   transition: border-color var(--duration-fast);
 }
 .settings-input:focus { outline: none; border-color: var(--color-primary); }
+.settings-textarea { height: auto; padding: 6px 8px; line-height: 1.5; resize: vertical; font-family: var(--font-mono, ui-monospace, monospace); }
+.settings-warn { margin: 5px 0 0; font-size: 0.68rem; color: var(--color-danger, #dc2626); line-height: 1.4; }
 .settings-events { display: flex; flex-wrap: wrap; gap: 6px 12px; }
 .settings-event {
   display: flex;

--- a/web/src/components/pipeline/stageSettings.test.ts
+++ b/web/src/components/pipeline/stageSettings.test.ts
@@ -6,6 +6,14 @@ import {
   normalizeWhen,
   hasWhen,
   whenSummary,
+  parseMatrix,
+  matrixToText,
+  hasMatrix,
+  matrixCellCount,
+  matrixError,
+  matrixSummary,
+  isValidAxisName,
+  MATRIX_MAX_CELLS,
 } from './stageSettings'
 
 describe('parseBranches', () => {
@@ -86,5 +94,82 @@ describe('hasWhen / whenSummary', () => {
     expect(whenSummary({ branches: ['main', 'develop'] })).toBe('main, develop')
     expect(whenSummary({ events: ['manual', 'schedule'] })).toBe('手动/定时')
     expect(whenSummary({ branches: ['main'], events: ['webhook'] })).toBe('main · Webhook')
+  })
+})
+
+describe('parseMatrix / matrixToText', () => {
+  it('parses one axis per line (name: a, b)', () => {
+    const m = parseMatrix('go: 1.21, 1.22\nos: linux')
+    expect(m).toEqual({ go: ['1.21', '1.22'], os: ['linux'] })
+  })
+
+  it('accepts = separator and trims + de-dups + drops empties', () => {
+    const m = parseMatrix('go = 1.21 , 1.22, 1.21 ,\n\n  \nos: linux')
+    expect(m).toEqual({ go: ['1.21', '1.22'], os: ['linux'] })
+  })
+
+  it('returns undefined when no usable axes', () => {
+    expect(parseMatrix('')).toBeUndefined()
+    expect(parseMatrix('   \n  ')).toBeUndefined()
+    expect(parseMatrix('justname')).toBeUndefined()
+    expect(parseMatrix('go:')).toBeUndefined()
+  })
+
+  it('round-trips through matrixToText', () => {
+    const m = { go: ['1.21', '1.22'], os: ['linux'] }
+    expect(matrixToText(m)).toBe('go: 1.21, 1.22\nos: linux')
+    expect(parseMatrix(matrixToText(m))).toEqual(m)
+  })
+
+  it('matrixToText of undefined is empty', () => {
+    expect(matrixToText(undefined)).toBe('')
+  })
+})
+
+describe('matrix derived helpers', () => {
+  it('hasMatrix reflects presence', () => {
+    expect(hasMatrix(undefined)).toBe(false)
+    expect(hasMatrix({})).toBe(false)
+    expect(hasMatrix({ go: ['1.21'] })).toBe(true)
+  })
+
+  it('matrixCellCount is the cartesian product', () => {
+    expect(matrixCellCount(undefined)).toBe(0)
+    expect(matrixCellCount({ go: ['1.21', '1.22'], os: ['linux'] })).toBe(2)
+    expect(matrixCellCount({ a: ['1', '2'], b: ['x', 'y'] })).toBe(4)
+  })
+
+  it('matrixSummary renders axis counts and total cells', () => {
+    expect(matrixSummary(undefined)).toBe('')
+    expect(matrixSummary({ go: ['1.21', '1.22'], os: ['linux'] })).toBe('go×2 · os×1 → 2 cell')
+  })
+
+  it('isValidAxisName mirrors backend identifier rule', () => {
+    expect(isValidAxisName('go')).toBe(true)
+    expect(isValidAxisName('go_1')).toBe(true)
+    expect(isValidAxisName('1go')).toBe(false)
+    expect(isValidAxisName('go-v')).toBe(false)
+    expect(isValidAxisName('go.v')).toBe(false)
+  })
+})
+
+describe('matrixError', () => {
+  it('null for empty / valid matrices', () => {
+    expect(matrixError(undefined)).toBeNull()
+    expect(matrixError({ go: ['1.21', '1.22'], os: ['linux'] })).toBeNull()
+  })
+
+  it('flags invalid axis names', () => {
+    expect(matrixError({ '1bad': ['x'] })).toMatch(/非法/)
+  })
+
+  it('flags cell explosion over the cap', () => {
+    const vals = Array.from({ length: MATRIX_MAX_CELLS + 1 }, (_, i) => `v${i}`)
+    expect(matrixError({ v: vals })).toMatch(/超过上限/)
+  })
+
+  it('allows exactly the cap', () => {
+    const vals = Array.from({ length: MATRIX_MAX_CELLS }, (_, i) => `v${i}`)
+    expect(matrixError({ v: vals })).toBeNull()
   })
 })

--- a/web/src/components/pipeline/stageSettings.ts
+++ b/web/src/components/pipeline/stageSettings.ts
@@ -83,3 +83,105 @@ export function whenSummary(when: StageWhen | undefined): string {
   }
   return parts.join(' · ')
 }
+
+// ─── Matrix build axes (P1) ──────────────────────────────────────────────────
+//
+// UI editor uses one textarea, one axis per line: `axisName: v1, v2, v3`
+// (or `axisName = v1, v2`). Empty/blank lines are ignored. Axis names must be
+// identifiers (matches backend stage_matrix.go isValidMatrixAxis); values split
+// on commas, trimmed, de-duped. Backend re-validates (caps cell count etc.).
+
+/** Cap on cells (cartesian product) — mirrors backend MatrixMaxCells for client-side preview. */
+export const MATRIX_MAX_CELLS = 50
+/** Cap on axes — mirrors backend MatrixMaxAxes. */
+export const MATRIX_MAX_AXES = 8
+
+const AXIS_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+/** Report whether an axis name is a valid identifier (mirrors backend). */
+export function isValidAxisName(name: string): boolean {
+  return AXIS_NAME_RE.test(name)
+}
+
+/**
+ * Parse the matrix textarea into an axes map. One axis per line: `name: a, b, c`.
+ * Trims + de-dups values, drops empty values/lines. Returns `undefined` when no
+ * usable axes (so the saved spec stays minimal / single-stage behavior).
+ */
+export function parseMatrix(text: string): Record<string, string[]> | undefined {
+  const out: Record<string, string[]> = {}
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim()
+    if (!line) continue
+    const sep = line.search(/[:=]/)
+    if (sep <= 0) continue
+    const name = line.slice(0, sep).trim()
+    if (!name) continue
+    const seen = new Set<string>()
+    const vals: string[] = []
+    for (const raw of line.slice(sep + 1).split(',')) {
+      const v = raw.trim()
+      if (v && !seen.has(v)) {
+        seen.add(v)
+        vals.push(v)
+      }
+    }
+    if (vals.length) out[name] = vals
+  }
+  return Object.keys(out).length ? out : undefined
+}
+
+/** Render an axes map back to the editable textarea (one `name: a, b` per line). */
+export function matrixToText(matrix: Record<string, string[]> | undefined): string {
+  if (!matrix) return ''
+  return Object.keys(matrix)
+    .map((name) => `${name}: ${(matrix[name] ?? []).join(', ')}`)
+    .join('\n')
+}
+
+/** Report whether a stage actually declares a matrix (for badges/labels). */
+export function hasMatrix(matrix: Record<string, string[]> | undefined): boolean {
+  return Boolean(matrix && Object.keys(matrix).length)
+}
+
+/** Cell count = cartesian product of all axis value counts (0 when no axes). */
+export function matrixCellCount(matrix: Record<string, string[]> | undefined): number {
+  if (!hasMatrix(matrix)) return 0
+  let cells = 1
+  for (const name of Object.keys(matrix!)) {
+    cells *= (matrix![name] ?? []).length
+  }
+  return cells
+}
+
+/**
+ * Validate parsed axes client-side (mirrors backend rules for fast feedback):
+ * returns an error message, or `null` when valid / empty.
+ */
+export function matrixError(matrix: Record<string, string[]> | undefined): string | null {
+  if (!hasMatrix(matrix)) return null
+  const names = Object.keys(matrix!)
+  for (const name of names) {
+    if (!isValidAxisName(name)) {
+      return `轴名「${name}」非法(须为标识符:字母/下划线起)`
+    }
+    if (!(matrix![name] ?? []).length) {
+      return `轴「${name}」至少需要一个值`
+    }
+  }
+  if (names.length > MATRIX_MAX_AXES) {
+    return `矩阵维度 ${names.length} 超过上限 ${MATRIX_MAX_AXES}`
+  }
+  const cells = matrixCellCount(matrix)
+  if (cells > MATRIX_MAX_CELLS) {
+    return `矩阵展开 ${cells} 个 cell,超过上限 ${MATRIX_MAX_CELLS}`
+  }
+  return null
+}
+
+/** Short chip summary, e.g. `go×2 · os×1 → 2 cell` (empty when no matrix). */
+export function matrixSummary(matrix: Record<string, string[]> | undefined): string {
+  if (!hasMatrix(matrix)) return ''
+  const parts = Object.keys(matrix!).map((n) => `${n}×${(matrix![n] ?? []).length}`)
+  return `${parts.join(' · ')} → ${matrixCellCount(matrix)} cell`
+}


### PR DESCRIPTION
## 背景
P1 能力,对标 GHA matrix / GitLab `parallel:matrix` / Jenkins matrix:一个阶段声明多维轴(`name → 值列表`),调度时展开成笛卡尔积的多个**并行 cell**,每个 cell 跑该阶段的 jobs,axis 值注入容器环境供命令引用。例:`{go: [1.21,1.22], os: [linux]}` → 2 个并行 cell,各带 `MATRIX_GO`/`MATRIX_OS`。

## 改动
**模型 / 校验**
- `pipeline.Stage` 加 `Matrix map[string][]string`(存 `spec_json`,无迁移,沿用既有扩展范式)。
- `internal/pipeline/stage_matrix.go`:轴名须为标识符、值非空去重、维度 ≤ `MatrixMaxAxes(8)`、cell 数(笛卡尔积) ≤ `MatrixMaxCells(50)`,经 `normalizeSpec` 贯穿(画布 PUT 与 YAML 导入同一套规则)。`MatrixEnvKey` 产出 `MATRIX_<大写轴名>`。

**调度展开(纯调度层,核心)**
- `internal/dagrun/matrix.go` `ExpandMatrix`:在 `BuildGraph` 之前把 1 个 matrix Stage 展开成 N 个 cell Stage。
  - cell id = `<stageID>__<轴字典序 key>`(确定性可复现);cell name = `原名 [go=1.21, os=linux]`。
  - **needs 重映射**:下游若 need 一个 matrix 阶段,改为 need 它的**全部 cell**(等所有 cell 完成);cell 自身 needs 把指向 matrix 上游的引用展开为该上游全部 cell。
  - cell 间并行、各自成败、`allowFailure`/`needs` 传播全部**复用既有 `dag.Schedule`,零改并发与失败语义**。空 Matrix → 原样返回(行为不变)。
- 各 cell 的 job 注入 `Config["__matrixEnv"]`(`map[string]string`),job id 追加 cell 后缀保证全局唯一。

**执行器(最小改动)**
- `dag_stage_exec.go`:仅在 `scriptStepFromJob` 读取 `__matrixEnv` → 并入 `step.Env`(新增一个 `matrixEnvVars` helper)。remote 执行器走同一 `scriptStepFromJob`,**零额外改动**。

**流水线即代码**
- `internal/pipelineyaml`:`stageNode` 加 `matrix` 字段,Parse/Marshal 支持,复用同一领域校验。

**前端**
- `web/src/api/pipeline.ts`:`PipelineStage`/`SavePipelineInput` 加 `matrix?: Record<string,string[]>`(保存路径直接透传,无需额外映射)。
- `stageSettings.ts`:`parseMatrix`/`matrixToText`/`hasMatrix`/`matrixCellCount`/`matrixError`/`matrixSummary`/`isValidAxisName` 纯函数。
- `StageColumn.vue`:阶段设置弹层加矩阵轴编辑(textarea,每行 `名称: 值1, 值2`)+ 客户端校验提示 + cell 数汇总 + 画布 chip;`PipelineCanvas.vue` 加 `update-matrix` 透传。

## 验证(全绿)
后端:`gofmt -l internal/`(空)· `go vet ./...` · `go build ./...` · `go test ./...` 全通过。
- 新增覆盖:dagrun 展开(2×1→2 cell、2×2、needs 对齐、空退化、cell 失败阻断下游、allowFailure cell 不阻断)、pipeline 矩阵校验(轴名/值/维度/cell 上限/恰上限)、pipelineyaml 解析与 cell 爆炸拒绝。

前端(`web/`):`npm run typecheck` · `npm run lint`(0 error)· `npx vitest run`(271 passed,新增 26 矩阵例)· `npm run build` 全通过。build 后已 `git restore web/dist/index.html`。

## 诚实边界
- **failFast 未做**:任一 cell 失败不会主动取消其余 cell,沿用既有 `needs` 传播语义(留后续)。
- **`renderYAML` 只读视图未渲染 matrix**:与既有 `needs`/`gate`/`when` 同样不在该视图渲染,保持一致(`.pipewright.yml` 导入/导出 Parse/Marshal 则完整支持 matrix)。
- axis 注入仅作用于 **script 类 job**(script/custom/build_frontend/build_backend/templated),与既有 `step.Env` 注入路径一致;非 script 类节点不消费 env(本身不跑容器命令)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)