### PR TITLE
feat(pipeline): 阶段内 job 级 DAG —— 横串竖并 + 真并发执行

### DIFF
--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -9,7 +9,9 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 
+	"github.com/huangchengsir/pipewright/internal/dag"
 	"github.com/huangchengsir/pipewright/internal/dagrun"
 	"github.com/huangchengsir/pipewright/internal/notify"
 	"github.com/huangchengsir/pipewright/internal/pipeline"
@@ -133,9 +135,15 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 
 		sink := &reporterSink{rep: rep}
 		hasPost := len(stage.Post) > 0
+		// 阶段内 job 级 DAG:任一 job 声明 needs → 按 job DAG 并发调度(无依赖 job 并行,各 job
+		// 独立克隆工作区以保并发安全);整阶段无 job needs → 沿用既有「按类型分组串行 + 单一阶段工作区」
+		// (零行为变化,守护存量流水线)。
+		hasJobDAG := stageHasJobNeeds(stage.Jobs)
 
-		// 工作区:有 script/build_image **或** 有 post 步骤时都需克隆(post 在同一工作区跑,可访问
-		// 构建产物,对齐 Jenkins post 语义);纯部署/通知阶段无工作区。
+		// 工作区:
+		//  - 非 DAG 路径:有 script/build_image **或** 有 post 步骤时克隆一份阶段工作区(沿用既有语义)。
+		//  - DAG 路径:job 各自克隆独立工作区,阶段级工作区仅 post 步骤(在其中跑)才需要。
+		// 纯部署/通知阶段无工作区。proj/settings 在 needsBuild||hasPost 时解析(两路径都可能用到)。
 		var (
 			proj      *project.Project
 			settings  *pipeline.Settings
@@ -149,6 +157,9 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 				return ErrBuildFailed
 			}
 			proj, settings = p, s
