### PR TITLE
feat(environments): 环境一等公民(部署历史 + 一键回滚视图)

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/cron"
 	"github.com/huangchengsir/pipewright/internal/dagrun"
 	"github.com/huangchengsir/pipewright/internal/deploy"
+	"github.com/huangchengsir/pipewright/internal/environments"
 	"github.com/huangchengsir/pipewright/internal/httpapi"
 	"github.com/huangchengsir/pipewright/internal/library"
 	"github.com/huangchengsir/pipewright/internal/mask"
@@ -150,6 +151,11 @@ func main() {
 	// 装配环境晋级流持久层(Story 8-7 / FR-8-7):环境链 + 逐环境变量/密钥 + 晋级记录。
 	// 晋级审批门复用上面的 approvalCoord/approvalStore(不另起协调器)。
 	promotionStore := promotion.NewStore(st.DB)
+
+	// 装配「环境一等公民」只读聚合服务(对标 GitLab environments):按环境聚合部署历史 +
+	// 一键回滚定位。纯查询既有表(pipeline_runs + deploy_targets + run_artifacts),零迁移、无副作用。
+	environmentsSvc := environments.NewService(st.DB)
+
 	// 重启清理:进程重启会丢失内存等待者,把残留 waiting_approval 运行清为 failed(孤儿不可恢复)。
 	if n, err := runSvc.FailOrphanedRuns(context.Background()); err != nil {
 		log.Printf("[run] 警告:清理孤儿运行失败:%v", err)
@@ -430,7 +436,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithRefs(refsLister), httpapi.WithArtifactStore(artStore), httpapi.WithServers(targetSvc), httpapi.WithRunnerConfig(runnerSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithChain(chainSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc), httpapi.WithParameters(parameterSvc), httpapi.WithPromotion(promotionStore), httpapi.WithDoraMetrics(doraMetricsSvc), httpapi.WithTemplates(templateSvc), httpapi.WithVariableGroups(varGroupSvc), httpapi.WithCustomNodes(customNodeSvc)),
+		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithRefs(refsLister), httpapi.WithArtifactStore(artStore), httpapi.WithServers(targetSvc), httpapi.WithRunnerConfig(runnerSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithChain(chainSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc), httpapi.WithParameters(parameterSvc), httpapi.WithPromotion(promotionStore), httpapi.WithEnvironments(environmentsSvc), httpapi.WithDoraMetrics(doraMetricsSvc), httpapi.WithTemplates(templateSvc), httpapi.WithVariableGroups(varGroupSvc), httpapi.WithCustomNodes(customNodeSvc)),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		// WriteTimeout 置 0:SSE 长连接(/api/runs/{id}/events)不可被写超时切断;

--- a/internal/environments/environments.go
+++ b/internal/environments/environments.go
@@ -1,0 +1,273 @@
+// Package environments 把「环境」做成可观测的一等只读对象(对标 GitLab environments):
+// 按环境聚合部署历史(哪个 run、何时、什么产物、成功/失败、目标机、谁触发),并标出每环境
+// 当前「活跃版本」(最近一次全成功部署),为一键回滚提供「上一次成功部署」的定位。
+//
+// 设计要点(务实、轻量、诚实):
+//   - **零迁移、纯查询既有表聚合**:数据已全在 pipeline_runs(resolved_environment / trigger_* /
+//     时间 / status)+ deploy_targets(每机结果)+ run_artifacts(产物)。本包只做只读 JOIN +
+//     内存分组,不新增表、不改 deploy 写路径(避免动 internal/deploy 与 run.Service 接口)。
+//   - **环境来源**:run.resolved_environment(webhook 分支映射解析出的目标环境)。只统计实际发生过
+//     部署(有 deploy_targets 行)的 run —— 没部署过的 run 不进环境时间线。
+//   - **活跃版本**:某环境时间线里最近一次「全机 success」的部署即当前活跃版本。
+//   - **回滚目标**:活跃版本之前最近一次「全机 success」的部署,即「上一次成功部署」;回滚 = 用
+//     那次 run 的同一产物 + 同一组目标机经既有 deploy 链路重发(执行编排在 httpapi 层注入 deploy.Service)。
+//
+// 本包只 import database/sql(+ 标准库);不 import run/deploy(避免环),与 promotion.Store 同范式。
+package environments
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// 领域错误。错误体绝无敏感数据(密钥 / 明文 / 内部栈)。
+var (
+	// ErrProjectNotFound 表示项目不存在。
+	ErrProjectNotFound = errors.New("environments: project not found")
+	// ErrEnvNotFound 表示该项目下无此环境的部署历史。
+	ErrEnvNotFound = errors.New("environments: environment has no deployment history")
+	// ErrNoRollbackTarget 表示该环境没有「上一次成功部署」可回滚(历史不足 / 仅一次成功)。
+	ErrNoRollbackTarget = errors.New("environments: no previous successful deployment to roll back to")
+)
+
+// 部署聚合状态(据该次部署的全部 deploy_targets 归并)。
+const (
+	// DeployStatusSuccess 表示该次部署全部目标机 success。
+	DeployStatusSuccess = "success"
+	// DeployStatusPartialFailed 表示有成功也有失败/回滚目标。
+	DeployStatusPartialFailed = "partial_failed"
+	// DeployStatusFailed 表示全部目标机失败/回滚。
+	DeployStatusFailed = "failed"
+)
+
+// TargetSummary 是某次部署在一台目标机上的结果摘要(只读视图;绝无明文密钥)。
+type TargetSummary struct {
+	ServerID   string `json:"serverId"`
+	ServerName string `json:"serverName"`
+	Status     string `json:"status"` // run.Target* 枚举:pending|deploying|success|failed|rolled_back
+}
+
+// Artifact 是某次部署所发布产物的只读摘要。
+type Artifact struct {
+	ID        string `json:"id"`
+	Type      string `json:"type"` // image|jar|dist|archive
+	Name      string `json:"name"`
+	Reference string `json:"reference"`
+}
+
+// Deployment 是某环境时间线上的一次部署事件(按环境聚合的核心单元)。
+type Deployment struct {
+	RunID       string          `json:"runId"`
+	Status      string          `json:"status"`      // success|partial_failed|failed(据 targets 归并)
+	Commit      string          `json:"commit"`      // 触发提交短 SHA(可空)
+	Branch      string          `json:"branch"`      // 触发分支
+	TriggeredBy string          `json:"triggeredBy"` // 触发者(展示;绝无敏感数据)
+	DeployedAt  string          `json:"deployedAt"`  // 该次部署最晚一台目标机结束时刻(RFC3339;未结束回退到开始时刻)
+	Active      bool            `json:"active"`      // 是否为该环境当前活跃版本(最近一次全成功)
+	Targets     []TargetSummary `json:"targets"`     // 每台目标机结果
+	Artifacts   []Artifact      `json:"artifacts"`   // 该 run 产物
+	ServerIDs   []string        `json:"-"`           // 该次部署涉及的目标机 id(供回滚重发;不出 JSON)
+
+	envName string // 该部署所属环境(内部分组用;不出 JSON)
+}
+
+// EnvironmentTimeline 是某环境的部署时间线(最近在前)。
+type EnvironmentTimeline struct {
+	Environment string       `json:"environment"`
+	Active      *Deployment  `json:"active"`      // 当前活跃版本(最近一次全成功);无则 nil
+	Deployments []Deployment `json:"deployments"` // 最近 N 次(按部署时间降序)
+}
+
+// Service 是环境部署历史的只读聚合 + 回滚定位领域接口。
+type Service struct {
+	db *sql.DB
+}
+
+// NewService 构造只读聚合 Service(纯参数化 SQL;无 init 副作用、不驻留)。
+func NewService(db *sql.DB) *Service { return &Service{db: db} }
+
+// defaultHistoryLimit 是每环境时间线默认返回的部署条数上限(防超大项目一次性回全量)。
+const defaultHistoryLimit = 50
+
+// ListEnvironments 返回某项目按环境聚合的全部部署时间线(每环境最近 limit 次;最近在前)。
+// limit<=0 用默认上限。项目不存在 → ErrProjectNotFound。无任何部署 → 空切片(非错误)。
+func (s *Service) ListEnvironments(ctx context.Context, projectID string, limit int) ([]EnvironmentTimeline, error) {
+	if err := s.assertProject(ctx, projectID); err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = defaultHistoryLimit
+	}
+	byEnv, order, err := s.loadDeploymentsByEnv(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]EnvironmentTimeline, 0, len(order))
+	for _, env := range order {
+		deps := byEnv[env]
+		markActive(deps)
+		var active *Deployment
+		for i := range deps {
+			if deps[i].Active {
+				a := deps[i]
+				active = &a
+				break
+			}
+		}
+		if len(deps) > limit {
+			deps = deps[:limit]
+		}
+		out = append(out, EnvironmentTimeline{Environment: env, Active: active, Deployments: deps})
+	}
+	return out, nil
+}
+
+// EnvironmentHistory 返回单个环境的部署时间线(最近 limit 次)。
+// 项目不存在 → ErrProjectNotFound;该环境无部署历史 → ErrEnvNotFound。
+func (s *Service) EnvironmentHistory(ctx context.Context, projectID, env string, limit int) (EnvironmentTimeline, error) {
+	env = strings.TrimSpace(env)
+	all, err := s.ListEnvironments(ctx, projectID, limit)
+	if err != nil {
+		return EnvironmentTimeline{}, err
+	}
+	for i := range all {
+		if all[i].Environment == env {
+			return all[i], nil
+		}
+	}
+	return EnvironmentTimeline{}, ErrEnvNotFound
+}
+
+// RollbackTarget 是「上一次成功部署」的定位结果(供 httpapi 层经 deploy.Service 重发)。
+type RollbackTarget struct {
+	Environment  string   // 目标环境
+	RunID        string   // 上一次成功部署的源运行 id
+	ArtifactID   string   // 该次部署发布的产物 id(首个可发布产物;无则空 → 由 HTTP 层 422)
+	Artifact     Artifact // 产物摘要
+	ServerIDs    []string // 该次部署涉及的目标机 id(原样重发)
+	CurrentRunID string   // 当前活跃版本的源运行 id(展示「从 X 回滚到 Y」)
+}
+
+// ResolveRollback 定位某环境「上一次成功部署」作为回滚目标(当前活跃版本之前最近一次全成功)。
+//
+// 规则:取该环境时间线 → 找当前活跃(最近全成功)→ 再往前找下一次全成功 = 回滚目标。
+// 若无活跃版本(从未全成功过)或活跃之前再无全成功 → ErrNoRollbackTarget。
+// 项目不存在 → ErrProjectNotFound;环境无历史 → ErrEnvNotFound。
+//
+// 本方法只**定位**,不执行;回滚执行(重发上一个产物到原目标机)由 httpapi 层经注入的
+// deploy.Service.Deploy 完成,复用既有部署链路(健康门控 / 多机扇出 / 失败诊断全复用)。
+func (s *Service) ResolveRollback(ctx context.Context, projectID, env string) (RollbackTarget, error) {
+	tl, err := s.EnvironmentHistory(ctx, projectID, env, defaultHistoryLimit)
+	if err != nil {
+		return RollbackTarget{}, err
+	}
+	// 找当前活跃版本下标(最近一次全成功)。
+	activeIdx := -1
+	for i := range tl.Deployments {
+		if tl.Deployments[i].Active {
+			activeIdx = i
+			break
+		}
+	}
+	if activeIdx < 0 {
+		return RollbackTarget{}, ErrNoRollbackTarget
+	}
+	// 在活跃之后(时间更早)找下一次全成功 = 回滚目标。
+	for i := activeIdx + 1; i < len(tl.Deployments); i++ {
+		d := tl.Deployments[i]
+		if d.Status != DeployStatusSuccess {
+			continue
+		}
+		rt := RollbackTarget{
+			Environment:  env,
+			RunID:        d.RunID,
+			ServerIDs:    d.ServerIDs,
+			CurrentRunID: tl.Deployments[activeIdx].RunID,
+		}
+		if len(d.Artifacts) > 0 {
+			art := pickDeployableArtifact(d.Artifacts)
+			rt.ArtifactID = art.ID
+			rt.Artifact = art
+		}
+		return rt, nil
+	}
+	return RollbackTarget{}, ErrNoRollbackTarget
+}
+
+// pickDeployableArtifact 选一次部署可重发的产物(优先 dist/jar/archive/image 中首个;否则取首个)。
+// 与 deploy.DeployForStage 的「首个可发布产物」语义对齐(顺序稳定:产物已按创建序返回)。
+func pickDeployableArtifact(arts []Artifact) Artifact {
+	for _, a := range arts {
+		switch a.Type {
+		case "dist", "jar", "archive", "image":
+			return a
+		}
+	}
+	return arts[0]
+}
+
+// assertProject 校验项目存在(项目不存在 → ErrProjectNotFound)。
+func (s *Service) assertProject(ctx context.Context, projectID string) error {
+	var one int
+	err := s.db.QueryRowContext(ctx, `SELECT 1 FROM projects WHERE id = ?`, strings.TrimSpace(projectID)).Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrProjectNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("environments: assert project: %w", err)
+	}
+	return nil
+}
+
+// markActive 在一组按时间降序的部署中,把最近一次「全成功」标记为活跃(其余 Active=false)。
+func markActive(deps []Deployment) {
+	for i := range deps {
+		if deps[i].Status == DeployStatusSuccess {
+			deps[i].Active = true
+			return
+		}
+	}
+}
+
+// sortByDeployedAtDesc 按部署时刻降序(最近在前);时刻并列用 runID 破并列保证稳定。
+func sortByDeployedAtDesc(deps []Deployment) {
+	sort.SliceStable(deps, func(i, j int) bool {
+		if deps[i].DeployedAt != deps[j].DeployedAt {
+			return deps[i].DeployedAt > deps[j].DeployedAt
+		}
+		return deps[i].RunID > deps[j].RunID
+	})
+}
+
+// aggregateTargetStatus 据一次部署的全部目标机状态归并出该次部署的整体状态。
+//   - 全 success            → success
+//   - 全 failed/rolled_back → failed
+//   - 其余(混合 / 含进行中)→ partial_failed
+func aggregateTargetStatus(targets []TargetSummary) string {
+	if len(targets) == 0 {
+		return DeployStatusFailed
+	}
+	allOK, allBad := true, true
+	for _, t := range targets {
+		ok := t.Status == "success"
+		bad := t.Status == "failed" || t.Status == "rolled_back"
+		if !ok {
+			allOK = false
+		}
+		if !bad {
+			allBad = false
+		}
+	}
+	switch {
+	case allOK:
+		return DeployStatusSuccess
+	case allBad:
+		return DeployStatusFailed
+	default:
+		return DeployStatusPartialFailed
+	}
+}

