### PR TITLE
fix(pipeline): 画布矩阵/post/services 经 JSON API 往返(补 wire DTO 漏字段)

### DIFF
--- a/internal/httpapi/pipelines.go
+++ b/internal/httpapi/pipelines.go
@@ -28,7 +28,14 @@ type stageDTO struct {
 	AllowFailure bool     `json:"allowFailure"`
 	When         whenDTO  `json:"when"`
 	Gate         bool     `json:"gate"`
-	Jobs         []jobDTO `json:"jobs"`
+	// Matrix / Post / Services 是 P1 阶段扩展(对标 matrix / Jenkins post / GitLab services)。
+	// 用 omitempty:未声明时不出现在响应里,保持原冻结契约的基线形状不变;声明时按领域
+	// json tag 原样回传,与画布编辑器(StagePostEditor / StageServicesEditor / 矩阵)读写的
+	// 形状 1:1。复用领域类型而非另立 DTO,杜绝 wire 与引擎消费形状漂移。
+	Matrix   map[string][]string    `json:"matrix,omitempty"`
+	Post     []pipeline.PostStep    `json:"post,omitempty"`
+	Services []pipeline.ServiceSpec `json:"services,omitempty"`
+	Jobs     []jobDTO               `json:"jobs"`
 }
 
 type whenDTO struct {
@@ -78,7 +85,7 @@ func toStageDTOs(in []pipeline.Stage) []stageDTO {
 		if needs == nil {
 			needs = []string{}
 		}
-		stages = append(stages, stageDTO{ID: st.ID, Name: st.Name, Kind: st.Kind, Needs: needs, AllowFailure: st.AllowFailure, When: toWhenDTO(st.When), Gate: st.Gate, Jobs: jobs})
+		stages = append(stages, stageDTO{ID: st.ID, Name: st.Name, Kind: st.Kind, Needs: needs, AllowFailure: st.AllowFailure, When: toWhenDTO(st.When), Gate: st.Gate, Matrix: st.Matrix, Post: st.Post, Services: st.Services, Jobs: jobs})
 	}
 	return stages
 }
@@ -105,7 +112,13 @@ type reqStage struct {
 		Events   []string `json:"events"`
 	} `json:"when"`
 	Gate bool `json:"gate"`
-	Jobs []struct {
+	// P1 阶段扩展:画布编辑器写入、随 PUT 上行。缺失这些字段时画布配置的
+	// 矩阵/后置步骤/旁挂服务会被静默丢弃(本次修复点)。领域层 Save/NormalizeSpec
+	// 兜规范化与校验(空 → nil = 行为不变)。
+	Matrix   map[string][]string    `json:"matrix"`
+	Post     []pipeline.PostStep    `json:"post"`
+	Services []pipeline.ServiceSpec `json:"services"`
+	Jobs     []struct {
 		ID      string         `json:"id"`
 		Name    string         `json:"name"`
 		Type    string         `json:"type"`
@@ -136,6 +149,9 @@ func reqStagesToDomain(in []reqStage) []pipeline.Stage {
 			AllowFailure: st.AllowFailure,
 			When:         pipeline.When{Branches: st.When.Branches, Events: st.When.Events},
 			Gate:         st.Gate,
+			Matrix:       st.Matrix,
+			Post:         st.Post,
+			Services:     st.Services,
 			Jobs:         jobs,
 		})
 	}

--- a/internal/httpapi/pipelines_test.go
+++ b/internal/httpapi/pipelines_test.go
@@ -133,6 +133,76 @@ func TestPipelineSaveRoundTrip(t *testing.T) {
 	}
 }
 