+		}
+		needStageWS := hasPost || (needsBuild && !hasJobDAG)
+		if needStageWS {
 			ws, mkErr := mkTempWorkspace()
 			if mkErr != nil {
 				_ = rep.Log(ctx, streamStderr, "创建临时工作区失败:"+mkErr.Error())
@@ -182,19 +193,26 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 
 		// 阶段主体(job 执行):捕获错误而非提前返回,以便其后无论成败都按条件跑 post 步骤。
 		jobErr := func() error {
-			if needsBuild {
-				// 旁挂服务(P1):阶段声明 services 时,起服务容器到临时网络,脚本容器加入同网按服务名互访;
-				// 阶段结束(成败/取消)拆除。驱动不支持容器网络能力 → 直接失败(不在缺依赖下假跑)。
-				var svcNetwork string
-				if len(stage.Services) > 0 {
-					net, ok := b.startStageServices(ctx, r, stage, rep)
-					if !ok {
-						return ErrBuildFailed
-					}
-					svcNetwork = net
-					defer b.stopStageServices(context.WithoutCancel(ctx), r, stage, net, rep)
+			// 旁挂服务(P1):阶段声明 services 时,起服务容器到临时网络,脚本容器加入同网按服务名互访;
+			// 阶段结束(成败/取消)拆除。驱动不支持容器网络能力 → 直接失败(不在缺依赖下假跑)。
+			// 两条执行路径(DAG / 类型分组)共用,故提到分支之前。
+			var svcNetwork string
+			if needsBuild && len(stage.Services) > 0 {
+				net, ok := b.startStageServices(ctx, r, stage, rep)
+				if !ok {
+					return ErrBuildFailed
 				}
+				svcNetwork = net
+				defer b.stopStageServices(context.WithoutCancel(ctx), r, stage, net, rep)
+			}
 
+			// ── 阶段内 job 级 DAG 路径:按 job 依赖并发调度,无依赖 job 并行、各自独立工作区 ──
+			if hasJobDAG {
+				return b.runStageJobsDAG(ctx, r, stage, rep, sink, proj, settings, svcNetwork, hasPushJob, reportSink)
+			}
+
+			// ── 既有路径(零行为变化):类型分组串行,共用单一阶段工作区 ──
+			if needsBuild {
 				// 步骤输出→下游变量(P1):同阶段 job 间经 $PIPEWRIGHT_ENV 文件传值,carriedEnv 累积注入后续 job。
 				var carriedEnv []pipeline.BuildVar
 				for _, jb := range scriptJobs {
@@ -268,6 +286,223 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 		}
 		return jobErr
 	}
+}
+
+// defaultJobDAGConcurrency 是「阶段内 job 级 DAG」的并发上限。阶段之间已可能并行,故 job 级再
+// 限一个较小上限,避免并发容器数无界放大拉爆宿主(0 = 由 dag 调度取节点数;这里给确定上限)。
+const defaultJobDAGConcurrency = 4
+
+// stageHasJobNeeds 报告阶段内是否有任一 job 声明了 job 级依赖(needs)。
+// 有 → 走 job 级 DAG 并发调度;无 → 走既有类型分组串行(向后兼容)。
+func stageHasJobNeeds(jobs []pipeline.Job) bool {
+	for _, jb := range jobs {
+		if len(jb.Needs) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// runStageJobsDAG 按「阶段内 job 级 DAG」并发执行该阶段的所有 job:无依赖的 job 并行跑、有 needs
+// 的 job 等其全部上游成功后再跑(复用 dag.Graph.Schedule,与阶段级调度同一内核)。每个需工作区的
+// job(script/build_image)各自克隆一份独立临时工作区以保并发安全;env 沿 needs 边传递(上游 job
+// 写 $PIPEWRIGHT_ENV → 下游合并注入)。任一 job 有效失败/取消 → 阶段失败。
+//
+// 并发安全:工作区各 job 独立(Clone 本就被阶段级并行调用,已并发安全);日志经 sink 的运行级
+// mutex 串行化;jobEnvOut 用 mutex 保护;buildcache/产物按 job 隔离键写入。
+func (b *Builder) runStageJobsDAG(
+	ctx context.Context,
+	r *run.Run,
+	stage pipeline.Stage,
+	rep dagrun.StageReporter,
+	sink *reporterSink,
+	proj *project.Project,
+	settings *pipeline.Settings,
+	svcNetwork string,
+	hasPushJob bool,
+	reportSink TestReportSink,
+) error {
+	nodes := make([]dag.Node, 0, len(stage.Jobs))
+	jobByID := make(map[string]pipeline.Job, len(stage.Jobs))
+	for _, jb := range stage.Jobs {
+		nodes = append(nodes, dag.Node{ID: jb.ID, Needs: jb.Needs})
+		jobByID[jb.ID] = jb
+	}
+	g, gerr := dag.New(nodes)
+	if gerr != nil {
+		// 保存期已校验过;这里再失败属防御(数据异常)。
+		_ = rep.Log(ctx, streamStderr, "阶段内 job 依赖图非法:"+gerr.Error())
+		return ErrBuildFailed
+	}
+
+	var envMu sync.Mutex
+	jobEnvOut := make(map[string][]pipeline.BuildVar, len(stage.Jobs)) // jobID → 该 job 产出的 env(供下游合并)
+
+	runJob := func(ctx context.Context, id string) error {
+		if canceled(ctx) {
+			return run.ErrCanceled
+		}
+		jb := jobByID[id]
+		// 收集上游(needs)产出的 env,按 needs 声明序合并(后者覆盖同名,与既有 carriedEnv 语义一致)。
+		var upstreamEnv []pipeline.BuildVar
+		if len(jb.Needs) > 0 {
+			envMu.Lock()
+			for _, dep := range jb.Needs {
+				upstreamEnv = append(upstreamEnv, jobEnvOut[dep]...)
+			}
+			envMu.Unlock()
+		}
+
+		switch {
+		case isScriptJob(jb.Type):
+			out, err := b.runScriptJobIsolated(ctx, sink, rep, r, jb, stage, proj, settings, svcNetwork, upstreamEnv, reportSink)
+			if err != nil {
+				return err
+			}
+			if len(out) > 0 {
+				envMu.Lock()
+				jobEnvOut[id] = out
+				envMu.Unlock()
+			}
+			return nil
+		case isBuildImageJob(jb.Type):
+			return b.runBuildImageJobIsolated(ctx, sink, rep, r, jb, stage, proj, settings, hasPushJob)
+		case isDeployJob(jb.Type):
+			return b.runDeployJob(ctx, rep, jb, r.ID)
+		case strings.TrimSpace(jb.Type) == "push_image":
+			// 推送随构建镜像节点完成(hasPushJob);本节点仅用于在 DAG 中编排顺序/展示。
+			_ = rep.Log(ctx, streamStdout, fmt.Sprintf("· 推送镜像「%s」:已随构建镜像节点完成推送(本节点用于编排顺序)", jb.Name))
+			return nil
+		case strings.TrimSpace(jb.Type) == "notify":
+			b.runNotifyJob(ctx, rep, jb, r)
+			return nil
+		default:
+			_ = rep.Log(ctx, streamStdout, fmt.Sprintf("· %s(%s)— 真实执行未接入;本节点放行", jb.Name, jb.Type))
+			return nil
+		}
+	}
+
+	res := g.Schedule(ctx, runJob, dag.Options{MaxConcurrency: defaultJobDAGConcurrency})
+
+	if canceled(ctx) {
+		return run.ErrCanceled
+	}
+	// 汇总:任一 job 失败(取消优先识别)→ 阶段失败。skipped 仅因上游失败,已由该上游失败反映。
+	for _, jb := range stage.Jobs {
+		nr := res[jb.ID]
+		switch nr.Status {
+		case dag.StatusFailed:
+			if errors.Is(nr.Err, run.ErrCanceled) {
+				return run.ErrCanceled
+			}
+			return ErrBuildFailed
+		case dag.StatusCanceled:
+			return run.ErrCanceled
+		}
+	}
+	return nil
+}
+
+// cloneJobWorkspace 为单个 job 克隆一份独立的临时工作区(并发安全),并恢复本 run 已归档的上游产物。
+// 返回 (workspace, commitTag, cleanup, err);调用方务必在用完后调用 cleanup()。失败时已自行清理。
+func (b *Builder) cloneJobWorkspace(ctx context.Context, r *run.Run, proj *project.Project, rep dagrun.StageReporter) (string, string, func(), error) {
+	ws, mkErr := mkTempWorkspace()
+	if mkErr != nil {
+		_ = rep.Log(ctx, streamStderr, "创建临时工作区失败:"+mkErr.Error())
+		return "", "", func() {}, ErrBuildFailed
+	}
+	cleanup := func() { _ = os.RemoveAll(ws) }
+
+	token := b.revealToken(proj.CredentialID)
+	resolved, cerr := b.cloner.Clone(ctx, proj.RepoURL, token, r.Trigger.Branch, r.Trigger.Commit, ws)
+	token = "" // 明文用完即弃
+	_ = token
+	if cerr != nil {
+		cleanup()
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return "", "", func() {}, run.ErrCanceled
+		}
+		_ = rep.Log(ctx, streamStderr, "源码克隆失败(鉴权/网络/ref 不存在或被 SSRF 拒绝)")
+		return "", "", func() {}, ErrBuildFailed
+	}
+	commitTag := "latest"
+	if resolved != nil && resolved.CommitShort != "" {
+		commitTag = resolved.CommitShort
+		if b.recordCommit != nil {
+			b.recordCommit(ctx, r.ID, resolved.CommitShort) // 同一 commit;并发重复记录幂等无害
+		}
+	}
+	// 跨阶段 + 阶段内上游 job 产物:把本 run 已归档的 jar/dist 真字节恢复进本 job 工作区原相对路径。
+	b.restorePriorArtifacts(ctx, r, ws, rep)
+	return ws, commitTag, cleanup, nil
+}
+
+// runScriptJobIsolated 在独立工作区内执行单个 script 类 job(DAG 路径用)。返回该 job 写入
+// $PIPEWRIGHT_ENV 的变量(供下游 needs 合并)。env 注入序与既有串行路径一致:
+// 运行参数 → 上游 job 输出 → job 自身 env → PIPEWRIGHT_ENV。产物 + 测试报告逐 job 收集/门禁。
+func (b *Builder) runScriptJobIsolated(
+	ctx context.Context,
+	sink *reporterSink,
+	rep dagrun.StageReporter,
+	r *run.Run,
+	jb pipeline.Job,
+	stage pipeline.Stage,
+	proj *project.Project,
+	settings *pipeline.Settings,
+	svcNetwork string,
+	upstreamEnv []pipeline.BuildVar,
+	reportSink TestReportSink,
+) ([]pipeline.BuildVar, error) {
+	_ = settings // 与既有 script 路径签名对齐;script 执行不直接用 settings
+	ws, _, cleanup, err := b.cloneJobWorkspace(ctx, r, proj, rep)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	step, verr := scriptStepFromJob(jb)
+	if verr != nil {
+		_ = rep.Log(ctx, streamStderr, fmt.Sprintf("script job「%s」配置无效:%v", jb.Name, verr))
+		return nil, ErrBuildFailed
+	}
+	base := append(runParamsAsEnv(r.Trigger.Params), upstreamEnv...)
+	step.Env = append(base, step.Env...)
+	step.Env = append(step.Env, pipewrightEnvVar())
+	if svcNetwork != "" {
+		step.Resource.Network = svcNetwork
+	}
+	b.restoreJobCache(ctx, rep, jb, r.Trigger.Branch, ws)
+	if err := b.runScriptStepWithOpts(ctx, sink, 0, step, ws); err != nil {
+		return nil, err // ErrBuildFailed / run.ErrCanceled
+	}
+	b.saveJobCache(ctx, rep, jb, r.Trigger.Branch, ws)
+	out := captureStageEnv(ctx, rep, ws)
+	b.collectScriptArtifacts(ctx, []pipeline.Job{jb}, ws, slugify(proj.Name), stage.Name, rep)
+	if rerr := collectStageReport(ctx, reportSink, r, stage, ws, rep); rerr != nil {
+		return out, rerr // 质量门禁阻断
+	}
+	return out, nil
+}
+
+// runBuildImageJobIsolated 在独立工作区内执行单个 build_image job(DAG 路径用):先克隆 + 恢复上游
+// 产物(jar/dist),再复用既有 runBuildImageJob 真实构建/推送。
+func (b *Builder) runBuildImageJobIsolated(
+	ctx context.Context,
+	sink *reporterSink,
+	rep dagrun.StageReporter,
+	r *run.Run,
+	jb pipeline.Job,
+	stage pipeline.Stage,
+	proj *project.Project,
+	settings *pipeline.Settings,
+	hasPushJob bool,
+) error {
+	ws, commitTag, cleanup, err := b.cloneJobWorkspace(ctx, r, proj, rep)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	return b.runBuildImageJob(ctx, sink, rep, jb, stage.Name, proj, settings, r.Trigger.ResolvedEnvironment, ws, commitTag, hasPushJob)
 }
 
 // runDeployJob 执行一个 deploy_ssh 节点:把本 run 已产出的产物经 SSH 部署到节点配置的目标机

--- a/internal/build/dag_stage_exec_test.go
+++ b/internal/build/dag_stage_exec_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -555,5 +556,113 @@ func TestRunDeployJobPassesImageParams(t *testing.T) {
 	// 空键不应混入(保持默认行为)。
 	if _, ok := dep.gotCfg["restartCommand"]; ok {
 		t.Errorf("空 restartCommand 不应入 cfg:%+v", dep.gotCfg)
+	}
+}
+
+// ─── 阶段内 job 级 DAG 并发执行(横串竖并)─────────────────────────────────────────
+
+// orderDriver 线程安全记录 RunToolchain 的调用顺序(按 image),并可按 image 配退出码 + 阻塞时长。
+type orderDriver struct {
+	mu    sync.Mutex
+	order []string
+	codes map[string]int // image → 退出码(缺省 0)
+	block time.Duration  // >0 时每次调用阻塞,放大并发窗口
+}
+
+func (d *orderDriver) Binary() string { return "fake" }
+func (d *orderDriver) RunToolchain(ctx context.Context, image, _, _ string, _ []string, _ []string, _ pipeline.Resource, onLine func(string, string)) (int, error) {
+	if d.block > 0 {
+		select {
+		case <-time.After(d.block):
+		case <-ctx.Done():
+			return -1, ctx.Err()
+		}
+	}
+	d.mu.Lock()
+	d.order = append(d.order, image)
+	code := d.codes[image]
+	d.mu.Unlock()
+	return code, nil
+}
+func (d *orderDriver) Build(context.Context, string, string, string, []string, []string, func(string, string)) (int, error) {
+	panic("Build not expected")
+}
+func (d *orderDriver) Tag(context.Context, string, string, func(string, string)) (int, error) {
+	panic("Tag not expected")
+}
+func (d *orderDriver) Login(context.Context, string, string, string, func(string, string)) (int, error) {
+	panic("Login not expected")
+}
+func (d *orderDriver) Push(context.Context, string, func(string, string)) (int, error) {
+	panic("Push not expected")
+}
+func (d *orderDriver) InspectImage(context.Context, string) (string, int64, error) {
+	panic("InspectImage not expected")
+}
+
+func (d *orderDriver) ran(image string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, i := range d.order {
+		if i == image {
+			return true
+		}
+	}
+	return false
+}
+
+// scriptJobID 构造一条带显式 ID + job 级 needs 的 script job(image 即用作顺序标记)。
+func scriptJobID(id, image string, needs ...string) pipeline.Job {
+	return pipeline.Job{
+		ID:     id,
+		Name:   id,
+		Type:   pipeline.StepTypeScript,
+		Config: map[string]any{"image": image, "commands": "echo " + id},
+		Needs:  needs,
+	}
+}
+
+// TestStageExecutorJobDAGRunsAllRespectingDeps:A、B 无依赖(并行),C needs [A,B](串行其后)。
+// 三个 job 都执行,且 C 一定在 A、B 之后(DAG 路径生效)。
+func TestStageExecutorJobDAGRunsAllRespectingDeps(t *testing.T) {
+	drv := &orderDriver{codes: map[string]int{}, block: 20 * time.Millisecond}
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b, nil)
+	stage := pipeline.Stage{ID: "s1", Name: "构建", Kind: pipeline.KindBuild, Jobs: []pipeline.Job{
+		scriptJobID("A", "imgA"),
+		scriptJobID("B", "imgB"),
+		scriptJobID("C", "imgC", "A", "B"),
+	}}
+	if err := exec(context.Background(), &run.Run{ProjectID: "p1"}, stage, &fakeReporter{}); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if len(drv.order) != 3 {
+		t.Fatalf("应执行 3 个 job, got %v", drv.order)
+	}
+	if drv.order[len(drv.order)-1] != "imgC" {
+		t.Errorf("C 必须在 A、B 之后(末位), got order=%v", drv.order)
+	}
+}
+
+// TestStageExecutorJobDAGFailureSkipsDependents:A 失败 → 其下游 C 被跳过(不执行),阶段失败;
+// 与 A 无依赖的 B 仍会执行。
+func TestStageExecutorJobDAGFailureSkipsDependents(t *testing.T) {
+	drv := &orderDriver{codes: map[string]int{"imgA": 1}} // A 非零退出 → 失败
+	b := newDAGTestBuilder(drv, &markerCloner{})
+	exec := NewStageExecutor(b, nil)
+	stage := pipeline.Stage{ID: "s1", Name: "构建", Kind: pipeline.KindBuild, Jobs: []pipeline.Job{
+		scriptJobID("A", "imgA"),
+		scriptJobID("B", "imgB"),
+		scriptJobID("C", "imgC", "A"),
+	}}
+	err := exec(context.Background(), &run.Run{ProjectID: "p1"}, stage, &fakeReporter{})
+	if !errors.Is(err, ErrBuildFailed) {
+		t.Fatalf("A 失败应使阶段失败, err = %v", err)
+	}
+	if drv.ran("imgC") {
+		t.Errorf("C 依赖失败的 A,应被跳过而非执行;order=%v", drv.order)
+	}
+	if !drv.ran("imgB") {
+		t.Errorf("B 与 A 无依赖,应仍执行;order=%v", drv.order)
 	}
 }

--- a/internal/httpapi/pipelines.go
+++ b/internal/httpapi/pipelines.go
@@ -60,6 +60,9 @@ type jobDTO struct {
 	Type    string         `json:"type"`
 	Summary string         `json:"summary"`
 	Config  map[string]any `json:"config"`
+	// Needs 是阶段内 job 级依赖(画布横向连线=串行)。omitempty:无依赖时不出现,
+	// 保持基线形状不变;有依赖时原样回传,与画布读写形状 1:1。
+	Needs []string `json:"needs,omitempty"`
 }
 
 // toStageDTOs 把领域阶段集合转契约 stageDTO 列表(切片/map 保证非 nil,JSON 输出 [] / {})。
@@ -79,6 +82,7 @@ func toStageDTOs(in []pipeline.Stage) []stageDTO {
 				Type:    jb.Type,
 				Summary: jb.Summary,
 				Config:  cfg,
+				Needs:   jb.Needs,
 			})
 		}
 		needs := st.Needs
@@ -124,6 +128,7 @@ type reqStage struct {
 		Type    string         `json:"type"`
 		Summary string         `json:"summary"`
 		Config  map[string]any `json:"config"`
+		Needs   []string       `json:"needs"`
 	} `json:"jobs"`
 }
 
@@ -139,6 +144,7 @@ func reqStagesToDomain(in []reqStage) []pipeline.Stage {
 				Type:    jb.Type,
 				Summary: jb.Summary,
 				Config:  jb.Config,
+				Needs:   jb.Needs,
 			})
 		}
 		stages = append(stages, pipeline.Stage{

--- a/internal/httpapi/pipelines_test.go
+++ b/internal/httpapi/pipelines_test.go
@@ -203,6 +203,70 @@ func TestPipelineSaveRoundTripMatrixPostServices(t *testing.T) {
 	}
 }
 
+// TestPipelineSaveRoundTripJobNeeds:阶段内 job 级依赖(横串竖并)经 PUT/GET 无损往返。
+// 此前 jobDTO/reqJob 不含 needs,画布的阶段内连线会在保存后丢失。
+func TestPipelineSaveRoundTripJobNeeds(t *testing.T) {
+	srv, client, csrf, projID := setupPipelineServer(t)
+	base := srv.URL + "/api/projects/" + projID + "/pipeline"
+
+	body := `{"stages":[
+	  {"name":"流水线源","kind":"source","jobs":[
+	    {"name":"Gitee 源","type":"git_source","summary":"main","config":{}}
+	  ]},
+	  {"name":"构建","kind":"build","jobs":[
+	    {"id":"j_fe","name":"前端构建","type":"build_frontend","config":{}},
+	    {"id":"j_be","name":"后端构建","type":"build_backend","config":{}},
+	    {"id":"j_img","name":"打镜像","type":"build_image","config":{},"needs":["j_fe","j_be"]}
+	  ]}
+	]}`
+	resp := doJSON(t, client, http.MethodPut, base, csrf, body)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("PUT status = %d, body=%s", resp.StatusCode, raw)
+	}
+
+	gresp := doJSON(t, client, http.MethodGet, base, csrf, "")
+	defer gresp.Body.Close()
+	graw, _ := io.ReadAll(gresp.Body)
+	var gdto map[string]any
+	if err := json.Unmarshal(graw, &gdto); err != nil {
+		t.Fatalf("decode GET: %v, body=%s", err, graw)
+	}
+	stages, _ := gdto["stages"].([]any)
+	var build map[string]any
+	for _, s := range stages {
+		if m, _ := s.(map[string]any); m["kind"] == "build" {
+			build = m
+		}
+	}
+	if build == nil {
+		t.Fatalf("GET 缺 build 阶段, body=%s", graw)
+	}
+	jobs, _ := build["jobs"].([]any)
+	var img map[string]any
+	for _, j := range jobs {
+		if m, _ := j.(map[string]any); m["id"] == "j_img" {
+			img = m
+		}
+	}
+	if img == nil {
+		t.Fatalf("GET 缺 j_img, body=%s", graw)
+	}
+	needs, _ := img["needs"].([]any)
+	if len(needs) != 2 {
+		t.Fatalf("j_img.needs = %v, want 2 项(往返保留); body=%s", img["needs"], graw)
+	}
+	// 无依赖的 j_fe 不应平白多出 needs 键(omitempty 基线不变)。
+	for _, j := range jobs {
+		if m, _ := j.(map[string]any); m["id"] == "j_fe" {
+			if _, ok := m["needs"]; ok {
+				t.Fatalf("无依赖 job 不应出现 needs 键(omitempty), got %v", m["needs"])
+			}
+		}
+	}
+}
+
 func TestPipelineSaveInvalidStage422(t *testing.T) {
 	srv, client, csrf, projID := setupPipelineServer(t)
 	base := srv.URL + "/api/projects/" + projID + "/pipeline"

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -58,12 +58,19 @@ var (
 
 // Job 是一个任务(阶段下的最小编排单元)。Config 为自由 KV(本期任意结构;
 // 2-4/2-6 才在内填强 schema)。Summary 为卡片副标题展示文本(可空)。
+//
+// Needs 是该 job 依赖的「同阶段内」其他 job 的 ID 列表,构成**阶段内 job 级 DAG**:
+// 画布上横向连线=串行(依赖)、纵向并排=并行(无依赖)。为空=该 job 在阶段内无前置依赖。
+// 当某阶段**任一 job** 声明 needs 时,执行层按 job 级 DAG 调度(无依赖 job 并发跑);
+// 整阶段无任何 job needs 时退化为既有「按类型分组串行」(向后兼容存量流水线)。
+// needs 只能引用同阶段内的 job,不可自指 / 成环(保存期校验,见 validateJobDAG)。
 type Job struct {
 	ID      string         `json:"id"`
 	Name    string         `json:"name"`
 	Type    string         `json:"type"`
 	Summary string         `json:"summary"`
 	Config  map[string]any `json:"config"`
+	Needs   []string       `json:"needs,omitempty"`
 }
 
 // Stage 是一个阶段(阶段列),含若干 Job。Kind 为 kind 枚举之一。
@@ -364,7 +371,14 @@ func normalizeSpec(in Spec) (Spec, error) {
 				Type:    jobType,
 				Summary: strings.TrimSpace(jb.Summary),
 				Config:  cfg,
+				Needs:   normalizeNeeds(jb.Needs),
 			})
+		}
+
+		// 阶段内 job 依赖校验:引用须为同阶段 job、不自指、不成环(阶段内 job 级 DAG)。
+		// 复用 dag 构造期校验(Kahn 环检测),错误归一为 ErrInvalidJob(不外泄内部细节)。
+		if err := validateJobDAG(jobs); err != nil {
+			return Spec{}, err
 		}
 
 		// Needs 规范化:trim、去空、去重、剔除自指(自指交由 dag 校验报错以给明确信息)。