--- a/internal/environments/environments_test.go
+++ b/internal/environments/environments_test.go
@@ -1,0 +1,323 @@
+package environments
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/huangchengsir/pipewright/internal/store"
+)
+
+// ---- 测试地基:真 SQLite store + 种子项目/运行/部署目标/产物 -----------------
+
+func testService(t *testing.T) (*Service, *sql.DB) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return NewService(st.DB), st.DB
+}
+
+func seedProject(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	credID := uuid.NewString()
+	if _, err := db.Exec(
+		`INSERT INTO credentials (id, name, type, scope, ciphertext, masked_value, created_at, updated_at)
+		 VALUES (?, 'c', 'git_token', '', X'00', 'm', ?, ?)`,
+		credID, now, now,
+	); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+	projID := uuid.NewString()
+	if _, err := db.Exec(
+		`INSERT INTO projects (id, name, repo_url, default_branch, credential_id, created_at, updated_at)
+		 VALUES (?, 'acme', 'https://example.com/p.git', 'main', ?, ?, ?)`,
+		projID, credID, now, now,
+	); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	return projID
+}
+
+// seedRun 插一个指定环境的成功 run。
+func seedRun(t *testing.T, db *sql.DB, projectID, env, commit string) string {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	id := uuid.NewString()
+	if _, err := db.Exec(
+		`INSERT INTO pipeline_runs
+		   (id, project_id, status, trigger_type, trigger_branch, trigger_commit, trigger_actor,
+		    resolved_environment, resolved_target_server_ids, params_json, created_at)
+		 VALUES (?, ?, 'success', 'webhook', 'main', ?, 'alice', ?, '[]', '{}', ?)`,
+		id, projectID, commit, env, now,
+	); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	return id
+}
+
+// seedTarget 给某 run 插一台目标机部署结果(at 决定部署时刻,递增以控制时间线顺序)。
+func seedTarget(t *testing.T, db *sql.DB, runID, serverID, status string, at time.Time) {
+	t.Helper()
+	ts := at.UTC().Format(time.RFC3339)
+	if _, err := db.Exec(
+		`INSERT INTO deploy_targets
+		   (id, run_id, server_id, server_name, status, message, started_at, finished_at)
+		 VALUES (?, ?, ?, ?, ?, '', ?, ?)`,
+		uuid.NewString(), runID, serverID, serverID+"-name", status, ts, ts,
+	); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+}
+
+func seedArtifact(t *testing.T, db *sql.DB, runID, typ, name, ref string) string {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	id := uuid.NewString()
+	if _, err := db.Exec(
+		`INSERT INTO run_artifacts (id, run_id, type, name, reference, size_bytes, metadata_json, created_at)
+		 VALUES (?, ?, ?, ?, ?, 0, '', ?)`,
+		id, runID, typ, name, ref, now,
+	); err != nil {
+		t.Fatalf("seed artifact: %v", err)
+	}
+	return id
+}
+
+// ---- 聚合:多 run 多环境正确分组 + 排序 + 活跃版本 --------------------------
+
+func TestListEnvironments_GroupsAndOrders(t *testing.T) {
+	svc, db := testService(t)
+	proj := seedProject(t, db)
+	base := time.Now().UTC().Add(-time.Hour)
+
+	// staging:两次部署(t0 成功、t1 成功)。
+	sRun0 := seedRun(t, db, proj, "staging", "aaa111")
+	seedTarget(t, db, sRun0, "srv-s1", "success", base)
+	sRun1 := seedRun(t, db, proj, "staging", "bbb222")
+	seedTarget(t, db, sRun1, "srv-s1", "success", base.Add(10*time.Minute))
+
+	// prod:一次部署(t2 成功,最近)。
+	pRun := seedRun(t, db, proj, "prod", "ccc333")
+	seedTarget(t, db, pRun, "srv-p1", "success", base.Add(20*time.Minute))
+
+	// 未部署的 run(无 deploy_targets)→ 不应出现。
+	_ = seedRun(t, db, proj, "dev", "ddd444")
+
+	tls, err := svc.ListEnvironments(context.Background(), proj, 0)
+	if err != nil {
+		t.Fatalf("ListEnvironments: %v", err)
+	}
+	if len(tls) != 2 {
+		t.Fatalf("want 2 environments (staging, prod), got %d: %+v", len(tls), tls)
+	}
+	// prod 最近部署在前。
+	if tls[0].Environment != "prod" {
+		t.Fatalf("want prod first (most recent), got %q", tls[0].Environment)
+	}
+	if tls[1].Environment != "staging" {
+		t.Fatalf("want staging second, got %q", tls[1].Environment)
+	}
+
+	// staging 时间线:最近在前 = sRun1。
+	staging := tls[1]
+	if len(staging.Deployments) != 2 {
+		t.Fatalf("staging want 2 deployments, got %d", len(staging.Deployments))
+	}
+	if staging.Deployments[0].RunID != sRun1 {
+		t.Fatalf("staging newest deployment should be sRun1, got %q", staging.Deployments[0].RunID)
+	}
+	// 活跃版本 = 最近一次全成功 = sRun1。
+	if staging.Active == nil || staging.Active.RunID != sRun1 {
+		t.Fatalf("staging active should be sRun1, got %+v", staging.Active)
+	}
+	if !staging.Deployments[0].Active {
+		t.Fatalf("newest staging deployment should be marked active")
+	}
+	if staging.Deployments[1].Active {
+		t.Fatalf("older staging deployment should not be active")
+	}
+}
+
+func TestListEnvironments_PartialAndFailedAggregation(t *testing.T) {
+	svc, db := testService(t)
+	proj := seedProject(t, db)
+	base := time.Now().UTC().Add(-time.Hour)
+
+	// 一次混合(一成功一失败)→ partial_failed。
+	run := seedRun(t, db, proj, "prod", "mix")
+	seedTarget(t, db, run, "srv-1", "success", base)
+	seedTarget(t, db, run, "srv-2", "failed", base.Add(time.Minute))
+
+	// 一次全失败 → failed。
+	run2 := seedRun(t, db, proj, "prod", "allbad")
+	seedTarget(t, db, run2, "srv-1", "failed", base.Add(2*time.Minute))
+
+	tl, err := svc.EnvironmentHistory(context.Background(), proj, "prod", 0)
+	if err != nil {
+		t.Fatalf("EnvironmentHistory: %v", err)
+	}
+	if len(tl.Deployments) != 2 {
+		t.Fatalf("want 2, got %d", len(tl.Deployments))
+	}
+	// 最近 = allbad(failed)。
+	if got := tl.Deployments[0].Status; got != DeployStatusFailed {
+		t.Fatalf("newest should be failed, got %q", got)
+	}
+	if got := tl.Deployments[1].Status; got != DeployStatusPartialFailed {
+		t.Fatalf("older should be partial_failed, got %q", got)
+	}
+	// 无全成功 → 无活跃版本。
+	if tl.Active != nil {
+		t.Fatalf("expected no active version, got %+v", tl.Active)
+	}
+}
+
+func TestListEnvironments_ProjectNotFound(t *testing.T) {
+	svc, _ := testService(t)
+	_, err := svc.ListEnvironments(context.Background(), "nope", 0)
+	if !errors.Is(err, ErrProjectNotFound) {
+		t.Fatalf("want ErrProjectNotFound, got %v", err)
+	}
+}
+
+func TestListEnvironments_NoDeployments(t *testing.T) {
+	svc, db := testService(t)
+	proj := seedProject(t, db)
+	tls, err := svc.ListEnvironments(context.Background(), proj, 0)
+	if err != nil {
+		t.Fatalf("ListEnvironments: %v", err)
+	}
+	if len(tls) != 0 {
+		t.Fatalf("want empty, got %+v", tls)
+	}
+}
+
+func TestEnvironmentHistory_NotFound(t *testing.T) {
+	svc, db := testService(t)
+	proj := seedProject(t, db)
+	run := seedRun(t, db, proj, "staging", "x")
+	seedTarget(t, db, run, "s1", "success", time.Now())
+
+	if _, err := svc.EnvironmentHistory(context.Background(), proj, "prod", 0); !errors.Is(err, ErrEnvNotFound) {
+		t.Fatalf("want ErrEnvNotFound, got %v", err)
+	}
+}
+
+// ---- 回滚定位:上一次成功部署 ------------------------------------------------
+
+func TestResolveRollback_HappyPath(t *testing.T) {
+	svc, db := testService(t)
+	proj := seedProject(t, db)
+	base := time.Now().UTC().Add(-time.Hour)
+
+	// 旧成功部署(回滚目标):产物 + 两台机。
+	old := seedRun(t, db, proj, "prod", "old-sha")
+	oldArt := seedArtifact(t, db, old, "dist", "web", "ref-old")
+	seedTarget(t, db, old, "srv-1", "success", base)
+	seedTarget(t, db, old, "srv-2", "success", base.Add(time.Minute))
+
+	// 当前活跃部署(最近全成功)。
+	cur := seedRun(t, db, proj, "prod", "new-sha")
+	seedArtifact(t, db, cur, "dist", "web", "ref-new")
+	seedTarget(t, db, cur, "srv-1", "success", base.Add(30*time.Minute))
+
+	rt, err := svc.ResolveRollback(context.Background(), proj, "prod")
+	if err != nil {
+		t.Fatalf("ResolveRollback: %v", err)
+	}
+	if rt.RunID != old {
+		t.Fatalf("rollback target run should be old, got %q", rt.RunID)
+	}
+	if rt.CurrentRunID != cur {
+		t.Fatalf("current run should be cur, got %q", rt.CurrentRunID)
+	}
+	if rt.ArtifactID != oldArt {
+		t.Fatalf("rollback artifact should be oldArt, got %q", rt.ArtifactID)
+	}
+	if len(rt.ServerIDs) != 2 {
+		t.Fatalf("want 2 server ids, got %v", rt.ServerIDs)
+	}
+}
+
+func TestResolveRollback_NoPreviousSuccess(t *testing.T) {
+	svc, db := testService(t)
+	proj := seedProject(t, db)
+	base := time.Now().UTC().Add(-time.Hour)
+
+	// 只有一次成功部署 → 无上一次成功可回滚。
+	cur := seedRun(t, db, proj, "prod", "only")
+	seedArtifact(t, db, cur, "dist", "web", "r")
+	seedTarget(t, db, cur, "srv-1", "success", base)
+
+	if _, err := svc.ResolveRollback(context.Background(), proj, "prod"); !errors.Is(err, ErrNoRollbackTarget) {
+		t.Fatalf("want ErrNoRollbackTarget, got %v", err)
+	}
+}
+
+func TestResolveRollback_SkipsFailedBetween(t *testing.T) {
+	svc, db := testService(t)
+	proj := seedProject(t, db)
+	base := time.Now().UTC().Add(-2 * time.Hour)
+
+	// 旧成功(回滚目标)。
+	old := seedRun(t, db, proj, "prod", "old")
+	seedArtifact(t, db, old, "dist", "web", "ref-old")
+	seedTarget(t, db, old, "srv-1", "success", base)
+
+	// 中间一次失败部署(不应被选为回滚目标)。
+	bad := seedRun(t, db, proj, "prod", "bad")
+	seedArtifact(t, db, bad, "dist", "web", "ref-bad")
+	seedTarget(t, db, bad, "srv-1", "failed", base.Add(20*time.Minute))
+
+	// 当前活跃成功。
+	cur := seedRun(t, db, proj, "prod", "cur")
+	seedArtifact(t, db, cur, "dist", "web", "ref-cur")
+	seedTarget(t, db, cur, "srv-1", "success", base.Add(40*time.Minute))
+
+	rt, err := svc.ResolveRollback(context.Background(), proj, "prod")
+	if err != nil {
+		t.Fatalf("ResolveRollback: %v", err)
+	}
+	if rt.RunID != old {
+		t.Fatalf("rollback should skip failed and target old, got %q", rt.RunID)
+	}
+	_ = bad
+}
+
+func TestResolveRollback_EnvNotFound(t *testing.T) {
+	svc, db := testService(t)
+	proj := seedProject(t, db)
+	if _, err := svc.ResolveRollback(context.Background(), proj, "ghost"); !errors.Is(err, ErrEnvNotFound) {
+		t.Fatalf("want ErrEnvNotFound, got %v", err)
+	}
+}
+
+func TestAggregateTargetStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []TargetSummary
+		want string
+	}{
+		{"all success", []TargetSummary{{Status: "success"}, {Status: "success"}}, DeployStatusSuccess},
+		{"all failed", []TargetSummary{{Status: "failed"}, {Status: "rolled_back"}}, DeployStatusFailed},
+		{"mixed", []TargetSummary{{Status: "success"}, {Status: "failed"}}, DeployStatusPartialFailed},
+		{"in progress", []TargetSummary{{Status: "deploying"}}, DeployStatusPartialFailed},
+		{"empty", nil, DeployStatusFailed},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := aggregateTargetStatus(c.in); got != c.want {
+				t.Fatalf("aggregateTargetStatus(%v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/environments/store.go
+++ b/internal/environments/store.go
@@ -1,0 +1,141 @@
+package environments
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+)
+
+// store.go 实现「按环境聚合部署历史」的只读查询(纯参数化 SQL,零迁移,JOIN 既有表):
+//
+//	pipeline_runs(resolved_environment / trigger_* / status)
+//	  ⨝ deploy_targets(每机结果;有行 = 实际部署过)
+//	  ⨝ run_artifacts(产物)
+//
+// 只统计 resolved_environment 非空 **且** 存在 deploy_targets 行的 run —— 即「实际向某环境部署过」。
+// 时间线按「该次部署最晚一台目标机结束时刻」降序(未结束回退到开始时刻),最近在前。
+
+// loadDeploymentsByEnv 取某项目全部已部署 run,按环境分组(每组按部署时刻降序)。
+// 返回 (env→[]Deployment, env 出现顺序);env 顺序按各环境最近部署时刻降序(活跃环境靠前)。
+func (s *Service) loadDeploymentsByEnv(ctx context.Context, projectID string) (map[string][]Deployment, []string, error) {
+	// 1) 拉「有部署目标的 run + 其环境/触发元数据」。一行一目标机,后续内存按 run 折叠。
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT r.id, r.resolved_environment, r.trigger_commit, r.trigger_branch, r.trigger_actor,
+		       dt.server_id, dt.server_name, dt.status, dt.started_at, dt.finished_at
+		FROM pipeline_runs r
+		JOIN deploy_targets dt ON dt.run_id = r.id
+		WHERE r.project_id = ? AND TRIM(r.resolved_environment) <> ''
+		ORDER BY r.id ASC, dt.started_at ASC, dt.rowid ASC`, projectID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("environments: query deployments: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	type acc struct {
+		dep    Deployment
+		latest string // 最晚目标机结束/开始时刻(决定部署时刻)
+	}
+	byRun := map[string]*acc{}
+	runOrder := []string{}
+	for rows.Next() {
+		var (
+			runID, env, commit, branch, actor string
+			serverID, serverName, status      string
+			startedAt                         string
+			finishedAt                        sql.NullString
+		)
+		if err := rows.Scan(&runID, &env, &commit, &branch, &actor,
+			&serverID, &serverName, &status, &startedAt, &finishedAt); err != nil {
+			return nil, nil, fmt.Errorf("environments: scan deployment row: %w", err)
+		}
+		a, ok := byRun[runID]
+		if !ok {
+			a = &acc{dep: Deployment{
+				RunID:       runID,
+				Commit:      commit,
+				Branch:      branch,
+				TriggeredBy: actor,
+				Targets:     []TargetSummary{},
+				Artifacts:   []Artifact{},
+				ServerIDs:   []string{},
+			}}
+			a.dep.envName = env
+			byRun[runID] = a
+			runOrder = append(runOrder, runID)
+		}
+		a.dep.Targets = append(a.dep.Targets, TargetSummary{ServerID: serverID, ServerName: serverName, Status: status})
+		a.dep.ServerIDs = append(a.dep.ServerIDs, serverID)
+		// 部署时刻取最晚的 finished_at(回退 started_at)。字符串 RFC3339 可直接字典序比较。
+		when := startedAt
+		if finishedAt.Valid && finishedAt.String > when {
+			when = finishedAt.String
+		}
+		if when > a.latest {
+			a.latest = when
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("environments: iterate deployments: %w", err)
+	}
+
+	// 2) 为每个 run 补产物 + 归并状态 + 落部署时刻。
+	for _, runID := range runOrder {
+		a := byRun[runID]
+		arts, aerr := s.loadArtifacts(ctx, runID)
+		if aerr != nil {
+			return nil, nil, aerr
+		}
+		a.dep.Artifacts = arts
+		a.dep.Status = aggregateTargetStatus(a.dep.Targets)
+		a.dep.DeployedAt = a.latest
+	}
+
+	// 3) 按环境分组(每组按部署时刻降序);记录环境出现顺序(按最近部署降序)。
+	byEnv := map[string][]Deployment{}
+	envLatest := map[string]string{}
+	for _, runID := range runOrder {
+		d := byRun[runID].dep
+		env := d.envName
+		byEnv[env] = append(byEnv[env], d)
+		if d.DeployedAt > envLatest[env] {
+			envLatest[env] = d.DeployedAt
+		}
+	}
+	for env := range byEnv {
+		deps := byEnv[env]
+		sortByDeployedAtDesc(deps)
+		byEnv[env] = deps
+	}
+	order := make([]string, 0, len(byEnv))
+	for env := range byEnv {
+		order = append(order, env)
+	}
+	sort.SliceStable(order, func(i, j int) bool {
+		if envLatest[order[i]] != envLatest[order[j]] {
+			return envLatest[order[i]] > envLatest[order[j]]
+		}
+		return order[i] < order[j]
+	})
+	return byEnv, order, nil
+}
+
+// loadArtifacts 取某 run 的全部产物摘要(按创建序;供时间线展示 + 回滚选品)。
+func (s *Service) loadArtifacts(ctx context.Context, runID string) ([]Artifact, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, type, name, reference FROM run_artifacts
+		 WHERE run_id = ? ORDER BY created_at ASC, rowid ASC`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("environments: query artifacts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	out := []Artifact{}
+	for rows.Next() {
+		var a Artifact
+		if err := rows.Scan(&a.ID, &a.Type, &a.Name, &a.Reference); err != nil {
+			return nil, fmt.Errorf("environments: scan artifact: %w", err)
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}

--- a/internal/httpapi/environments.go
+++ b/internal/httpapi/environments.go
@@ -1,0 +1,217 @@
+package httpapi
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/audit"
+	"github.com/huangchengsir/pipewright/internal/deploy"
+	"github.com/huangchengsir/pipewright/internal/environments"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// environments.go 暴露「环境一等公民」只读聚合 + 一键回滚端点(对标 GitLab environments)。
+//
+//	GET  /api/projects/{id}/environments/deployments        → 按环境聚合的部署时间线(每环境最近 N 次 + 活跃版本)
+//	GET  /api/projects/{id}/environments/{env}/history       → 单环境时间线
+//	POST /api/projects/{id}/environments/{env}/rollback      → 一键回滚到上一次成功部署(需 CSRF)
+//
+// 聚合是纯查询既有表(零迁移);回滚定位由 environments.Service 完成,执行复用既有 deploy.Service.Deploy
+// 链路(重发上一次成功部署的同一产物到同一组目标机)。env 路径段经 URL 解码(chi 已解)。
+
+// ---- 只读聚合 DTO --------------------------------------------------------------
+
+type envTargetDTO struct {
+	ServerID   string `json:"serverId"`
+	ServerName string `json:"serverName"`
+	Status     string `json:"status"`
+}
+
+type envArtifactDTO struct {
+	ID        string `json:"id"`
+	Type      string `json:"type"`
+	Name      string `json:"name"`
+	Reference string `json:"reference"`
+}
+
+type envDeploymentDTO struct {
+	RunID       string           `json:"runId"`
+	Status      string           `json:"status"`
+	Commit      string           `json:"commit"`
+	Branch      string           `json:"branch"`
+	TriggeredBy string           `json:"triggeredBy"`
+	DeployedAt  string           `json:"deployedAt"`
+	Active      bool             `json:"active"`
+	Targets     []envTargetDTO   `json:"targets"`
+	Artifacts   []envArtifactDTO `json:"artifacts"`
+}
+
+type envTimelineDTO struct {
+	Environment string             `json:"environment"`
+	Active      *envDeploymentDTO  `json:"active"`
+	Deployments []envDeploymentDTO `json:"deployments"`
+}
+
+func toEnvDeploymentDTO(d environments.Deployment) envDeploymentDTO {
+	targets := make([]envTargetDTO, 0, len(d.Targets))
+	for _, t := range d.Targets {
+		targets = append(targets, envTargetDTO{ServerID: t.ServerID, ServerName: t.ServerName, Status: t.Status})
+	}
+	arts := make([]envArtifactDTO, 0, len(d.Artifacts))
+	for _, a := range d.Artifacts {
+		arts = append(arts, envArtifactDTO{ID: a.ID, Type: a.Type, Name: a.Name, Reference: a.Reference})
+	}
+	return envDeploymentDTO{
+		RunID:       d.RunID,
+		Status:      d.Status,
+		Commit:      d.Commit,
+		Branch:      d.Branch,
+		TriggeredBy: d.TriggeredBy,
+		DeployedAt:  d.DeployedAt,
+		Active:      d.Active,
+		Targets:     targets,
+		Artifacts:   arts,
+	}
+}
+
+func toEnvTimelineDTO(tl environments.EnvironmentTimeline) envTimelineDTO {
+	deps := make([]envDeploymentDTO, 0, len(tl.Deployments))
+	for i := range tl.Deployments {
+		deps = append(deps, toEnvDeploymentDTO(tl.Deployments[i]))
+	}
+	out := envTimelineDTO{Environment: tl.Environment, Deployments: deps}
+	if tl.Active != nil {
+		a := toEnvDeploymentDTO(*tl.Active)
+		out.Active = &a
+	}
+	return out
+}
+
+func writeEnvError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, environments.ErrProjectNotFound):
+		writeError(w, http.StatusNotFound, "project_not_found", "项目不存在")
+	case errors.Is(err, environments.ErrEnvNotFound):
+		writeError(w, http.StatusNotFound, "environment_not_found", "该环境暂无部署历史")
+	case errors.Is(err, environments.ErrNoRollbackTarget):
+		writeError(w, http.StatusUnprocessableEntity, "no_rollback_target", "该环境没有可回滚的上一次成功部署")
+	default:
+		writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+	}
+}
+
+// makeListEnvironmentDeploymentsHandler 返回 GET /api/projects/{id}/environments/deployments。
+func makeListEnvironmentDeploymentsHandler(svc *environments.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "环境服务未初始化")
+			return
+		}
+		tls, err := svc.ListEnvironments(r.Context(), chi.URLParam(r, "id"), 0)
+		if err != nil {
+			writeEnvError(w, err)
+			return
+		}
+		items := make([]envTimelineDTO, 0, len(tls))
+		for i := range tls {
+			items = append(items, toEnvTimelineDTO(tls[i]))
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"environments": items})
+	}
+}
+
+// makeEnvironmentHistoryHandler 返回 GET /api/projects/{id}/environments/{env}/history。
+func makeEnvironmentHistoryHandler(svc *environments.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "环境服务未初始化")
+			return
+		}
+		tl, err := svc.EnvironmentHistory(r.Context(), chi.URLParam(r, "id"), chi.URLParam(r, "env"), 0)
+		if err != nil {
+			writeEnvError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, toEnvTimelineDTO(tl))
+	}
+}
+
+// rollbackResponse 是回滚响应:复用 deploy targets 形状 + 回滚溯源(从哪个 run 回滚到哪个 run)。
+type rollbackResponse struct {
+	Environment string      `json:"environment"`
+	FromRunID   string      `json:"fromRunId"`  // 回滚前的活跃版本 run
+	ToRunID     string      `json:"toRunId"`    // 回滚目标(上一次成功部署)run
+	ArtifactID  string      `json:"artifactId"` // 重发的产物
+	Targets     []targetDTO `json:"targets"`    // 重发后的每机结果(复用部署 targets 形状)
+}
+
+// makeRollbackEnvironmentHandler 返回 POST /api/projects/{id}/environments/{env}/rollback(认证 + CSRF)。
+//
+// 定位该环境「上一次成功部署」(当前活跃版本之前最近一次全成功)→ 经既有 deploy.Service.Deploy
+// 把那次的同一产物重发到原目标机(复用健康门控 / 多机扇出 / 失败诊断全链路)→ 返回重发后的 targets。
+//
+// 项目不存在 / 环境无历史 → 404;无可回滚目标 / 产物缺失 / 服务器不存在 → 422;
+// 重发执行失败由 deploy.Deploy 内化为每机 failed(整体 200,不 500)。
+func makeRollbackEnvironmentHandler(envSvc *environments.Service, deploySvc deploy.Service, runSvc run.Service, rec audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if envSvc == nil || deploySvc == nil || runSvc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "回滚服务未初始化")
+			return
+		}
+		projectID := chi.URLParam(r, "id")
+		env := chi.URLParam(r, "env")
+
+		rt, err := envSvc.ResolveRollback(r.Context(), projectID, env)
+		if err != nil {
+			writeEnvError(w, err)
+			return
+		}
+		if rt.ArtifactID == "" {
+			writeError(w, http.StatusUnprocessableEntity, "artifact_not_found", "上一次成功部署无可重发产物")
+			return
+		}
+
+		// 复用既有部署链路重发上一次成功部署的产物到原目标机(默认 rolling 策略)。
+		results, derr := deploySvc.Deploy(r.Context(), deploy.DeployInput{
+			RunID:      rt.RunID,
+			ArtifactID: rt.ArtifactID,
+			ServerIDs:  rt.ServerIDs,
+		})
+		if derr != nil {
+			writeDeployError(w, derr)
+			return
+		}
+
+		recordAudit(r.Context(), rec, audit.Entry{
+			Actor:      auditActor,
+			Action:     "environment.rollback",
+			TargetType: audit.TargetProject,
+			TargetID:   projectID,
+			Detail: map[string]any{
+				"environment": env,
+				"fromRunId":   rt.CurrentRunID,
+				"toRunId":     rt.RunID,
+				"artifactId":  rt.ArtifactID,
+			},
+			IP: clientIP(r),
+		})
+
+		// 回读权威持久化结果(与 run-detail targets 同源)。
+		out := make([]targetDTO, 0, len(results))
+		if targets, lerr := runSvc.ListDeployTargets(r.Context(), rt.RunID); lerr == nil {
+			out = toTargetDTOs(targets)
+		} else {
+			for i := range results {
+				out = append(out, targetResultToDTO(results[i]))
+			}
+		}
+		writeJSON(w, http.StatusOK, rollbackResponse{
+			Environment: env,
+			FromRunID:   rt.CurrentRunID,
+			ToRunID:     rt.RunID,
+			ArtifactID:  rt.ArtifactID,
+			Targets:     out,
+		})
+	}
+}

