### PR TITLE
feat(pipeline): 阶段 post/finally 后置步骤(P1)

### DIFF
--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -120,8 +120,8 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 		}
 
 		needsBuild := len(scriptJobs) > 0 || len(buildImageJobs) > 0
-		// 没有任何可执行节点(script/build_image/deploy_ssh/notify)→ 诚实占位放行。
-		if !needsBuild && len(deployJobs) == 0 && len(notifyJobs) == 0 {
+		// 没有任何可执行节点(script/build_image/deploy_ssh/notify)且无 post → 诚实占位放行。
+		if !needsBuild && len(deployJobs) == 0 && len(notifyJobs) == 0 && len(stage.Post) == 0 {
 			for _, jb := range stage.Jobs {
 				_ = rep.Log(ctx, streamStdout, fmt.Sprintf("· %s(%s)— 真实执行未接入;本阶段放行", jb.Name, jb.Type))
 			}
@@ -132,19 +132,29 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 		}
 
 		sink := &reporterSink{rep: rep}
+		hasPost := len(stage.Post) > 0
 
-		// ── 构建部分:仅当有 script / build_image 才克隆工作区并执行(部署/通知不需要工作区)──
-		if needsBuild {
-			proj, settings, perr := b.resolve(ctx, r)
+		// 工作区:有 script/build_image **或** 有 post 步骤时都需克隆(post 在同一工作区跑,可访问
+		// 构建产物,对齐 Jenkins post 语义);纯部署/通知阶段无工作区。
+		var (
+			proj      *project.Project
+			settings  *pipeline.Settings
+			workspace string
+			commitTag = "latest"
+		)
+		if needsBuild || hasPost {
+			p, s, perr := b.resolve(ctx, r)
 			if perr != nil {
 				_ = rep.Log(ctx, streamStderr, "无法加载项目构建配置:"+perr.Error())
 				return ErrBuildFailed
 			}
-			workspace, mkErr := mkTempWorkspace()
+			proj, settings = p, s
+			ws, mkErr := mkTempWorkspace()
 			if mkErr != nil {
 				_ = rep.Log(ctx, streamStderr, "创建临时工作区失败:"+mkErr.Error())
 				return ErrBuildFailed
 			}
+			workspace = ws
 			defer func() { _ = os.RemoveAll(workspace) }() // 宿主零污染
 
 			token := b.revealToken(proj.CredentialID)
@@ -158,74 +168,85 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 				_ = rep.Log(ctx, streamStderr, "源码克隆失败(鉴权/网络/ref 不存在或被 SSRF 拒绝)")
 				return ErrBuildFailed
 			}
-			if resolved != nil && resolved.CommitShort != "" && b.recordCommit != nil {
-				b.recordCommit(ctx, r.ID, resolved.CommitShort)
-			}
-
-			// 步骤输出→下游变量(P1):同阶段 job 间经 $PIPEWRIGHT_ENV 文件传值,carriedEnv 累积注入后续 job。
-			var carriedEnv []pipeline.BuildVar
-			for _, jb := range scriptJobs {
-				if canceled(ctx) {
-					return run.ErrCanceled
-				}
-				step, verr := scriptStepFromJob(jb)
-				if verr != nil {
-					_ = rep.Log(ctx, streamStderr, fmt.Sprintf("script job「%s」配置无效:%v", jb.Name, verr))
-					return ErrBuildFailed
-				}
-				// 注入顺序:运行参数 → 上游 job 输出(carriedEnv)→ job 自身 env(后者覆盖同名)→ PIPEWRIGHT_ENV(系统,末位防覆盖)。
-				base := append(runParamsAsEnv(r.Trigger.Params), carriedEnv...)
-				step.Env = append(base, step.Env...)
-				step.Env = append(step.Env, pipewrightEnvVar())
-				// 构建依赖缓存(#61):执行前恢复(暖构建)、成功后保存(best-effort,缓存问题绝不让构建失败)。
-				// 任务级 timeout/retry(#63):零值时 runScriptStepWithOpts 退化为单次无超时执行(旧行为)。
-				b.restoreJobCache(ctx, rep, jb, r.Trigger.Branch, workspace)
-				if err := b.runScriptStepWithOpts(ctx, sink, 0, step, workspace); err != nil {
-					return err // ErrBuildFailed / run.ErrCanceled
-				}
-				b.saveJobCache(ctx, rep, jb, r.Trigger.Branch, workspace)
-				// 捕获本 job 写入 $PIPEWRIGHT_ENV 的变量,供后续同阶段 job 引用。
-				carriedEnv = append(carriedEnv, captureStageEnv(ctx, rep, workspace)...)
-			}
-
-			commitTag := "latest"
 			if resolved != nil && resolved.CommitShort != "" {
 				commitTag = resolved.CommitShort
-			}
-			for _, jb := range buildImageJobs {
-				if canceled(ctx) {
-					return run.ErrCanceled
+				if b.recordCommit != nil {
+					b.recordCommit(ctx, r.ID, resolved.CommitShort)
 				}
-				if err := b.runBuildImageJob(ctx, sink, rep, jb, stage.Name, proj, settings, r.Trigger.ResolvedEnvironment, workspace, commitTag, hasPushJob); err != nil {
+			}
+		}
+
+		// 阶段主体(job 执行):捕获错误而非提前返回,以便其后无论成败都按条件跑 post 步骤。
+		jobErr := func() error {
+			if needsBuild {
+				// 步骤输出→下游变量(P1):同阶段 job 间经 $PIPEWRIGHT_ENV 文件传值,carriedEnv 累积注入后续 job。
+				var carriedEnv []pipeline.BuildVar
+				for _, jb := range scriptJobs {
+					if canceled(ctx) {
+						return run.ErrCanceled
+					}
+					step, verr := scriptStepFromJob(jb)
+					if verr != nil {
+						_ = rep.Log(ctx, streamStderr, fmt.Sprintf("script job「%s」配置无效:%v", jb.Name, verr))
+						return ErrBuildFailed
+					}
+					// 注入顺序:运行参数 → 上游 job 输出(carriedEnv)→ job 自身 env(后者覆盖同名)→ PIPEWRIGHT_ENV(系统,末位防覆盖)。
+					base := append(runParamsAsEnv(r.Trigger.Params), carriedEnv...)
+					step.Env = append(base, step.Env...)
+					step.Env = append(step.Env, pipewrightEnvVar())
+					// 构建依赖缓存(#61):执行前恢复(暖构建)、成功后保存(best-effort,缓存问题绝不让构建失败)。
+					// 任务级 timeout/retry(#63):零值时 runScriptStepWithOpts 退化为单次无超时执行(旧行为)。
+					b.restoreJobCache(ctx, rep, jb, r.Trigger.Branch, workspace)
+					if err := b.runScriptStepWithOpts(ctx, sink, 0, step, workspace); err != nil {
+						return err // ErrBuildFailed / run.ErrCanceled
+					}
+					b.saveJobCache(ctx, rep, jb, r.Trigger.Branch, workspace)
+					// 捕获本 job 写入 $PIPEWRIGHT_ENV 的变量,供后续同阶段 job 引用。
+					carriedEnv = append(carriedEnv, captureStageEnv(ctx, rep, workspace)...)
+				}
+
+				for _, jb := range buildImageJobs {
+					if canceled(ctx) {
+						return run.ErrCanceled
+					}
+					if err := b.runBuildImageJob(ctx, sink, rep, jb, stage.Name, proj, settings, r.Trigger.ResolvedEnvironment, workspace, commitTag, hasPushJob); err != nil {
+						return err
+					}
+				}
+
+				b.collectScriptArtifacts(ctx, scriptJobs, workspace, slugify(proj.Name), stage.Name, rep)
+				if err := collectStageReport(ctx, reportSink, r, stage, workspace, rep); err != nil {
 					return err
 				}
 			}
 
-			b.collectScriptArtifacts(ctx, scriptJobs, workspace, slugify(proj.Name), stage.Name, rep)
-			if err := collectStageReport(ctx, reportSink, r, stage, workspace, rep); err != nil {
-				return err
+			// ── 部署节点(deploy_ssh):把本 run 已产出的产物经 SSH 部署到目标机(中途部署,不动 run 终态)──
+			for _, jb := range deployJobs {
+				if canceled(ctx) {
+					return run.ErrCanceled
+				}
+				if err := b.runDeployJob(ctx, rep, jb, r.ID); err != nil {
+					return err
+				}
 			}
-		}
 
-		// ── 部署节点(deploy_ssh):把本 run 已产出的产物经 SSH 部署到目标机(中途部署,不动 run 终态)──
-		for _, jb := range deployJobs {
-			if canceled(ctx) {
-				return run.ErrCanceled
+			// ── 通知节点(notify):按节点配的渠道发通知(best-effort,不因通知失败而失败本阶段)──
+			for _, jb := range notifyJobs {
+				if canceled(ctx) {
+					return run.ErrCanceled
+				}
+				b.runNotifyJob(ctx, rep, jb, r)
 			}
-			if err := b.runDeployJob(ctx, rep, jb, r.ID); err != nil {
-				return err
-			}
-		}
 
-		// ── 通知节点(notify):按节点配的渠道发通知(best-effort,不因通知失败而失败本阶段)──
-		for _, jb := range notifyJobs {
-			if canceled(ctx) {
-				return run.ErrCanceled
-			}
-			b.runNotifyJob(ctx, rep, jb, r)
-		}
+			return nil
+		}()
 
-		return nil
+		// 阶段后置步骤(P1 · 对标 Jenkins post):无论 job 成败,按 condition 在同工作区跑清理/通知/归档
+		// (best-effort,post 失败只记日志、不改阶段结果)。用 WithoutCancel,使取消/失败后清理仍能跑。
+		if hasPost && workspace != "" {
+			b.runStagePost(context.WithoutCancel(ctx), sink, r, stage, workspace, jobErr != nil, rep)
+		}
+		return jobErr
 	}
 }
 

--- a/internal/build/stage_post.go
+++ b/internal/build/stage_post.go
@@ -1,0 +1,52 @@
+package build
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/huangchengsir/pipewright/internal/dagrun"
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// stage_post.go 执行阶段「后置步骤」(P1 · 对标 Jenkins post / GitLab after_script)。
+//
+// 阶段的 job 跑完后(无论成功失败),按 condition(always/on_success/on_failure)在**同一克隆工作区**
+// 跑脚本类清理/通知/归档步骤。best-effort:post 步骤失败只记日志、**不改阶段结果**(jobErr 不被覆盖)。
+// 调用方已用 context.WithoutCancel 传入 ctx,故阶段被取消/失败后清理仍能运行;此处再叠总超时上界。
+
+// postTotalTimeout 是一个阶段全部 post 步骤的总超时上界(防清理脚本挂死拖住调度)。
+const postTotalTimeout = 10 * time.Minute
+
+// runStagePost 按 condition 顺序执行阶段后置步骤。stageFailed 表示阶段主体是否失败(on_failure/on_success 据此)。
+func (b *Builder) runStagePost(ctx context.Context, sink run.StepSink, r *run.Run, stage pipeline.Stage, workspace string, stageFailed bool, rep dagrun.StageReporter) {
+	if len(stage.Post) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, postTotalTimeout)
+	defer cancel()
+
+	statusWord := "成功"
+	if stageFailed {
+		statusWord = "失败"
+	}
+	for i, ps := range stage.Post {
+		if !pipeline.PostConditionMatches(ps.Condition, stageFailed) {
+			continue
+		}
+		_ = rep.Log(ctx, streamStdout, fmt.Sprintf("→ 阶段后置步骤 #%d(condition=%s,阶段%s)…", i+1, ps.Condition, statusWord))
+		step := pipeline.PipelineStep{
+			Type:     pipeline.StepTypeScript,
+			Image:    ps.Image,
+			Commands: ps.Commands,
+			WorkDir:  ps.WorkDir,
+		}
+		// post 也享运行参数环境(便于引用分支/参数);不接步骤输出捕获(post 不向下游传值)。
+		step.Env = append(runParamsAsEnv(r.Trigger.Params), step.Env...)
+		if err := b.runScriptStep(ctx, sink, 0, step, workspace); err != nil {
+			// best-effort:记日志,继续后续 post 步骤,绝不覆盖阶段结果。
+			_ = rep.Log(ctx, streamStderr, fmt.Sprintf("· 阶段后置步骤 #%d 未成功(best-effort,不影响阶段结果):%v", i+1, err))
+		}
+	}
+}

--- a/internal/build/stage_post_test.go
+++ b/internal/build/stage_post_test.go
@@ -1,0 +1,140 @@
+package build
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// postRecDriver 记录每次 RunToolchain 的镜像(按调用序),并可让指定镜像返回非零(失败)。
+type postRecDriver struct {
+	images    []string
+	failImage string
+}
+
+func (d *postRecDriver) Binary() string { return "fake" }
+func (d *postRecDriver) RunToolchain(_ context.Context, image, _, _ string, _ []string, _ []string, _ pipeline.Resource, _ func(string, string)) (int, error) {
+	d.images = append(d.images, image)
+	if image == d.failImage {
+		return 1, nil
+	}
+	return 0, nil
+}
+func (d *postRecDriver) Build(context.Context, string, string, string, []string, []string, func(string, string)) (int, error) {
+	panic("Build not expected")
+}
+func (d *postRecDriver) Tag(context.Context, string, string, func(string, string)) (int, error) {
+	panic("Tag not expected")
+}
+func (d *postRecDriver) Login(context.Context, string, string, string, func(string, string)) (int, error) {
+	panic("Login not expected")
+}
+func (d *postRecDriver) Push(context.Context, string, func(string, string)) (int, error) {
+	panic("Push not expected")
+}
+func (d *postRecDriver) InspectImage(context.Context, string) (string, int64, error) {
+	panic("InspectImage not expected")
+}
+
+func postStage(jobImage string, post []pipeline.PostStep) pipeline.Stage {
+	return pipeline.Stage{
+		ID: "s1", Name: "构建", Kind: pipeline.KindBuild,
+		Post: post,
+		Jobs: []pipeline.Job{scriptJob("job", jobImage, "echo work")},
+	}
+}
+
+var postSet = []pipeline.PostStep{
+	{Condition: pipeline.PostAlways, Image: "post-always", Commands: []string{"echo a"}},
+	{Condition: pipeline.PostOnSuccess, Image: "post-ok", Commands: []string{"echo ok"}},
+	{Condition: pipeline.PostOnFailure, Image: "post-fail", Commands: []string{"echo fail"}},
+}
+
+func contains(ss []string, s string) bool {
+	for _, x := range ss {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+// 阶段成功 → post always + on_success 跑,on_failure 跳过。
+func TestStagePostOnSuccess(t *testing.T) {
+	drv := &postRecDriver{}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b, nil)
+	if err := exec(context.Background(), &run.Run{ProjectID: "p1"}, postStage("job-img", postSet), &fakeReporter{}); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if !contains(drv.images, "post-always") || !contains(drv.images, "post-ok") {
+		t.Errorf("成功时 always+on_success 应跑;images=%v", drv.images)
+	}
+	if contains(drv.images, "post-fail") {
+		t.Errorf("成功时 on_failure 不应跑;images=%v", drv.images)
+	}
+	// 顺序:job 先于 post。
+	if drv.images[0] != "job-img" {
+		t.Errorf("job 应先于 post;images=%v", drv.images)
+	}
+}
+
+// 阶段失败 → post always + on_failure 跑,on_success 跳过;exec 返回失败(jobErr 不被 post 覆盖)。
+func TestStagePostOnFailure(t *testing.T) {
+	drv := &postRecDriver{failImage: "job-img"}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b, nil)
+	err := exec(context.Background(), &run.Run{ProjectID: "p1"}, postStage("job-img", postSet), &fakeReporter{})
+	if err == nil {
+		t.Fatal("job 失败,exec 应返回错误")
+	}
+	if !contains(drv.images, "post-always") || !contains(drv.images, "post-fail") {
+		t.Errorf("失败时 always+on_failure 应跑;images=%v", drv.images)
+	}
+	if contains(drv.images, "post-ok") {
+		t.Errorf("失败时 on_success 不应跑;images=%v", drv.images)
+	}
+}
+
+// post 步骤本身失败 → best-effort,不改阶段结果(exec 仍成功)。
+func TestStagePostFailureDoesNotFailStage(t *testing.T) {
+	drv := &postRecDriver{failImage: "post-always"}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b, nil)
+	if err := exec(context.Background(), &run.Run{ProjectID: "p1"}, postStage("job-img", postSet), &fakeReporter{}); err != nil {
+		t.Fatalf("post 失败不应令阶段失败,got %v", err)
+	}
+	if !contains(drv.images, "post-ok") {
+		t.Errorf("post-always 失败后仍应继续跑后续匹配 post(post-ok);images=%v", drv.images)
+	}
+}
+
+// 纯 post 阶段(无可执行 job,仅 post)也跑 post(在克隆工作区)。
+func TestPostOnlyStageRuns(t *testing.T) {
+	drv := &postRecDriver{}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b, nil)
+	stage := pipeline.Stage{ID: "s", Name: "清理", Kind: pipeline.KindCustom, Post: []pipeline.PostStep{
+		{Condition: pipeline.PostAlways, Image: "cleanup", Commands: []string{"echo clean"}},
+	}}
+	if err := exec(context.Background(), &run.Run{ProjectID: "p1"}, stage, &fakeReporter{}); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if !contains(drv.images, "cleanup") || len(drv.images) != 1 {
+		t.Errorf("纯 post 阶段应只跑 post;images=%v", drv.images)
+	}
+}
+
+func TestStagePostMessageHasCondition(t *testing.T) {
+	rep := &fakeReporter{}
+	drv := &postRecDriver{}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b, nil)
+	_ = exec(context.Background(), &run.Run{ProjectID: "p1"}, postStage("job-img", postSet[:1]), rep)
+	if !strings.Contains(strings.Join(rep.logs, "\n"), "阶段后置步骤") {
+		t.Errorf("应有 post 步骤日志;logs=%v", rep.logs)
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -87,7 +87,11 @@ type Stage struct {
 	// axis 值以 `MATRIX_<AXIS>`(大写)注入 cell 各 script job 的容器环境供命令引用。
 	// 空(nil / 无轴)= 行为不变(单 stage)。校验/展开见 stage_matrix.go 与 dagrun.ExpandMatrix。
 	Matrix map[string][]string `json:"matrix,omitempty"`
-	Jobs   []Job               `json:"jobs"`
+	// Post 是阶段「后置步骤」(P1,对标 Jenkins post / GitLab after_script):阶段的 job 跑完后
+	// **无论成功失败都按条件执行**,在同一克隆工作区运行(可访问构建产物),用于清理 / 通知 / 归档日志。
+	// 空 = 行为不变。校验/执行见 stage_post.go 与 dag_stage_exec.go runStagePost。
+	Post []PostStep `json:"post,omitempty"`
+	Jobs []Job      `json:"jobs"`
 }
 
 // Spec 是流水线编排声明式配置(阶段集合)。
@@ -368,7 +372,13 @@ func normalizeSpec(in Spec) (Spec, error) {
 			return Spec{}, merr
 		}
 
-		out.Stages = append(out.Stages, Stage{ID: stageID, Name: name, Kind: kind, Needs: needs, AllowFailure: st.AllowFailure, When: normalizeWhen(st.When), Gate: st.Gate, Matrix: matrix, Jobs: jobs})
+		// Post 后置步骤规范化 + 校验(condition 枚举 / image+commands 非空):空 → nil(行为不变)。
+		post, perr := normalizePost(st.Post)
+		if perr != nil {
+			return Spec{}, perr
+		}
+
+		out.Stages = append(out.Stages, Stage{ID: stageID, Name: name, Kind: kind, Needs: needs, AllowFailure: st.AllowFailure, When: normalizeWhen(st.When), Gate: st.Gate, Matrix: matrix, Post: post, Jobs: jobs})
 	}
 
 	// 源阶段不变式:流水线必须恰有一个 source 阶段(引用项目仓库)。前端不渲染删源阶段的入口,

