### PR TITLE
feat(build): 阶段旁挂服务 services(测试旁挂 DB/redis · P1)

### DIFF
--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -179,6 +179,18 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 		// 阶段主体(job 执行):捕获错误而非提前返回,以便其后无论成败都按条件跑 post 步骤。
 		jobErr := func() error {
 			if needsBuild {
+				// 旁挂服务(P1):阶段声明 services 时,起服务容器到临时网络,脚本容器加入同网按服务名互访;
+				// 阶段结束(成败/取消)拆除。驱动不支持容器网络能力 → 直接失败(不在缺依赖下假跑)。
+				var svcNetwork string
+				if len(stage.Services) > 0 {
+					net, ok := b.startStageServices(ctx, r, stage, rep)
+					if !ok {
+						return ErrBuildFailed
+					}
+					svcNetwork = net
+					defer b.stopStageServices(context.WithoutCancel(ctx), r, stage, net, rep)
+				}
+
 				// 步骤输出→下游变量(P1):同阶段 job 间经 $PIPEWRIGHT_ENV 文件传值,carriedEnv 累积注入后续 job。
 				var carriedEnv []pipeline.BuildVar
 				for _, jb := range scriptJobs {
@@ -194,6 +206,10 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 					base := append(runParamsAsEnv(r.Trigger.Params), carriedEnv...)
 					step.Env = append(base, step.Env...)
 					step.Env = append(step.Env, pipewrightEnvVar())
+					// 旁挂服务网络:脚本容器加入,按服务名互访。
+					if svcNetwork != "" {
+						step.Resource.Network = svcNetwork
+					}
 					// 构建依赖缓存(#61):执行前恢复(暖构建)、成功后保存(best-effort,缓存问题绝不让构建失败)。
 					// 任务级 timeout/retry(#63):零值时 runScriptStepWithOpts 退化为单次无超时执行(旧行为)。
 					b.restoreJobCache(ctx, rep, jb, r.Trigger.Branch, workspace)

--- a/internal/build/services.go
+++ b/internal/build/services.go
@@ -1,0 +1,151 @@
+package build
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/huangchengsir/pipewright/internal/dagrun"
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// services.go 实现阶段「旁挂服务」(P1 · 对标 GitLab services / Woodpecker services)。
+//
+// 阶段声明 services(DB/redis 等)时:建一个临时 docker 网络 → 各服务容器 detached 起在该网络上
+// (network-alias=服务名)→ 脚本容器加入同网络(经 Resource.Network)→ 脚本里按服务名互访
+// (如 `psql -h testdb`)→ 阶段结束(成败/取消)拆除服务容器 + 网络。
+//
+// 「建网/起服务/停服务/删网」是**可选** Driver 能力(ServiceRunner):shellDriver 实现;若运行时
+// 驱动不具备(如纯 fake),则声明了 services 的阶段直接判失败并明确报错(绝不静默跳过 → 否则测试
+// 在缺依赖下假跑出误导结果)。
+
+// ServiceRunner 是旁挂服务所需的可选容器能力。b.driver 类型断言到它;不具备则 services 阶段失败。
+type ServiceRunner interface {
+	CreateNetwork(ctx context.Context, network string, onLine func(stream, line string)) (int, error)
+	RemoveNetwork(ctx context.Context, network string, onLine func(stream, line string)) (int, error)
+	// RunService 以 detached 容器起一个服务:`run -d --name <containerName> --network <network>
+	// --network-alias <alias> [-e K=V...] [-p host:ctr...] <image>`。返回退出码。
+	RunService(ctx context.Context, containerName, alias, image, network string, env, ports []string, onLine func(stream, line string)) (int, error)
+	// StopService 强制删除服务容器(`rm -f <containerName>`)。返回退出码。
+	StopService(ctx context.Context, containerName string, onLine func(stream, line string)) (int, error)
+}
+
+// ─── shellDriver 实现 ServiceRunner ──────────────────────────────────────────
+
+func (d *shellDriver) CreateNetwork(ctx context.Context, network string, onLine func(stream, line string)) (int, error) {
+	args := []string{"network", "create", network}
+	emitCmd(onLine, d.bin, args)
+	return d.cmdr.Stream(ctx, d.bin, args, "", onLine)
+}
+
+func (d *shellDriver) RemoveNetwork(ctx context.Context, network string, onLine func(stream, line string)) (int, error) {
+	args := []string{"network", "rm", network}
+	emitCmd(onLine, d.bin, args)
+	return d.cmdr.Stream(ctx, d.bin, args, "", onLine)
+}
+
+func (d *shellDriver) RunService(ctx context.Context, containerName, alias, image, network string, env, ports []string, onLine func(stream, line string)) (int, error) {
+	args := []string{"run", "-d", "--name", containerName, "--network", network, "--network-alias", alias}
+	display := []string{"run", "-d", "--name", containerName, "--network", network, "--network-alias", alias}
+	for _, kv := range env {
+		args = append(args, "-e", kv)
+		display = append(display, "-e", maskKV(kv)) // 服务 env 可能含口令:回显只列 key
+	}
+	for _, p := range ports {
+		args = append(args, "-p", p)
+		display = append(display, "-p", p)
+	}
+	args = append(args, image)
+	display = append(display, image)
+	emitCmd(onLine, d.bin, display)
+	return d.cmdr.Stream(ctx, d.bin, args, "", onLine)
+}
+
+func (d *shellDriver) StopService(ctx context.Context, containerName string, onLine func(stream, line string)) (int, error) {
+	args := []string{"rm", "-f", containerName}
+	emitCmd(onLine, d.bin, args)
+	return d.cmdr.Stream(ctx, d.bin, args, "", onLine)
+}
+
+// ─── 执行器集成 ──────────────────────────────────────────────────────────────
+
+// stageNetworkName 为阶段旁挂服务造一个唯一 docker 网络名(run 短 id + 阶段 id,sanitize)。
+func stageNetworkName(runID, stageID string) string {
+	short := runID
+	if len(short) > 8 {
+		short = short[:8]
+	}
+	return "pw-svc-" + sanitizeDockerName(short+"-"+stageID)
+}
+
+// sanitizeDockerName 把任意串净化为 docker 名安全(仅字母数字下划线连字符;空 → x)。
+func sanitizeDockerName(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	out := b.String()
+	if out == "" {
+		return "x"
+	}
+	return out
+}
+
+// startStageServices 起阶段旁挂服务,返回 (网络名, ok)。ok=false 表示失败(调用方应判阶段失败)。
+// 驱动不具备 ServiceRunner → 明确报错失败(不静默跳过)。任一服务起失败 → 拆除已起的 + 失败。
+func (b *Builder) startStageServices(ctx context.Context, r *run.Run, stage pipeline.Stage, rep dagrun.StageReporter) (string, bool) {
+	runner, ok := b.driver.(ServiceRunner)
+	if !ok {
+		_ = rep.Log(ctx, streamStderr, "阶段声明了旁挂服务(services),但当前构建驱动不支持容器网络能力,无法运行")
+		return "", false
+	}
+	network := stageNetworkName(r.ID, stage.ID)
+	if code, err := runner.CreateNetwork(ctx, network, mkLineLogger(ctx, rep)); err != nil || code != 0 {
+		_ = rep.Log(ctx, streamStderr, fmt.Sprintf("创建服务网络失败(code=%d):%v", code, err))
+		return "", false
+	}
+	started := make([]string, 0, len(stage.Services))
+	for _, sv := range stage.Services {
+		cname := network + "-" + sv.Name
+		_ = rep.Log(ctx, streamStdout, fmt.Sprintf("→ 起旁挂服务「%s」(%s)…", sv.Name, sv.Image))
+		if code, err := runner.RunService(ctx, cname, sv.Name, sv.Image, network, sv.Env, sv.Ports, mkLineLogger(ctx, rep)); err != nil || code != 0 {
+			_ = rep.Log(ctx, streamStderr, fmt.Sprintf("旁挂服务「%s」启动失败(code=%d):%v", sv.Name, code, err))
+			// 拆除已起的服务 + 网络,避免泄漏。
+			for _, c := range started {
+				_, _ = runner.StopService(context.WithoutCancel(ctx), c, nil)
+			}
+			_, _ = runner.RemoveNetwork(context.WithoutCancel(ctx), network, nil)
+			return "", false
+		}
+		started = append(started, cname)
+	}
+	return network, true
+}
+
+// stopStageServices 拆除阶段旁挂服务容器 + 网络(best-effort,失败只记日志)。
+func (b *Builder) stopStageServices(ctx context.Context, r *run.Run, stage pipeline.Stage, network string, rep dagrun.StageReporter) {
+	runner, ok := b.driver.(ServiceRunner)
+	if !ok || network == "" {
+		return
+	}
+	for _, sv := range stage.Services {
+		cname := network + "-" + sv.Name
+		if _, err := runner.StopService(ctx, cname, nil); err != nil {
+			_ = rep.Log(ctx, streamStderr, fmt.Sprintf("清理旁挂服务「%s」失败(best-effort):%v", sv.Name, err))
+		}
+	}
+	if _, err := runner.RemoveNetwork(ctx, network, nil); err != nil {
+		_ = rep.Log(ctx, streamStderr, fmt.Sprintf("清理服务网络失败(best-effort):%v", err))
+	}
+}
+
+// mkLineLogger 把 StageReporter 适配成 onLine 回调(服务起停日志流)。
+func mkLineLogger(ctx context.Context, rep dagrun.StageReporter) func(stream, line string) {
+	return func(stream, line string) { _ = rep.Log(ctx, stream, line) }
+}

--- a/internal/build/services_test.go
+++ b/internal/build/services_test.go
@@ -1,0 +1,111 @@
+package build
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/pipeline"
+	"github.com/huangchengsir/pipewright/internal/run"
+)
+
+// svcDriver 实现 Driver + ServiceRunner,记录服务生命周期 + 脚本容器看到的网络。
+type svcDriver struct {
+	createdNetwork string
+	ranServices    []string // alias
+	ranOnNetwork   string
+	scriptNetwork  string
+	stopped        []string
+	removedNetwork string
+}
+
+func (d *svcDriver) Binary() string { return "fake" }
+func (d *svcDriver) RunToolchain(_ context.Context, _, _, _ string, _ []string, _ []string, res pipeline.Resource, _ func(string, string)) (int, error) {
+	d.scriptNetwork = res.Network
+	return 0, nil
+}
+func (d *svcDriver) Build(context.Context, string, string, string, []string, []string, func(string, string)) (int, error) {
+	return 0, nil
+}
+func (d *svcDriver) Tag(context.Context, string, string, func(string, string)) (int, error) {
+	return 0, nil
+}
+func (d *svcDriver) Login(context.Context, string, string, string, func(string, string)) (int, error) {
+	return 0, nil
+}
+func (d *svcDriver) Push(context.Context, string, func(string, string)) (int, error) { return 0, nil }
+func (d *svcDriver) InspectImage(context.Context, string) (string, int64, error) {
+	return "", 0, nil
+}
+
+// ServiceRunner
+func (d *svcDriver) CreateNetwork(_ context.Context, network string, _ func(string, string)) (int, error) {
+	d.createdNetwork = network
+	return 0, nil
+}
+func (d *svcDriver) RemoveNetwork(_ context.Context, network string, _ func(string, string)) (int, error) {
+	d.removedNetwork = network
+	return 0, nil
+}
+func (d *svcDriver) RunService(_ context.Context, _, alias, _, network string, _, _ []string, _ func(string, string)) (int, error) {
+	d.ranServices = append(d.ranServices, alias)
+	d.ranOnNetwork = network
+	return 0, nil
+}
+func (d *svcDriver) StopService(_ context.Context, containerName string, _ func(string, string)) (int, error) {
+	d.stopped = append(d.stopped, containerName)
+	return 0, nil
+}
+
+func servicesStage() pipeline.Stage {
+	return pipeline.Stage{
+		ID: "test", Name: "测试", Kind: pipeline.KindBuild,
+		Services: []pipeline.ServiceSpec{{Name: "testdb", Image: "postgres:16", Env: []string{"POSTGRES_PASSWORD=x"}}},
+		Jobs:     []pipeline.Job{scriptJob("it", "busybox", "psql -h testdb -c 'select 1'")},
+	}
+}
+
+// 旁挂服务:建网 → 起服务 → 脚本容器加入同网 → 拆除。
+func TestStageServicesLifecycle(t *testing.T) {
+	drv := &svcDriver{}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b, nil)
+	if err := exec(context.Background(), &run.Run{ID: "run12345678abc", ProjectID: "p1"}, servicesStage(), &fakeReporter{}); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if drv.createdNetwork == "" {
+		t.Fatal("应创建服务网络")
+	}
+	if len(drv.ranServices) != 1 || drv.ranServices[0] != "testdb" {
+		t.Errorf("应起服务 testdb;ran=%v", drv.ranServices)
+	}
+	if drv.ranOnNetwork != drv.createdNetwork {
+		t.Errorf("服务应起在所建网络上;svc-net=%q created=%q", drv.ranOnNetwork, drv.createdNetwork)
+	}
+	if drv.scriptNetwork != drv.createdNetwork {
+		t.Errorf("脚本容器应加入服务网络;script-net=%q created=%q", drv.scriptNetwork, drv.createdNetwork)
+	}
+	// 拆除:停服务 + 删网。
+	if len(drv.stopped) != 1 || drv.removedNetwork != drv.createdNetwork {
+		t.Errorf("应拆除服务容器+网络;stopped=%v removedNet=%q", drv.stopped, drv.removedNetwork)
+	}
+}
+
+// 驱动不支持容器网络能力(无 ServiceRunner)+ 阶段声明 services → 明确失败(不静默假跑)。
+func TestStageServicesUnsupportedDriverFails(t *testing.T) {
+	drv := &recordingDriver{code: 0} // 不实现 ServiceRunner
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b, nil)
+	rep := &fakeReporter{}
+	err := exec(context.Background(), &run.Run{ID: "r1", ProjectID: "p1"}, servicesStage(), rep)
+	if err == nil {
+		t.Fatal("不支持服务能力时,声明 services 的阶段应失败")
+	}
+	if !strings.Contains(strings.Join(rep.logs, "\n"), "不支持容器网络能力") {
+		t.Errorf("应有明确的能力不支持日志;logs=%v", rep.logs)
+	}
+	// 脚本不应被执行(依赖未就绪)。
+	if drv.callCount != 0 {
+		t.Errorf("服务起不来不应跑脚本;callCount=%d", drv.callCount)
+	}
+}