--- a/internal/httpapi/environments_test.go
+++ b/internal/httpapi/environments_test.go
@@ -1,0 +1,215 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/huangchengsir/pipewright/internal/auth"
+	"github.com/huangchengsir/pipewright/internal/deploy"
+	"github.com/huangchengsir/pipewright/internal/environments"
+	"github.com/huangchengsir/pipewright/internal/project"
+	"github.com/huangchengsir/pipewright/internal/run"
+	"github.com/huangchengsir/pipewright/internal/vault"
+)
+
+// stubDeploy 是一个记录入参的部署服务替身(回滚端点只需 Deploy 被以正确参数调用)。
+type stubDeploy struct {
+	lastInput deploy.DeployInput
+	result    []deploy.TargetResult
+}
+
+func (s *stubDeploy) Deploy(_ context.Context, in deploy.DeployInput) ([]deploy.TargetResult, error) {
+	s.lastInput = in
+	now := time.Now().UTC()
+	if s.result != nil {
+		return s.result, nil
+	}
+	out := make([]deploy.TargetResult, 0, len(in.ServerIDs))
+	for _, sid := range in.ServerIDs {
+		out = append(out, deploy.TargetResult{ServerID: sid, ServerName: sid, Status: run.TargetSuccess, StartedAt: now, FinishedAt: &now})
+	}
+	return out, nil
+}
+func (s *stubDeploy) RetryFailed(context.Context, deploy.RetryInput) ([]deploy.TargetResult, error) {
+	return nil, nil
+}
+func (s *stubDeploy) ContinueDeploy(context.Context, deploy.ContinueInput) ([]deploy.TargetResult, error) {
+	return nil, nil
+}
+func (s *stubDeploy) AbortDeploy(context.Context, deploy.AbortInput) ([]deploy.TargetResult, error) {
+	return nil, nil
+}
+func (s *stubDeploy) DeployForStage(context.Context, string, []string, map[string]string, string) ([]deploy.TargetResult, error) {
+	return nil, nil
+}
+
+// setupEnvironmentsServer 构造带 auth + project + run + environments + (stub)deploy 的测试 server。
+func setupEnvironmentsServer(t *testing.T) (*httptest.Server, *http.Client, string, string, run.Service, *stubDeploy) {
+	t.Helper()
+	st := testStoreAuth(t)
+	svc := auth.NewService(st.DB, nil)
+	if err := svc.Bootstrap("admin", "testpass"); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	v := vault.New(st.DB, testMasterKey())
+	psvc := project.New(st.DB, v, stubProber{branch: "main"})
+	rsvc := run.New(st.DB)
+	envSvc := environments.NewService(st.DB)
+	dep := &stubDeploy{}
+	pool := run.NewWorkerPool(rsvc)
+	pool.Start()
+	t.Cleanup(func() { pool.Stop(context.Background()) })
+
+	srv := httptest.NewServer(New(testWebFSAuth(), svc,
+		WithVault(v), WithProjects(psvc), WithRuns(rsvc, pool),
+		WithEnvironments(envSvc), WithDeploy(dep)))
+	t.Cleanup(srv.Close)
+
+	client := newTestClient(t)
+	csrf := loginWithClient(t, client, srv.URL)
+
+	credID := newGitCred(t, client, srv.URL, csrf, "ghp_env")
+	resp := doJSON(t, client, http.MethodPost, srv.URL+"/api/projects", csrf,
+		`{"name":"acme","repoUrl":"https://gitee.com/acme/shop.git","credentialId":"`+credID+`"}`)
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	var p map[string]any
+	_ = json.Unmarshal(raw, &p)
+	projID, _ := p["id"].(string)
+	if projID == "" {
+		t.Fatalf("create project failed: %s", raw)
+	}
+	return srv, client, csrf, projID, rsvc, dep
+}
+
+// seedDeployedRun 直接落一个「向某环境部署过」的成功 run(run + deploy_targets + artifact)。
+func seedDeployedRun(t *testing.T, rsvc run.Service, projID, env string, at time.Time) (runID, artID, serverID string) {
+	t.Helper()
+	ctx := context.Background()
+	r, err := rsvc.Create(ctx, projID, run.Trigger{Type: run.TriggerWebhook, ResolvedEnvironment: env, Branch: "main"})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if err := rsvc.SetDeployTerminal(ctx, r.ID, run.StatusSuccess); err != nil {
+		t.Fatalf("force success: %v", err)
+	}
+	art, err := rsvc.AddArtifact(ctx, run.Artifact{RunID: r.ID, Type: "dist", Name: "web", Reference: "ref-" + env})
+	if err != nil {
+		t.Fatalf("add artifact: %v", err)
+	}
+	serverID = "srv-" + uuid.NewString()[:8]
+	fin := at
+	if err := rsvc.SaveDeployTargets(ctx, r.ID, []run.DeployTarget{{
+		RunID: r.ID, ServerID: serverID, ServerName: serverID, Status: run.TargetSuccess,
+		StartedAt: at, FinishedAt: &fin,
+	}}); err != nil {
+		t.Fatalf("save deploy targets: %v", err)
+	}
+	return r.ID, art.ID, serverID
+}
+
+func TestEnvironmentDeploymentsEndpoint(t *testing.T) {
+	srv, client, _, projID, rsvc, _ := setupEnvironmentsServer(t)
+	base := time.Now().UTC().Add(-time.Hour)
+	seedDeployedRun(t, rsvc, projID, "staging", base)
+	prodRun, _, _ := seedDeployedRun(t, rsvc, projID, "prod", base.Add(30*time.Minute))
+
+	resp, err := client.Get(srv.URL + "/api/projects/" + projID + "/environments/deployments")
+	if err != nil {
+		t.Fatalf("GET deployments: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d: %s", resp.StatusCode, raw)
+	}
+	var got struct {
+		Environments []struct {
+			Environment string `json:"environment"`
+			Active      *struct {
+				RunID string `json:"runId"`
+			} `json:"active"`
+			Deployments []map[string]any `json:"deployments"`
+		} `json:"environments"`
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	_ = json.Unmarshal(raw, &got)
+	if len(got.Environments) != 2 {
+		t.Fatalf("want 2 environments, got %d: %s", len(got.Environments), raw)
+	}
+	if got.Environments[0].Environment != "prod" {
+		t.Fatalf("prod (most recent) should be first, got %q", got.Environments[0].Environment)
+	}
+	if got.Environments[0].Active == nil || got.Environments[0].Active.RunID != prodRun {
+		t.Fatalf("prod active should be prodRun, got %+v", got.Environments[0].Active)
+	}
+}
+
+func TestEnvironmentRollbackEndpoint(t *testing.T) {
+	srv, client, csrf, projID, rsvc, dep := setupEnvironmentsServer(t)
+	base := time.Now().UTC().Add(-2 * time.Hour)
+
+	// 旧成功(回滚目标)+ 当前活跃成功。
+	oldRun, oldArt, oldServer := seedDeployedRun(t, rsvc, projID, "prod", base)
+	curRun, _, _ := seedDeployedRun(t, rsvc, projID, "prod", base.Add(time.Hour))
+
+	resp := doJSON(t, client, http.MethodPost, srv.URL+"/api/projects/"+projID+"/environments/prod/rollback", csrf, ``)
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("rollback = %d: %s", resp.StatusCode, raw)
+	}
+	var out struct {
+		Environment string `json:"environment"`
+		FromRunID   string `json:"fromRunId"`
+		ToRunID     string `json:"toRunId"`
+		ArtifactID  string `json:"artifactId"`
+	}
+	_ = json.Unmarshal(raw, &out)
+	if out.ToRunID != oldRun {
+		t.Fatalf("rollback target should be oldRun %q, got %q", oldRun, out.ToRunID)
+	}
+	if out.FromRunID != curRun {
+		t.Fatalf("from run should be curRun %q, got %q", curRun, out.FromRunID)
+	}
+	if out.ArtifactID != oldArt {
+		t.Fatalf("artifact should be oldArt %q, got %q", oldArt, out.ArtifactID)
+	}
+	// 验证 deploy.Service 被以正确入参调用(重发旧 run 的旧产物到原目标机)。
+	if dep.lastInput.RunID != oldRun || dep.lastInput.ArtifactID != oldArt {
+		t.Fatalf("deploy called with wrong run/artifact: %+v", dep.lastInput)
+	}
+	if len(dep.lastInput.ServerIDs) != 1 || dep.lastInput.ServerIDs[0] != oldServer {
+		t.Fatalf("deploy should target original server %q, got %v", oldServer, dep.lastInput.ServerIDs)
+	}
+}
+
+func TestEnvironmentRollbackNoTarget(t *testing.T) {
+	srv, client, csrf, projID, rsvc, _ := setupEnvironmentsServer(t)
+	// 仅一次成功 → 无可回滚目标 → 422。
+	seedDeployedRun(t, rsvc, projID, "prod", time.Now().UTC().Add(-time.Hour))
+	resp := doJSON(t, client, http.MethodPost, srv.URL+"/api/projects/"+projID+"/environments/prod/rollback", csrf, ``)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("want 422, got %d: %s", resp.StatusCode, raw)
+	}
+}
+
+func TestEnvironmentHistoryNotFound(t *testing.T) {
+	srv, client, _, projID, _, _ := setupEnvironmentsServer(t)
+	resp, err := client.Get(srv.URL + "/api/projects/" + projID + "/environments/ghost/history")
+	if err != nil {
+		t.Fatalf("GET history: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", resp.StatusCode)
+	}
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -25,6 +25,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/chain"
 	"github.com/huangchengsir/pipewright/internal/cron"
 	"github.com/huangchengsir/pipewright/internal/deploy"
+	"github.com/huangchengsir/pipewright/internal/environments"
 	"github.com/huangchengsir/pipewright/internal/library"
 	"github.com/huangchengsir/pipewright/internal/notify"
 	"github.com/huangchengsir/pipewright/internal/oauth"
@@ -83,6 +84,7 @@ type options struct {
 	approvalCoord    *approval.Coordinator
 	approvalStore    *approval.Store
 	promotionStore   *promotion.Store
+	environments     *environments.Service
 	doraMetrics      run.MetricsService
 	templates        library.TemplateService
 	varGroups        library.VarGroupService
@@ -110,6 +112,14 @@ func WithApprovals(coord *approval.Coordinator, store *approval.Store) Option {
 // 不传则晋级端点返回 503。
 func WithPromotion(store *promotion.Store) Option {
 	return func(o *options) { o.promotionStore = store }
+}
+
+// WithEnvironments 注入「环境一等公民」只读聚合服务(对标 GitLab environments),挂载
+// 按环境部署历史时间线 + 单环境历史 + 一键回滚路由。聚合纯查询既有表(零迁移);回滚执行复用
+// 既有 deploy.Service(经 WithDeploy 注入)。GET 过 auth;rollback 为写方法,过 auth + CSRF + 审计。
+// 不传则相关端点返回 503(服务未初始化);未注入 deploy 时回滚端点 503。
+func WithEnvironments(s *environments.Service) Option {
+	return func(o *options) { o.environments = s }
 }
 
 // WithDoraMetrics 注入 DORA 指标只读聚合服务(FR-8-15),挂载 GET /api/metrics/dora 路由
@@ -409,6 +419,14 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		ar.Get("/projects/{id}/environments", makeGetEnvironmentsHandler(o.promotionStore))
 		ar.Put("/projects/{id}/environments", makeSaveEnvironmentsHandler(o.promotionStore, aud))
 		ar.Get("/projects/{id}/promotions", makeListProjectPromotionsHandler(o.promotionStore))
+
+		// 环境一等公民(对标 GitLab environments):按环境聚合部署历史 + 一键回滚到上一次成功部署。
+		// 比 /projects/{id}/environments 多一段(/deployments、/{env}/...),chi 精确匹配不会被吞。
+		// 纯查询既有表(零迁移);回滚执行复用 o.deployer(经 WithDeploy 注入)。
+		// GET 过 auth;rollback 为写方法,过 auth + CSRF + 审计。o.environments 为 nil → 503。
+		ar.Get("/projects/{id}/environments/deployments", makeListEnvironmentDeploymentsHandler(o.environments))
+		ar.Get("/projects/{id}/environments/{env}/history", makeEnvironmentHistoryHandler(o.environments))
+		ar.Post("/projects/{id}/environments/{env}/rollback", makeRollbackEnvironmentHandler(o.environments, o.deployer, o.runs, aud))
 
 		// 流水线编排配置(Story 2.2)。pl 为 nil 时 handler 返回 503。
 		// 与 /projects/{id}/trigger 同在 {id} 路由组内并存(不会被 /projects/{id} 吞)。

--- a/web/src/api/environments.helpers.test.ts
+++ b/web/src/api/environments.helpers.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { canRollback, previousSuccess, shortCommit, toBadgeStatus } from './environments.helpers'
+import type { EnvDeployment, EnvironmentTimeline } from './environments'
+
+function dep(partial: Partial<EnvDeployment>): EnvDeployment {
+  return {
+    runId: 'r',
+    status: 'success',
+    commit: '',
+    branch: 'main',
+    triggeredBy: 'alice',
+    deployedAt: '2026-01-01T00:00:00Z',
+    active: false,
+    targets: [],
+    artifacts: [],
+    ...partial,
+  }
+}
+
+function timeline(deployments: EnvDeployment[]): EnvironmentTimeline {
+  const active = deployments.find((d) => d.active) ?? null
+  return { environment: 'prod', active, deployments }
+}
+
+describe('toBadgeStatus', () => {
+  it('maps aggregated statuses to the badge vocabulary', () => {
+    expect(toBadgeStatus('success')).toBe('success')
+    expect(toBadgeStatus('partial_failed')).toBe('partial')
+    expect(toBadgeStatus('failed')).toBe('failed')
+    expect(toBadgeStatus('anything-else')).toBe('failed')
+  })
+})
+
+describe('shortCommit', () => {
+  it('truncates to 8 chars and falls back to em-dash', () => {
+    expect(shortCommit('abcdef1234567')).toBe('abcdef12')
+    expect(shortCommit('')).toBe('—')
+  })
+})
+
+describe('previousSuccess / canRollback', () => {
+  it('finds the next all-success after the active deployment', () => {
+    const tl = timeline([
+      dep({ runId: 'cur', active: true, status: 'success' }),
+      dep({ runId: 'bad', status: 'failed' }),
+      dep({ runId: 'old', status: 'success' }),
+    ])
+    expect(previousSuccess(tl)?.runId).toBe('old')
+    expect(canRollback(tl)).toBe(true)
+  })
+
+  it('returns null when there is only one success (the active one)', () => {
+    const tl = timeline([dep({ runId: 'only', active: true, status: 'success' })])
+    expect(previousSuccess(tl)).toBeNull()
+    expect(canRollback(tl)).toBe(false)
+  })
+
+  it('returns null when there is no active version at all', () => {
+    const tl = timeline([dep({ runId: 'f1', status: 'failed' }), dep({ runId: 'f2', status: 'failed' })])
+    expect(previousSuccess(tl)).toBeNull()
+    expect(canRollback(tl)).toBe(false)
+  })
+
+  it('skips failed/partial deployments between active and the rollback target', () => {
+    const tl = timeline([
+      dep({ runId: 'cur', active: true, status: 'success' }),
+      dep({ runId: 'p', status: 'partial_failed' }),
+      dep({ runId: 'f', status: 'failed' }),
+      dep({ runId: 'target', status: 'success' }),
+    ])
+    expect(previousSuccess(tl)?.runId).toBe('target')
+  })
+})

--- a/web/src/api/environments.helpers.ts
+++ b/web/src/api/environments.helpers.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure helpers for the Environments UI — tested in environments.helpers.test.ts.
+ *
+ * Kept framework-free (no Vue) so the rollback-eligibility / previous-success logic
+ * is unit-testable in isolation from the view.
+ */
+
+import type { BadgeStatus } from '../components/ui/StatusBadge.vue'
+import type { EnvDeployment, EnvironmentTimeline } from './environments'
+
+/** Map the aggregated deployment status to the frozen StatusBadge vocabulary. */
+export function toBadgeStatus(status: string): BadgeStatus {
+  switch (status) {
+    case 'success':
+      return 'success'
+    case 'partial_failed':
+      return 'partial'
+    default:
+      return 'failed'
+  }
+}
+
+/** Short commit SHA for display (8 chars; em-dash when empty). */
+export function shortCommit(commit: string): string {
+  return commit ? commit.slice(0, 8) : '—'
+}
+
+/** The previous successful deployment (the rollback target): the next all-success after the active one. */
+export function previousSuccess(tl: EnvironmentTimeline): EnvDeployment | null {
+  const activeIdx = tl.deployments.findIndex((d) => d.active)
+  if (activeIdx < 0) return null
+  return tl.deployments.slice(activeIdx + 1).find((d) => d.status === 'success') ?? null
+}
+
+/** Whether an environment can be rolled back: it has an active version and a prior successful deployment. */
+export function canRollback(tl: EnvironmentTimeline): boolean {
+  return previousSuccess(tl) !== null
+}

--- a/web/src/api/environments.ts
+++ b/web/src/api/environments.ts
@@ -1,0 +1,95 @@
+/**
+ * Environments API — first-class environments (GitLab-environments parity).
+ *
+ *   GET  /api/projects/{id}/environments/deployments      → per-environment deployment timelines + active version
+ *   GET  /api/projects/{id}/environments/{env}/history     → single environment timeline
+ *   POST /api/projects/{id}/environments/{env}/rollback    → one-click rollback to the previous successful deployment
+ *
+ * Read-only aggregation over existing pipeline-run data (pipeline_runs + deploy_targets +
+ * run_artifacts); zero migration. Rollback re-runs the previous successful deployment's
+ * artifact onto the same set of target servers via the existing deploy pipeline.
+ *
+ * Errors follow the canonical envelope; callers inspect `err.apiError?.code` on HttpError.
+ */
+
+import { http } from './http'
+
+/** Aggregated deployment status across all target servers of one deployment. */
+export type EnvDeployStatus = 'success' | 'partial_failed' | 'failed'
+
+/** One target server's result within a deployment. */
+export interface EnvTarget {
+  serverId: string
+  serverName: string
+  /** Per-target status: pending|deploying|success|failed|rolled_back. */
+  status: string
+}
+
+/** Artifact published by a deployment. */
+export interface EnvArtifact {
+  id: string
+  /** image|jar|dist|archive. */
+  type: string
+  name: string
+  reference: string
+}
+
+/** A single deployment event on an environment's timeline. */
+export interface EnvDeployment {
+  runId: string
+  status: EnvDeployStatus
+  commit: string
+  branch: string
+  triggeredBy: string
+  /** RFC3339; the latest target-server finish time of this deployment. */
+  deployedAt: string
+  /** Whether this is the environment's current active version (most recent all-success). */
+  active: boolean
+  targets: EnvTarget[]
+  artifacts: EnvArtifact[]
+}
+
+/** One environment's deployment timeline (most recent first). */
+export interface EnvironmentTimeline {
+  environment: string
+  /** Current active version (most recent all-success); null when never fully succeeded. */
+  active: EnvDeployment | null
+  deployments: EnvDeployment[]
+}
+
+interface EnvironmentsResponse {
+  environments: EnvironmentTimeline[]
+}
+
+/** Rollback result: deploy targets shape + provenance (from which run to which run). */
+export interface RollbackResult {
+  environment: string
+  /** Run that was active before rollback. */
+  fromRunId: string
+  /** Rollback target (previous successful deployment) run. */
+  toRunId: string
+  artifactId: string
+  targets: EnvTarget[]
+}
+
+/** List per-environment deployment timelines for a project (most-recently-deployed env first). */
+export async function listEnvironmentDeployments(projectId: string): Promise<EnvironmentTimeline[]> {
+  const res = await http.get<EnvironmentsResponse>(
+    `/api/projects/${encodeURIComponent(projectId)}/environments/deployments`,
+  )
+  return res.environments ?? []
+}
+
+/** Fetch a single environment's deployment timeline. */
+export function getEnvironmentHistory(projectId: string, env: string): Promise<EnvironmentTimeline> {
+  return http.get<EnvironmentTimeline>(
+    `/api/projects/${encodeURIComponent(projectId)}/environments/${encodeURIComponent(env)}/history`,
+  )
+}
+
+/** One-click rollback an environment to its previous successful deployment. */
+export function rollbackEnvironment(projectId: string, env: string): Promise<RollbackResult> {
+  return http.post<RollbackResult>(
+    `/api/projects/${encodeURIComponent(projectId)}/environments/${encodeURIComponent(env)}/rollback`,
+  )
+}

--- a/web/src/layouts/AppShell.vue
+++ b/web/src/layouts/AppShell.vue
@@ -10,6 +10,7 @@ import {
   Bell,
   Settings,
   Stack2,
+  Rocket,
 } from '@vicons/tabler'
 import { NIcon } from 'naive-ui'
 import ThemeToggle from '../components/ThemeToggle.vue'
@@ -29,6 +30,8 @@ const navItems: NavItem[] = [
   { name: 'runs',          to: '/runs',          icon: GitFork,    label: '运行',  ariaLabel: '运行' },
   // FR-8-13: 复用库(流水线模板 + 变量组)。
   { name: 'library',       to: '/library',       icon: Stack2,     label: '复用库', ariaLabel: '复用库' },
+  // 环境一等公民:按环境聚合的部署历史 + 一键回滚(对标 GitLab environments)。
+  { name: 'environments',  to: '/environments',  icon: Rocket,     label: '环境',  ariaLabel: '环境部署历史' },
   // FR-8-15: DORA 四指标仪表盘(交付效能;只读聚合)。
   { name: 'dora',          to: '/metrics/dora',  icon: ChartBar,   label: 'DORA 指标', ariaLabel: 'DORA 指标' },
   // Story 6-1: 多机状态总览(服务器层指标 FR-15);登记在 设置 → 服务器。

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -12,6 +12,8 @@ const Runs        = () => import('../views/Runs.vue')
 const Library     = () => import('../views/Library.vue')
 // FR-8-15: DORA 四指标仪表盘(部署频率 / 前置时长 / 变更失败率 / MTTR;只读聚合)
 const DoraDashboard = () => import('../views/DoraDashboard.vue')
+// 环境一等公民:按环境聚合部署历史 + 一键回滚(对标 GitLab environments;只读聚合 + 复用部署链路回滚)
+const Environments = () => import('../views/Environments.vue')
 // Story 6-1: multi-host status overview (server-layer CPU/memory/disk metrics, FR-15)
 const ServerStatus = () => import('../views/ServerStatus.vue')
 // Story 6-5: configurable anomaly detection & alerts (FR-23)
@@ -78,6 +80,9 @@ const router = createRouter({
         { path: 'runs/:id', name: 'run-detail', component: RunDetail },
         // FR-8-15: DORA 指标仪表盘(只读聚合;projectId / window 经 query 即状态)
         { path: 'metrics/dora', name: 'dora', component: DoraDashboard },
+
+        // 环境一等公民:按环境聚合部署历史 + 一键回滚。projectId 落 query(URL 即状态)。
+        { path: 'environments', name: 'environments', component: Environments },
         // 顶层「服务器」占位页 → 重定向到真实的多机状态页(登记在 /settings/servers)。
         { path: 'servers', name: 'servers', redirect: { name: 'server-status' } },
         // Story 6-1: multi-host status overview (server-layer metrics, FR-15)

--- a/web/src/views/Environments.vue
+++ b/web/src/views/Environments.vue
@@ -1,0 +1,520 @@
+<!--
+  Environments.vue — 环境一等公民(对标 GitLab environments)。
+
+  把「环境」做成可观测的一等对象:
+    · 按环境聚合部署历史(哪个 run、何时、什么产物、成功/失败、目标机、谁触发)。
+    · 每环境一张卡:醒目的「当前活跃版本」头部 + 时间线轨道(最近 N 次部署)。
+    · 一键回滚:回滚到「上一次成功部署」(当前活跃版本之前最近一次全成功),复用既有部署链路重发。
+    · URL 即状态:projectId 落 query,可分享、可前进后退(web-patterns「URL as state」)。
+
+  数据为既有运行数据上的**只读聚合**(无新表):部署 = 实际向某环境执行过部署(有 deploy_targets)
+  的 run;活跃版本 = 最近一次全机成功;回滚目标 = 活跃之前最近一次全机成功。
+-->
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import {
+  listEnvironmentDeployments,
+  rollbackEnvironment,
+  type EnvironmentTimeline,
+} from '../api/environments'
+import { canRollback, previousSuccess, shortCommit, toBadgeStatus } from '../api/environments.helpers'
+import { listProjects, type Project } from '../api/projects'
+import { HttpError } from '../api/http'
+import { useConfirm } from '../composables/useConfirm'
+import { useToast } from '../composables/useToast'
+import AppButton from '../components/ui/AppButton.vue'
+import ErrorState from '../components/ui/ErrorState.vue'
+import EmptyState from '../components/ui/EmptyState.vue'
+import SkeletonBlock from '../components/ui/SkeletonBlock.vue'
+import StatusBadge from '../components/ui/StatusBadge.vue'
+
+type LoadState = 'idle' | 'loading' | 'error'
+
+const route = useRoute()
+const router = useRouter()
+const confirm = useConfirm()
+const toast = useToast()
+
+const loadState = ref<LoadState>('idle')
+const loadError = ref('')
+const timelines = ref<EnvironmentTimeline[]>([])
+const projects = ref<Project[]>([])
+/** 正在回滚中的环境名(禁用按钮 + loading)。 */
+const rollingBack = ref<string>('')
+
+// ─── URL as state ───────────────────────────────────────────────────────────
+
+const projectId = computed<string>(() => {
+  const p = route.query.projectId
+  return typeof p === 'string' ? p : ''
+})
+
+function setProject(id: string): void {
+  const next: Record<string, string> = { ...(route.query as Record<string, string>) }
+  if (id) next.projectId = id
+  else delete next.projectId
+  void router.replace({ query: next })
+}
+
+function onProjectChange(e: Event): void {
+  setProject((e.target as HTMLSelectElement).value)
+}
+
+// ─── derived display ──────────────────────────────────────────────────────────
+
+function formatWhen(iso: string): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? '—' : d.toLocaleString()
+}
+
+// ─── load ─────────────────────────────────────────────────────────────────────
+
+async function load(): Promise<void> {
+  loadState.value = 'loading'
+  loadError.value = ''
+  try {
+    timelines.value = await listEnvironmentDeployments(projectId.value)
+    loadState.value = 'idle'
+  } catch (err) {
+    if (err instanceof HttpError) {
+      loadError.value =
+        err.status === 0
+          ? '无法连接到服务器,请检查后端是否运行后重试'
+          : (err.apiError?.message ?? `加载环境部署历史失败(${err.status})`)
+    } else {
+      loadError.value = '加载环境部署历史失败,请稍后重试'
+    }
+    loadState.value = 'error'
+  }
+}
+
+async function loadProjects(): Promise<void> {
+  try {
+    projects.value = await listProjects()
+    // 未选项目且有项目 → 默认选首个(环境历史强依赖某个项目)。
+    if (!projectId.value && projects.value.length > 0) {
+      setProject(projects.value[0].id)
+    }
+  } catch {
+    projects.value = []
+  }
+}
+
+// ─── rollback ───────────────────────────────────────────────────────────────
+
+async function onRollback(tl: EnvironmentTimeline): Promise<void> {
+  const prev = previousSuccess(tl)
+  if (!prev) return
+  const ok = await confirm.open({
+    title: `回滚环境「${tl.environment}」`,
+    body: `将把该环境回滚到上一次成功部署(运行 ${shortCommit(prev.commit)} · ${formatWhen(prev.deployedAt)}),即把那次的产物重新部署到原目标机。此操作会触发一次真实部署。`,
+    confirmLabel: '确认回滚',
+    variant: 'danger',
+  })
+  if (!ok) return
+
+  rollingBack.value = tl.environment
+  try {
+    const res = await rollbackEnvironment(projectId.value, tl.environment)
+    const failed = res.targets.filter((t) => t.status === 'failed' || t.status === 'rolled_back').length
+    if (failed === 0) {
+      toast.success(`环境「${tl.environment}」已回滚`, { detail: `重发产物到 ${res.targets.length} 台目标机` })
+    } else {
+      toast.error(`环境「${tl.environment}」回滚部分失败`, { detail: `${failed}/${res.targets.length} 台目标机失败` })
+    }
+    await load()
+  } catch (err) {
+    const msg =
+      err instanceof HttpError ? (err.apiError?.message ?? `回滚失败(${err.status})`) : '回滚失败,请稍后重试'
+    toast.error(`环境「${tl.environment}」回滚失败`, { detail: msg })
+  } finally {
+    rollingBack.value = ''
+  }
+}
+
+// query 变化 → 重新拉取(URL 即状态的单一数据流)。
+watch(projectId, () => void load())
+
+onMounted(() => {
+  void loadProjects()
+  if (projectId.value) void load()
+})
+</script>
+
+<template>
+  <div class="env-view">
+    <header class="view-header">
+      <div class="view-header__text">
+        <h1 class="view-title">环境</h1>
+        <p class="view-sub">
+          按环境聚合的部署历史与当前活跃版本 · 一键回滚到上一次成功部署
+        </p>
+      </div>
+      <AppButton variant="default" :loading="loadState === 'loading'" @click="load">刷新</AppButton>
+    </header>
+
+    <!-- Project filter -->
+    <div class="env-controls">
+      <label class="env-controls__field">
+        <span class="env-controls__label">项目</span>
+        <select class="select" :value="projectId" @change="onProjectChange" aria-label="按项目筛选">
+          <option value="" disabled>请选择项目</option>
+          <option v-for="p in projects" :key="p.id" :value="p.id">{{ p.name }}</option>
+        </select>
+      </label>
+    </div>
+
+    <!-- No project selected -->
+    <EmptyState
+      v-if="!projectId"
+      title="请选择一个项目"
+      description="环境部署历史按项目聚合,先在上方选择项目。"
+    />
+
+    <!-- Error -->
+    <ErrorState
+      v-else-if="loadState === 'error'"
+      title="加载环境部署历史失败"
+      :description="loadError"
+      @retry="load"
+    />
+
+    <!-- Loading skeleton -->
+    <div v-else-if="loadState === 'loading' && timelines.length === 0" class="env-grid" aria-busy="true">
+      <div v-for="n in 2" :key="n" class="skeleton-card">
+        <SkeletonBlock :height="16" width="30%" />
+        <SkeletonBlock :height="40" width="70%" />
+        <SkeletonBlock :height="14" width="90%" />
+        <SkeletonBlock :height="14" width="60%" />
+      </div>
+    </div>
+
+    <!-- Empty -->
+    <EmptyState
+      v-else-if="timelines.length === 0"
+      title="该项目暂无环境部署历史"
+      description="向某环境执行过部署后(webhook 分支映射解析出环境名并完成部署),这里会按环境聚合展示时间线。"
+    />
+
+    <!-- Content -->
+    <div v-else class="env-grid">
+      <article v-for="tl in timelines" :key="tl.environment" class="env-card">
+        <!-- Active version hero -->
+        <div class="env-card__head">
+          <div class="env-card__name-row">
+            <h2 class="env-card__name">{{ tl.environment }}</h2>
+            <span v-if="tl.active" class="env-card__live" title="当前活跃版本">● 活跃</span>
+            <span v-else class="env-card__stale" title="尚无全成功部署">无活跃版本</span>
+          </div>
+
+          <div v-if="tl.active" class="env-card__active">
+            <div class="env-card__active-meta">
+              <code class="env-card__commit">{{ shortCommit(tl.active.commit) }}</code>
+              <span class="env-card__branch">{{ tl.active.branch || '—' }}</span>
+              <StatusBadge :status="toBadgeStatus(tl.active.status)" />
+            </div>
+            <div class="env-card__active-sub">
+              <span>{{ formatWhen(tl.active.deployedAt) }}</span>
+              <span class="env-card__dot" aria-hidden="true">·</span>
+              <span>{{ tl.active.triggeredBy || '—' }}</span>
+              <span class="env-card__dot" aria-hidden="true">·</span>
+              <span>{{ tl.active.targets.length }} 台目标机</span>
+            </div>
+          </div>
+
+          <AppButton
+            variant="default"
+            :disabled="!canRollback(tl) || rollingBack === tl.environment"
+            :loading="rollingBack === tl.environment"
+            :title="canRollback(tl) ? '回滚到上一次成功部署' : '无可回滚的上一次成功部署'"
+            @click="onRollback(tl)"
+          >
+            回滚
+          </AppButton>
+        </div>
+
+        <!-- Deployment timeline rail -->
+        <ol class="env-timeline" :aria-label="`${tl.environment} 部署历史`">
+          <li
+            v-for="dep in tl.deployments"
+            :key="dep.runId"
+            class="env-timeline__item"
+            :class="{
+              'env-timeline__item--active': dep.active,
+              'env-timeline__item--failed': dep.status === 'failed',
+              'env-timeline__item--partial': dep.status === 'partial_failed',
+            }"
+          >
+            <span class="env-timeline__node" aria-hidden="true" />
+            <div class="env-timeline__body">
+              <div class="env-timeline__line1">
+                <code class="env-timeline__commit">{{ shortCommit(dep.commit) }}</code>
+                <StatusBadge :status="toBadgeStatus(dep.status)" />
+                <span v-if="dep.active" class="env-timeline__tag">活跃</span>
+              </div>
+              <div class="env-timeline__line2">
+                <span>{{ formatWhen(dep.deployedAt) }}</span>
+                <span class="env-card__dot" aria-hidden="true">·</span>
+                <span>{{ dep.triggeredBy || '—' }}</span>
+                <span class="env-card__dot" aria-hidden="true">·</span>
+                <span class="env-timeline__servers">{{ dep.targets.map((t) => t.serverName).join(', ') || '—' }}</span>
+              </div>
+              <div v-if="dep.artifacts.length > 0" class="env-timeline__artifacts">
+                <span v-for="a in dep.artifacts" :key="a.id" class="env-timeline__artifact">
+                  {{ a.type }}:{{ a.name }}
+                </span>
+              </div>
+            </div>
+          </li>
+        </ol>
+      </article>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.env-view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.view-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+.view-title {
+  font-size: var(--text-display);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+.view-sub {
+  margin: var(--space-1) 0 0;
+  color: var(--color-dim);
+  font-size: var(--text-body);
+}
+
+.env-controls {
+  display: flex;
+  gap: var(--space-4);
+  align-items: flex-end;
+}
+.env-controls__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.env-controls__label {
+  font-size: var(--text-label);
+  color: var(--color-dim);
+  font-weight: 600;
+}
+.select {
+  appearance: none;
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-md);
+  color: var(--color-text);
+  padding: 8px 32px 8px 12px;
+  font-size: var(--text-body);
+  min-width: 220px;
+}
+
+.env-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+  gap: var(--space-4);
+}
+
+.env-card {
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-card);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Active version hero */
+.env-card__head {
+  padding: var(--space-4);
+  background: linear-gradient(180deg, var(--color-card-2), var(--color-card));
+  border-bottom: 1px solid var(--color-border);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+  gap: var(--space-3);
+  align-items: center;
+}
+.env-card__name-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  grid-column: 1 / 2;
+}
+.env-card__name {
+  margin: 0;
+  font-size: var(--text-kpi);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.env-card__live {
+  font-size: var(--text-micro);
+  font-weight: 700;
+  color: var(--color-green);
+  letter-spacing: 0.02em;
+}
+.env-card__stale {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+}
+.env-card__active {
+  grid-column: 1 / 2;
+  grid-row: 2 / 3;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.env-card__active-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+.env-card__commit {
+  font-family: var(--font-mono, monospace);
+  font-size: var(--text-body);
+  font-weight: 600;
+  color: var(--color-text);
+}
+.env-card__branch {
+  font-size: var(--text-label);
+  color: var(--color-dim);
+}
+.env-card__active-sub {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: var(--text-label);
+  color: var(--color-dim);
+}
+.env-card__dot {
+  color: var(--color-faint);
+}
+/* Rollback button spans both rows on the right. */
+.env-card__head > :deep(button) {
+  grid-column: 2 / 3;
+  grid-row: 1 / 3;
+}
+
+/* Timeline rail */
+.env-timeline {
+  list-style: none;
+  margin: 0;
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  position: relative;
+}
+.env-timeline::before {
+  content: '';
+  position: absolute;
+  left: calc(var(--space-4) + 5px);
+  top: var(--space-4);
+  bottom: var(--space-4);
+  width: 2px;
+  background: var(--color-border);
+}
+.env-timeline__item {
+  position: relative;
+  display: flex;
+  gap: var(--space-3);
+  padding-left: var(--space-4);
+}
+.env-timeline__node {
+  position: absolute;
+  left: 0;
+  top: 4px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--color-card);
+  border: 2px solid var(--color-border-strong);
+  z-index: 1;
+}
+.env-timeline__item--active .env-timeline__node {
+  background: var(--color-green);
+  border-color: var(--color-green);
+  box-shadow: 0 0 0 4px color-mix(in oklch, var(--color-green) 22%, transparent);
+}
+.env-timeline__item--failed .env-timeline__node {
+  border-color: var(--color-red);
+}
+.env-timeline__item--partial .env-timeline__node {
+  border-color: var(--color-primary);
+}
+.env-timeline__body {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+.env-timeline__line1 {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+.env-timeline__commit {
+  font-family: var(--font-mono, monospace);
+  font-size: var(--text-label);
+  font-weight: 600;
+}
+.env-timeline__tag {
+  font-size: var(--text-micro);
+  font-weight: 700;
+  color: var(--color-green);
+}
+.env-timeline__line2 {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: var(--text-micro);
+  color: var(--color-dim);
+}
+.env-timeline__servers {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 220px;
+}
+.env-timeline__artifacts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 2px;
+}
+.env-timeline__artifact {
+  font-size: var(--text-micro);
+  background: var(--color-inset);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-sm);
+  padding: 1px 6px;
+  color: var(--color-dim);
+}
+
+.skeleton-card {
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-card);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+</style>


### PR DESCRIPTION
## 背景

把「环境」做成可观测的一等对象(对标 GitLab environments):按环境聚合部署历史(哪个 run、何时、什么产物、成功/失败、目标机、谁触发、当前活跃版本),并提供一键回滚到「上一次成功部署」。

## 改动

**后端(新包 + 新文件为主)**
- `internal/environments`:**只读聚合服务**,纯查询既有表(`pipeline_runs.resolved_environment` + `deploy_targets` + `run_artifacts`)按环境聚合部署时间线。
  - **零迁移**:数据已全在既有表,JOIN + 内存分组即可,不新增表、不改 `internal/deploy` 写路径、不动 `run.Service` 接口(诚实选了「纯查询」而非新写一张 `environment_deployments` 表,更轻、不碰别的并发流在动的文件)。
  - **活跃版本** = 某环境最近一次全机 success;**回滚目标** = 活跃之前最近一次全机 success。
- `internal/httpapi/environments.go`:
  - `GET /api/projects/{id}/environments/deployments` — 按环境聚合时间线 + 活跃版本
  - `GET /api/projects/{id}/environments/{env}/history` — 单环境时间线
  - `POST /api/projects/{id}/environments/{env}/rollback` — 一键回滚(auth + CSRF + 审计)
  - 回滚执行**复用既有 `deploy.Service.Deploy`**:重发上一次成功部署的同一产物到原目标机(健康门控/多机扇出/失败诊断全链路复用)。
- router/main 仅最小附加(新 `WithEnvironments` Option + 三条路由 + 装配)。

**前端(新视图 + 新 API client)**
- `/environments` 视图:环境卡(醒目「当前活跃版本」头部 + 部署时间线轨道)+ 一键回滚(确认弹窗 + toast 反馈),`projectId` 落 query(URL 即状态)。
- AppShell 新增「环境」导航入口。

## 验证(全绿)

后端:`gofmt -l`(空)、`go vet ./...`、`go build ./...`、`go test ./...` 全过。
- 聚合:多 run 多环境正确分组/排序/活跃版本、status 归并(success/partial/failed)、项目不存在/无部署/环境不存在错误。
- 回滚定位:happy path、无上一次成功 → 422、跳过中间失败部署、环境不存在 → 404。
- httpapi 端点:列表排序 + 活跃版本、回滚以正确 run/artifact/server 调 deploy、无目标 422、历史 404。

前端:`npm run typecheck`、`npm run lint`(0 error)、`npm run test`(264 passed,含新增 11 个回滚资格/上一次成功定位纯逻辑用例)、`npm run build` 全过。`web/dist/index.html` 已 restore。

## 诚实边界

- **review apps(每分支临时环境 + auto-stop)未做**:需改动 trigger/webhook 接收与 deploy 路径,超出本 PR 合理范围,留作后续;本期**不加占位 schema**以免死代码。
- 回滚是「重发上一次成功产物到原目标机」(对齐 deploy 的 rolling 重发语义),不是真正的不可变 release 切换;边界与既有部署原语一致。
- 部署时刻取该次部署最晚一台目标机的 finished_at(回退 started_at),RFC3339 字典序排序。

🤖 Generated with [Claude Code](https://claude.com/claude-code)