@@ -453,6 +467,39 @@ func validateStageDAG(stages []Stage) error {
 			return fmt.Errorf("%w: stage dependencies form a cycle", ErrInvalidStage)
 		default:
 			return fmt.Errorf("%w: invalid stage dependencies", ErrInvalidStage)
+		}
+	}
+	return nil
+}
+
+// validateJobDAG 用 dag 包做「阶段内」job 依赖的构造期校验(存在性 + 自指 + 环)。
+// 与 validateStageDAG 同构,但作用域限于单个阶段的 jobs,错误归一为 ErrInvalidJob。
+func validateJobDAG(jobs []Job) error {
+	// 无任何 job 声明 needs → 不构图(向后兼容:阶段内扁平 job 列表无需 DAG 校验)。
+	hasNeeds := false
+	for _, jb := range jobs {
+		if len(jb.Needs) > 0 {
+			hasNeeds = true
+			break
+		}
+	}
+	if !hasNeeds {
+		return nil
+	}
+	nodes := make([]dag.Node, 0, len(jobs))
+	for _, jb := range jobs {
+		nodes = append(nodes, dag.Node{ID: jb.ID, Needs: jb.Needs})
+	}
+	if _, err := dag.New(nodes); err != nil {
+		switch {
+		case errors.Is(err, dag.ErrUnknownDep):
+			return fmt.Errorf("%w: job needs reference an unknown job in the stage", ErrInvalidJob)
+		case errors.Is(err, dag.ErrSelfDep):
+			return fmt.Errorf("%w: job must not depend on itself", ErrInvalidJob)
+		case errors.Is(err, dag.ErrCycle):
+			return fmt.Errorf("%w: job dependencies form a cycle", ErrInvalidJob)
+		default:
+			return fmt.Errorf("%w: invalid job dependencies", ErrInvalidJob)
 		}
 	}
 	return nil

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -198,6 +198,73 @@ func TestSaveInvalidJobType(t *testing.T) {
 	}
 }
 