--- a/internal/build/shell_driver.go
+++ b/internal/build/shell_driver.go
@@ -71,6 +71,11 @@ func (d *shellDriver) RunToolchain(ctx context.Context, image, hostDir, workdir 
 		args = append(args, "--memory", mem)
 		display = append(display, "--memory", mem)
 	}
+	// 旁挂服务(services):脚本容器加入服务网络,按服务名(network-alias)互访。运行时设置,非 secret。
+	if net := strings.TrimSpace(res.Network); net != "" {
+		args = append(args, "--network", net)
+		display = append(display, "--network", net)
+	}
 	for _, kv := range env {
 		args = append(args, "-e", kv)
 		display = append(display, "-e", maskKV(kv)) // 环境变量可能含 secret:回显只列 key

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -91,7 +91,11 @@ type Stage struct {
 	// **无论成功失败都按条件执行**,在同一克隆工作区运行(可访问构建产物),用于清理 / 通知 / 归档日志。
 	// 空 = 行为不变。校验/执行见 stage_post.go 与 dag_stage_exec.go runStagePost。
 	Post []PostStep `json:"post,omitempty"`
-	Jobs []Job      `json:"jobs"`
+	// Services 是阶段「旁挂服务」(P1,对标 GitLab services / Woodpecker services):测试旁挂
+	// DB/redis 等容器,与脚本容器同 docker 网络、按服务名互访(testdb:5432)。空 = 行为不变。
+	// 校验/执行见 stage_services.go 与 dag_stage_exec.go runStageServices。
+	Services []ServiceSpec `json:"services,omitempty"`
+	Jobs     []Job         `json:"jobs"`
 }
 
 // Spec 是流水线编排声明式配置(阶段集合)。
@@ -378,7 +382,13 @@ func normalizeSpec(in Spec) (Spec, error) {
 			return Spec{}, perr
 		}
 
-		out.Stages = append(out.Stages, Stage{ID: stageID, Name: name, Kind: kind, Needs: needs, AllowFailure: st.AllowFailure, When: normalizeWhen(st.When), Gate: st.Gate, Matrix: matrix, Post: post, Jobs: jobs})
+		// Services 旁挂服务规范化 + 校验(服务名标识符/唯一、image 非空):空 → nil(行为不变)。
+		services, serr := normalizeServices(st.Services)
+		if serr != nil {
+			return Spec{}, serr
+		}
+
+		out.Stages = append(out.Stages, Stage{ID: stageID, Name: name, Kind: kind, Needs: needs, AllowFailure: st.AllowFailure, When: normalizeWhen(st.When), Gate: st.Gate, Matrix: matrix, Post: post, Services: services, Jobs: jobs})
 	}
 
 	// 源阶段不变式:流水线必须恰有一个 source 阶段(引用项目仓库)。前端不渲染删源阶段的入口,

