### PR TITLE
fix(promotion): 晋级面板提交 gated 晋级后即时显示审批按钮

### DIFF
--- a/web/src/components/run/PromotionPanel.vue
+++ b/web/src/components/run/PromotionPanel.vue
@@ -137,7 +137,13 @@ async function decidePromotion(approve: boolean): Promise<void> {
     const stageId = `promote:${target}`
     if (approve) await approveStage(props.runId, stageId)
     else await rejectStage(props.runId, stageId)
-    await loadHistory() // 决定后 pending → promoted / rejected
+    // 审批端点只是给阻塞的 promote 协程投递决定,最终状态(promoted/rejected)由该协程写库,
+    // 与 approve 响应之间有微小窗口 → 轮询几次直到 pending 落定,确保面板及时切走待审块。
+    await loadHistory()
+    for (let i = 0; i < 5 && pendingPromotion.value; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 200))
+      await loadHistory()
+    }
   } catch (err) {
     promotionError.value =
       err instanceof HttpError
@@ -167,49 +173,72 @@ function cancelConfirm(): void {
   showConfirm.value = false
 }
 
+/** 把晋级请求错误映射为展示文案;gate_rejected 是审批拒绝/超时的正常终态,返回空串(不作错误横幅)。 */
+function mapPromoteError(err: unknown): string {
+  if (!(err instanceof HttpError)) return '晋级请求失败,请稍后重试。'
+  const code = err.apiError?.code ?? ''
+  switch (code) {
+    case 'chain_not_configured':
+      return '项目尚未配置环境链,请在「触发设置」中添加环境链后再晋级。'
+    case 'run_not_successful':
+      return '仅成功完成的运行可晋级。'
+    case 'already_promoted':
+      return '该运行已晋级到此环境。'
+    case 'already_at_top':
+      return '已到达链尾,无更高环境可晋级。'
+    case 'skip_env':
+      return '只能按顺序逐级晋级,不可跳级。'
+    case 'gate_rejected':
+      return '' // 审批拒绝/超时是正常终态,历史已反映 rejected,不弹错误横幅
+    default:
+      return err.apiError?.message ?? `晋级失败(${err.status})`
+  }
+}
+
 async function doPromote(): Promise<void> {
   showConfirm.value = false
   if (promoting.value || !nextEnv.value) return
+  const target = nextEnv.value.name
+  const gated = isNextGated.value
   promoting.value = true
   promotionError.value = ''
   promoted.value = false
-  try {
-    const dto = await promoteRun(props.runId, {
-      targetEnvironment: nextEnv.value.name,
-    })
-    // Regardless of 200 or 409-with-record, push to history
-    promotions.value = [dto, ...promotions.value.filter((p) => p.id !== dto.id)]
-    if (dto.status === 'pending') {
-      // Gated: notify parent to load approval gate
-      emit('promotion-pending')
-    } else if (dto.status === 'promoted') {
-      promoted.value = true
-    }
-  } catch (err) {
-    if (err instanceof HttpError) {
-      const code = err.apiError?.code ?? ''
-      switch (code) {
-        case 'chain_not_configured':
-          promotionError.value = '项目尚未配置环境链,请在「触发设置」中添加环境链后再晋级。'
-          break
-        case 'run_not_successful':
-          promotionError.value = '仅成功完成的运行可晋级。'
-          break
-        case 'already_promoted':
-          promotionError.value = '该运行已晋级到此环境。'
-          break
-        case 'already_at_top':
-          promotionError.value = '已到达链尾,无更高环境可晋级。'
-          break
-        case 'skip_env':
-          promotionError.value = '只能按顺序逐级晋级,不可跳级。'
-          break
-        default:
-          promotionError.value = err.apiError?.message ?? `晋级失败(${err.status})`
+
+  if (gated) {
+    // gated 晋级:POST /promote 在服务端会阻塞,挂起直到 /approve|/reject 投递决定
+    // (promotion/coordinator.go Promote → Gate.Await)。因此**绝不能 await** 这个请求——
+    // 否则待审晋级的批准/拒绝按钮永远渲染不出来(此前的 bug)。pending 记录在阻塞前已写库,
+    // 故发起请求后立即拉历史把它显示出来;请求最终(审批决定后)settle 时再刷新一次历史。
+    const inflight = promoteRun(props.runId, { targetEnvironment: target })
+    inflight.then(
+      () => loadHistory(), // 批准 → promoted
+      (err) => {
+        const msg = mapPromoteError(err)
+        if (msg) promotionError.value = msg
+        return loadHistory() // 拒绝/超时 → rejected(或快速校验错误)
+      },
+    )
+    emit('promotion-pending')
+    try {
+      await loadHistory()
+      // 偶发竞态(记录刚写库)用一次轻量重试兜底,确保 pending 块即时出现。
+      if (!pendingPromotion.value) {
+        await new Promise((resolve) => setTimeout(resolve, 300))
+        await loadHistory()
       }
-    } else {
-      promotionError.value = '晋级请求失败,请稍后重试。'
+    } finally {
+      promoting.value = false
     }
+    return
+  }
+
+  // 非 gated:同步晋级,直接 await 即可拿到 promoted 记录。
+  try {
+    const dto = await promoteRun(props.runId, { targetEnvironment: target })
+    promotions.value = [dto, ...promotions.value.filter((p) => p.id !== dto.id)]
+    if (dto.status === 'promoted') promoted.value = true
+  } catch (err) {
+    promotionError.value = mapPromoteError(err)
   } finally {
     promoting.value = false
   }


### PR DESCRIPTION
## 问题
gated 晋级的 `POST /runs/{id}/promote` 在服务端**阻塞**等待审批门决定(`promotion.Coordinator` → `Gate.Await`),前端却 `await` 该请求 → Promise 永不 resolve → 渲染待审「批准/拒绝」按钮的代码执行不到,只能手动刷新(`loadHistory` 读到已写库的 pending 记录)按钮才出现。鸡生蛋。

## 修复(纯前端,贴合既有阻塞式审批架构)
- gated 分支**不再 await** 挂起请求,发起后立即 `loadHistory()` 把 pending + 批准/拒绝按钮渲染出来(带一次 300ms 重试兜底竞态);请求最终在审批决定后 settle 时再刷新历史。
- `decidePromotion` 审批后轮询直至 pending 落定(服务端 promote 协程写最终状态与 `/approve` 响应有微小窗口)。
- 错误文案抽成 `mapPromoteError`;`gate_rejected`(正常拒绝/超时)不再误弹错误横幅。

## 验证
真 docker e2e 演示环境实测:提交 gated 晋级后无需手动刷新,批准/拒绝按钮即时出现。`typecheck` / `lint` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)