### PR TITLE
feat(pipeline): post/services 画布 GUI 编辑器(可视化配)

### DIFF
--- a/web/src/components/pipeline/PipelineCanvas.vue
+++ b/web/src/components/pipeline/PipelineCanvas.vue
@@ -318,6 +318,8 @@ function handleDrawerUpdate(patch: Partial<PipelineJob>): void {
             @update-when="(when) => updateStage(stage.id, { when })"
             @update-gate="(v) => updateStage(stage.id, { gate: v })"
             @update-matrix="(matrix) => updateStage(stage.id, { matrix })"
+            @update-post="(post) => updateStage(stage.id, { post })"
+            @update-services="(services) => updateStage(stage.id, { services })"
           />
         </template>
 

--- a/web/src/components/pipeline/StageColumn.vue
+++ b/web/src/components/pipeline/StageColumn.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import type { PipelineStage, StageWhen } from '../../api/pipeline'
+import type { PipelineStage, StageWhen, PipelinePostStep, PipelineServiceSpec } from '../../api/pipeline'
 import JobCard from './JobCard.vue'
+import StagePostEditor from './StagePostEditor.vue'
+import StageServicesEditor from './StageServicesEditor.vue'
 import { eligibleNeeds, toggleNeed } from './stageDeps'
 import {
   WHEN_EVENTS,
@@ -17,6 +19,10 @@ import {
   hasMatrix,
   matrixSummary,
   matrixError,
+  hasPost,
+  postSummary,
+  hasServices,
+  servicesSummary,
   type WhenEvent,
 } from './stageSettings'
 
@@ -39,6 +45,8 @@ const emit = defineEmits<{
   (e: 'update-when', when: StageWhen | undefined): void
   (e: 'update-gate', value: boolean): void
   (e: 'update-matrix', matrix: Record<string, string[]> | undefined): void
+  (e: 'update-post', post: PipelinePostStep[] | undefined): void
+  (e: 'update-services', services: PipelineServiceSpec[] | undefined): void
 }>()
 
 function stageLabel(index: number): string {
@@ -75,12 +83,19 @@ const branchText = computed<string>(() => branchesToText(props.stage.when?.branc
 
 const currentEvents = computed<string[]>(() => props.stage.when?.events ?? [])
 
-/** Active when settings, gate, or matrix → highlight the settings button. */
+/** Active when settings, gate, matrix, post, or services → highlight the settings button. */
 const hasStageRules = computed(
-  () => hasWhen(props.stage.when) || props.stage.gate === true || hasMatrix(props.stage.matrix),
+  () =>
+    hasWhen(props.stage.when) ||
+    props.stage.gate === true ||
+    hasMatrix(props.stage.matrix) ||
+    hasPost(props.stage.post) ||
+    hasServices(props.stage.services),
 )
 
 const whenChip = computed(() => whenSummary(props.stage.when))
+const postChip = computed(() => postSummary(props.stage.post))
+const servicesChip = computed(() => servicesSummary(props.stage.services))
 
 // ─── Matrix build axes (P1) ───────────────────────────────────────────────────
 
@@ -210,6 +225,14 @@ function resetDrag(): void {
         <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
         {{ matrixChip }}
       </span>
+      <span v-if="servicesChip" class="stage-rule-chip stage-rule-chip--svc" title="旁挂服务(同网按服务名互访)">
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v6c0 1.7 3.6 3 8 3s8-1.3 8-3V5M4 11v6c0 1.7 3.6 3 8 3s8-1.3 8-3v-6"/></svg>
+        {{ servicesChip }}
+      </span>
+      <span v-if="postChip" class="stage-rule-chip stage-rule-chip--post" title="后置步骤(无论成败按条件跑)">
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><path d="M21 12a9 9 0 1 1-6.2-8.5"/><path d="M21 3v6h-6"/></svg>
+        {{ postChip }}
+      </span>
     </div>
 
     <!-- Dependency editor popover -->
@@ -286,6 +309,24 @@ function resetDrag(): void {
       ></textarea>
       <p v-if="matrixWarn" class="settings-warn" role="alert">{{ matrixWarn }}</p>
       <p class="deps-hint">展开成并行 cell(笛卡尔积),各注入 <code>MATRIX_&lt;轴名&gt;</code> 环境变量;空 = 不展开</p>
+
+      <div class="deps-divider"></div>
+      <div class="deps-popover-title">旁挂服务(services)</div>
+      <StageServicesEditor
+        :services="stage.services"
+        :stage-id="stage.id"
+        @update="emit('update-services', $event)"
+      />
+      <p class="deps-hint">测试旁挂 DB/redis:与脚本容器同网,脚本里按服务名互访(如 <code>psql -h testdb</code>)</p>
+
+      <div class="deps-divider"></div>
+      <div class="deps-popover-title">后置步骤(post)</div>
+      <StagePostEditor
+        :steps="stage.post"
+        :stage-id="stage.id"
+        @update="emit('update-post', $event)"
+      />
+      <p class="deps-hint">阶段 job 跑完后按条件执行(同工作区),用于清理/通知/归档;空 = 无</p>
     </div>
 
     <!-- Job cards -->
@@ -444,6 +485,8 @@ function resetDrag(): void {
 .stage-rule-chip--when { background: var(--color-primary-soft); color: var(--color-primary); }
 .stage-rule-chip--gate { background: var(--color-amber-soft, rgba(217, 119, 6, 0.14)); color: var(--color-amber, #b45309); }
 .stage-rule-chip--matrix { background: var(--color-violet-soft, rgba(124, 58, 237, 0.13)); color: var(--color-violet, #6d28d9); }
+.stage-rule-chip--svc { background: var(--color-cyan-soft, rgba(8, 145, 178, 0.13)); color: var(--color-cyan, #0e7490); }
+.stage-rule-chip--post { background: var(--color-amber-soft, rgba(217, 119, 6, 0.14)); color: var(--color-amber, #b45309); }
 
 /* ─── Settings popover fields ─────────────────────────────────────────────── */
 .settings-popover { width: 232px; }

--- a/web/src/components/pipeline/StagePostEditor.vue
+++ b/web/src/components/pipeline/StagePostEditor.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+/**
+ * StagePostEditor — 阶段「后置步骤」(P1 · 对标 Jenkins post)的画布行编辑器。
+ *
+ * 每行一个 post 步骤:触发条件(总是/成功时/失败时)+ 镜像 + 多行命令(+ 可选工作目录)。
+ * 结构化 v-model 回传 PipelinePostStep[](空数组回传 undefined)。
+ */
+import { computed } from 'vue'
+import type { PipelinePostStep } from '../../api/pipeline'
+import { POST_CONDITIONS, POST_CONDITION_LABELS, type PostCondition } from './stageSettings'
+
+const props = defineProps<{
+  steps: PipelinePostStep[] | undefined
+  stageId: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'update', steps: PipelinePostStep[] | undefined): void
+}>()
+
+const rows = computed<PipelinePostStep[]>(() => props.steps ?? [])
+
+function commit(next: PipelinePostStep[]): void {
+  emit('update', next.length > 0 ? next : undefined)
+}
+function patch(i: number, p: Partial<PipelinePostStep>): void {
+  commit(rows.value.map((s, idx) => (idx === i ? { ...s, ...p } : s)))
+}
+function addRow(): void {
+  commit([...rows.value, { condition: 'always', image: '', commands: [] }])
+}
+function removeRow(i: number): void {
+  commit(rows.value.filter((_, idx) => idx !== i))
+}
+function commandsText(s: PipelinePostStep): string {
+  return (s.commands ?? []).join('\n')
+}
+function setCommands(i: number, text: string): void {
+  patch(i, { commands: text.replace(/\r/g, '').split('\n') })
+}
+</script>
+
+<template>
+  <div class="post-editor">
+    <div v-for="(step, i) in rows" :key="i" class="post-row">
+      <div class="post-line">
+        <select
+          class="settings-input post-cond"
+          :value="step.condition"
+          :aria-label="`触发条件 ${i + 1}`"
+          @change="patch(i, { condition: ($event.target as HTMLSelectElement).value as PostCondition })"
+        >
+          <option v-for="c in POST_CONDITIONS" :key="c" :value="c">{{ POST_CONDITION_LABELS[c] }}</option>
+        </select>
+        <input
+          class="settings-input post-image"
+          type="text"
+          :value="step.image"
+          placeholder="busybox"
+          :aria-label="`后置步骤镜像 ${i + 1}`"
+          @change="patch(i, { image: ($event.target as HTMLInputElement).value.trim() })"
+        />
+        <button class="post-del" :aria-label="`删除后置步骤 ${i + 1}`" @click="removeRow(i)">✕</button>
+      </div>
+      <textarea
+        class="settings-input settings-textarea post-cmds"
+        rows="2"
+        :value="commandsText(step)"
+        placeholder="清理/通知命令(每行一条)&#10;如 curl -fsS $WEBHOOK"
+        :aria-label="`后置步骤命令 ${i + 1}`"
+        @change="setCommands(i, ($event.target as HTMLTextAreaElement).value)"
+      ></textarea>
+    </div>
+    <button class="settings-add-link" @click="addRow">+ 添加后置步骤</button>
+  </div>
+</template>
+
+<style scoped>
+.post-editor { display: flex; flex-direction: column; gap: 8px; }
+.post-row {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 7px;
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-amber, #b8860b);
+  border-radius: var(--rounded-md, 8px);
+  background: var(--color-inset);
+}
+.post-line { display: flex; align-items: center; gap: 5px; }
+.post-cond { flex: 0 0 84px; }
+.post-image { flex: 1; }
+.post-cmds { width: 100%; font-family: var(--font-mono); font-size: 0.74rem; }
+.post-del {
+  flex: none; width: 22px; height: 22px; border: none; background: none;
+  color: var(--color-faint); cursor: pointer; border-radius: 5px;
+}
+.post-del:hover { color: var(--color-danger, #dc2626); background: var(--color-card); }
+.settings-add-link {
+  align-self: flex-start; background: none; border: none; padding: 0;
+  color: var(--color-primary); font: inherit; font-size: 0.76rem; font-weight: 600; cursor: pointer;
+}
+.settings-add-link:hover { text-decoration: underline; }
+</style>

--- a/web/src/components/pipeline/StageServicesEditor.vue
+++ b/web/src/components/pipeline/StageServicesEditor.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+/**
+ * StageServicesEditor — 阶段「旁挂服务」(P1)的画布行编辑器。
+ *
+ * 每行一个服务:名称 + 镜像 + 可选环境变量(K=V 逗号分隔)。结构化 v-model 回传 PipelineServiceSpec[]
+ * (空数组回传 undefined 表示无服务)。端口映射较少用 → 仍可经 .pipewright.yml 配,此处不暴露。
+ */
+import { computed } from 'vue'
+import type { PipelineServiceSpec } from '../../api/pipeline'
+import { envToText, parseEnvText } from './stageSettings'
+
+const props = defineProps<{
+  services: PipelineServiceSpec[] | undefined
+  stageId: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'update', services: PipelineServiceSpec[] | undefined): void
+}>()
+
+const rows = computed<PipelineServiceSpec[]>(() => props.services ?? [])
+
+function commit(next: PipelineServiceSpec[]): void {
+  emit('update', next.length > 0 ? next : undefined)
+}
+
+function patch(i: number, p: Partial<PipelineServiceSpec>): void {
+  commit(rows.value.map((s, idx) => (idx === i ? { ...s, ...p } : s)))
+}
+function addRow(): void {
+  commit([...rows.value, { name: '', image: '' }])
+}
+function removeRow(i: number): void {
+  commit(rows.value.filter((_, idx) => idx !== i))
+}
+function setEnv(i: number, text: string): void {
+  patch(i, { env: parseEnvText(text) })
+}
+</script>
+
+<template>
+  <div class="svc-editor">
+    <div v-for="(svc, i) in rows" :key="i" class="svc-row">
+      <div class="svc-line">
+        <input
+          class="settings-input svc-name"
+          type="text"
+          :value="svc.name"
+          placeholder="testdb"
+          :aria-label="`服务名 ${i + 1}`"
+          @change="patch(i, { name: ($event.target as HTMLInputElement).value.trim() })"
+        />
+        <span class="svc-colon">:</span>
+        <input
+          class="settings-input svc-image"
+          type="text"
+          :value="svc.image"
+          placeholder="postgres:16"
+          :aria-label="`服务镜像 ${i + 1}`"
+          @change="patch(i, { image: ($event.target as HTMLInputElement).value.trim() })"
+        />
+        <button class="svc-del" :aria-label="`删除服务 ${i + 1}`" @click="removeRow(i)">✕</button>
+      </div>
+      <input
+        class="settings-input svc-env"
+        type="text"
+        :value="envToText(svc.env)"
+        placeholder="环境变量(可选):POSTGRES_PASSWORD=x, POSTGRES_DB=app"
+        :aria-label="`服务环境变量 ${i + 1}`"
+        @change="setEnv(i, ($event.target as HTMLInputElement).value)"
+      />
+    </div>
+    <button class="settings-add-link" @click="addRow">+ 添加服务</button>
+  </div>
+</template>
+
+<style scoped>
+.svc-editor { display: flex; flex-direction: column; gap: 8px; }
+.svc-row {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 7px;
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-cyan, #0891b2);
+  border-radius: var(--rounded-md, 8px);
+  background: var(--color-inset);
+}
+.svc-line { display: flex; align-items: center; gap: 5px; }
+.svc-colon { color: var(--color-faint); font-family: var(--font-mono); }
+.svc-name { flex: 0 0 32%; }
+.svc-image { flex: 1; }
+.svc-env { width: 100%; font-size: 0.74rem; }
+.svc-del {
+  flex: none; width: 22px; height: 22px; border: none; background: none;
+  color: var(--color-faint); cursor: pointer; border-radius: 5px;
+}
+.svc-del:hover { color: var(--color-danger, #dc2626); background: var(--color-card); }
+.settings-add-link {
+  align-self: flex-start; background: none; border: none; padding: 0;
+  color: var(--color-primary); font: inherit; font-size: 0.76rem; font-weight: 600; cursor: pointer;
+}
+.settings-add-link:hover { text-decoration: underline; }
+</style>

--- a/web/src/components/pipeline/stageSettings.test.ts
+++ b/web/src/components/pipeline/stageSettings.test.ts
@@ -14,6 +14,12 @@ import {
   matrixSummary,
   isValidAxisName,
   MATRIX_MAX_CELLS,
+  hasPost,
+  postSummary,
+  hasServices,
+  servicesSummary,
+  envToText,
+  parseEnvText,
 } from './stageSettings'
 
 describe('parseBranches', () => {
@@ -171,5 +177,21 @@ describe('matrixError', () => {
   it('allows exactly the cap', () => {
     const vals = Array.from({ length: MATRIX_MAX_CELLS }, (_, i) => `v${i}`)
     expect(matrixError({ v: vals })).toBeNull()
+  })
+})
+
+describe('post + services helpers (P1 canvas editors)', () => {
+  it('hasPost / postSummary', () => {
+    expect(hasPost(undefined)).toBe(false)
+    expect(hasPost([])).toBe(false)
+    expect(postSummary([{ condition: 'always', image: 'x', commands: ['c'] }])).toBe('post×1')
+  })
+  it('hasServices / servicesSummary', () => {
+    expect(hasServices(undefined)).toBe(false)
+    expect(servicesSummary([{ name: 'testdb', image: 'postgres' }, { name: 'redis', image: 'redis' }])).toBe('svc: testdb, redis')
+  })
+  it('envToText / parseEnvText round-trip + drops invalid', () => {
+    expect(envToText(['A=1', 'B=2'])).toBe('A=1, B=2')
+    expect(parseEnvText('A=1, B=2 ,  , bad')).toEqual(['A=1', 'B=2'])
   })
 })

--- a/web/src/components/pipeline/stageSettings.ts
+++ b/web/src/components/pipeline/stageSettings.ts
@@ -6,7 +6,7 @@
  * the markup and event wiring; all branch-glob / event-set math lives here.
  */
 
-import type { StageWhen } from '../../api/pipeline'
+import type { StageWhen, PipelinePostStep, PipelineServiceSpec } from '../../api/pipeline'
 
 /** Trigger event types a stage's `when` can gate on (backend枚举 in stage_when.go). */
 export const WHEN_EVENTS = ['manual', 'webhook', 'schedule'] as const
@@ -184,4 +184,47 @@ export function matrixSummary(matrix: Record<string, string[]> | undefined): str
   if (!hasMatrix(matrix)) return ''
   const parts = Object.keys(matrix!).map((n) => `${n}×${(matrix![n] ?? []).length}`)
   return `${parts.join(' · ')} → ${matrixCellCount(matrix)} cell`
+}
+
+// ─── Post steps + Services (P1) — chips/summary helpers for the canvas editors ──
+
+/** Post step condition options (matches backend stage_post.go). */
+export const POST_CONDITIONS = ['always', 'on_success', 'on_failure'] as const
+export type PostCondition = (typeof POST_CONDITIONS)[number]
+
+export const POST_CONDITION_LABELS: Record<PostCondition, string> = {
+  always: '总是',
+  on_success: '成功时',
+  on_failure: '失败时',
+}
+
+export function hasPost(post: PipelinePostStep[] | undefined): boolean {
+  return Boolean(post && post.length > 0)
+}
+
+/** Short chip summary, e.g. `post×2`. */
+export function postSummary(post: PipelinePostStep[] | undefined): string {
+  return hasPost(post) ? `post×${post!.length}` : ''
+}
+
+export function hasServices(services: PipelineServiceSpec[] | undefined): boolean {
+  return Boolean(services && services.length > 0)
+}
+
+/** Short chip summary, e.g. `svc: testdb, redis`. */
+export function servicesSummary(services: PipelineServiceSpec[] | undefined): string {
+  if (!hasServices(services)) return ''
+  return 'svc: ' + services!.map((s) => s.name || '?').join(', ')
+}
+
+/** env array (["K=V", ...]) ↔ one-line comma text "K=V, K2=V2" for the compact services editor. */
+export function envToText(env: string[] | undefined): string {
+  return (env ?? []).join(', ')
+}
+
+export function parseEnvText(text: string): string[] {
+  return text
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s !== '' && s.includes('='))
 }


### PR DESCRIPTION
## 背景
P1 的 **post / services** 此前只能经 `.pipewright.yml` 配(matrix 已有画布编辑器)。本次补齐:在**画布阶段设置弹层**可视化配置,与 matrix 并列。

## 改动(纯前端,后端零改)
- **`StageServicesEditor.vue`**:行编辑器(服务名 + 镜像 + 可选环境变量 `K=V`),结构化 v-model。
- **`StagePostEditor.vue`**:行编辑器(触发条件 总是/成功时/失败时 + 镜像 + 多行命令),结构化 v-model。
- **`StageColumn.vue`**:设置弹层(矩阵之后)嵌两编辑器;阶段头加 `svc`/`post` chip;`settingsActive` 纳入 post/services。
- **`PipelineCanvas.vue`**:`update-post`/`update-services` → `updateStage` 透传(经 `savePipeline` 直传 `editStages` 落库)。
- **`stageSettings.ts`**:`hasPost`/`postSummary`/`hasServices`/`servicesSummary`/`envToText`/`parseEnvText` 纯函数。

结构化数组直接 v-model(无文本 round-trip 损耗)。

## 验证
- `stageSettings` helper 单测;**typecheck / lint 0err / vitest 291 / build** 全绿。
- **真二进制 + 浏览器 e2e**:登录 → 流水线编辑器 → 阶段设置弹层显示「旁挂服务 / 后置步骤」编辑器 → 加服务(testdb:postgres:16)+ 加后置步骤(busybox)→ 阶段头出 `svc`/`post` chip,**0 console error**。

## 诚实边界
services 端口映射(ports)较少用,GUI 不暴露(仍可经 `.pipewright.yml` 配);post `workDir` GUI 暂不暴露(YAML 可配)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)