+// TestSaveValidJobDAG 验证阶段内 job 级依赖(横串竖并):合法 needs 被保存且无损往返。
+func TestSaveValidJobDAG(t *testing.T) {
+	svc, _, projID := newSvc(t)
+	spec := Spec{Stages: []Stage{
+		{Name: "源", Kind: KindSource, Jobs: []Job{{Name: "src", Type: "git_source"}}},
+		{ID: "s_build", Name: "构建", Kind: KindBuild, Jobs: []Job{
+			{ID: "j_fe", Name: "前端构建", Type: "build_frontend"},                               // 无依赖(与 j_be 并行)
+			{ID: "j_be", Name: "后端构建", Type: "build_backend"},                                // 无依赖(与 j_fe 并行)
+			{ID: "j_img", Name: "打镜像", Type: "build_image", Needs: []string{"j_fe", "j_be"}}, // 依赖二者(串行其后)
+		}},
+	}}
+	cfg, err := svc.Save(context.Background(), projID, spec)
+	if err != nil {
+		t.Fatalf("合法 job DAG Save: %v", err)
+	}
+	var img Job
+	for _, jb := range cfg.Spec.Stages[1].Jobs {
+		if jb.ID == "j_img" {
+			img = jb
+		}
+	}
+	if len(img.Needs) != 2 {
+		t.Fatalf("打镜像 needs 应往返保留 2 项, got %v", img.Needs)
+	}
+}
+
+// TestSaveJobSelfDep 验证 job 自指被拒。
+func TestSaveJobSelfDep(t *testing.T) {
+	svc, _, projID := newSvc(t)
+	spec := Spec{Stages: []Stage{
+		{Name: "源", Kind: KindSource, Jobs: []Job{{Name: "src", Type: "git_source"}}},
+		{Name: "构建", Kind: KindBuild, Jobs: []Job{{ID: "j1", Name: "j1", Type: "t", Needs: []string{"j1"}}}},
+	}}
+	if _, err := svc.Save(context.Background(), projID, spec); !errors.Is(err, ErrInvalidJob) {
+		t.Fatalf("job 自指 err = %v, want ErrInvalidJob", err)
+	}
+}
+
+// TestSaveJobCycle 验证 job 依赖成环被拒。
+func TestSaveJobCycle(t *testing.T) {
+	svc, _, projID := newSvc(t)
+	spec := Spec{Stages: []Stage{
+		{Name: "源", Kind: KindSource, Jobs: []Job{{Name: "src", Type: "git_source"}}},
+		{Name: "构建", Kind: KindBuild, Jobs: []Job{
+			{ID: "a", Name: "a", Type: "t", Needs: []string{"b"}},
+			{ID: "b", Name: "b", Type: "t", Needs: []string{"a"}},
+		}},
+	}}
+	if _, err := svc.Save(context.Background(), projID, spec); !errors.Is(err, ErrInvalidJob) {
+		t.Fatalf("job 成环 err = %v, want ErrInvalidJob", err)
+	}
+}
+
+// TestSaveJobUnknownDep 验证 job needs 引用阶段内不存在的 job 被拒(跨阶段引用也算未知)。
+func TestSaveJobUnknownDep(t *testing.T) {
+	svc, _, projID := newSvc(t)
+	spec := Spec{Stages: []Stage{
+		{Name: "源", Kind: KindSource, Jobs: []Job{{Name: "src", Type: "git_source"}}},
+		{Name: "构建", Kind: KindBuild, Jobs: []Job{
+			{ID: "a", Name: "a", Type: "t", Needs: []string{"nonexistent"}},
+		}},
+	}}
+	if _, err := svc.Save(context.Background(), projID, spec); !errors.Is(err, ErrInvalidJob) {
+		t.Fatalf("job 未知依赖 err = %v, want ErrInvalidJob", err)
+	}
+}
+
 func TestSaveDuplicateStageID(t *testing.T) {
 	svc, _, projID := newSvc(t)
 	spec := Spec{Stages: []Stage{

--- a/web/src/api/pipeline.ts
+++ b/web/src/api/pipeline.ts
@@ -24,6 +24,14 @@ export interface PipelineJob {
   summary: string
   /** Arbitrary KV object; free-form in this story, tightened in 2-4/2-6 */
   config: Record<string, string>
+  /**
+   * Intra-stage job-level dependencies: IDs of other jobs *in the same stage* this
+   * job depends on. Canvas semantics — horizontal link = serial (this `needs` that);
+   * jobs with no path between them run in parallel (vertical lanes). Empty/absent =
+   * no intra-stage dependency. The engine schedules a stage's jobs by this DAG and
+   * runs independent jobs concurrently (each in its own isolated workspace).
+   */
+  needs?: string[]
 }
 
 /** Conditional execution rule (Epic 8 · 8-5). Empty = always run. */

--- a/web/src/components/pipeline/JobCard.vue
+++ b/web/src/components/pipeline/JobCard.vue
@@ -9,11 +9,16 @@ defineProps<{
   selected: boolean
   dragging?: boolean
   dragOver?: boolean
+  /** Names of upstream jobs this job depends on (intra-stage DAG); shown as chips. */
+  upstreamNames?: string[]
+  /** True when the stage renders the intra-stage DAG (enables the per-job deps button). */
+  inDag?: boolean
 }>()
 
 const emit = defineEmits<{
   (e: 'select'): void
   (e: 'delete'): void
+  (e: 'edit-deps'): void
   (e: 'dragstart'): void
   (e: 'dragend'): void
   (e: 'dragenter'): void
@@ -23,6 +28,11 @@ const emit = defineEmits<{
 function handleDelete(e: MouseEvent): void {
   e.stopPropagation()
   emit('delete')
+}
+
+function handleEditDeps(e: MouseEvent): void {
+  e.stopPropagation()
+  emit('edit-deps')
 }
 </script>
 
@@ -52,6 +62,18 @@ function handleDelete(e: MouseEvent): void {
       <JobTypeIcon :type="job.type" :size="24" />
       <span class="job-name">{{ job.name }}</span>
       <button
+        v-if="inDag"
+        class="job-card-del job-card-deps"
+        :aria-label="`编辑任务 ${job.name} 的依赖`"
+        title="编辑依赖(决定与哪些任务串行/并行)"
+        @click="handleEditDeps"
+      >
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <circle cx="6" cy="6" r="2.4"/><circle cx="6" cy="18" r="2.4"/><circle cx="18" cy="12" r="2.4"/>
+          <path d="M8 6.6c5 0 3 5.4 8 5.4M8 17.4c5 0 3-5.4 8-5.4"/>
+        </svg>
+      </button>
+      <button
         class="job-card-del"
         :aria-label="`删除任务 ${job.name}`"
         title="删除此任务"
@@ -64,6 +86,10 @@ function handleDelete(e: MouseEvent): void {
     </div>
     <div class="job-card-type">{{ jobTypeLabel(job.type) }}</div>
     <div v-if="job.summary" class="job-summary">{{ job.summary }}</div>
+    <div v-if="upstreamNames && upstreamNames.length" class="job-up-chips" aria-label="上游依赖任务">
+      <span class="job-up-arrow" aria-hidden="true">⟵</span>
+      <span v-for="n in upstreamNames" :key="n" class="job-up-chip">{{ n }}</span>
+    </div>
   </div>
 </template>
 
@@ -92,5 +118,30 @@ function handleDelete(e: MouseEvent): void {
 .job-card--dragover {
   border-color: var(--color-primary);
   box-shadow: 0 -2px 0 0 var(--color-primary);
+}
+
+/* deps button sits left of delete; reuse job-card-del sizing/hover */
+.job-card-deps { color: var(--color-faint); }
+.job-card-deps:hover { color: var(--color-primary); }
+
+.job-up-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  margin-top: 7px;
+}
+.job-up-arrow { color: var(--color-faint); font-size: 0.72rem; }
+.job-up-chip {
+  font-size: 0.64rem;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 7px;
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 </style>

--- a/web/src/components/pipeline/PipelineCanvas.vue
+++ b/web/src/components/pipeline/PipelineCanvas.vue
@@ -106,7 +106,15 @@ function deleteJob(stageId: string, jobId: string): void {
   if (selectedJobId.value === jobId) selectedJobId.value = null
   const next = props.stages.map((s) => {
     if (s.id !== stageId) return s
-    return { ...s, jobs: s.jobs.filter((j) => j.id !== jobId) }
+    // Drop the job and strip any sibling job needs referencing it (else save 422s).
+    return {
+      ...s,
+      jobs: s.jobs
+        .filter((j) => j.id !== jobId)
+        .map((j) =>
+          j.needs?.includes(jobId) ? { ...j, needs: j.needs.filter((n) => n !== jobId) } : j,
+        ),
+    }
   })
   emit('update', next)
 }
@@ -119,13 +127,15 @@ interface PickerState {
   stageId: string
   jobId: string
   current: string
+  /** Intra-stage deps to seed on the new job (serial/parallel add); empty = orphan. */
+  needs: string[]
 }
 
-const picker = ref<PickerState>({ open: false, mode: 'add', stageId: '', jobId: '', current: '' })
+const picker = ref<PickerState>({ open: false, mode: 'add', stageId: '', jobId: '', current: '', needs: [] })
 
-/** Open the type picker to add a new job to a stage. */
-function requestAddJob(stageId: string): void {
-  picker.value = { open: true, mode: 'add', stageId, jobId: '', current: '' }
+/** Open the type picker to add a new job to a stage. `needs` seeds intra-stage deps. */
+function requestAddJob(stageId: string, needs: string[] = []): void {
+  picker.value = { open: true, mode: 'add', stageId, jobId: '', current: '', needs }
 }
 
 /** Open the type picker to change the selected job's type (from the drawer). */
@@ -137,6 +147,7 @@ function requestChangeType(): void {
     stageId: selectedStage.value.id,
     jobId: selectedJob.value.id,
     current: selectedJob.value.type,
+    needs: [],
   }
 }
 
@@ -156,6 +167,7 @@ function onPickerSelect(type: string): void {
       summary: '',
       // 模板节点带预填配置(深拷贝避免共享引用);普通节点空配置。
       config:  { ...(getJobTypeSpec(type)?.defaultConfig ?? {}) },
+      ...(p.needs.length ? { needs: [...p.needs] } : {}),
     }
     addJobToStage(p.stageId, newJob)
   } else {
@@ -184,6 +196,7 @@ function onPickerSelectCustom(node: CustomNode): void {
       type:    node.nodeType,
       summary: node.summary ?? '',
       config,
+      ...(p.needs.length ? { needs: [...p.needs] } : {}),
     }
     addJobToStage(p.stageId, newJob)
   } else {
@@ -339,12 +352,13 @@ function handleDrawerUpdate(patch: Partial<PipelineJob>): void {
             role="listitem"
             @select-job="selectJob"
             @delete-job="(jobId) => deleteJob(stage.id, jobId)"
-            @add-job="requestAddJob(stage.id)"
+            @add-job="(needs) => requestAddJob(stage.id, needs)"
             @delete-stage="deleteStage(stage.id)"
             @reorder-job="(p) => reorderJob(stage.id, p.from, p.to)"
             :settings-active="selectedStageSettingsId === stage.id"
             @update-needs="(needs) => updateStage(stage.id, { needs })"
             @update-allow-failure="(v) => updateStage(stage.id, { allowFailure: v })"
+            @update-job-needs="(p) => updateJob(stage.id, p.jobId, { needs: p.needs })"
             @open-settings="openStageSettings(stage.id)"
           />
         </template>

--- a/web/src/components/pipeline/StageColumn.vue
+++ b/web/src/components/pipeline/StageColumn.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
-import type { PipelineStage } from '../../api/pipeline'
+import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
+import type { PipelineStage, PipelineJob } from '../../api/pipeline'
 import JobCard from './JobCard.vue'
 import { eligibleNeeds, toggleNeed } from './stageDeps'
+import { hasAnyJobNeeds, layoutJobs, eligibleJobNeeds } from './jobDeps'
 import {
   hasWhen,
   whenSummary,
@@ -27,11 +28,14 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'select-job', jobId: string): void
   (e: 'delete-job', jobId: string): void
-  (e: 'add-job'): void
+  /** Add a job to this stage; optional `needs` seeds its intra-stage dependencies. */
+  (e: 'add-job', needs?: string[]): void
   (e: 'delete-stage'): void
   (e: 'reorder-job', payload: { from: number; to: number }): void
   (e: 'update-needs', needs: string[]): void
   (e: 'update-allow-failure', value: boolean): void
+  /** Update one job's intra-stage dependencies (横串竖并). */
+  (e: 'update-job-needs', payload: { jobId: string; needs: string[] }): void
   /** Open this stage's settings in the shared right-side drawer (条件/审批门/矩阵/服务/后置). */
   (e: 'open-settings'): void
 }>()
@@ -61,6 +65,112 @@ function toggleDep(needId: string): void {
   emit('update-needs', toggleNeed(currentNeeds.value, needId))
 }
 
+// ─── Intra-stage job DAG (横串竖并) ───────────────────────────────────────────
+// 阶段内任一 job 声明 needs → 渲染二维 DAG(横=串行连线、纵=并行并排);否则纵向列表(原样)。
+
+const useDag = computed(() => hasAnyJobNeeds(props.stage.jobs))
+const layout = computed(() => layoutJobs(props.stage.jobs))
+
+/** jobId → 其上游 job 名(卡片上展示 chip)。 */
+const upstreamNamesByJob = computed<Record<string, string[]>>(() => {
+  const byId = new Map(props.stage.jobs.map((j) => [j.id, j.name]))
+  const out: Record<string, string[]> = {}
+  for (const j of props.stage.jobs) {
+    if (j.needs && j.needs.length) out[j.id] = j.needs.map((n) => byId.get(n) ?? n)
+  }
+  return out
+})
+
+/** 加节点的锚点:优先当前选中(且属本阶段)的 job,否则取声明序最后一个。 */
+const anchorJob = computed<PipelineJob | null>(() => {
+  const sel = props.stage.jobs.find((j) => j.id === props.selectedJobId)
+  if (sel) return sel
+  return props.stage.jobs.length ? props.stage.jobs[props.stage.jobs.length - 1] : null
+})
+
+function addPlain(): void {
+  emit('add-job', [])
+}
+/** 串行节点:依赖锚点 job(出现在其右侧,串行其后)。 */
+function addSerial(): void {
+  emit('add-job', anchorJob.value ? [anchorJob.value.id] : [])
+}
+/** 并行节点:与锚点 job 同上游(出现在同一 rank 的并行车道)。 */
+function addParallel(): void {
+  emit('add-job', anchorJob.value ? [...(anchorJob.value.needs ?? [])] : [])
+}
+
+// ─── Per-job dependency editor (popover) ──────────────────────────────────────
+
+const jobDepsForId = ref<string | null>(null)
+const jobDepsJob = computed<PipelineJob | null>(
+  () => props.stage.jobs.find((j) => j.id === jobDepsForId.value) ?? null,
+)
+const jobDepChoices = computed<PipelineJob[]>(() =>
+  jobDepsJob.value ? eligibleJobNeeds(props.stage.jobs, jobDepsJob.value.id) : [],
+)
+
+function openJobDeps(jobId: string): void {
+  jobDepsForId.value = jobDepsForId.value === jobId ? null : jobId
+}
+function toggleJobDep(needId: string): void {
+  const job = jobDepsJob.value
+  if (!job) return
+  emit('update-job-needs', { jobId: job.id, needs: toggleNeed(job.needs ?? [], needId) })
+}
+
+// ─── Intra-stage edge overlay (SVG connectors, 横向串行) ───────────────────────
+
+const dagRef = ref<HTMLElement | null>(null)
+const dagOverlay = ref({ w: 0, h: 0 })
+const dagPaths = ref<string[]>([])
+
+function measureEdges(): void {
+  const root = dagRef.value
+  if (!root) {
+    dagPaths.value = []
+    return
+  }
+  const nodes = new Map<string, HTMLElement>()
+  root.querySelectorAll<HTMLElement>('.job-node').forEach((el) => {
+    const id = el.dataset.jobId
+    if (id) nodes.set(id, el)
+  })
+  dagOverlay.value = { w: root.scrollWidth, h: root.scrollHeight }
+  const paths: string[] = []
+  for (const j of props.stage.jobs) {
+    for (const need of j.needs ?? []) {
+      const a = nodes.get(need)
+      const b = nodes.get(j.id)
+      if (!a || !b) continue
+      const x1 = a.offsetLeft + a.offsetWidth
+      const y1 = a.offsetTop + a.offsetHeight / 2
+      const x2 = b.offsetLeft
+      const y2 = b.offsetTop + b.offsetHeight / 2
+      const dx = Math.max(18, Math.abs(x2 - x1) * 0.5)
+      paths.push(`M${x1},${y1} C${x1 + dx},${y1} ${x2 - dx},${y2} ${x2},${y2}`)
+    }
+  }
+  dagPaths.value = paths
+}
+
+let ro: ResizeObserver | null = null
+function remeasure(): void {
+  void nextTick(measureEdges)
+}
+onMounted(() => {
+  ro = new ResizeObserver(() => measureEdges())
+  if (dagRef.value) ro.observe(dagRef.value)
+  remeasure()
+})
+onBeforeUnmount(() => ro?.disconnect())
+watch(dagRef, (el) => {
+  ro?.disconnect()
+  if (el && ro) ro.observe(el)
+  remeasure()
+})
+watch(() => props.stage.jobs, remeasure, { deep: true })
+
 // ─── Stage rule chips (when 条件 / gate 审批门 / matrix / services / post) ──────
 // 编辑全部下沉到右侧 StageDrawer(复用 JobDrawer 卡片骨架);此处只渲染汇总 chip。
 
@@ -79,7 +189,7 @@ const postChip = computed(() => postSummary(props.stage.post))
 const servicesChip = computed(() => servicesSummary(props.stage.services))
 const matrixChip = computed(() => matrixSummary(props.stage.matrix))
 
-// ─── Drag-to-reorder (within this stage) ──────────────────────────────────────
+// ─── Drag-to-reorder (within this stage; flat-list mode only) ──────────────────
 
 const dragFrom = ref<number | null>(null)
 const dragOver = ref<number | null>(null)
@@ -105,7 +215,7 @@ function resetDrag(): void {
 </script>
 
 <template>
-  <div class="stage-col">
+  <div class="stage-col" :class="{ 'stage-col--dag': useDag }">
     <!-- Stage header -->
     <div class="stage-header">
       <span class="stage-index" aria-hidden="true">{{ stageLabel(stageIndex) }}</span>
@@ -144,7 +254,7 @@ function resetDrag(): void {
         v-if="stage.kind !== 'source'"
         class="stage-add-job"
         :aria-label="`在阶段 ${stage.name} 中添加任务`"
-        @click="emit('add-job')"
+        @click="addPlain"
       >+ 任务</button>
       <button
         v-if="stage.kind !== 'source'"
@@ -190,7 +300,7 @@ function resetDrag(): void {
       </span>
     </div>
 
-    <!-- Dependency editor popover -->
+    <!-- Stage dependency editor popover -->
     <div v-if="depsOpen && stage.kind !== 'source'" class="deps-popover" role="group" aria-label="阶段依赖编辑">
       <div class="deps-popover-title">依赖的上游阶段</div>
       <p v-if="depChoices.length === 0" class="deps-empty">没有可选的上游阶段</p>
@@ -214,36 +324,109 @@ function resetDrag(): void {
       <p class="deps-hint">留空 = 无显式依赖;全流水线无依赖时按从左到右线性执行</p>
     </div>
 
-    <!-- Job cards -->
-    <JobCard
-      v-for="(job, i) in stage.jobs"
-      :key="job.id"
-      :job="job"
-      :stage-kind="stage.kind"
-      :selected="job.id === selectedJobId"
-      :dragging="dragFrom === i"
-      :drag-over="dragOver === i && dragFrom !== i"
-      @select="emit('select-job', job.id)"
-      @delete="emit('delete-job', job.id)"
-      @dragstart="onDragStart(i)"
-      @dragend="resetDrag"
-      @dragenter="onDragEnter(i)"
-      @drop="onDrop(i)"
-    />
+    <!-- Per-job dependency editor popover (横串竖并) -->
+    <div v-if="jobDepsJob" class="deps-popover deps-popover--job" role="group" :aria-label="`任务 ${jobDepsJob.name} 的依赖`">
+      <div class="deps-popover-title">「{{ jobDepsJob.name }}」依赖的上游任务</div>
+      <p v-if="jobDepChoices.length === 0" class="deps-empty">本阶段没有其他可选任务</p>
+      <label v-for="opt in jobDepChoices" :key="opt.id" class="deps-option">
+        <input
+          type="checkbox"
+          :checked="(jobDepsJob.needs ?? []).includes(opt.id)"
+          @change="toggleJobDep(opt.id)"
+        />
+        <span>{{ opt.name }}</span>
+      </label>
+      <p class="deps-hint">勾选 = 串行(本任务排在其后);不勾任何项 = 与其并行</p>
+      <button class="deps-done" @click="jobDepsForId = null">完成</button>
+    </div>
 
-    <!-- Add job trigger (source stage has no add-job since it's preset) -->
-    <button
-      v-if="stage.kind !== 'source'"
-      class="add-job-btn"
-      :aria-label="`在阶段 ${stage.name} 末尾添加任务`"
-      @click="emit('add-job')"
-    >+ 添加任务</button>
+    <!-- Job cards — 2-D DAG (横串竖并) when this stage declares any job needs -->
+    <div
+      v-if="useDag"
+      ref="dagRef"
+      class="job-dag"
+      :style="{ '--ranks': layout.ranks }"
+      aria-label="阶段内任务依赖图"
+    >
+      <svg
+        v-if="dagPaths.length"
+        class="job-dag-overlay"
+        :width="dagOverlay.w"
+        :height="dagOverlay.h"
+        :viewBox="`0 0 ${dagOverlay.w} ${dagOverlay.h}`"
+        aria-hidden="true"
+      >
+        <path v-for="(d, i) in dagPaths" :key="i" class="job-edge" :d="d" />
+        <path v-for="(d, i) in dagPaths" :key="`f${i}`" class="job-edge-flow" :d="d" />
+      </svg>
+      <div
+        v-for="job in stage.jobs"
+        :key="job.id"
+        class="job-node"
+        :data-job-id="job.id"
+        :style="{
+          gridColumn: (layout.positions.get(job.id)?.rank ?? 0) + 1,
+          gridRow: (layout.positions.get(job.id)?.lane ?? 0) + 1,
+        }"
+      >
+        <JobCard
+          :job="job"
+          :stage-kind="stage.kind"
+          :selected="job.id === selectedJobId"
+          :in-dag="true"
+          :upstream-names="upstreamNamesByJob[job.id]"
+          @select="emit('select-job', job.id)"
+          @delete="emit('delete-job', job.id)"
+          @edit-deps="openJobDeps(job.id)"
+        />
+      </div>
+    </div>
+
+    <!-- Job cards — flat vertical list (no intra-stage deps; original behavior) -->
+    <template v-else>
+      <JobCard
+        v-for="(job, i) in stage.jobs"
+        :key="job.id"
+        :job="job"
+        :stage-kind="stage.kind"
+        :selected="job.id === selectedJobId"
+        :dragging="dragFrom === i"
+        :drag-over="dragOver === i && dragFrom !== i"
+        @select="emit('select-job', job.id)"
+        @delete="emit('delete-job', job.id)"
+        @dragstart="onDragStart(i)"
+        @dragend="resetDrag"
+        @dragenter="onDragEnter(i)"
+        @drop="onDrop(i)"
+      />
+    </template>
+
+    <!-- Add-job triggers: plain / serial(→) / parallel(↓) (source stage is preset) -->
+    <div v-if="stage.kind !== 'source'" class="add-job-row">
+      <button
+        class="add-job-btn add-job-btn--serial"
+        :aria-label="`在阶段 ${stage.name} 加一个串行任务(依赖上一个)`"
+        title="串行节点:排在锚点任务之后(横向连线)"
+        @click="addSerial"
+      >+ 串行节点</button>
+      <button
+        class="add-job-btn add-job-btn--parallel"
+        :aria-label="`在阶段 ${stage.name} 加一个并行任务`"
+        title="并行节点:与锚点任务并行(纵向并排)"
+        @click="addParallel"
+      >+ 并行节点</button>
+    </div>
   </div>
 </template>
 
 <style scoped>
 .stage-col {
   position: relative;
+}
+
+/* DAG mode: let the column grow horizontally to fit the rank grid. */
+.stage-col--dag {
+  width: auto;
 }
 
 .stage-name-text {
@@ -316,6 +499,7 @@ function resetDrag(): void {
   border-radius: var(--rounded);
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.22);
 }
+.deps-popover--job { z-index: 41; }
 .deps-popover-title {
   font-size: 0.7rem;
   font-weight: 600;
@@ -338,6 +522,77 @@ function resetDrag(): void {
 .deps-option--toggle { color: var(--color-dim); }
 .deps-divider { height: 1px; background: var(--color-border); margin: 8px 0; }
 .deps-hint { margin: 7px 0 0; font-size: 0.68rem; color: var(--color-faint); line-height: 1.4; }
+.deps-done {
+  margin-top: 9px;
+  width: 100%;
+  height: 26px;
+  border: none;
+  border-radius: var(--rounded-md);
+  background: var(--color-primary);
+  color: #fff;
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.deps-done:hover { filter: brightness(1.06); }
+
+/* ─── Intra-stage job DAG grid (横=rank/串行, 纵=lane/并行)──────────────────── */
+.job-dag {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(var(--ranks, 1), 200px);
+  grid-auto-rows: min-content;
+  column-gap: 54px;
+  row-gap: 12px;
+  align-items: start;
+  width: max-content;
+  padding-bottom: 4px;
+}
+.job-node {
+  width: 200px;
+  position: relative;
+  z-index: 1;
+}
+/* grid handles vertical rhythm; drop the list margin inside the DAG */
+.job-dag :deep(.job-card) { margin-bottom: 0; }
+
+.job-dag-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  overflow: visible;
+}
+.job-edge {
+  fill: none;
+  stroke: var(--color-border-strong);
+  stroke-width: 2;
+}
+.job-edge-flow {
+  fill: none;
+  stroke: var(--color-primary);
+  stroke-width: 2;
+  stroke-dasharray: 5 12;
+  opacity: 0.75;
+  animation: job-dag-flow 1.4s linear infinite;
+}
+@keyframes job-dag-flow {
+  to { stroke-dashoffset: -34; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .job-edge-flow { animation: none; }
+}
+
+/* ─── Add-job row (serial / parallel) ─────────────────────────────────────── */
+.add-job-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+.add-job-row .add-job-btn { width: auto; flex: 1; }
+.add-job-btn--serial { /* horizontal serial accent */ }
+.add-job-btn--parallel { /* vertical parallel accent */ }
 
 /* ─── Condition / gate chips ──────────────────────────────────────────────── */
 .stage-deps-count--dot {

--- a/web/src/components/pipeline/jobDeps.test.ts
+++ b/web/src/components/pipeline/jobDeps.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import type { PipelineJob } from '../../api/pipeline'
+import {
+  jobDependsOn,
+  canAddJobNeed,
+  eligibleJobNeeds,
+  hasAnyJobNeeds,
+  layoutJobs,
+} from './jobDeps'
+
+function job(id: string, needs: string[] = []): PipelineJob {
+  return { id, name: id.toUpperCase(), type: 'script', summary: '', config: {}, needs }
+}
+
+describe('jobDeps', () => {
+  // A, B parallel roots; C needs both (serial after A and B)
+  const fan: PipelineJob[] = [job('A'), job('B'), job('C', ['A', 'B'])]
+
+  describe('jobDependsOn', () => {
+    it('finds direct and transitive deps', () => {
+      const chain = [job('A'), job('B', ['A']), job('C', ['B'])]
+      expect(jobDependsOn(chain, 'C', 'B')).toBe(true)
+      expect(jobDependsOn(chain, 'C', 'A')).toBe(true) // transitive
+    })
+    it('is directional', () => {
+      expect(jobDependsOn(fan, 'A', 'C')).toBe(false)
+      expect(jobDependsOn(fan, 'C', 'A')).toBe(true)
+    })
+  })
+
+  describe('canAddJobNeed', () => {
+    it('rejects self and cycle-closing edges', () => {
+      expect(canAddJobNeed(fan, 'A', 'A')).toBe(false)
+      // C depends on A; making A need C would cycle.
+      expect(canAddJobNeed(fan, 'A', 'C')).toBe(false)
+    })
+    it('allows safe edges', () => {
+      expect(canAddJobNeed(fan, 'C', 'A')).toBe(true)
+      expect(canAddJobNeed(fan, 'B', 'A')).toBe(true)
+    })
+  })
+
+  describe('eligibleJobNeeds', () => {
+    it('excludes self and cycle-creating jobs', () => {
+      const ids = eligibleJobNeeds(fan, 'A').map((j) => j.id)
+      expect(ids).toContain('B')
+      expect(ids).not.toContain('A') // self
+      expect(ids).not.toContain('C') // would cycle (C needs A)
+    })
+  })
+
+  describe('hasAnyJobNeeds', () => {
+    it('detects intra-stage deps', () => {
+      expect(hasAnyJobNeeds(fan)).toBe(true)
+      expect(hasAnyJobNeeds([job('A'), job('B')])).toBe(false)
+    })
+  })
+
+  describe('layoutJobs', () => {
+    it('ranks serial chains horizontally, parallel jobs into lanes', () => {
+      const { positions, ranks, lanes } = layoutJobs(fan)
+      expect(positions.get('A')?.rank).toBe(0)
+      expect(positions.get('B')?.rank).toBe(0)
+      expect(positions.get('C')?.rank).toBe(1) // after A & B
+      // A and B share rank 0 → different lanes (parallel)
+      expect(positions.get('A')?.lane).not.toBe(positions.get('B')?.lane)
+      expect(ranks).toBe(2)
+      expect(lanes).toBe(2) // rank 0 has two lanes
+    })
+    it('handles a flat list (all roots) as a single rank', () => {
+      const { ranks, lanes } = layoutJobs([job('A'), job('B'), job('C')])
+      expect(ranks).toBe(1)
+      expect(lanes).toBe(3)
+    })
+    it('ignores needs referencing jobs outside the stage (defensive)', () => {
+      const { positions, ranks } = layoutJobs([job('A', ['ghost'])])
+      expect(positions.get('A')?.rank).toBe(0)
+      expect(ranks).toBe(1)
+    })
+  })
+})

--- a/web/src/components/pipeline/jobDeps.ts
+++ b/web/src/components/pipeline/jobDeps.ts
@@ -1,0 +1,113 @@
+/**
+ * jobDeps — pure helpers for editing *intra-stage* job-level dependencies.
+ *
+ * Mirrors stageDeps but operates within a single stage's job list. A job's `needs`
+ * lists IDs of other jobs *in the same stage* that must finish first. Canvas semantics:
+ *   - horizontal link = serial (this job `needs` that job)
+ *   - jobs with no path between them sit in parallel lanes (vertical) and run concurrently
+ *
+ * The backend re-validates the job DAG (dag.New) on save, so these are UX guardrails,
+ * not the source of truth. Edge direction: `J needs N` means N is upstream of J.
+ */
+
+import type { PipelineJob } from '../../api/pipeline'
+import { toggleNeed } from './stageDeps'
+
+export { toggleNeed }
+
+/** Does `fromId` (transitively) depend on `targetId` via job needs edges? */
+export function jobDependsOn(
+  jobs: ReadonlyArray<PipelineJob>,
+  fromId: string,
+  targetId: string,
+): boolean {
+  const byId = new Map(jobs.map((j) => [j.id, j]))
+  const seen = new Set<string>()
+  const stack: string[] = [...(byId.get(fromId)?.needs ?? [])]
+  while (stack.length) {
+    const id = stack.pop() as string
+    if (id === targetId) return true
+    if (seen.has(id)) continue
+    seen.add(id)
+    const node = byId.get(id)
+    if (node?.needs) stack.push(...node.needs)
+  }
+  return false
+}
+
+/**
+ * Is it safe to add `needId` to `jobId.needs`? Safe iff a different job in the same
+ * stage and `needId` does not already (transitively) depend on `jobId` (would cycle).
+ */
+export function canAddJobNeed(
+  jobs: ReadonlyArray<PipelineJob>,
+  jobId: string,
+  needId: string,
+): boolean {
+  if (jobId === needId) return false
+  return !jobDependsOn(jobs, needId, jobId)
+}
+
+/** Jobs eligible to be an upstream dependency of `jobId` (every other cycle-safe job). */
+export function eligibleJobNeeds(
+  jobs: ReadonlyArray<PipelineJob>,
+  jobId: string,
+): PipelineJob[] {
+  return jobs.filter((j) => j.id !== jobId && !jobDependsOn(jobs, j.id, jobId))
+}
+
+/** Does this stage declare any intra-stage job dependency? (false ⇒ flat vertical list) */
+export function hasAnyJobNeeds(jobs: ReadonlyArray<PipelineJob>): boolean {
+  return jobs.some((j) => (j.needs?.length ?? 0) > 0)
+}
+
+/** One job's grid position in the intra-stage DAG: rank = serial depth (x), lane = parallel slot (y). */
+export interface JobLayout {
+  id: string
+  rank: number
+  lane: number
+}
+
+/**
+ * Compute a 2-D grid layout for a stage's jobs from their needs DAG:
+ *   - rank = longest dependency depth (root jobs with no in-stage needs → 0); maps to X (serial →)
+ *   - lane = slot among jobs sharing a rank, in declaration order; maps to Y (parallel ↓)
+ *
+ * needs referencing jobs outside the list are ignored (defensive). A cycle (should never
+ * reach here — validated on save) is broken by treating a re-entered node as rank 0.
+ */
+export function layoutJobs(jobs: ReadonlyArray<PipelineJob>): {
+  positions: Map<string, JobLayout>
+  ranks: number
+  lanes: number
+} {
+  const byId = new Map(jobs.map((j) => [j.id, j]))
+  const rankCache = new Map<string, number>()
+  const computing = new Set<string>()
+  const rankOf = (id: string): number => {
+    const cached = rankCache.get(id)
+    if (cached !== undefined) return cached
+    if (computing.has(id)) return 0 // cycle guard (defensive)
+    computing.add(id)
+    const deps = (byId.get(id)?.needs ?? []).filter((n) => byId.has(n))
+    let r = 0
+    for (const d of deps) r = Math.max(r, rankOf(d) + 1)
+    computing.delete(id)
+    rankCache.set(id, r)
+    return r
+  }
+
+  const positions = new Map<string, JobLayout>()
+  const laneNext = new Map<number, number>() // rank → next free lane
+  let ranks = 0
+  for (const j of jobs) {
+    const rank = rankOf(j.id)
+    const lane = laneNext.get(rank) ?? 0
+    laneNext.set(rank, lane + 1)
+    positions.set(j.id, { id: j.id, rank, lane })
+    ranks = Math.max(ranks, rank + 1)
+  }
+  let lanes = 1
+  for (const n of laneNext.values()) lanes = Math.max(lanes, n)
+  return { positions, ranks, lanes }
+}


### PR DESCRIPTION
## 背景
此前一个阶段内的多个 job 是扁平列表、按类型分组**串行**执行,画布上纵向堆叠不表达任何并行/串行语义(如「后端镜像」「推送镜像」竖排却实际串行)。本功能让阶段内 job 之间可声明依赖,构成**阶段内 DAG**:

- 画布**横向连线 = 串行**(依赖),**纵向并排 = 并行**(无依赖)
- 无依赖的 job 在引擎里**真并发执行**(各自独立工作区)

## 后端
- `pipeline.Job` 加 `Needs []string`;保存期校验阶段内 job DAG(引用须同阶段、不自指、不成环),复用 `dag.New` 环检测,错误归一 `ErrInvalidJob`。
- `dag_stage_exec.go`:阶段任一 job 声明 `needs` → 走新调度路径,复用 `dag.Graph.Schedule`(与阶段级调度同一内核)按 job DAG 并发调度(无依赖 job 并行 + 信号量限流),**每个 job 独立克隆工作区**保并发安全,env 沿 `needs` 边合并传递,产物逐 job 归档;无 job needs 的阶段保持既有「类型分组串行」(**零回归**)。`push_image` 仍折叠进 `build_image`。
- httpapi:`jobDTO` / `reqJob` 双向映射加 `needs`。

## 前端
- `PipelineJob` 加 `needs`;新建 `jobDeps.ts`(防环 + 二维布局:rank=串行/横,lane=并行/竖)。
- `StageColumn` 在阶段有 job needs 时渲染二维 DAG(CSS grid + SVG 贝塞尔连线,复用 `measureEdges` 思路),加「+串行节点 / +并行节点」入口与每节点依赖编辑 popover;否则保持纵向列表。
- `JobCard` 加依赖入口 + 上游 chip;删 job 时剥离悬挂依赖。

## 测试
- pipeline 4 例(合法往返 / 自指 / 成环 / 未知依赖)
- 引擎 2 例(**-race**:顺序遵守依赖 / 失败传播跳过下游)
- httpapi `needs` 往返 1 例
- 前端 `jobDeps` 9 例
- 全量 `go test ./...`、`vue-tsc`、`eslint`、`vitest`(308)绿;真 docker e2e 演示环境实测加节点 + 连线 + 保存往返。

🤖 Generated with [Claude Code](https://claude.com/claude-code)