--- a/internal/pipeline/stage_post.go
+++ b/internal/pipeline/stage_post.go
@@ -1,0 +1,99 @@
+package pipeline
+
+import (
+	"fmt"
+	"strings"
+)
+
+// stage_post.go 定义阶段「后置步骤」(post,P1 · 对标 Jenkins post / GitLab after_script)的模型与校验。
+//
+// 阶段的 job 跑完后,post 步骤**无论阶段成功失败都按 condition 执行**(在同一克隆工作区,可访问构建
+// 产物),用于清理 / 通知 / 归档。执行见 internal/build/dag_stage_exec.go 的 runStagePost。
+
+// post 步骤条件枚举。
+const (
+	// PostAlways:无论成功失败都跑(清理类)。
+	PostAlways = "always"
+	// PostOnSuccess:仅阶段成功跑。
+	PostOnSuccess = "on_success"
+	// PostOnFailure:仅阶段失败(含取消)跑。
+	PostOnFailure = "on_failure"
+)
+
+// maxPostSteps 是单阶段后置步骤条数上界(防误填巨量)。
+const maxPostSteps = 32
+
+// PostStep 是一个阶段后置步骤(脚本类:镜像 + 多行命令 + 可选工作目录 + 触发条件)。
+type PostStep struct {
+	// Condition 为 always | on_success | on_failure(空 → always)。
+	Condition string `json:"condition"`
+	// Image 是运行镜像(必填)。
+	Image string `json:"image"`
+	// Commands 是多行命令(顺序执行,至少一条非空)。
+	Commands []string `json:"commands"`
+	// WorkDir 是容器内相对工作目录(相对克隆工作区根;空 = 根)。
+	WorkDir string `json:"workDir,omitempty"`
+}
+
+// PostConditionMatches 报告某 condition 在「阶段是否失败」下是否应执行。
+func PostConditionMatches(condition string, stageFailed bool) bool {
+	switch normalizePostCondition(condition) {
+	case PostOnSuccess:
+		return !stageFailed
+	case PostOnFailure:
+		return stageFailed
+	default: // always
+		return true
+	}
+}
+
+func normalizePostCondition(c string) string {
+	switch strings.TrimSpace(strings.ToLower(c)) {
+	case PostOnSuccess:
+		return PostOnSuccess
+	case PostOnFailure:
+		return PostOnFailure
+	case PostAlways, "":
+		return PostAlways
+	default:
+		return "" // 非法标记,由 normalizePost 校验报错
+	}
+}
+
+// normalizePost 规范化 + 校验阶段后置步骤:condition 合法、image 非空、至少一条非空命令。
+// 空输入 → nil(行为不变)。
+func normalizePost(in []PostStep) ([]PostStep, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	if len(in) > maxPostSteps {
+		return nil, fmt.Errorf("%w: post 步骤数 %d 超过上限 %d", ErrInvalidStage, len(in), maxPostSteps)
+	}
+	out := make([]PostStep, 0, len(in))
+	for i, ps := range in {
+		cond := strings.TrimSpace(strings.ToLower(ps.Condition))
+		if cond == "" {
+			cond = PostAlways
+		}
+		if cond != PostAlways && cond != PostOnSuccess && cond != PostOnFailure {
+			return nil, fmt.Errorf("%w: post 步骤 #%d 的 condition %q 非法(须为 always/on_success/on_failure)", ErrInvalidStage, i+1, ps.Condition)
+		}
+		image := strings.TrimSpace(ps.Image)
+		if image == "" {
+			return nil, fmt.Errorf("%w: post 步骤 #%d 缺少镜像(image)", ErrInvalidStage, i+1)
+		}
+		cmds := make([]string, 0, len(ps.Commands))
+		hasCmd := false
+		for _, c := range ps.Commands {
+			cmds = append(cmds, c)
+			if strings.TrimSpace(c) != "" {
+				hasCmd = true
+			}
+		}
+		if !hasCmd {
+			return nil, fmt.Errorf("%w: post 步骤 #%d 至少需要一条非空命令", ErrInvalidStage, i+1)
+		}
+		out = append(out, PostStep{Condition: cond, Image: image, Commands: cmds, WorkDir: strings.TrimSpace(ps.WorkDir)})
+	}
+	return out, nil
+}