+// TestPipelineSaveRoundTripMatrixPostServices 锁画布 P1 扩展(矩阵/后置步骤/旁挂服务)
+// 经 JSON 画布 API 的端到端往返:此前 reqStage/stageDTO 未含这些字段,画布配置在 PUT
+// 时被静默丢弃、GET 也读不回(浏览器全量测试发现的真实回归)。
+func TestPipelineSaveRoundTripMatrixPostServices(t *testing.T) {
+	srv, client, csrf, projID := setupPipelineServer(t)
+	base := srv.URL + "/api/projects/" + projID + "/pipeline"
+
+	body := `{"stages":[
+	  {"name":"流水线源","kind":"source","jobs":[
+	    {"name":"Gitee 源","type":"git_source","summary":"main","config":{}}
+	  ]},
+	  {"name":"构建","kind":"build",
+	    "matrix":{"go":["1.21","1.22"],"os":["linux"]},
+	    "services":[{"name":"testdb","image":"postgres:16","env":["POSTGRES_PASSWORD=pw"],"ports":["5432"]},{"name":"redis","image":"redis:7"}],
+	    "post":[{"condition":"always","image":"alpine","commands":["echo collect"]},{"condition":"on_failure","image":"alpine","commands":["echo notify"]}],
+	    "jobs":[{"name":"打镜像","type":"build_image","summary":"docker build","config":{"dockerfile":"Dockerfile"}}]},
+	  {"name":"部署","kind":"deploy","jobs":[]}
+	]}`
+	resp := doJSON(t, client, http.MethodPut, base, csrf, body)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("PUT status = %d, body=%s", resp.StatusCode, raw)
+	}
+
+	// 刷新 GET:矩阵/post/services 必须读得回(否则画布编辑器形同虚设)。
+	gresp := doJSON(t, client, http.MethodGet, base, csrf, "")
+	defer gresp.Body.Close()
+	graw, _ := io.ReadAll(gresp.Body)
+	var gdto map[string]any
+	if err := json.Unmarshal(graw, &gdto); err != nil {
+		t.Fatalf("decode GET: %v, body=%s", err, graw)
+	}
+	stages, _ := gdto["stages"].([]any)
+	var build map[string]any
+	for _, s := range stages {
+		if m, _ := s.(map[string]any); m["kind"] == "build" {
+			build = m
+		}
+	}
+	if build == nil {
+		t.Fatalf("GET 缺 build 阶段, body=%s", graw)
+	}
+
+	matrix, _ := build["matrix"].(map[string]any)
+	if goAxis, _ := matrix["go"].([]any); len(goAxis) != 2 {
+		t.Fatalf("matrix.go = %v, want 2 值; body=%s", matrix["go"], graw)
+	}
+	if post, _ := build["post"].([]any); len(post) != 2 {
+		t.Fatalf("post = %v, want 2 步; body=%s", build["post"], graw)
+	}
+	svcs, _ := build["services"].([]any)
+	if len(svcs) != 2 {
+		t.Fatalf("services = %v, want 2 个; body=%s", build["services"], graw)
+	}
+	s0, _ := svcs[0].(map[string]any)
+	if s0["name"] != "testdb" || s0["image"] != "postgres:16" {
+		t.Fatalf("service[0] = %v, want testdb/postgres:16", s0)
+	}
+	// 源/部署阶段不应平白多出这些键(omitempty 基线契约不变)。
+	for _, s := range stages {
+		m, _ := s.(map[string]any)
+		if m["kind"] == "source" {
+			if _, ok := m["matrix"]; ok {
+				t.Fatalf("源阶段不应出现 matrix 键(omitempty), got %v", m["matrix"])
+			}
+		}
+	}
+}
+
 func TestPipelineSaveInvalidStage422(t *testing.T) {
 	srv, client, csrf, projID := setupPipelineServer(t)
 	base := srv.URL + "/api/projects/" + projID + "/pipeline"


### PR DESCRIPTION
## 背景 / 问题

浏览器全量测试发现的真实回归:阶段的 **matrix / post / services**(P1)已落进领域模型 `pipeline.Stage`、YAML 导入与执行引擎,画布也有 `StagePostEditor` / `StageServicesEditor` / 矩阵编辑器读写这些字段——但**流水线画布的 JSON 契约从未补上对应字段**:

- `GET /api/projects/{id}/pipeline` 的 `stageDTO` 不含 matrix/post/services → 有数据也读不回,刷新后编辑器一片空白。
- `PUT /api/projects/{id}/pipeline` 的 `reqStage` 不含这些字段 → 画布保存时被 `encoding/json` **静默丢弃**。

结果:画布三个 P1 编辑器形同虚设,配完一保存/刷新即丢(仅 YAML 导入路径能用)。

## 修复

`internal/httpapi/pipelines.go`:`stageDTO` 与 `reqStage` 补 `matrix`/`post`/`services`,并在 `toStageDTOs` / `reqStagesToDomain` 透传。

- 复用领域类型 `pipeline.PostStep` / `pipeline.ServiceSpec`,杜绝 wire 与引擎消费形状漂移。
- GET 侧用 `omitempty`:未声明时不出现在响应里,保持原冻结契约基线形状不变(源/部署阶段不平白多键)。
- 领域 `Save` / `NormalizeSpec` 仍兜规范化与校验(空 → nil = 行为不变)。

## 验证

- 新增 `TestPipelineSaveRoundTripMatrixPostServices` 锁端到端往返(PUT 含矩阵/2 post/2 services → GET 读得回 + 源阶段无 matrix 键)。
- 全后端门禁绿:`go vet ./...` / `go build ./...` / `go test ./...` / `gofmt -l`(空)。
- 真机浏览器复核:起真二进制 → 画布构建阶段保存矩阵/post/services → 刷新后阶段 chip 回显 `go×2 · os×1 → 2 cell`、`svc: testdb, redis`,设置弹层数据完整。

🤖 Generated with [Claude Code](https://claude.com/claude-code)