### PR TITLE
feat(pipeline): 阶段设置复用 JobDrawer 内联检视面板(替代独立弹层)

### DIFF
--- a/web/src/components/pipeline/PipelineCanvas.vue
+++ b/web/src/components/pipeline/PipelineCanvas.vue
@@ -5,6 +5,7 @@ import type { Credential } from '../../api/credentials'
 import type { Server } from '../../api/servers'
 import StageColumn from './StageColumn.vue'
 import JobDrawer from './JobDrawer.vue'
+import StageDrawer from './StageDrawer.vue'
 import JobTypePicker from './JobTypePicker.vue'
 import type { CustomNode } from '../../api/customNodes'
 import { jobTypeLabel, getJobTypeSpec } from './jobConfigSchema'
@@ -50,10 +51,37 @@ const selectedStage = computed<PipelineStage | null>(() => {
 
 function selectJob(jobId: string): void {
   selectedJobId.value = selectedJobId.value === jobId ? null : jobId
+  // Job drawer + stage-settings drawer share the one right slot — mutually exclusive.
+  if (selectedJobId.value) selectedStageSettingsId.value = null
 }
 
 function closeDrawer(): void {
   selectedJobId.value = null
+}
+
+// ─── Selected stage settings (shares the right drawer slot with the job drawer) ─
+
+const selectedStageSettingsId = ref<string | null>(null)
+
+const selectedSettingsStage = computed<PipelineStage | null>(() =>
+  selectedStageSettingsId.value
+    ? props.stages.find((s) => s.id === selectedStageSettingsId.value) ?? null
+    : null,
+)
+
+const selectedSettingsIndex = computed<number>(() =>
+  selectedStageSettingsId.value
+    ? props.stages.findIndex((s) => s.id === selectedStageSettingsId.value)
+    : -1,
+)
+
+function openStageSettings(stageId: string): void {
+  selectedStageSettingsId.value = selectedStageSettingsId.value === stageId ? null : stageId
+  if (selectedStageSettingsId.value) selectedJobId.value = null
+}
+
+function closeStageSettings(): void {
+  selectedStageSettingsId.value = null
 }
 
 // ─── Mutation helpers ─────────────────────────────────────────────────────────
@@ -189,6 +217,7 @@ function deleteStage(stageId: string): void {
   if (idx < 0) return
   // Deselect if selected job was in this stage
   if (selectedStage.value?.id === stageId) selectedJobId.value = null
+  if (selectedStageSettingsId.value === stageId) selectedStageSettingsId.value = null
   // Drop the deleted stage and strip any dangling needs referencing it (else save 422s).
   const next = props.stages
     .filter((s) => s.id !== stageId)
@@ -313,13 +342,10 @@ function handleDrawerUpdate(patch: Partial<PipelineJob>): void {
             @add-job="requestAddJob(stage.id)"
             @delete-stage="deleteStage(stage.id)"
             @reorder-job="(p) => reorderJob(stage.id, p.from, p.to)"
+            :settings-active="selectedStageSettingsId === stage.id"
             @update-needs="(needs) => updateStage(stage.id, { needs })"
             @update-allow-failure="(v) => updateStage(stage.id, { allowFailure: v })"
-            @update-when="(when) => updateStage(stage.id, { when })"
-            @update-gate="(v) => updateStage(stage.id, { gate: v })"
-            @update-matrix="(matrix) => updateStage(stage.id, { matrix })"
-            @update-post="(post) => updateStage(stage.id, { post })"
-            @update-services="(services) => updateStage(stage.id, { services })"
+            @open-settings="openStageSettings(stage.id)"
           />
         </template>
 
@@ -351,7 +377,7 @@ function handleDrawerUpdate(patch: Partial<PipelineJob>): void {
       </template>
     </div>
 
-    <!-- ─── Right-side drawer (selected job) ──────────────────────────── -->
+    <!-- ─── Right-side drawer (selected job OR stage settings — one shared slot) ─ -->
     <JobDrawer
       v-if="selectedJob && selectedStage"
       :job="selectedJob"
@@ -361,6 +387,18 @@ function handleDrawerUpdate(patch: Partial<PipelineJob>): void {
       @close="closeDrawer"
       @update="handleDrawerUpdate"
       @change-type="requestChangeType"
+    />
+
+    <StageDrawer
+      v-else-if="selectedSettingsStage"
+      :stage="selectedSettingsStage"
+      :stage-index="selectedSettingsIndex"
+      @close="closeStageSettings"
+      @update-when="(when) => updateStage(selectedSettingsStage!.id, { when })"
+      @update-gate="(v) => updateStage(selectedSettingsStage!.id, { gate: v })"
+      @update-matrix="(matrix) => updateStage(selectedSettingsStage!.id, { matrix })"
+      @update-post="(post) => updateStage(selectedSettingsStage!.id, { post })"
+      @update-services="(services) => updateStage(selectedSettingsStage!.id, { services })"
     />
 
     <!-- Type picker modal (add new job / change type) -->

--- a/web/src/components/pipeline/StageColumn.vue
+++ b/web/src/components/pipeline/StageColumn.vue
@@ -1,29 +1,17 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import type { PipelineStage, StageWhen, PipelinePostStep, PipelineServiceSpec } from '../../api/pipeline'
+import type { PipelineStage } from '../../api/pipeline'
 import JobCard from './JobCard.vue'
-import StagePostEditor from './StagePostEditor.vue'
-import StageServicesEditor from './StageServicesEditor.vue'
 import { eligibleNeeds, toggleNeed } from './stageDeps'
 import {
-  WHEN_EVENTS,
-  WHEN_EVENT_LABELS,
-  parseBranches,
-  branchesToText,
-  toggleWhenEvent,
-  normalizeWhen,
   hasWhen,
   whenSummary,
-  parseMatrix,
-  matrixToText,
   hasMatrix,
   matrixSummary,
-  matrixError,
   hasPost,
   postSummary,
   hasServices,
   servicesSummary,
-  type WhenEvent,
 } from './stageSettings'
 
 const props = defineProps<{
@@ -32,6 +20,8 @@ const props = defineProps<{
   selectedJobId: string | null
   /** All stages — used to compute cycle-safe dependency options. */
   allStages: PipelineStage[]
+  /** True when this stage's settings drawer is open (highlights the gear button). */
+  settingsActive?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -42,11 +32,8 @@ const emit = defineEmits<{
   (e: 'reorder-job', payload: { from: number; to: number }): void
   (e: 'update-needs', needs: string[]): void
   (e: 'update-allow-failure', value: boolean): void
-  (e: 'update-when', when: StageWhen | undefined): void
-  (e: 'update-gate', value: boolean): void
-  (e: 'update-matrix', matrix: Record<string, string[]> | undefined): void
-  (e: 'update-post', post: PipelinePostStep[] | undefined): void
-  (e: 'update-services', services: PipelineServiceSpec[] | undefined): void
+  /** Open this stage's settings in the shared right-side drawer (条件/审批门/矩阵/服务/后置). */
+  (e: 'open-settings'): void
 }>()
 
 function stageLabel(index: number): string {
@@ -74,16 +61,10 @@ function toggleDep(needId: string): void {
   emit('update-needs', toggleNeed(currentNeeds.value, needId))
 }
 
-// ─── Stage settings (when 条件 · 8-5 / gate 审批门 · 8-4) ──────────────────────
+// ─── Stage rule chips (when 条件 / gate 审批门 / matrix / services / post) ──────
+// 编辑全部下沉到右侧 StageDrawer(复用 JobDrawer 卡片骨架);此处只渲染汇总 chip。
 
-const settingsOpen = ref(false)
-
-/** Editable branch-glob text (parsed → array only on commit). */
-const branchText = computed<string>(() => branchesToText(props.stage.when?.branches))
-
-const currentEvents = computed<string[]>(() => props.stage.when?.events ?? [])
-
-/** Active when settings, gate, matrix, post, or services → highlight the settings button. */
+/** Any stage rule set → highlight the gear button + show the dot. */
 const hasStageRules = computed(
   () =>
     hasWhen(props.stage.when) ||
@@ -96,33 +77,7 @@ const hasStageRules = computed(
 const whenChip = computed(() => whenSummary(props.stage.when))
 const postChip = computed(() => postSummary(props.stage.post))
 const servicesChip = computed(() => servicesSummary(props.stage.services))
-
-// ─── Matrix build axes (P1) ───────────────────────────────────────────────────
-
-/** Editable matrix text (one `axis: a, b` per line), parsed → map only on commit. */
-const matrixText = computed<string>(() => matrixToText(props.stage.matrix))
-
-/** Chip summary for the matrix (empty when none). */
 const matrixChip = computed(() => matrixSummary(props.stage.matrix))
-
-/** Client-side validation message for the current matrix (null = ok/empty). */
-const matrixWarn = computed(() => matrixError(props.stage.matrix))
-
-/** Commit edited matrix text → parsed axes map (or undefined when empty). */
-function commitMatrix(text: string): void {
-  emit('update-matrix', parseMatrix(text))
-}
-
-/** Commit a new branch-glob set, preserving the current events. */
-function commitBranches(text: string): void {
-  emit('update-when', normalizeWhen(parseBranches(text), currentEvents.value))
-}
-
-/** Toggle a trigger event, preserving the current branch globs. */
-function toggleEvent(ev: WhenEvent): void {
-  const events = toggleWhenEvent(currentEvents.value, ev)
-  emit('update-when', normalizeWhen(props.stage.when?.branches ?? [], events))
-}
 
 // ─── Drag-to-reorder (within this stage) ──────────────────────────────────────
 
@@ -173,11 +128,11 @@ function resetDrag(): void {
       <button
         v-if="stage.kind !== 'source'"
         class="stage-deps-btn"
-        :class="{ 'stage-deps-btn--active': settingsOpen || hasStageRules }"
-        :aria-label="`编辑阶段 ${stage.name} 的条件与审批门`"
-        :aria-expanded="settingsOpen"
-        title="条件执行 / 审批门"
-        @click="settingsOpen = !settingsOpen"
+        :class="{ 'stage-deps-btn--active': settingsActive || hasStageRules }"
+        :aria-label="`编辑阶段 ${stage.name} 的设置(条件/审批门/矩阵/服务/后置)`"
+        :aria-expanded="settingsActive"
+        title="阶段设置:条件 / 审批门 / 矩阵 / 服务 / 后置"
+        @click="emit('open-settings')"
       >
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
           <circle cx="12" cy="12" r="3"/>
@@ -257,76 +212,6 @@ function resetDrag(): void {
         <span>失败不阻断下游(allowFailure)</span>
       </label>
       <p class="deps-hint">留空 = 无显式依赖;全流水线无依赖时按从左到右线性执行</p>
-    </div>
-
-    <!-- Stage settings popover (when 条件 + gate 审批门) -->
-    <div v-if="settingsOpen && stage.kind !== 'source'" class="deps-popover settings-popover" role="group" aria-label="阶段条件与审批门编辑">
-      <div class="deps-popover-title">条件执行(when)</div>
-      <label class="settings-field-label" :for="`branches-${stage.id}`">分支(glob,空格/逗号分隔)</label>
-      <input
-        :id="`branches-${stage.id}`"
-        class="settings-input"
-        type="text"
-        :value="branchText"
-        placeholder="如 main release/*"
-        @change="commitBranches(($event.target as HTMLInputElement).value)"
-      />
-      <div class="settings-events-label">触发事件</div>
-      <div class="settings-events">
-        <label v-for="ev in WHEN_EVENTS" :key="ev" class="settings-event">
-          <input
-            type="checkbox"
-            :checked="currentEvents.includes(ev)"
-            @change="toggleEvent(ev)"
-          />
-          <span>{{ WHEN_EVENT_LABELS[ev] }}</span>
-        </label>
-      </div>
-      <p class="deps-hint">两者都留空 = 始终执行;不满足时本阶段及下游跳过(不计失败)</p>
-
-      <div class="deps-divider"></div>
-      <div class="deps-popover-title">审批门(gate)</div>
-      <label class="deps-option deps-option--toggle">
-        <input
-          type="checkbox"
-          :checked="stage.gate === true"
-          @change="emit('update-gate', ($event.target as HTMLInputElement).checked)"
-        />
-        <span>进入本阶段前需人工审批</span>
-      </label>
-      <p class="deps-hint">开启后运行将暂停在此,等待批准/拒绝</p>
-
-      <div class="deps-divider"></div>
-      <div class="deps-popover-title">矩阵构建(matrix)</div>
-      <label class="settings-field-label" :for="`matrix-${stage.id}`">轴(每行一个:<code>名称: 值1, 值2</code>)</label>
-      <textarea
-        :id="`matrix-${stage.id}`"
-        class="settings-input settings-textarea"
-        rows="3"
-        :value="matrixText"
-        placeholder="go: 1.21, 1.22&#10;os: linux"
-        @change="commitMatrix(($event.target as HTMLTextAreaElement).value)"
-      ></textarea>
-      <p v-if="matrixWarn" class="settings-warn" role="alert">{{ matrixWarn }}</p>
-      <p class="deps-hint">展开成并行 cell(笛卡尔积),各注入 <code>MATRIX_&lt;轴名&gt;</code> 环境变量;空 = 不展开</p>
-
-      <div class="deps-divider"></div>
-      <div class="deps-popover-title">旁挂服务(services)</div>
-      <StageServicesEditor
-        :services="stage.services"
-        :stage-id="stage.id"
-        @update="emit('update-services', $event)"
-      />
-      <p class="deps-hint">测试旁挂 DB/redis:与脚本容器同网,脚本里按服务名互访(如 <code>psql -h testdb</code>)</p>
-
-      <div class="deps-divider"></div>
-      <div class="deps-popover-title">后置步骤(post)</div>
-      <StagePostEditor
-        :steps="stage.post"
-        :stage-id="stage.id"
-        @update="emit('update-post', $event)"
-      />
-      <p class="deps-hint">阶段 job 跑完后按条件执行(同工作区),用于清理/通知/归档;空 = 无</p>
     </div>
 
     <!-- Job cards -->
@@ -488,41 +373,4 @@ function resetDrag(): void {
 .stage-rule-chip--svc { background: var(--color-cyan-soft, rgba(8, 145, 178, 0.13)); color: var(--color-cyan, #0e7490); }
 .stage-rule-chip--post { background: var(--color-amber-soft, rgba(217, 119, 6, 0.14)); color: var(--color-amber, #b45309); }
 
-/* ─── Settings popover fields ─────────────────────────────────────────────── */
-.settings-popover { width: 232px; }
-.settings-field-label,
-.settings-events-label {
-  display: block;
-  font-size: 0.68rem;
-  font-weight: 600;
-  color: var(--color-dim);
-  margin: 2px 0 5px;
-}
-.settings-events-label { margin-top: 10px; }
-.settings-input {
-  width: 100%;
-  height: 28px;
-  padding: 0 8px;
-  font: inherit;
-  font-size: 0.76rem;
-  color: var(--color-text);
-  background: var(--color-bg-subtle, var(--color-card));
-  border: 1px solid var(--color-border-strong);
-  border-radius: var(--rounded-md);
-  box-sizing: border-box;
-  transition: border-color var(--duration-fast);
-}
-.settings-input:focus { outline: none; border-color: var(--color-primary); }
-.settings-textarea { height: auto; padding: 6px 8px; line-height: 1.5; resize: vertical; font-family: var(--font-mono, ui-monospace, monospace); }
-.settings-warn { margin: 5px 0 0; font-size: 0.68rem; color: var(--color-danger, #dc2626); line-height: 1.4; }
-.settings-events { display: flex; flex-wrap: wrap; gap: 6px 12px; }
-.settings-event {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 0.76rem;
-  color: var(--color-text);
-  cursor: pointer;
-}
-.settings-event input { width: 14px; height: 14px; accent-color: var(--color-primary); cursor: pointer; }
 </style>

--- a/web/src/components/pipeline/StageDrawer.vue
+++ b/web/src/components/pipeline/StageDrawer.vue
@@ -1,0 +1,220 @@
+<script setup lang="ts">
+/**
+ * StageDrawer — 阶段级设置的右侧内联检视面板。
+ *
+ * 复用与 JobDrawer 完全相同的 `.job-drawer` / `.drawer-*` 卡片骨架(来自 pipeline.css):
+ * 同一右侧槽位、同样的滚动容器与输入样式,与「点 job 弹出的配置卡」一致 —— 而非另起
+ * 一个覆盖式弹层。承载阶段的 条件(when)/ 审批门(gate)/ 矩阵(matrix)/ 旁挂服务
+ * (services)/ 后置步骤(post)五块。字段编辑逻辑(分支解析、事件开关、矩阵解析)在此,
+ * 经 update-* 事件回传 PipelineCanvas → updateStage 落库。
+ */
+import { computed } from 'vue'
+import type { PipelineStage, StageWhen, PipelinePostStep, PipelineServiceSpec } from '../../api/pipeline'
+import StagePostEditor from './StagePostEditor.vue'
+import StageServicesEditor from './StageServicesEditor.vue'
+import {
+  WHEN_EVENTS,
+  WHEN_EVENT_LABELS,
+  parseBranches,
+  branchesToText,
+  toggleWhenEvent,
+  normalizeWhen,
+  parseMatrix,
+  matrixToText,
+  matrixError,
+  matrixSummary,
+  type WhenEvent,
+} from './stageSettings'
+import './pipeline.css'
+
+const props = defineProps<{
+  stage: PipelineStage
+  stageIndex: number
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'update-when', when: StageWhen | undefined): void
+  (e: 'update-gate', value: boolean): void
+  (e: 'update-matrix', matrix: Record<string, string[]> | undefined): void
+  (e: 'update-post', post: PipelinePostStep[] | undefined): void
+  (e: 'update-services', services: PipelineServiceSpec[] | undefined): void
+}>()
+
+const branchText = computed<string>(() => branchesToText(props.stage.when?.branches))
+const currentEvents = computed<string[]>(() => props.stage.when?.events ?? [])
+
+const matrixText = computed<string>(() => matrixToText(props.stage.matrix))
+const matrixWarn = computed(() => matrixError(props.stage.matrix))
+const matrixChip = computed(() => matrixSummary(props.stage.matrix))
+
+function commitBranches(text: string): void {
+  emit('update-when', normalizeWhen(parseBranches(text), currentEvents.value))
+}
+function toggleEvent(ev: WhenEvent): void {
+  const events = toggleWhenEvent(currentEvents.value, ev)
+  emit('update-when', normalizeWhen(props.stage.when?.branches ?? [], events))
+}
+function commitMatrix(text: string): void {
+  emit('update-matrix', parseMatrix(text))
+}
+</script>
+
+<template>
+  <aside class="job-drawer" aria-label="阶段设置">
+    <!-- Head — 与 JobDrawer 同骨架 -->
+    <div class="drawer-head">
+      <span class="drawer-icon" aria-hidden="true">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <circle cx="12" cy="12" r="3"/>
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
+        </svg>
+      </span>
+      <div class="drawer-title">
+        {{ stage.name }}
+        <small class="drawer-subtitle">阶段设置 · 第 {{ stageIndex }} 阶段</small>
+      </div>
+      <button class="drawer-close" aria-label="关闭设置" @click="emit('close')">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path d="M18 6 6 18M6 6l12 12"/>
+        </svg>
+      </button>
+    </div>
+
+    <!-- 条件执行(WHEN) -->
+    <div class="drawer-section">
+      <div class="drawer-section-label">条件执行 · when</div>
+      <div class="drawer-field">
+        <div class="drawer-field-label">分支(glob,空格/逗号分隔)</div>
+        <input
+          class="drawer-input"
+          type="text"
+          :value="branchText"
+          placeholder="如 main release/*"
+          aria-label="分支条件"
+          @change="commitBranches(($event.target as HTMLInputElement).value)"
+        />
+      </div>
+      <div class="drawer-field">
+        <div class="drawer-field-label">触发事件</div>
+        <div class="drawer-events">
+          <label v-for="ev in WHEN_EVENTS" :key="ev" class="drawer-event">
+            <input type="checkbox" :checked="currentEvents.includes(ev)" @change="toggleEvent(ev)" />
+            <span>{{ WHEN_EVENT_LABELS[ev] }}</span>
+          </label>
+        </div>
+      </div>
+      <p class="drawer-hint">两者都留空 = 始终执行;不满足时本阶段及下游跳过(不计失败)</p>
+    </div>
+
+    <!-- 审批门(GATE) -->
+    <div class="drawer-section">
+      <div class="drawer-section-label">审批门 · gate</div>
+      <label class="drawer-toggle">
+        <input
+          type="checkbox"
+          :checked="stage.gate === true"
+          @change="emit('update-gate', ($event.target as HTMLInputElement).checked)"
+        />
+        <span>进入本阶段前需人工审批</span>
+      </label>
+      <p class="drawer-hint">开启后运行将暂停在此,等待批准/拒绝</p>
+    </div>
+
+    <!-- 矩阵构建(MATRIX) -->
+    <div class="drawer-section">
+      <div class="drawer-section-head">
+        <div class="drawer-section-label">矩阵构建 · matrix</div>
+        <span v-if="matrixChip" class="drawer-section-badge">{{ matrixChip }}</span>
+      </div>
+      <div class="drawer-field">
+        <div class="drawer-field-label">轴(每行一个:<code>名称: 值1, 值2</code>)</div>
+        <textarea
+          class="drawer-input drawer-textarea is-mono"
+          rows="3"
+          :value="matrixText"
+          placeholder="go: 1.21, 1.22&#10;os: linux"
+          aria-label="矩阵轴"
+          @change="commitMatrix(($event.target as HTMLTextAreaElement).value)"
+        ></textarea>
+      </div>
+      <p v-if="matrixWarn" class="drawer-warn" role="alert">{{ matrixWarn }}</p>
+      <p class="drawer-hint">展开成并行 cell(笛卡尔积),各注入 <code>MATRIX_&lt;轴名&gt;</code> 环境变量;空 = 不展开</p>
+    </div>
+
+    <!-- 旁挂服务(SERVICES) -->
+    <div class="drawer-section">
+      <div class="drawer-section-label">旁挂服务 · services</div>
+      <StageServicesEditor
+        :services="stage.services"
+        :stage-id="stage.id"
+        @update="emit('update-services', $event)"
+      />
+      <p class="drawer-hint">测试旁挂 DB/redis:与脚本容器同网,脚本里按服务名互访(如 <code>psql -h testdb</code>)</p>
+    </div>
+
+    <!-- 后置步骤(POST) -->
+    <div class="drawer-section">
+      <div class="drawer-section-label">后置步骤 · post</div>
+      <StagePostEditor
+        :steps="stage.post"
+        :stage-id="stage.id"
+        @update="emit('update-post', $event)"
+      />
+      <p class="drawer-hint">阶段 job 跑完后按条件执行(同工作区),用于清理/通知/归档;空 = 无</p>
+    </div>
+  </aside>
+</template>
+
+<style scoped>
+.drawer-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 9px;
+}
+.drawer-section-head .drawer-section-label { margin-bottom: 0; }
+.drawer-section-badge {
+  font-size: 0.66rem;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 100px;
+  background: var(--color-violet-soft, rgba(124, 58, 237, 0.13));
+  color: var(--color-violet, #6d28d9);
+  white-space: nowrap;
+}
+
+.drawer-textarea {
+  height: auto;
+  min-height: 78px;
+  padding: 9px 11px;
+  line-height: 1.5;
+  resize: vertical;
+}
+.is-mono { font-family: var(--font-mono, ui-monospace, monospace); font-size: 0.8rem; }
+
+.drawer-events { display: flex; flex-wrap: wrap; gap: 8px 16px; }
+.drawer-event {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.82rem;
+  color: var(--color-text);
+  cursor: pointer;
+}
+.drawer-event input { width: 15px; height: 15px; accent-color: var(--color-primary); cursor: pointer; }
+
+.drawer-warn { margin: 7px 0 0; font-size: 0.72rem; color: var(--color-danger, #dc2626); line-height: 1.45; }
+
+.drawer-hint { margin: 9px 0 0; font-size: 0.72rem; color: var(--color-faint); line-height: 1.5; }
+.drawer-hint code,
+.drawer-field-label code {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.92em;
+  padding: 0 3px;
+  border-radius: 3px;
+  background: var(--color-inset);
+  color: var(--color-dim);
+}
+</style>

--- a/web/src/components/pipeline/StagePostEditor.vue
+++ b/web/src/components/pipeline/StagePostEditor.vue
@@ -81,16 +81,50 @@ function setCommands(i: number, text: string): void {
   display: flex;
   flex-direction: column;
   gap: 5px;
-  padding: 7px;
+  padding: 8px;
   border: 1px solid var(--color-border);
   border-left: 3px solid var(--color-amber, #b8860b);
   border-radius: var(--rounded-md, 8px);
   background: var(--color-inset);
 }
-.post-line { display: flex; align-items: center; gap: 5px; }
-.post-cond { flex: 0 0 84px; }
-.post-image { flex: 1; }
-.post-cmds { width: 100%; font-family: var(--font-mono); font-size: 0.74rem; }
+.post-line { display: flex; align-items: center; gap: 6px; }
+
+/* Self-contained input/select/textarea styling(不依赖父组件 scoped class):
+   box-sizing + min-width:0 防止溢出抽屉右缘。 */
+.post-editor input,
+.post-editor select,
+.post-editor textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0 10px;
+  font: inherit;
+  font-size: 0.82rem;
+  color: var(--color-text);
+  background: var(--color-card);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded, 8px);
+  transition: border-color var(--duration-fast), box-shadow var(--duration-fast);
+}
+.post-editor input,
+.post-editor select { height: 34px; }
+.post-editor select { cursor: pointer; }
+.post-editor input:focus,
+.post-editor select:focus,
+.post-editor textarea:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-soft);
+}
+.post-cond { flex: 0 0 92px; min-width: 0; }
+.post-image { flex: 1; min-width: 0; }
+.post-cmds {
+  width: 100%;
+  padding: 8px 10px;
+  line-height: 1.5;
+  resize: vertical;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+}
 .post-del {
   flex: none; width: 22px; height: 22px; border: none; background: none;
   color: var(--color-faint); cursor: pointer; border-radius: 5px;

--- a/web/src/components/pipeline/StageServicesEditor.vue
+++ b/web/src/components/pipeline/StageServicesEditor.vue
@@ -80,17 +80,38 @@ function setEnv(i: number, text: string): void {
   display: flex;
   flex-direction: column;
   gap: 5px;
-  padding: 7px;
+  padding: 8px;
   border: 1px solid var(--color-border);
   border-left: 3px solid var(--color-cyan, #0891b2);
   border-radius: var(--rounded-md, 8px);
   background: var(--color-inset);
 }
-.svc-line { display: flex; align-items: center; gap: 5px; }
-.svc-colon { color: var(--color-faint); font-family: var(--font-mono); }
-.svc-name { flex: 0 0 32%; }
-.svc-image { flex: 1; }
-.svc-env { width: 100%; font-size: 0.74rem; }
+.svc-line { display: flex; align-items: center; gap: 6px; }
+.svc-colon { color: var(--color-faint); font-family: var(--font-mono); flex: none; }
+
+/* Self-contained input styling (不依赖父组件 scoped class):box-sizing + min-width:0
+   保证 flex 内输入框能收缩、不溢出抽屉右缘。 */
+.svc-editor input {
+  width: 100%;
+  box-sizing: border-box;
+  height: 34px;
+  padding: 0 10px;
+  font: inherit;
+  font-size: 0.82rem;
+  color: var(--color-text);
+  background: var(--color-card);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded, 8px);
+  transition: border-color var(--duration-fast), box-shadow var(--duration-fast);
+}
+.svc-editor input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-soft);
+}
+.svc-name { flex: 0 0 34%; min-width: 0; }
+.svc-image { flex: 1; min-width: 0; }
+.svc-env { width: 100%; font-size: 0.76rem; }
 .svc-del {
   flex: none; width: 22px; height: 22px; border: none; background: none;
   color: var(--color-faint); cursor: pointer; border-radius: 5px;

--- a/web/src/components/pipeline/pipeline.css
+++ b/web/src/components/pipeline/pipeline.css
@@ -7,6 +7,10 @@
 /* ─── Canvas host ─────────────────────────────────────────────────────────── */
 .pipeline-canvas {
   flex: 1;
+  /* min-width:0:flex 行里画布默认 min-width:auto = 内容 min-content,阶段一多就拒绝收缩,
+     把右侧 360px 检视抽屉顶出 .canvas-body(overflow:hidden)右缘、抽屉右侧(✕/输入框)被裁。
+     置 0 让画布收缩到剩余空间,超宽的阶段流在自身 overflow:auto 内横向滚动,抽屉始终完整。 */
+  min-width: 0;
   overflow: auto;
   background-color: var(--color-canvas);
   background-image: radial-gradient(oklch(100% 0 0 / 0.04) 1px, transparent 1px);

--- a/web/src/views/ProjectPipeline.vue
+++ b/web/src/views/ProjectPipeline.vue
@@ -624,7 +624,14 @@ const projectName = computed(() => String(route.params.id))
 .pipeline-root {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  /*
+   * 流水线编辑器是「定高应用面板」(画布横向内滚 + 右侧检视抽屉纵向内滚 + 非画布 tab
+   * 内滚),需要一个相对视口确定的高度。父级 .main-inner 是 min-height:100vh(随内容
+   * 增高,height:100% 无法解析成确定值),会导致抽屉撑满内容、被 overflow:hidden 链裁掉
+   * 底部(后置步骤够不到)。这里按视口减去 .main-inner 的上下内边距锁定高度,使内部
+   * overflow:auto/hidden 的滚动真正生效。
+   */
+  height: calc(100vh - var(--main-pad-top) - var(--main-pad-bottom));
   min-height: 0;
   gap: 0;
 }


### PR DESCRIPTION
## 背景

阶段设置原本是锚在阶段列上的窄绝对定位弹层:五块(条件/审批门/矩阵/服务/后置)挤一条、被画布裁切;且服务/后置的输入框因依赖父组件 scoped 的 `.settings-input`(跨组件不生效)沦为裸原生框,在 flex 里不收缩、溢出抽屉右缘,后置步骤还够不到底。

用户反馈两点:① 输入框丑/溢出、后置步骤拉不到底;② **为什么不复用既有「点 job 弹出的配置卡」那个右侧面板,而要单独做一个?**

## 改动(复用 JobDrawer 的内联右侧卡片)

- **新 `StageDrawer.vue`**:复用与 JobDrawer 完全相同的 `.job-drawer` / `.drawer-*` 骨架(`pipeline.css`)——同一右侧槽、同样的滚动容器与输入样式。承载 `when/gate/matrix/services/post` 五块,字段编辑逻辑(分支解析/事件开关/矩阵解析)内聚于此,经 `update-*` 回传。
- **`PipelineCanvas`**:新增 `selectedStageSettingsId`;`StageDrawer` 与 `JobDrawer` 共用右槽并**互斥**(开一个自动关另一个)。`StageColumn` 齿轮按钮改 `emit('open-settings')`,`settings-active` 高亮。
- **`StageColumn` 瘦身**:删掉内联弹层编辑器与其 when/matrix 编辑逻辑,只留汇总 chip + 齿轮入口。
- **`StageServicesEditor` / `StagePostEditor`**:输入/下拉/文本域改自包含样式(`box-sizing` + `min-width:0`),不再依赖父级 scoped class —— 杜绝裸框与溢出。
- **`ProjectPipeline`**:`.pipeline-root` 由 `height:100%`(父级 `.main-inner` 是 `min-height:100vh`,% 解析为 auto → 随内容增高,抽屉被 `overflow:hidden` 链裁底)改为 `calc(100vh - var(--main-pad-top) - var(--main-pad-bottom))`,锁定为定高应用面板,使右侧抽屉内部 `overflow:auto` 真正滚动 —— 后置步骤可滚到底,且不产生整页溢出。

纯前端,无后端改动。承接 #72 的 matrix/post/services 往返。

## 验证

- `npm run typecheck` / `lint`(0 err)/ `vitest`(291 通过)全绿。
- 真机(真实 `aireboot` 项目)复核:画布开阶段设置内联面板,矩阵(`node×2`)/服务(`pg:postgres:16`)/后置(`失败时 alpine`)完整且可滚到底;点 job 切回任务配置卡;画布 tab 与变量 tab 均无整页溢出;0 page error;互斥单卡成立。

🤖 Generated with [Claude Code](https://claude.com/claude-code)