--- a/internal/pipeline/stage_post_test.go
+++ b/internal/pipeline/stage_post_test.go
@@ -1,0 +1,65 @@
+package pipeline
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestPostConditionMatches(t *testing.T) {
+	cases := []struct {
+		cond   string
+		failed bool
+		want   bool
+	}{
+		{PostAlways, false, true}, {PostAlways, true, true},
+		{PostOnSuccess, false, true}, {PostOnSuccess, true, false},
+		{PostOnFailure, false, false}, {PostOnFailure, true, true},
+		{"", false, true}, {"", true, true}, // 空 → always
+		{"ALWAYS", true, true}, // 大小写容错
+	}
+	for _, c := range cases {
+		if got := PostConditionMatches(c.cond, c.failed); got != c.want {
+			t.Errorf("PostConditionMatches(%q, failed=%v) = %v, want %v", c.cond, c.failed, got, c.want)
+		}
+	}
+}
+
+func TestNormalizePost(t *testing.T) {
+	t.Run("valid + condition 默认 always + trim", func(t *testing.T) {
+		got, err := normalizePost([]PostStep{
+			{Condition: " On_Failure ", Image: " busybox ", Commands: []string{"echo cleanup"}, WorkDir: " sub "},
+			{Image: "alpine", Commands: []string{"echo always"}}, // 空 condition → always
+		})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if got[0].Condition != PostOnFailure || got[0].Image != "busybox" || got[0].WorkDir != "sub" {
+			t.Errorf("step0 = %+v", got[0])
+		}
+		if got[1].Condition != PostAlways {
+			t.Errorf("empty condition should default always, got %q", got[1].Condition)
+		}
+	})
+
+	t.Run("empty → nil", func(t *testing.T) {
+		if got, _ := normalizePost(nil); got != nil {
+			t.Errorf("nil → nil, got %v", got)
+		}
+	})
+
+	bad := []struct {
+		name  string
+		steps []PostStep
+	}{
+		{"bad condition", []PostStep{{Condition: "weird", Image: "x", Commands: []string{"c"}}}},
+		{"no image", []PostStep{{Condition: "always", Commands: []string{"c"}}}},
+		{"no commands", []PostStep{{Condition: "always", Image: "x", Commands: []string{"  ", ""}}}},
+	}
+	for _, b := range bad {
+		t.Run(b.name, func(t *testing.T) {
+			if _, err := normalizePost(b.steps); !errors.Is(err, ErrInvalidStage) {
+				t.Fatalf("want ErrInvalidStage, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/pipelineyaml/pipelineyaml.go
+++ b/internal/pipelineyaml/pipelineyaml.go
@@ -65,12 +65,21 @@ type stageNode struct {
 	Gate         bool                `yaml:"gate,omitempty"`
 	When         *whenNode           `yaml:"when,omitempty"`
 	Matrix       map[string][]string `yaml:"matrix,omitempty"`
+	Post         []postNode          `yaml:"post,omitempty"`
 	Jobs         []jobNode           `yaml:"jobs,omitempty"`
 }
 
 type whenNode struct {
 	Branches []string `yaml:"branches,omitempty"`
 	Events   []string `yaml:"events,omitempty"`
+}
+
+// postNode 是阶段后置步骤的 YAML 块(P1 · 对标 Jenkins post)。
+type postNode struct {
+	Condition string   `yaml:"condition,omitempty"`
+	Image     string   `yaml:"image"`
+	Commands  []string `yaml:"commands,omitempty"`
+	WorkDir   string   `yaml:"workDir,omitempty"`
 }
 
 type jobNode struct {
@@ -145,6 +154,7 @@ func Parse(data []byte) (pipeline.Config, error) {
 			When:         when,
 			Gate:         sn.Gate,
 			Matrix:       sn.Matrix,
+			Post:         postsFromNodes(sn.Post),
 			Jobs:         jobs,
 		})
 	}
@@ -176,6 +186,7 @@ func Marshal(spec pipeline.Spec) ([]byte, error) {
 			AllowFailure: st.AllowFailure,
 			Gate:         st.Gate,
 			Matrix:       st.Matrix,
+			Post:         postsToNodes(st.Post),
 		}
 		if !st.When.IsEmpty() {
 			sn.When = &whenNode{Branches: nonEmpty(st.When.Branches), Events: nonEmpty(st.When.Events)}
@@ -314,6 +325,29 @@ func nonEmpty(in []string) []string {
 		return nil
 	}
 	return in
+}
+
+// postsFromNodes / postsToNodes 在 YAML postNode 与领域 pipeline.PostStep 间转换(校验由 NormalizeSpec 统一做)。
+func postsFromNodes(in []postNode) []pipeline.PostStep {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]pipeline.PostStep, 0, len(in))
+	for _, pn := range in {
+		out = append(out, pipeline.PostStep{Condition: pn.Condition, Image: pn.Image, Commands: pn.Commands, WorkDir: pn.WorkDir})
+	}
+	return out
+}
+
+func postsToNodes(in []pipeline.PostStep) []postNode {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]postNode, 0, len(in))
+	for _, ps := range in {
+		out = append(out, postNode{Condition: ps.Condition, Image: ps.Image, Commands: ps.Commands, WorkDir: ps.WorkDir})
+	}
+	return out
 }
 
 // asString 把 Job.Config 的 any 值尽量转字符串(画布存的恒为字符串;JSON 回读亦如此)。

--- a/web/src/api/pipeline.ts
+++ b/web/src/api/pipeline.ts
@@ -52,7 +52,20 @@ export interface PipelineStage {
    * `MATRIX_<AXIS>` injected as container env. Empty = no expansion (single stage).
    */
   matrix?: Record<string, string[]>
+  /**
+   * Stage post steps (P1 · Jenkins post): run after the stage's jobs regardless of
+   * success/failure, by condition, in the same workspace (cleanup/notify/archive).
+   */
+  post?: PipelinePostStep[]
   jobs: PipelineJob[]
+}
+
+/** A stage post step (P1). condition: always | on_success | on_failure. */
+export interface PipelinePostStep {
+  condition: 'always' | 'on_success' | 'on_failure'
+  image: string
+  commands: string[]
+  workDir?: string
 }
 
 export interface PipelineDTO {
@@ -76,6 +89,7 @@ export interface SavePipelineInput {
     when?: StageWhen
     gate?: boolean
     matrix?: Record<string, string[]>
+    post?: PipelinePostStep[]
     jobs: Array<{
       id?: string
       name: string


### PR DESCRIPTION
## 背景
对标 **Jenkins post / GitLab after_script**(benchmark P1)。阶段的 job 跑完后,post 步骤**无论成功失败都按 condition(always/on_success/on_failure)执行**,在**同一克隆工作区**运行(可访问构建产物),用于清理 / 通知 / 归档日志。

## 后端
- **pipeline**:`Stage` 加 `Post []PostStep`(spec_json 无迁移);`stage_post.go` 定义模型 + `PostConditionMatches` + `normalizePost` 校验(condition 枚举 / image+commands 非空 / ≤32 条),经 `normalizeSpec` 贯穿(画布 PUT 与 YAML 导入同一套规则)。
- **build**:**重构 `NewStageExecutor`** —— 工作区生命周期上提(有 build **或** post 都克隆),job 执行包进 `jobErr` 闭包(捕获错误而非提前返回),其后无论成败按 condition 跑 post;post 用 `context.WithoutCancel` + 总超时,使取消/失败后清理仍能跑;**post 失败 best-effort 只记日志、不覆盖阶段结果**。
- **pipelineyaml**:post 块 Parse/Marshal(`.pipewright.yml` PaC 完整支持)。
- **前端 pipeline.ts**:`PipelinePostStep` 类型 + Stage/Save 透传(YAML 导入的 post 经画布保存不丢)。

## 验证
- pipeline:`PostConditionMatches` 矩阵 + `normalizePost` 校验(坏 condition/无 image/无命令)。
- build:成功→always+on_success 跑、失败→always+on_failure 跑且 exec 返回失败、**post 失败不改阶段结果**、纯 post 阶段、日志含条件。
- **go test 36 包 + 前端 typecheck/vitest 288/lint 0err/build** 全绿。

## 诚实边界
post 步骤的**画布 GUI 编辑器留快进项**(现经 `.pipewright.yml` 导入配置 + 画布保存完整 round-trip,功能完整可用);纯部署/通知阶段的 post 也享独立克隆工作区。

> P1 services 旁挂容器为下一个 PR(需扩 Driver 容器网络生命周期)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)