### PR TITLE
fix(run): 先校正悬挂步骤再落终态(消除 TestReconcileHangingSteps flake)

### DIFF
--- a/internal/run/pool.go
+++ b/internal/run/pool.go
@@ -432,12 +432,14 @@ func (p *WorkerPool) execute(runID string) {
 	if runErr != nil {
 		final = StatusFailed
 	}
+	// **先**校正所有非终态步骤,**再**落 run 终态:保证「run 一旦观测到终态,其步骤必已一致」
+	// (StepDone 失败/runner 漏置不致留下"run=终态但 step 永远 running")。顺序反了会有竞态窗口
+	// ——观测方(SSE/轮询/waitForStatus)在 run 终态与步骤校正之间读到悬挂步骤。
+	sink.reconcile(final)
 	// 用后台 ctx 落终态:取消场景下派生 ctx 已 Done,仍须持久化终态。
 	if err := p.svc.transition(context.Background(), runID, StatusRunning, final, false); err != nil {
 		log.Printf("[run] run %s: to %s failed: %v", runID, final, err)
 	}
-	// 落终态后校正所有非终态步骤(StepDone 失败/runner 漏置不致留下"run=终态但 step 永远 running")。
-	sink.reconcile(final)
 
 	// run 落 failed 后触发 best-effort 自动诊断(已注入钩子时)。绝不阻断 run 终态:
 	// 在独立 goroutine + recover 中调用,钩子失败仅记日志(NFR-10 优雅降级)。


### PR DESCRIPTION
## 根因
`WorkerPool.execute` 原先顺序:**先 `transition` 落 run 终态 → 后 `reconcile` 校正非终态步骤**。两步之间存在竞态窗口:观测方(SSE / 轮询 / 测试 `waitForStatus`)在 run 已是终态、但步骤尚未校正时读取,会看到「run=终态但 step 仍 running」。`TestReconcileHangingSteps` 因此**偶发 CI 失败**(本地连跑常过,CI 负载下暴露;上个 PR #70 就撞到一次,`gh run rerun` 才过)。

## 修复
交换顺序 —— **先 `reconcile(final)` 校正步骤、再 `transition` 落 run 终态**,确立不变式:**「run 一旦观测到终态,其步骤必已一致」**。
- `reconcile` 只需 `final` 值,不依赖其已持久化 → 交换安全。
- SSE 事件顺序变为「步骤事件先于 run 终态事件」,正是期望(客户端收到终态事件后读步骤必为终态)。

## 验证
- `go test ./internal/run/ -run TestReconcileHangingSteps -count=50 -race` **全过**。
- `internal/run` 全包 `-race -count=3` + 全包 `go test`(36 包)+ gofmt/vet 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)