--- a/internal/pipeline/settings.go
+++ b/internal/pipeline/settings.go
@@ -167,11 +167,14 @@ type PipelineStep struct {
 type Resource struct {
 	CPU    string `json:"cpu,omitempty"`
 	Memory string `json:"memory,omitempty"`
+	// Network 是容器加入的 docker 网络名:由执行器在「旁挂服务(services)」阶段运行时设置,
+	// 让脚本容器与服务容器同网、按服务名互访。**非用户配置项**(用户只配 cpu/memory),空=默认网络。
+	Network string `json:"network,omitempty"`
 }
 
-// IsZero 判断资源规格是否为空(两字段都未配)。
+// IsZero 判断资源规格是否为空(cpu/memory/network 都未配)。
 func (r Resource) IsZero() bool {
-	return strings.TrimSpace(r.CPU) == "" && strings.TrimSpace(r.Memory) == ""
+	return strings.TrimSpace(r.CPU) == "" && strings.TrimSpace(r.Memory) == "" && strings.TrimSpace(r.Network) == ""
 }
 
 // Settings 是构建/部署配置领域模型(冻结 DTO 外层形状)。

--- a/internal/pipeline/stage_services.go
+++ b/internal/pipeline/stage_services.go
@@ -1,0 +1,70 @@
+package pipeline
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// stage_services.go 定义阶段「旁挂服务」(services,P1 · 对标 GitLab services / Woodpecker services)
+// 的模型与校验。服务容器(DB/redis 等)与该阶段脚本容器同 docker 网络、按服务名(network-alias)
+// 互访(如脚本里 `psql -h testdb`)。执行见 internal/build/dag_stage_exec.go 的 runStageServices。
+
+// maxStageServices 是单阶段旁挂服务数上界。
+const maxStageServices = 16
+
+// 服务名:docker network-alias / 容器名安全(字母/下划线起,后接字母数字下划线连字符)。
+var serviceNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]*$`)
+
+// ServiceSpec 是一个旁挂服务(镜像 + 服务名 + 可选环境变量 + 可选端口映射)。
+type ServiceSpec struct {
+	// Name 是服务名:同网络内的访问主机名(network-alias)+ 容器名后缀。必填、阶段内唯一。
+	Name string `json:"name"`
+	// Image 是服务镜像(如 postgres:16 / redis:7)。必填。
+	Image string `json:"image"`
+	// Env 是服务容器环境变量(K=V,如 POSTGRES_PASSWORD=x)。可选。
+	Env []string `json:"env,omitempty"`
+	// Ports 是端口映射(host:container,可选;同网络互访通常无需暴露端口)。
+	Ports []string `json:"ports,omitempty"`
+}
+
+// normalizeServices 规范化 + 校验阶段旁挂服务:服务名合法/唯一、image 非空。空 → nil(行为不变)。
+func normalizeServices(in []ServiceSpec) ([]ServiceSpec, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	if len(in) > maxStageServices {
+		return nil, fmt.Errorf("%w: 旁挂服务数 %d 超过上限 %d", ErrInvalidStage, len(in), maxStageServices)
+	}
+	out := make([]ServiceSpec, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for i, sv := range in {
+		name := strings.TrimSpace(sv.Name)
+		if !serviceNameRe.MatchString(name) {
+			return nil, fmt.Errorf("%w: 服务 #%d 名称 %q 非法(须字母/下划线起,仅含字母数字下划线连字符)", ErrInvalidStage, i+1, sv.Name)
+		}
+		if _, dup := seen[name]; dup {
+			return nil, fmt.Errorf("%w: 服务名 %q 重复", ErrInvalidStage, name)
+		}
+		seen[name] = struct{}{}
+		image := strings.TrimSpace(sv.Image)
+		if image == "" {
+			return nil, fmt.Errorf("%w: 服务 %q 缺少镜像(image)", ErrInvalidStage, name)
+		}
+		out = append(out, ServiceSpec{Name: name, Image: image, Env: trimNonEmpty(sv.Env), Ports: trimNonEmpty(sv.Ports)})
+	}
+	return out, nil
+}
+
+func trimNonEmpty(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if t := strings.TrimSpace(s); t != "" {
+			out = append(out, t)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/pipeline/stage_services_test.go
+++ b/internal/pipeline/stage_services_test.go
@@ -1,0 +1,46 @@
+package pipeline
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNormalizeServices(t *testing.T) {
+	t.Run("valid + trim", func(t *testing.T) {
+		got, err := normalizeServices([]ServiceSpec{
+			{Name: " testdb ", Image: " postgres:16 ", Env: []string{"POSTGRES_PASSWORD=x", "  "}, Ports: []string{"5432:5432"}},
+		})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if got[0].Name != "testdb" || got[0].Image != "postgres:16" {
+			t.Errorf("svc = %+v", got[0])
+		}
+		if len(got[0].Env) != 1 { // 空 env 行被剔除
+			t.Errorf("env = %v", got[0].Env)
+		}
+	})
+
+	t.Run("empty → nil", func(t *testing.T) {
+		if got, _ := normalizeServices(nil); got != nil {
+			t.Errorf("nil → nil, got %v", got)
+		}
+	})
+
+	bad := []struct {
+		name  string
+		specs []ServiceSpec
+	}{
+		{"bad name", []ServiceSpec{{Name: "1bad", Image: "x"}}},
+		{"empty name", []ServiceSpec{{Name: "  ", Image: "x"}}},
+		{"dup name", []ServiceSpec{{Name: "db", Image: "x"}, {Name: "db", Image: "y"}}},
+		{"no image", []ServiceSpec{{Name: "db"}}},
+	}
+	for _, b := range bad {
+		t.Run(b.name, func(t *testing.T) {
+			if _, err := normalizeServices(b.specs); !errors.Is(err, ErrInvalidStage) {
+				t.Fatalf("want ErrInvalidStage, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/pipelineyaml/pipelineyaml.go
+++ b/internal/pipelineyaml/pipelineyaml.go
@@ -66,7 +66,16 @@ type stageNode struct {
 	When         *whenNode           `yaml:"when,omitempty"`
 	Matrix       map[string][]string `yaml:"matrix,omitempty"`
 	Post         []postNode          `yaml:"post,omitempty"`
+	Services     []serviceNode       `yaml:"services,omitempty"`
 	Jobs         []jobNode           `yaml:"jobs,omitempty"`
+}
+
+// serviceNode 是阶段旁挂服务的 YAML 块(P1 · 对标 GitLab services)。
+type serviceNode struct {
+	Name  string   `yaml:"name"`
+	Image string   `yaml:"image"`
+	Env   []string `yaml:"env,omitempty"`
+	Ports []string `yaml:"ports,omitempty"`
 }
 
 type whenNode struct {
@@ -155,6 +164,7 @@ func Parse(data []byte) (pipeline.Config, error) {
 			Gate:         sn.Gate,
 			Matrix:       sn.Matrix,
 			Post:         postsFromNodes(sn.Post),
+			Services:     servicesFromNodes(sn.Services),
 			Jobs:         jobs,
 		})
 	}
@@ -187,6 +197,7 @@ func Marshal(spec pipeline.Spec) ([]byte, error) {
 			Gate:         st.Gate,
 			Matrix:       st.Matrix,
 			Post:         postsToNodes(st.Post),
+			Services:     servicesToNodes(st.Services),
 		}
 		if !st.When.IsEmpty() {
 			sn.When = &whenNode{Branches: nonEmpty(st.When.Branches), Events: nonEmpty(st.When.Events)}
@@ -346,6 +357,28 @@ func postsToNodes(in []pipeline.PostStep) []postNode {
 	out := make([]postNode, 0, len(in))
 	for _, ps := range in {
 		out = append(out, postNode{Condition: ps.Condition, Image: ps.Image, Commands: ps.Commands, WorkDir: ps.WorkDir})
+	}
+	return out
+}
+
+func servicesFromNodes(in []serviceNode) []pipeline.ServiceSpec {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]pipeline.ServiceSpec, 0, len(in))
+	for _, sn := range in {
+		out = append(out, pipeline.ServiceSpec{Name: sn.Name, Image: sn.Image, Env: sn.Env, Ports: sn.Ports})
+	}
+	return out
+}
+
+func servicesToNodes(in []pipeline.ServiceSpec) []serviceNode {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]serviceNode, 0, len(in))
+	for _, sv := range in {
+		out = append(out, serviceNode{Name: sv.Name, Image: sv.Image, Env: sv.Env, Ports: sv.Ports})
 	}
 	return out
 }

--- a/web/src/api/pipeline.ts
+++ b/web/src/api/pipeline.ts
@@ -57,6 +57,11 @@ export interface PipelineStage {
    * success/failure, by condition, in the same workspace (cleanup/notify/archive).
    */
   post?: PipelinePostStep[]
+  /**
+   * Stage sidecar services (P1 · GitLab services): DB/redis containers on the same
+   * docker network as the script container, reachable by service name.
+   */
+  services?: PipelineServiceSpec[]
   jobs: PipelineJob[]
 }
 
@@ -66,6 +71,14 @@ export interface PipelinePostStep {
   image: string
   commands: string[]
   workDir?: string
+}
+
+/** A stage sidecar service (P1). Reachable by `name` on the shared network. */
+export interface PipelineServiceSpec {
+  name: string
+  image: string
+  env?: string[]
+  ports?: string[]
 }
 
 export interface PipelineDTO {
@@ -90,6 +103,7 @@ export interface SavePipelineInput {
     gate?: boolean
     matrix?: Record<string, string[]>
     post?: PipelinePostStep[]
+    services?: PipelineServiceSpec[]
     jobs: Array<{
       id?: string
       name: string


### PR DESCRIPTION
## 背景
对标 **GitLab services / Woodpecker services**(benchmark P1)。阶段声明 `services`(postgres/redis 等),执行时建临时 docker 网络 → 各服务容器 detached 起在该网络(`network-alias`=服务名)→ 脚本容器加入同网 → 脚本按服务名互访(`psql -h testdb`)→ 阶段结束(成败/取消)拆除服务容器 + 网络。

## 设计(最小侵入)
- 服务生命周期是**可选 Driver 能力 `ServiceRunner`**(CreateNetwork/RunService/StopService/RemoveNetwork),shellDriver 实现;`b.driver` 类型断言到它 —— **不改 Driver 接口签名,零 fake 改动**。驱动不具备该能力而阶段声明了 services → **明确判失败**(不在缺依赖下假跑出误导结果)。
- 脚本容器入网经既有 `Resource` 参数(新增 `Resource.Network` 字段,执行器运行时设置,非用户配置)→ **不改 `RunToolchain` 签名**,fakes 无感。
- **pipeline**:`Stage` 加 `Services []ServiceSpec`(spec_json 无迁移)+ `stage_services.go` 校验(服务名标识符/唯一、image 非空、≤16),经 `normalizeSpec` 贯穿;pipelineyaml services Parse/Marshal;前端 `pipeline.ts` 类型 + Stage/Save 透传。

## 验证
- pipeline 校验(名/唯一/image/trim)+ **build 集成**(建网→起服务→脚本入同网→拆除;不支持能力的驱动→明确失败且不跑脚本)。
- **go test 36 包 + 前端 typecheck/vitest 288/lint 0err/build** 全绿。

## 诚实边界
① 服务无就绪门控(detached 起即返回,脚本需自行重试等 DB 就绪)—— readiness 留后续;② 远程 runner 的服务网络未接(仅本地 shellDriver);③ 画布 GUI 编辑器留快进项(现经 `.pipewright.yml` 配置 + 画布 round-trip,功能完整可用);④ 真 docker 服务网络 e2e 未做(单测 fake 验编排,真容器网络待)。

> 至此 **benchmark P1 全部交付**(services / post-finally / 步骤输出→下游变量 / 环境一等公民 / matrix / 工作室实例短清单)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)