### PR TITLE
feat: 通知(飞书/节点模板)· 运行详情节点级 · AI 生成增强 · 画布/诊断 UX

### DIFF
--- a/internal/ai/analyze.go
+++ b/internal/ai/analyze.go
@@ -133,59 +133,113 @@ func (a goGitAnalyzer) Analyze(ctx context.Context, repoURL, token string) RepoA
 	return analysis
 }
 
-// detectStack 读 memfs 工作区根的 manifest 文件,推断语言/版本/构建工具/产物。
-// 顺序:Dockerfile(产物提示)→ node → go → java → python;首个命中确定主语言,
-// 但 Dockerfile 与产物类型可叠加。Signals 累积所有证据。
+// scanDepth 是 manifest 探测下钻的最大目录层数(根=0)。monorepo(如 backend/ + frontend/)
+// 的项目文件常在子目录,只扫根会「未识别」;下钻 2 层覆盖常见单层/双层子项目布局。
+const scanDepth = 2
+
+// scanSkipDirs 是探测时跳过的噪声目录(依赖/产物/VCS;避免误判 + 限制扫描量)。
+var scanSkipDirs = map[string]bool{
+	"node_modules": true, "target": true, "dist": true, "build": true,
+	"vendor": true, "out": true, "bin": true, "venv": true, "__pycache__": true,
+}
+
+// detectStack 推断语言/版本/构建工具/产物。先扫工作区根,根无 manifest 时下钻子目录
+// (monorepo 友好:backend/pom.xml、frontend/package.json 等)。顺序:Dockerfile(产物提示)
+// → node → go → java → python;**首个命中**确定主语言,但**所有命中**都进 Signals(含子目录
+// 路径),让 monorepo 的多技术栈都暴露给 LLM。
 func detectStack(fs billy.Filesystem) RepoAnalysis {
 	res := RepoAnalysis{Signals: []string{}}
 
-	hasDockerfile := fileExists(fs, "Dockerfile")
-	if hasDockerfile {
+	if dir, ok := findFileDir(fs, "Dockerfile", scanDepth); ok {
 		res.HasDockerfile = true
-		res.Signals = append(res.Signals, "Dockerfile")
+		res.Signals = append(res.Signals, sigName("Dockerfile", dir))
 	}
 
-	switch {
-	case fileExists(fs, "package.json"):
-		res.Language = langNode
-		res.BuildTool = "npm"
-		res.ArtifactHint = artifactFor(langNode, hasDockerfile)
-		res.Signals = append(res.Signals, "package.json")
-		if v := detectNodeVersion(fs); v != "" {
-			res.LanguageVersion = v
+	type spec struct{ file, lang, tool string }
+	specs := []spec{
+		{"package.json", langNode, "npm"},
+		{"go.mod", langGo, "go"},
+		{"pom.xml", langJava, "maven"},
+		{"build.gradle", langJava, "gradle"},
+		{"build.gradle.kts", langJava, "gradle"},
+		{"requirements.txt", langPython, "pip"},
+		{"pyproject.toml", langPython, "pip"},
+	}
+	for _, sp := range specs {
+		dir, ok := findFileDir(fs, sp.file, scanDepth)
+		if !ok {
+			continue
 		}
-	case fileExists(fs, "go.mod"):
-		res.Language = langGo
-		res.BuildTool = "go"
-		res.ArtifactHint = artifactFor(langGo, hasDockerfile)
-		res.Signals = append(res.Signals, "go.mod")
-		if v := detectGoVersion(fs); v != "" {
-			res.LanguageVersion = v
-			res.Signals = append(res.Signals, "go "+v)
+		res.Signals = append(res.Signals, sigName(sp.file, dir))
+		if res.Language != "" {
+			continue // 主语言已定;其余命中仅作附加信号(monorepo 多栈)
 		}
-	case fileExists(fs, "pom.xml"):
-		res.Language = langJava
-		res.BuildTool = "maven"
-		res.ArtifactHint = artifactFor(langJava, hasDockerfile)
-		res.Signals = append(res.Signals, "pom.xml")
-	case fileExists(fs, "build.gradle") || fileExists(fs, "build.gradle.kts"):
-		res.Language = langJava
-		res.BuildTool = "gradle"
-		res.ArtifactHint = artifactFor(langJava, hasDockerfile)
-		res.Signals = append(res.Signals, "build.gradle")
-	case fileExists(fs, "requirements.txt"):
-		res.Language = langPython
-		res.BuildTool = "pip"
-		res.ArtifactHint = artifactFor(langPython, hasDockerfile)
-		res.Signals = append(res.Signals, "requirements.txt")
-	case fileExists(fs, "pyproject.toml"):
-		res.Language = langPython
-		res.BuildTool = "pip"
-		res.ArtifactHint = artifactFor(langPython, hasDockerfile)
-		res.Signals = append(res.Signals, "pyproject.toml")
+		res.Language = sp.lang
+		res.BuildTool = sp.tool
+		res.ArtifactHint = artifactFor(sp.lang, res.HasDockerfile)
+		sub := fs
+		if dir != "" {
+			if c, cerr := fs.Chroot(dir); cerr == nil {
+				sub = c
+			}
+		}
+		switch sp.lang {
+		case langNode:
+			if v := detectNodeVersion(sub); v != "" {
+				res.LanguageVersion = v
+			}
+		case langGo:
+			if v := detectGoVersion(sub); v != "" {
+				res.LanguageVersion = v
+				res.Signals = append(res.Signals, "go "+v)
+			}
+		}
 	}
 
 	return res
+}
+
+// findFileDir 在工作区根及子目录(限 maxDepth 层、跳过噪声目录)按 BFS 查找名为 name 的文件,
+// 返回其所在目录(根 = "")与是否命中。BFS 保证「根命中优先于子目录」(存量单体项目行为不变)。
+func findFileDir(fs billy.Filesystem, name string, maxDepth int) (string, bool) {
+	type node struct {
+		dir   string
+		depth int
+	}
+	queue := []node{{"", 0}}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		if fileExists(fs, sigName(name, cur.dir)) {
+			return cur.dir, true
+		}
+		if cur.depth >= maxDepth {
+			continue
+		}
+		entries, err := fs.ReadDir(cur.dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			n := e.Name()
+			if scanSkipDirs[n] || strings.HasPrefix(n, ".") {
+				continue
+			}
+			queue = append(queue, node{sigName(n, cur.dir), cur.depth + 1})
+		}
+	}
+	return "", false
+}
+
+// sigName 把目录前缀与文件名拼成路径(根目录 → 文件名本身)。
+func sigName(name, dir string) string {
+	if dir == "" {
+		return name
+	}
+	return dir + "/" + name
 }
 
 // artifactFor 由语言 + 是否有 Dockerfile 推断产物类型提示。

--- a/internal/ai/analyze_test.go
+++ b/internal/ai/analyze_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -107,6 +108,31 @@ func TestAnalyzeGoRepo(t *testing.T) {
 	}
 	if res.BuildTool != "go" {
 		t.Fatalf("BuildTool = %q, want go", res.BuildTool)
+	}
+}
+
+// monorepo:根无 manifest,项目文件在 backend/ frontend/ 子目录(如 aireboot)。
+// 旧版只扫根 → 「未识别」;下钻后应识别出语言 + 子目录 Dockerfile,且两栈都进 Signals。
+func TestAnalyzeMonorepoSubdirs(t *testing.T) {
+	url := makeBareRepo(t, map[string]string{
+		"README.md":             "# app\n",
+		"backend/pom.xml":       "<project></project>",
+		"frontend/package.json": `{"name":"web","engines":{"node":"20"}}`,
+		"backend/Dockerfile":    "FROM eclipse-temurin:21\n",
+	})
+	res := newInsecureRepoAnalyzer().Analyze(context.Background(), url, "")
+	if !res.Cloned {
+		t.Fatalf("expected Cloned=true, degrade=%q", res.DegradeReason)
+	}
+	if res.Language == "" {
+		t.Fatalf("monorepo 子目录技术栈应被识别,得空(未识别)")
+	}
+	if !res.HasDockerfile {
+		t.Fatalf("应在子目录发现 Dockerfile")
+	}
+	joined := strings.Join(res.Signals, ",")
+	if !strings.Contains(joined, "frontend/package.json") || !strings.Contains(joined, "backend/pom.xml") {
+		t.Fatalf("Signals 应含 monorepo 两栈带路径,得 %v", res.Signals)
 	}
 }
 

--- a/internal/ai/catalog.go
+++ b/internal/ai/catalog.go
@@ -1,0 +1,46 @@
+package ai
+
+// 节点目录(AI 生成流水线的「可用工具清单」)。
+//
+// 痛点:旧 prompt 只举 git_source/build_image/deploy 三种 type,LLM 不知道产品其余节点存在,
+// 只会产最粗的三段式。这里把**全部可用节点**作为工具清单喂给 LLM:内置节点(下方 Go 目录,
+// 新增模板节点在此登记即自动生效)+ 复用库里的用户自定义节点(运行时从 DB 动态拼入,见
+// httpapi 装配)。目录与前端 jobConfigSchema 的节点种类对齐,改动时请同步两侧。
+
+// NodeKind 是一个可用节点的描述(喂给 LLM 的工具条目)。
+type NodeKind struct {
+	Type        string // job.type(LLM 只能从目录里选)
+	Label       string // 人读名
+	Category    string // source|build|deploy|quality|notify|custom
+	Description string // 用途 + 关键配置/适用场景(给 LLM 判断何时用)
+	Custom      bool   // true = 复用库里的用户自定义节点(按 Label 名称选用,type 通常为 templated)
+}
+
+// BuiltinNodeCatalog 返回内置节点的工具清单(新增内置/模板节点在此登记即生效)。
+// 顺序按典型流水线推进(源 → 构建 → 部署 → 通知),便于 LLM 组合。
+func BuiltinNodeCatalog() []NodeKind {
+	return []NodeKind{
+		{Type: "git_source", Label: "Gitee 源", Category: "source",
+			Description: "拉取 Git 仓库源码到构建工作区。每条流水线必须恰有一个 source 阶段,含一个 git_source。"},
+		{Type: "build_frontend", Label: "前端构建", Category: "build",
+			Description: "Node 容器内装依赖并构建前端,产出 dist。适合含 package.json 的前端/子目录。"},
+		{Type: "build_backend", Label: "后端构建", Category: "build",
+			Description: "Maven/Gradle 容器内打包后端,产出 jar。适合含 pom.xml / build.gradle 的后端/子目录。"},
+		{Type: "build_image", Label: "构建镜像", Category: "build",
+			Description: "用 Dockerfile 或工具链构建 Docker 镜像(产物=image)。有 Dockerfile 时优先用它。"},
+		{Type: "push_image", Label: "推送镜像", Category: "build",
+			Description: "把构建出的镜像推送到镜像仓库。通常紧随 build_image,部署 image 产物前需要。"},
+		{Type: "script", Label: "自定义脚本", Category: "build",
+			Description: "隔离容器内执行任意命令(跑测试、lint、代码扫描、自定义步骤等)。"},
+		{Type: "deploy_ssh", Label: "SSH 部署", Category: "deploy",
+			Description: "经 SSH 把产物(jar/dist/image)部署到目标服务器。"},
+		{Type: "deploy_frontend", Label: "前端推送部署", Category: "deploy",
+			Description: "把前端 dist 经 SSH 零停机部署到服务器(滚动 + reload)。"},
+		{Type: "health_check", Label: "健康检查", Category: "deploy",
+			Description: "部署后探测服务健康(HTTP/命令),失败可回滚。建议接在部署节点之后。"},
+		{Type: "notify", Label: "通知", Category: "notify",
+			Description: "运行到此节点时向已配渠道(飞书/Webhook/邮件)发通知,支持标题/正文模板。"},
+		{Type: "templated", Label: "自定义节点", Category: "custom",
+			Description: "用户自定义节点:参数 + 命令模板({{参数}}),用于产品未内置的步骤。"},
+	}
+}

--- a/internal/ai/generate.go
+++ b/internal/ai/generate.go
@@ -26,20 +26,29 @@ const maxLLMRespBytes = 1 << 20 // 1MB
 // generateMaxTokens 是 chat 请求的 max_tokens(够装一份结构化提案)。
 const generateMaxTokens = 2048
 
-// GenerateInput 是生成提案的入参:仓库分析 + 自然语言补充(均可空)。
+// GenerateInput 是生成提案的入参:仓库分析 + 自然语言补充(均可空)+ 可用节点目录。
 type GenerateInput struct {
 	Analysis RepoAnalysis
 	NL       string
+	// Catalog 是可用节点工具清单(内置 + 复用库自定义节点);空时回退内置目录,
+	// 使 LLM 始终知道全部可组合节点,而非只会产粗粒度三段式。
+	Catalog []NodeKind
 }
 
 // ---- Proposal 结构(冻结契约;对齐 2-2 spec / 2-4 build / 2-3 branchMappings 子集) ----
 
 // ProposalJob 是提案中的一个任务(对齐 pipeline.Job 子集)。
+// Config 是 LLM 据仓库分析填好的可执行配置(命令/镜像/Dockerfile 路径/端口等),
+// 让生成的流水线**直接可用**;环境相关项(serverId/渠道/凭据)留空交用户选。
 type ProposalJob struct {
-	ID      string `json:"id"`
-	Name    string `json:"name"`
-	Type    string `json:"type"`
-	Summary string `json:"summary"`
+	ID      string         `json:"id"`
+	Name    string         `json:"name"`
+	Type    string         `json:"type"`
+	Summary string         `json:"summary"`
+	Config  map[string]any `json:"config,omitempty"`
+	// Needs 是同阶段内本 job 依赖的其它 job 的 name(有数据依赖必填,如镜像依赖后端构建产物)。
+	// 无 needs = 与同阶段其它 job 并行;有 needs = 等依赖完成后串行。apply 时按 name 映射为 job id。
+	Needs []string `json:"needs,omitempty"`
 }
 
 // ProposalStage 是提案中的一个阶段(对齐 pipeline.Stage 子集)。
@@ -358,23 +367,72 @@ func buildPrompt(in GenerateInput) string {
 		b.WriteString("(无)\n")
 	}
 
+	// 可用节点工具清单:LLM 的 job.type 只能从这里选,从而充分利用产品全部节点(而非只会三段式)。
+	catalog := in.Catalog
+	if len(catalog) == 0 {
+		catalog = BuiltinNodeCatalog()
+	}
+	b.WriteString("\n## 可用节点类型(job.type 只能取下列之一;按需组合多阶段,阶段内无依赖的 job 会并行)\n")
+	var customs []NodeKind
+	for _, nk := range catalog {
+		if nk.Custom {
+			customs = append(customs, nk)
+			continue
+		}
+		b.WriteString("- " + nk.Type + "(" + nk.Label + "·" + nk.Category + "):" + nk.Description + "\n")
+	}
+	if len(customs) > 0 {
+		b.WriteString("### 复用库中的自定义节点(可直接选用:job.type 用 templated,job.name 用下列名称)\n")
+		for _, nk := range customs {
+			b.WriteString("- 「" + nk.Label + "」:" + nk.Description + "\n")
+		}
+	}
 	b.WriteString(`
+## 串行 / 并行(关键!用每个 job 的 needs 表达节点依赖)
+同一阶段内:**没有 needs 的 job 并行执行;有 needs 的 job 必须等其依赖的 job 完成后才串行执行**。
+needs 填「本阶段内它所依赖的其它 job 的 name」(数组)。**凡有数据/产物依赖的 job 必须设 needs**,否则会并行跑、拿不到上游产物而失败。常见依赖:
+- build_image 要用上游构建产物(jar/dist)→ needs 填 build_backend(及 build_frontend)的 name。**Dockerfile 里 COPY 了 jar/dist 的,必须依赖对应构建 job,不能并行!**
+- push_image → needs 填 build_image 的 name。
+- health_check → needs 填 deploy_ssh / deploy_frontend 的 name。
+- 互不依赖的(如 build_frontend 与 build_backend)不写 needs,让它们并行加速。
+
+## 组合指引
+- monorepo 前后端可并行:同一构建阶段放 build_frontend 与 build_backend(互不依赖 → 并行),build_image 用 needs 串在它们之后。
+- 有 Dockerfile → 用 build_image(产 image),需远端部署再加 push_image(needs build_image);无 Dockerfile → 用 build_frontend/build_backend 产 dist/jar。
+- 部署后接 health_check(needs deploy_ssh);关键阶段(部署成功/失败)可接 notify。
+- 仅在内置节点无法表达的步骤才用 script 或库中的自定义节点(templated)。
+
+## 每个节点的 config(关键!尽量据仓库分析填满,让流水线直接可用)
+为每个 job 填 "config" 对象,**凡能从仓库分析推断的都填**;只有环境相关项(serverId/channel/credentialId)留空给用户选。各类型 config 字段:
+- build_frontend/build_backend/script:image(运行镜像,据语言/版本选,如 node:20、maven:3.9-eclipse-temurin-21)、commands(多行命令,据构建工具写,如 "cd <子目录>\nmvn -B -DskipTests package")、artifactPath(产物路径,如 "backend/target/*.jar"、"frontend/dist")。命令里的子目录要用分析里检测到的真实路径(如 backend/、frontend/)。
+- build_image:buildModel("dockerfile" 有 Dockerfile 否则 "toolchain")、dockerfilePath(检测到的 Dockerfile 路径,如 "backend/Dockerfile")、context(Dockerfile 所在目录,如 "backend")、artifactType("image")。
+- push_image:无需 config(随 build_image 推送)。
+- deploy_ssh/deploy_frontend:artifactType("image" 或 "dist")、containerName(据项目名取,如 "<proj>-app")、ports(如 "8080:8080")、strategy("recreate"|"rolling");serverId 留空(用户选目标机)。
+- health_check:probeMode("http")、url(据服务端口/框架填,Spring Boot 用 "http://localhost:<宿主端口>/actuator/health",其它用 "/healthz")、expectStatus("200")、retries("10")、intervalSeconds("3")。
+- notify:titleTemplate/bodyTemplate(可用 {{project}} {{branch}} {{status}});channel 留空(用户选渠道)。
+- git_source:config 留空 {}。
+
 ## 输出要求
 只输出一个 JSON 对象(不要任何解释文字、不要 markdown 代码块),严格符合以下结构:
 {
   "stages": [
-    { "name": "流水线源", "kind": "source", "jobs": [ { "name": "...", "type": "git_source", "summary": "..." } ] },
-    { "name": "构建", "kind": "build", "jobs": [ { "name": "...", "type": "build_image", "summary": "..." } ] },
-    { "name": "部署", "kind": "deploy", "jobs": [ { "name": "...", "type": "deploy", "summary": "..." } ] }
+    { "name": "流水线源", "kind": "source", "jobs": [ { "name": "拉取源码", "type": "git_source", "summary": "...", "config": {} } ] },
+    { "name": "构建镜像", "kind": "build", "jobs": [
+        { "name": "后端构建", "type": "build_backend", "summary": "...", "config": { "image": "maven:3.9-eclipse-temurin-21", "commands": "cd backend\nmvn -B -DskipTests package", "artifactPath": "backend/target/*.jar" } },
+        { "name": "前端构建", "type": "build_frontend", "summary": "...", "config": { "image": "node:20", "commands": "cd frontend\nnpm install\nnpm run build", "artifactPath": "frontend/dist" } },
+        { "name": "构建镜像", "type": "build_image", "summary": "...", "needs": ["后端构建", "前端构建"], "config": { "buildModel": "dockerfile", "dockerfilePath": "backend/Dockerfile", "context": "backend", "artifactType": "image" } } ] },
+    { "name": "部署", "kind": "deploy", "jobs": [
+        { "name": "SSH 部署", "type": "deploy_ssh", "summary": "...", "config": { "artifactType": "image", "containerName": "app", "ports": "8080:8080", "strategy": "recreate" } },
+        { "name": "健康检查", "type": "health_check", "summary": "...", "needs": ["SSH 部署"], "config": { "probeMode": "http", "url": "http://localhost:8080/actuator/health", "expectStatus": "200", "retries": "10", "intervalSeconds": "3" } } ] }
   ],
   "build": { "model": "toolchain|dockerfile", "toolchain": { "language": "node|go|java|python", "version": "..." }, "artifactType": "image|jar|dist", "dockerfilePath": "" },
   "branchMappings": [ { "branchPattern": "main", "environment": "生产" } ],
   "rationale": "一句话说明推荐依据"
 }
 约束:
-- kind 仅能为 source/build/deploy/notify/custom;必须恰有一个 source 阶段。
-- build.model:有 Dockerfile 用 dockerfile,否则用 toolchain。
-- 不要包含任何凭据、密钥或 credentialId。
+- job.type 必须取自上面「可用节点类型」清单;kind 为 source/build/deploy/quality/notify/custom;必须恰有一个 source 阶段(含 git_source)。
+- config 尽量据仓库分析填满(命令/镜像/Dockerfile 路径/context/端口/产物),让流水线开箱即跑;仅 serverId/channel/credentialId 等环境相关项留空。
+- 充分利用合适的节点类型,别把所有事都塞进一个 build_image;不要包含任何凭据、密钥或 credentialId。
 `)
 	return b.String()
 }

--- a/internal/ai/generate_buildprompt_test.go
+++ b/internal/ai/generate_buildprompt_test.go
@@ -1,0 +1,35 @@
+package ai
+
+import (
+	"strings"
+	"testing"
+)
+
+// buildPrompt 必须把可用节点目录(内置 + 自定义)当工具清单写进 prompt,
+// 否则 LLM 不知道这些节点存在、只会产粗粒度三段式。
+func TestBuildPromptIncludesCatalog(t *testing.T) {
+	in := GenerateInput{
+		Analysis: RepoAnalysis{Cloned: true, Language: "node"},
+		Catalog: append(BuiltinNodeCatalog(), NodeKind{
+			Type: "templated", Label: "我的扫描节点", Category: "custom",
+			Description: "跑安全扫描", Custom: true,
+		}),
+	}
+	p := buildPrompt(in)
+	for _, want := range []string{"build_frontend", "build_backend", "push_image", "health_check", "notify", "可用节点类型"} {
+		if !strings.Contains(p, want) {
+			t.Fatalf("prompt 缺内置节点 %q", want)
+		}
+	}
+	if !strings.Contains(p, "我的扫描节点") {
+		t.Fatalf("prompt 应含复用库自定义节点名")
+	}
+}
+
+// 空 Catalog 时回退内置目录(仍把全部内置节点喂 LLM)。
+func TestBuildPromptCatalogFallback(t *testing.T) {
+	p := buildPrompt(GenerateInput{Analysis: RepoAnalysis{Cloned: true}})
+	if !strings.Contains(p, "build_image") || !strings.Contains(p, "deploy_ssh") {
+		t.Fatalf("空 Catalog 应回退内置目录")
+	}
+}

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -212,7 +212,11 @@ func (b *Builder) Run(ctx context.Context, r *run.Run, sink run.StepSink) error 
 	for _, cs := range customSteps {
 		steps = append(steps, cs.Name)
 	}
-	if err := sink.Plan(ctx, steps); err != nil {
+	decls := make([]run.StepDecl, len(steps))
+	for i, n := range steps {
+		decls[i] = run.StepDecl{Name: n} // 非 DAG 单镜像构建路径:无阶段分组(前端单级回退)
+	}
+	if err := sink.Plan(ctx, decls); err != nil {
 		return err
 	}
 
@@ -584,7 +588,7 @@ func (b *Builder) lineSink(sink run.StepSink, ordinal int) func(stream, line str
 
 // failPlan 在尚未 Plan 时的早失败:声明单步、置 failed、写失败日志、返回错误。
 func (b *Builder) failPlan(ctx context.Context, sink run.StepSink, stepName, msg string) error {
-	if err := sink.Plan(ctx, []string{stepName}); err == nil {
+	if err := sink.Plan(ctx, []run.StepDecl{{Name: stepName}}); err == nil {
 		_ = sink.StepRunning(ctx, 0)
 		_ = sink.Log(ctx, streamStderr, 0, msg)
 		_ = sink.StepDone(ctx, 0, run.StepFailed)

--- a/internal/build/builder_test.go
+++ b/internal/build/builder_test.go
@@ -69,10 +69,13 @@ type fakeSink struct {
 
 func newFakeSink() *fakeSink { return &fakeSink{done: map[int]string{}} }
 
-func (s *fakeSink) Plan(_ context.Context, names []string) error {
+func (s *fakeSink) Plan(_ context.Context, steps []run.StepDecl) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.plan = names
+	s.plan = s.plan[:0]
+	for _, st := range steps {
+		s.plan = append(s.plan, st.Name)
+	}
 	return nil
 }
 func (s *fakeSink) StepRunning(_ context.Context, ordinal int) error {

--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -125,7 +125,9 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 		// 没有任何可执行节点(script/build_image/deploy_ssh/notify)且无 post → 诚实占位放行。
 		if !needsBuild && len(deployJobs) == 0 && len(notifyJobs) == 0 && len(stage.Post) == 0 {
 			for _, jb := range stage.Jobs {
-				_ = rep.Log(ctx, streamStdout, fmt.Sprintf("· %s(%s)— 真实执行未接入;本阶段放行", jb.Name, jb.Type))
+				_ = rep.JobRunning(ctx, jb.ID)
+				_ = rep.JobReporter(jb.ID).Log(ctx, streamStdout, fmt.Sprintf("· %s(%s)— 真实执行未接入;本阶段放行", jb.Name, jb.Type))
+				_ = rep.JobDone(ctx, jb.ID, run.StepSuccess)
 			}
 			if len(stage.Jobs) == 0 {
 				_ = rep.Log(ctx, streamStdout, fmt.Sprintf("阶段「%s」无 job", stage.Name))
@@ -219,9 +221,13 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 					if canceled(ctx) {
 						return run.ErrCanceled
 					}
+					_ = rep.JobRunning(ctx, jb.ID)
+					jrep := rep.JobReporter(jb.ID)
+					jsink := &reporterSink{rep: jrep}
 					step, verr := scriptStepFromJob(jb)
 					if verr != nil {
-						_ = rep.Log(ctx, streamStderr, fmt.Sprintf("script job「%s」配置无效:%v", jb.Name, verr))
+						_ = jrep.Log(ctx, streamStderr, fmt.Sprintf("script job「%s」配置无效:%v", jb.Name, verr))
+						_ = rep.JobDone(ctx, jb.ID, run.StepFailed)
 						return ErrBuildFailed
 					}
 					// 注入顺序:运行参数 → 上游 job 输出(carriedEnv)→ job 自身 env(后者覆盖同名)→ PIPEWRIGHT_ENV(系统,末位防覆盖)。
@@ -234,22 +240,29 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 					}
 					// 构建依赖缓存(#61):执行前恢复(暖构建)、成功后保存(best-effort,缓存问题绝不让构建失败)。
 					// 任务级 timeout/retry(#63):零值时 runScriptStepWithOpts 退化为单次无超时执行(旧行为)。
-					b.restoreJobCache(ctx, rep, jb, r.Trigger.Branch, workspace)
-					if err := b.runScriptStepWithOpts(ctx, sink, 0, step, workspace); err != nil {
+					b.restoreJobCache(ctx, jrep, jb, r.Trigger.Branch, workspace)
+					if err := b.runScriptStepWithOpts(ctx, jsink, 0, step, workspace); err != nil {
+						_ = rep.JobDone(ctx, jb.ID, run.StepFailed)
 						return err // ErrBuildFailed / run.ErrCanceled
 					}
-					b.saveJobCache(ctx, rep, jb, r.Trigger.Branch, workspace)
+					b.saveJobCache(ctx, jrep, jb, r.Trigger.Branch, workspace)
 					// 捕获本 job 写入 $PIPEWRIGHT_ENV 的变量,供后续同阶段 job 引用。
-					carriedEnv = append(carriedEnv, captureStageEnv(ctx, rep, workspace)...)
+					carriedEnv = append(carriedEnv, captureStageEnv(ctx, jrep, workspace)...)
+					_ = rep.JobDone(ctx, jb.ID, run.StepSuccess)
 				}
 
 				for _, jb := range buildImageJobs {
 					if canceled(ctx) {
 						return run.ErrCanceled
 					}
-					if err := b.runBuildImageJob(ctx, sink, rep, jb, stage.Name, proj, settings, r.Trigger.ResolvedEnvironment, workspace, commitTag, hasPushJob); err != nil {
+					_ = rep.JobRunning(ctx, jb.ID)
+					jrep := rep.JobReporter(jb.ID)
+					jsink := &reporterSink{rep: jrep}
+					if err := b.runBuildImageJob(ctx, jsink, jrep, jb, stage.Name, proj, settings, r.Trigger.ResolvedEnvironment, workspace, commitTag, hasPushJob); err != nil {
+						_ = rep.JobDone(ctx, jb.ID, run.StepFailed)
 						return err
 					}
+					_ = rep.JobDone(ctx, jb.ID, run.StepSuccess)
 				}
 
 				b.collectScriptArtifacts(ctx, scriptJobs, workspace, slugify(proj.Name), stage.Name, rep)
@@ -263,9 +276,13 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 				if canceled(ctx) {
 					return run.ErrCanceled
 				}
-				if err := b.runDeployJob(ctx, rep, jb, r.ID); err != nil {
+				_ = rep.JobRunning(ctx, jb.ID)
+				jrep := rep.JobReporter(jb.ID)
+				if err := b.runDeployJob(ctx, jrep, jb, r.ID); err != nil {
+					_ = rep.JobDone(ctx, jb.ID, run.StepFailed)
 					return err
 				}
+				_ = rep.JobDone(ctx, jb.ID, run.StepSuccess)
 			}
 
 			// ── 通知节点(notify):按节点配的渠道发通知(best-effort,不因通知失败而失败本阶段)──
@@ -273,7 +290,9 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 				if canceled(ctx) {
 					return run.ErrCanceled
 				}
-				b.runNotifyJob(ctx, rep, jb, r)
+				_ = rep.JobRunning(ctx, jb.ID)
+				b.runNotifyJob(ctx, rep.JobReporter(jb.ID), jb, r)
+				_ = rep.JobDone(ctx, jb.ID, run.StepSuccess)
 			}
 
 			return nil
@@ -353,36 +372,59 @@ func (b *Builder) runStageJobsDAG(
 			envMu.Unlock()
 		}
 
-		switch {
-		case isScriptJob(jb.Type):
-			out, err := b.runScriptJobIsolated(ctx, sink, rep, r, jb, stage, proj, settings, svcNetwork, upstreamEnv, reportSink)
-			if err != nil {
-				return err
+		// 节点级 step:本 job 独占一个 step,日志/产物经 job 级 rep/sink 归到该节点 ordinal。
+		_ = rep.JobRunning(ctx, jb.ID)
+		jrep := rep.JobReporter(jb.ID)
+		jsink := &reporterSink{rep: jrep}
+
+		jobErr := func() error {
+			switch {
+			case isScriptJob(jb.Type):
+				out, err := b.runScriptJobIsolated(ctx, jsink, jrep, r, jb, stage, proj, settings, svcNetwork, upstreamEnv, reportSink)
+				if err != nil {
+					return err
+				}
+				if len(out) > 0 {
+					envMu.Lock()
+					jobEnvOut[id] = out
+					envMu.Unlock()
+				}
+				return nil
+			case isBuildImageJob(jb.Type):
+				return b.runBuildImageJobIsolated(ctx, jsink, jrep, r, jb, stage, proj, settings, hasPushJob)
+			case isDeployJob(jb.Type):
+				return b.runDeployJob(ctx, jrep, jb, r.ID)
+			case strings.TrimSpace(jb.Type) == "push_image":
+				// 推送随构建镜像节点完成(hasPushJob);本节点仅用于在 DAG 中编排顺序/展示。
+				_ = jrep.Log(ctx, streamStdout, fmt.Sprintf("· 推送镜像「%s」:已随构建镜像节点完成推送(本节点用于编排顺序)", jb.Name))
+				return nil
+			case strings.TrimSpace(jb.Type) == "notify":
+				b.runNotifyJob(ctx, jrep, jb, r)
+				return nil
+			default:
+				_ = jrep.Log(ctx, streamStdout, fmt.Sprintf("· %s(%s)— 真实执行未接入;本节点放行", jb.Name, jb.Type))
+				return nil
 			}
-			if len(out) > 0 {
-				envMu.Lock()
-				jobEnvOut[id] = out
-				envMu.Unlock()
-			}
-			return nil
-		case isBuildImageJob(jb.Type):
-			return b.runBuildImageJobIsolated(ctx, sink, rep, r, jb, stage, proj, settings, hasPushJob)
-		case isDeployJob(jb.Type):
-			return b.runDeployJob(ctx, rep, jb, r.ID)
-		case strings.TrimSpace(jb.Type) == "push_image":
-			// 推送随构建镜像节点完成(hasPushJob);本节点仅用于在 DAG 中编排顺序/展示。
-			_ = rep.Log(ctx, streamStdout, fmt.Sprintf("· 推送镜像「%s」:已随构建镜像节点完成推送(本节点用于编排顺序)", jb.Name))
-			return nil
-		case strings.TrimSpace(jb.Type) == "notify":
-			b.runNotifyJob(ctx, rep, jb, r)
-			return nil
-		default:
-			_ = rep.Log(ctx, streamStdout, fmt.Sprintf("· %s(%s)— 真实执行未接入;本节点放行", jb.Name, jb.Type))
-			return nil
+		}()
+
+		status := run.StepSuccess
+		if jobErr != nil {
+			status = run.StepFailed
 		}
+		_ = rep.JobDone(ctx, jb.ID, status)
+		return jobErr
 	}
 
 	res := g.Schedule(ctx, runJob, dag.Options{MaxConcurrency: defaultJobDAGConcurrency})
+
+	// 因上游失败/取消而从未执行的 job:显式标 skipped(其 runJob 未被调到,JobDone 未触发),
+	// 使其在运行详情里如实显示「跳过」而非被阶段失败兜底成 failed。
+	for _, jb := range stage.Jobs {
+		switch res[jb.ID].Status {
+		case dag.StatusSkipped, dag.StatusCanceled:
+			_ = rep.JobDone(ctx, jb.ID, run.StepSkipped)
+		}
+	}
 
 	if canceled(ctx) {
 		return run.ErrCanceled
@@ -584,6 +626,26 @@ func (b *Builder) runNotifyJob(ctx context.Context, rep dagrun.StageReporter, jb
 		Title:  "流水线通知",
 		Body:   fmt.Sprintf("流水线执行到通知节点:分支 %s,commit %s。", r.Trigger.Branch, commit),
 		Fields: map[string]string{"branch": r.Trigger.Branch, "commit": commit, "runId": r.ID, "stage": "notify"},
+	}
+	// 节点级内联模板(可选):配了标题/正文模板就按 {{占位}} 渲染覆盖默认文案,
+	// 占位语义与「通知」设置里的模板一致(project/branch/commit/status/runId 等)。
+	titleTpl := strings.TrimSpace(cfgString(jb.Config, "titleTemplate"))
+	bodyTpl := strings.TrimSpace(cfgString(jb.Config, "bodyTemplate"))
+	if titleTpl != "" || bodyTpl != "" {
+		vars := notify.TemplateVars{
+			Project: r.ProjectName,
+			Branch:  r.Trigger.Branch,
+			Commit:  commit,
+			Status:  r.Status,
+			Event:   "notify",
+			RunID:   r.ID,
+		}
+		if titleTpl != "" {
+			payload.Title = notify.RenderText(titleTpl, vars)
+		}
+		if bodyTpl != "" {
+			payload.Body = notify.RenderText(bodyTpl, vars)
+		}
 	}
 	if err := b.notifier.SendVia(ctx, chID, payload); err != nil {
 		_ = rep.Log(ctx, streamStderr, "通知发送失败(best-effort):"+err.Error())
@@ -892,7 +954,7 @@ type reporterSink struct {
 	rep dagrun.StageReporter
 }
 
-func (s *reporterSink) Plan(context.Context, []string) error        { return nil }
+func (s *reporterSink) Plan(context.Context, []run.StepDecl) error  { return nil }
 func (s *reporterSink) StepRunning(context.Context, int) error      { return nil }
 func (s *reporterSink) StepDone(context.Context, int, string) error { return nil }
 func (s *reporterSink) SetFailureLog(context.Context, string) error { return nil }

--- a/internal/build/dag_stage_exec_test.go
+++ b/internal/build/dag_stage_exec_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/huangchengsir/pipewright/internal/dagrun"
 	"github.com/huangchengsir/pipewright/internal/deploy"
 	"github.com/huangchengsir/pipewright/internal/pipeline"
 	"github.com/huangchengsir/pipewright/internal/project"
@@ -20,8 +21,9 @@ import (
 
 // fakeReporter 记录 dagrun.StageReporter 调用。
 type fakeReporter struct {
-	logs []string
-	arts []run.Artifact
+	logs    []string
+	arts    []run.Artifact
+	jobDone []string // 记录 "jobID=status",验证节点级上报
 }
 
 func (r *fakeReporter) Log(_ context.Context, _ string, line string) error {
@@ -32,6 +34,14 @@ func (r *fakeReporter) EmitArtifact(_ context.Context, a run.Artifact) error {
 	r.arts = append(r.arts, a)
 	return nil
 }
+
+// 节点级 step:测试 fake 记录 job 终态;JobReporter 返回自身(日志继续累计到同一 fake)。
+func (r *fakeReporter) JobRunning(_ context.Context, _ string) error { return nil }
+func (r *fakeReporter) JobDone(_ context.Context, jobID, status string) error {
+	r.jobDone = append(r.jobDone, jobID+"="+status)
+	return nil
+}
+func (r *fakeReporter) JobReporter(string) dagrun.StageReporter { return r }
 
 // recordingDriver 记录 RunToolchain 调用并按配置回退码/日志(其余 Driver 方法不应被调到)。
 type recordingDriver struct {

--- a/internal/dagrun/dagrun.go
+++ b/internal/dagrun/dagrun.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/huangchengsir/pipewright/internal/dag"
@@ -46,10 +47,20 @@ func (f SpecLoaderFunc) Get(ctx context.Context, projectID, _ string) (*pipeline
 
 // StageReporter 给 StageExecutor 上报「本阶段」的日志/产物(自动关联到该阶段的 run_steps 序号)。
 type StageReporter interface {
-	// Log 报告本阶段一行日志(stream ∈ stdout|stderr)。落库前由 StepSink 脱敏。
+	// Log 报告一行日志(stream ∈ stdout|stderr)。落库前由 StepSink 脱敏。
+	// 阶段级 reporter:路由到本阶段首个节点 step;节点级 reporter(JobReporter 得到):路由到该节点 step。
 	Log(ctx context.Context, stream, line string) error
-	// EmitArtifact 报告本阶段产出的一条构建产物。
+	// EmitArtifact 报告一条构建产物。
 	EmitArtifact(ctx context.Context, a run.Artifact) error
+
+	// ── 节点(job)级 step:运行详情下沉到节点粒度 ──
+	// JobRunning 将该 job 对应的 step 置 running。
+	JobRunning(ctx context.Context, jobID string) error
+	// JobDone 将该 job 对应的 step 置终态(success|failed|skipped)。
+	JobDone(ctx context.Context, jobID, status string) error
+	// JobReporter 返回一个绑定到该 job step 序号的 reporter:其 Log/EmitArtifact 都归到该节点,
+	// 供执行器把每个 job 的日志/产物归到各自 step(无需改动各 job 执行函数体)。
+	JobReporter(jobID string) StageReporter
 }
 
 // StageExecutor 执行单个阶段(跑其 job/step);返回非 nil 表示该阶段失败。须响应 ctx 取消。
@@ -148,27 +159,48 @@ func (r *Runner) Run(ctx context.Context, rn *run.Run, sink run.StepSink) error 
 		return fmt.Errorf("dagrun: build graph: %w", err)
 	}
 
-	// 拓扑序决定 run_steps 的展示序与序号;每个阶段 = 一个 step。
+	// 节点级:拓扑序决定阶段展示序;每个阶段内的 job 按声明序各占一个 step(ordinal 全局连续)。
+	// jobOrdinals[stageID] = 该阶段各 job 的全局 ordinal(jobID→ordinal);stageFirstOrd 供阶段级日志归位。
 	order := graph.TopoOrder()
-	ordinalOf := make(map[string]int, len(order))
-	names := make([]string, 0, len(order))
 	stageByID := make(map[string]pipeline.Stage, len(stages))
 	for _, st := range stages {
 		stageByID[st.ID] = st
 	}
-	for i, id := range order {
-		ordinalOf[id] = i
-		names = append(names, stageByID[id].Name)
+	decls := make([]run.StepDecl, 0, len(order))
+	jobOrdinals := make(map[string]map[string]int, len(order))
+	stageFirstOrd := make(map[string]int, len(order))
+	ord := 0
+	for _, id := range order {
+		st := stageByID[id]
+		stageFirstOrd[id] = ord
+		m := make(map[string]int, len(st.Jobs))
+		if len(st.Jobs) == 0 {
+			// 无 job 的阶段:留一个以阶段名命名的占位 step(键用 stageID,供 finishRemaining 收尾)。
+			decls = append(decls, run.StepDecl{Name: st.Name, Stage: st.Name})
+			m[id] = ord
+			ord++
+		}
+		for _, jb := range st.Jobs {
+			m[jb.ID] = ord
+			decls = append(decls, run.StepDecl{Name: jb.Name, Stage: st.Name})
+			ord++
+		}
+		jobOrdinals[id] = m
 	}
 
-	var mu sync.Mutex // 串行化对 sink 的全部调用(阶段可能并行)
+	var mu sync.Mutex // 串行化对 sink 的全部调用(阶段/节点可能并行)
 	lockedSink := func(fn func() error) error {
 		mu.Lock()
 		defer mu.Unlock()
 		return fn()
 	}
 
-	if err := lockedSink(func() error { return sink.Plan(ctx, names) }); err != nil {
+	// 失败日志捕获:DAG 执行器只把 job 输出经 Log 落 run_logs,从不调 SetFailureLog,导致
+	// 失败 run 的 failure_log 为空、AI 诊断「无失败日志」。这里旁路所有经 sink 的日志行(限量
+	// 尾部缓冲),阶段失败时把尾部作为 failure_log 落库,喂给 7-2 诊断。脱敏在诊断出网前统一做。
+	tap := &tapSink{StepSink: sink}
+
+	if err := lockedSink(func() error { return sink.Plan(ctx, decls) }); err != nil {
 		return fmt.Errorf("dagrun: plan: %w", err)
 	}
 
@@ -178,76 +210,104 @@ func (r *Runner) Run(ctx context.Context, rn *run.Run, sink run.StepSink) error 
 	}
 
 	result := graph.Schedule(ctx, func(ctx context.Context, stageID string) error {
-		ord := ordinalOf[stageID]
 		stage := stageByID[stageID]
-		// 条件执行(Story 8-5):when 不满足 → 跳过(非失败),其下游照「未成功」跳过。
+		rep := &stageReporter{sink: tap, mu: &mu, jobOrd: jobOrdinals[stageID], firstOrd: stageFirstOrd[stageID]}
+		// 条件执行(Story 8-5):when 不满足 → 整阶段所有节点 skipped(非失败),其下游照「未成功」跳过。
 		if !stage.When.Matches(rn.Trigger.Branch, rn.Trigger.Type) {
-			_ = lockedSink(func() error {
-				return sink.Log(ctx, "stdout", ord, fmt.Sprintf(
-					"阶段「%s」条件不满足(分支=%q 触发=%q),跳过", stage.Name, rn.Trigger.Branch, rn.Trigger.Type))
-			})
+			_ = rep.Log(ctx, "stdout", fmt.Sprintf(
+				"阶段「%s」条件不满足(分支=%q 触发=%q),跳过", stage.Name, rn.Trigger.Branch, rn.Trigger.Type))
+			rep.finishRemaining(ctx, run.StepSkipped)
 			return dag.ErrSkip
-		}
-		if err := lockedSink(func() error { return sink.StepRunning(ctx, ord) }); err != nil {
-			return err
 		}
 		// 人工审批门(Story 8-4):进入该阶段前阻塞等待批准。run 状态由 gate 置 waiting_approval。
 		if stage.Gate && r.gate != nil {
-			_ = lockedSink(func() error {
-				return sink.Log(ctx, "stdout", ord, fmt.Sprintf("⏸ 阶段「%s」等待人工审批…", stage.Name))
-			})
+			_ = rep.Log(ctx, "stdout", fmt.Sprintf("⏸ 阶段「%s」等待人工审批…", stage.Name))
 			approved, gerr := r.gate(ctx, rn, stage)
 			if gerr != nil {
-				_ = lockedSink(func() error {
-					return sink.Log(ctx, "stderr", ord, fmt.Sprintf("审批门中断:%v", gerr))
-				})
-				_ = lockedSink(func() error { return sink.StepDone(ctx, ord, run.StepFailed) })
+				_ = rep.Log(ctx, "stderr", fmt.Sprintf("审批门中断:%v", gerr))
+				rep.finishRemaining(ctx, run.StepFailed)
 				return gerr
 			}
 			if !approved {
-				_ = lockedSink(func() error { return sink.Log(ctx, "stderr", ord, "⛔ 审批被拒绝,终止该阶段") })
-				_ = lockedSink(func() error { return sink.StepDone(ctx, ord, run.StepFailed) })
+				_ = rep.Log(ctx, "stderr", "⛔ 审批被拒绝,终止该阶段")
+				rep.finishRemaining(ctx, run.StepFailed)
 				return ErrGateRejected
 			}
-			_ = lockedSink(func() error { return sink.Log(ctx, "stdout", ord, "✅ 审批通过,继续执行") })
+			_ = rep.Log(ctx, "stdout", "✅ 审批通过,继续执行")
 		}
-		rep := &stageReporter{sink: sink, mu: &mu, ordinal: ord}
+		// 阶段执行体按节点(job)各自上报 running/done(见 build.NewStageExecutor)。执行器未显式
+		// 标记的节点由 finishRemaining 兜底:阶段成功→success(如 stub/占位节点);阶段失败→failed
+		// (执行器应已把真失败节点标 failed、上游跳过节点标 skipped;剩余未报的归并到失败结果)。
 		execErr := r.exec(ctx, rn, stage, rep)
-		status := run.StepSuccess
+		sweep := run.StepSuccess
 		if execErr != nil {
-			status = run.StepFailed
+			sweep = run.StepFailed
 		}
-		_ = lockedSink(func() error { return sink.StepDone(ctx, ord, status) })
+		rep.finishRemaining(ctx, sweep)
 		return execErr
 	}, dag.Options{MaxConcurrency: maxc})
 
-	// 被跳过/取消(从未执行)的阶段:其 step 终态记为 skipped(条件跳过 + 上游未成功皆然),避免悬挂 pending。
+	// 被跳过/取消(从未进入执行)的阶段:其全部节点 step 记为 skipped,避免悬挂 pending。
 	for id, nr := range result {
 		if nr.Status == dag.StatusSkipped || nr.Status == dag.StatusCanceled {
-			ord := ordinalOf[id]
-			_ = lockedSink(func() error { return sink.StepDone(ctx, ord, run.StepSkipped) })
+			rep := &stageReporter{sink: tap, mu: &mu, jobOrd: jobOrdinals[id], firstOrd: stageFirstOrd[id]}
+			rep.finishRemaining(ctx, run.StepSkipped)
 		}
 	}
 
 	// 整体失败判定:仅当有阶段**真失败**(StatusFailed)。条件跳过 / 上游被跳过不令整体失败
 	// (上游若真失败,该失败阶段本身即计入 StatusFailed)。
 	if result.Counts()[dag.StatusFailed] > 0 {
+		// 把捕获的日志尾部落为 failure_log,喂 7-2 AI 诊断(best-effort,不阻断终态)。
+		if fl := tap.tail(); fl != "" {
+			_ = lockedSink(func() error { return sink.SetFailureLog(ctx, fl) })
+		}
 		return fmt.Errorf("dagrun: pipeline failed (%v)", summarize(result))
 	}
 	return nil
 }
 
-// stageReporter 把阶段级日志/产物绑定到该阶段的 step 序号,并经 mutex 串行化对 sink 的调用。
-type stageReporter struct {
-	sink    run.StepSink
-	mu      *sync.Mutex
-	ordinal int
+// tapSink 包装真实 StepSink:在转发 Log 的同时把日志行旁路进限量尾部缓冲,供阶段失败时
+// 合成 failure_log(DAG 执行器各 job 输出本只落 run_logs、不进 failure_log)。并发安全。
+type tapSink struct {
+	run.StepSink
+	mu  sync.Mutex
+	buf []string
 }
 
+const tapMaxLines = 400 // 仅留尾部若干行(失败原因通常在末);诊断侧另按字符再截断 + 脱敏
+
+func (t *tapSink) Log(ctx context.Context, stream string, stepOrdinal int, line string) error {
+	t.mu.Lock()
+	t.buf = append(t.buf, line)
+	if len(t.buf) > tapMaxLines {
+		t.buf = t.buf[len(t.buf)-tapMaxLines:]
+	}
+	t.mu.Unlock()
+	return t.StepSink.Log(ctx, stream, stepOrdinal, line)
+}
+
+func (t *tapSink) tail() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return strings.Join(t.buf, "\n")
+}
+
+// stageReporter 把一个阶段的节点(job)级 step 上报绑定到各 job 的全局 ordinal,并经 mutex
+// 串行化对 sink 的调用。阶段级日志(无 job 上下文)归到本阶段首个节点 step(firstOrd)。
+type stageReporter struct {
+	sink     run.StepSink
+	mu       *sync.Mutex
+	jobOrd   map[string]int // jobID → 全局 step ordinal
+	firstOrd int            // 阶段级日志/产物归位的 step ordinal
+	done     map[string]bool
+}
+
+// Log 阶段级日志 → 归到首个节点 step(节点级 reporter 见 jobReporter 覆盖到各自 ordinal)。
 func (s *stageReporter) Log(ctx context.Context, stream, line string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.sink.Log(ctx, stream, s.ordinal, line)
+	return s.sink.Log(ctx, stream, s.firstOrd, line)
 }
 
 func (s *stageReporter) EmitArtifact(ctx context.Context, a run.Artifact) error {
@@ -255,6 +315,91 @@ func (s *stageReporter) EmitArtifact(ctx context.Context, a run.Artifact) error 
 	defer s.mu.Unlock()
 	return s.sink.EmitArtifact(ctx, a)
 }
+
+func (s *stageReporter) JobRunning(ctx context.Context, jobID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ord, ok := s.jobOrd[jobID]
+	if !ok {
+		return nil
+	}
+	return s.sink.StepRunning(ctx, ord)
+}
+
+func (s *stageReporter) JobDone(ctx context.Context, jobID, status string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ord, ok := s.jobOrd[jobID]
+	if !ok {
+		return nil
+	}
+	if s.done == nil {
+		s.done = make(map[string]bool, len(s.jobOrd))
+	}
+	s.done[jobID] = true
+	return s.sink.StepDone(ctx, ord, status)
+}
+
+// JobReporter 返回绑定到该 job ordinal 的节点级 reporter(Log/EmitArtifact 都归该节点)。
+// 找不到 jobID(防御)→ 回退到首节点 ordinal。
+func (s *stageReporter) JobReporter(jobID string) StageReporter {
+	ord, ok := s.jobOrd[jobID]
+	if !ok {
+		ord = s.firstOrd
+	}
+	return &jobReporter{sink: s.sink, mu: s.mu, ordinal: ord}
+}
+
+// finishRemaining 把本阶段尚未被执行器标记终态的节点 step 统一收尾为 status(skipped/failed),
+// 兜底「上游失败被跳过 / 顺序路径提前返回 / 占位放行」等执行器未显式上报的节点,避免悬挂 pending。
+func (s *stageReporter) finishRemaining(ctx context.Context, status string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for jobID, ord := range s.jobOrd {
+		if s.done[jobID] {
+			continue
+		}
+		if s.done == nil {
+			s.done = make(map[string]bool, len(s.jobOrd))
+		}
+		s.done[jobID] = true
+		_ = s.sink.StepDone(ctx, ord, status)
+	}
+}
+
+// jobReporter 是绑定到单个 job step ordinal 的节点级 reporter;其 Log/EmitArtifact 都归该节点。
+// JobRunning/JobDone/JobReporter 作用于自身 ordinal(执行器拿到它后直接用 Log/EmitArtifact 即可)。
+type jobReporter struct {
+	sink    run.StepSink
+	mu      *sync.Mutex
+	ordinal int
+}
+
+func (j *jobReporter) Log(ctx context.Context, stream, line string) error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.sink.Log(ctx, stream, j.ordinal, line)
+}
+
+func (j *jobReporter) EmitArtifact(ctx context.Context, a run.Artifact) error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.sink.EmitArtifact(ctx, a)
+}
+
+func (j *jobReporter) JobRunning(ctx context.Context, _ string) error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.sink.StepRunning(ctx, j.ordinal)
+}
+
+func (j *jobReporter) JobDone(ctx context.Context, _, status string) error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.sink.StepDone(ctx, j.ordinal, status)
+}
+
+func (j *jobReporter) JobReporter(string) StageReporter { return j }
 
 // summarize 汇总各终态计数(用于失败错误信息,不含敏感内容)。
 func summarize(res dag.Result) map[dag.Status]int { return res.Counts() }

--- a/internal/dagrun/dagrun_test.go
+++ b/internal/dagrun/dagrun_test.go
@@ -37,10 +37,13 @@ type fakeSink struct {
 
 func newFakeSink() *fakeSink { return &fakeSink{done: map[int]string{}} }
 
-func (s *fakeSink) Plan(_ context.Context, names []string) error {
+func (s *fakeSink) Plan(_ context.Context, steps []run.StepDecl) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.planned = append([]string{}, names...)
+	s.planned = s.planned[:0]
+	for _, st := range steps {
+		s.planned = append(s.planned, st.Name)
+	}
 	return nil
 }
 func (s *fakeSink) StepRunning(_ context.Context, ord int) error {
@@ -291,7 +294,8 @@ func TestRunnerLinearSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if !equal(sink.planned, []string{"源", "构建", "部署"}) {
+	// 节点级:src 阶段的 job「clone」各占一步;无 job 的阶段用阶段名占位。
+	if !equal(sink.planned, []string{"clone", "构建", "部署"}) {
 		t.Errorf("planned = %v", sink.planned)
 	}
 	for ord := 0; ord < 3; ord++ {

--- a/internal/httpapi/ai_generate.go
+++ b/internal/httpapi/ai_generate.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/huangchengsir/pipewright/internal/ai"
+	"github.com/huangchengsir/pipewright/internal/library"
 	"github.com/huangchengsir/pipewright/internal/pipeline"
 	"github.com/huangchengsir/pipewright/internal/project"
 	"github.com/huangchengsir/pipewright/internal/trigger"
@@ -28,10 +30,12 @@ type aiAnalysisDTO struct {
 }
 
 type aiProposalJobDTO struct {
-	ID      string `json:"id"`
-	Name    string `json:"name"`
-	Type    string `json:"type"`
-	Summary string `json:"summary"`
+	ID      string         `json:"id"`
+	Name    string         `json:"name"`
+	Type    string         `json:"type"`
+	Summary string         `json:"summary"`
+	Config  map[string]any `json:"config,omitempty"` // LLM 填好的可执行配置(前端原样回传 apply)
+	Needs   []string       `json:"needs,omitempty"`  // 同阶段依赖的 job name(串行);空=并行
 }
 
 type aiProposalStageDTO struct {
@@ -107,7 +111,7 @@ func toAIProposalDTO(p *ai.Proposal) *aiProposalDTO {
 	for _, st := range p.Stages {
 		jobs := make([]aiProposalJobDTO, 0, len(st.Jobs))
 		for _, jb := range st.Jobs {
-			jobs = append(jobs, aiProposalJobDTO{ID: jb.ID, Name: jb.Name, Type: jb.Type, Summary: jb.Summary})
+			jobs = append(jobs, aiProposalJobDTO{ID: jb.ID, Name: jb.Name, Type: jb.Type, Summary: jb.Summary, Config: jb.Config, Needs: jb.Needs})
 		}
 		stages = append(stages, aiProposalStageDTO{ID: st.ID, Name: st.Name, Kind: st.Kind, Jobs: jobs})
 	}
@@ -130,13 +134,14 @@ func toAIProposalDTO(p *ai.Proposal) *aiProposalDTO {
 
 // aiGenerateDeps 聚合 generate/apply 两 handler 所需服务(复用已注入服务,无新顶层依赖)。
 type aiGenerateDeps struct {
-	analyzer ai.RepoAnalyzer
-	aiSvc    ai.Service
-	projects project.Service
-	pipes    pipeline.Service
-	settings pipeline.SettingsService
-	triggers trigger.Service
-	vault    vault.Vault
+	analyzer    ai.RepoAnalyzer
+	aiSvc       ai.Service
+	projects    project.Service
+	pipes       pipeline.Service
+	settings    pipeline.SettingsService
+	triggers    trigger.Service
+	vault       vault.Vault
+	customNodes library.CustomNodeService // 复用库自定义节点(动态拼入 AI 节点目录;可 nil)
 }
 
 // reasonAINotConfigured 是 AI 未配置时的友好引导(不阻断手动建项目;HTTP 200,available=false)。
@@ -195,9 +200,31 @@ func makeAIGenerateHandler(d aiGenerateDeps) http.HandlerFunc {
 			Analysis:  toAIAnalysisDTO(analysis),
 		}
 
+		// 动态节点目录:内置工具清单 + 复用库自定义节点(运行时拼入,新增即生效),作为
+		// LLM 可组合的「可用节点」全集,避免只产粗粒度三段式。
+		catalog := ai.BuiltinNodeCatalog()
+		if d.customNodes != nil {
+			if nodes, lerr := d.customNodes.List(ctx); lerr == nil {
+				for _, cn := range nodes {
+					desc := strings.TrimSpace(cn.Summary)
+					if desc == "" {
+						desc = strings.TrimSpace(cn.Description)
+					}
+					nt := strings.TrimSpace(cn.NodeType)
+					if nt == "" {
+						nt = "templated"
+					}
+					catalog = append(catalog, ai.NodeKind{
+						Type: nt, Label: cn.Name, Category: "custom", Description: desc, Custom: true,
+					})
+				}
+			}
+		}
+
 		proposal, gerr := d.aiSvc.Generate(ctx, ai.GenerateInput{
 			Analysis: analysis,
 			NL:       req.NLSupplement,
+			Catalog:  catalog,
 		})
 		switch {
 		case gerr == nil:
@@ -302,10 +329,12 @@ type aiProposalReq struct {
 		Name string `json:"name"`
 		Kind string `json:"kind"`
 		Jobs []struct {
-			ID      string `json:"id"`
-			Name    string `json:"name"`
-			Type    string `json:"type"`
-			Summary string `json:"summary"`
+			ID      string         `json:"id"`
+			Name    string         `json:"name"`
+			Type    string         `json:"type"`
+			Summary string         `json:"summary"`
+			Config  map[string]any `json:"config"`
+			Needs   []string       `json:"needs"`
 		} `json:"jobs"`
 	} `json:"stages"`
 	Build struct {
@@ -349,12 +378,37 @@ func applySelectedStages(ctx context.Context, svc pipeline.Service, projectID st
 		want[sid] = struct{}{}
 	}
 
-	// 把第 i 个提案阶段转为 pipeline.Stage(id 留空让服务端补,避免与既有冲突)。
+	// 把第 i 个提案阶段转为 pipeline.Stage。为每个 job 分配稳定 id(服务端保留已给 id),
+	// 并把 LLM 按「依赖 job 的 name」写的 needs 映射为对应 job id —— 实现节点级串行依赖
+	// (如 build_image needs build_backend),否则同阶段全并行、镜像拿不到 jar 而失败。
 	toStage := func(i int) pipeline.Stage {
 		st := prop.Stages[i]
+		// 先给每个 job 定 id,并建 name/原 id → 分配 id 的映射(供 needs 解析)。
+		ids := make([]string, len(st.Jobs))
+		refToID := make(map[string]string, len(st.Jobs)*2)
+		for k, jb := range st.Jobs {
+			aid := fmt.Sprintf("aijob_%d_%d", i, k)
+			ids[k] = aid
+			if n := strings.TrimSpace(jb.Name); n != "" {
+				refToID[n] = aid
+			}
+			if id := strings.TrimSpace(jb.ID); id != "" {
+				refToID[id] = aid
+			}
+		}
 		jobs := make([]pipeline.Job, 0, len(st.Jobs))
-		for _, jb := range st.Jobs {
-			jobs = append(jobs, pipeline.Job{ID: "", Name: jb.Name, Type: jb.Type, Summary: jb.Summary, Config: map[string]any{}})
+		for k, jb := range st.Jobs {
+			cfg := jb.Config
+			if cfg == nil {
+				cfg = map[string]any{}
+			}
+			needs := make([]string, 0, len(jb.Needs))
+			for _, ref := range jb.Needs {
+				if id, ok := refToID[strings.TrimSpace(ref)]; ok && id != ids[k] {
+					needs = append(needs, id)
+				}
+			}
+			jobs = append(jobs, pipeline.Job{ID: ids[k], Name: jb.Name, Type: jb.Type, Summary: jb.Summary, Config: cfg, Needs: needs})
 		}
 		return pipeline.Stage{ID: "", Name: st.Name, Kind: st.Kind, Jobs: jobs}
 	}

--- a/internal/httpapi/notifications.go
+++ b/internal/httpapi/notifications.go
@@ -52,6 +52,10 @@ func toChannelDTO(c *notify.Channel) channelDTO {
 	switch c.Type {
 	case notify.TypeWebhook:
 		cfg.URL = c.Config.URL
+	case notify.TypeFeishu:
+		// 飞书:回显 webhook 地址 + 是否已配签名密钥(密钥本身绝不回显)。
+		cfg.URL = c.Config.URL
+		cfg.HasPassword = c.HasSecret
 	case notify.TypeEmail:
 		cfg.SMTPHost = c.Config.SMTPHost
 		cfg.SMTPPort = c.Config.SMTPPort

--- a/internal/httpapi/notify_e2e_test.go
+++ b/internal/httpapi/notify_e2e_test.go
@@ -269,7 +269,7 @@ func TestNotifyHookProjectOverrideEndToEnd(t *testing.T) {
 type branchFailRunner struct{}
 
 func (branchFailRunner) Run(ctx context.Context, r *run.Run, sink run.StepSink) error {
-	_ = sink.Plan(ctx, []string{"step"})
+	_ = sink.Plan(ctx, []run.StepDecl{{Name: "step"}})
 	_ = sink.StepRunning(ctx, 0)
 	if r.Trigger.Branch == "fail" {
 		_ = sink.StepDone(ctx, 0, run.StepFailed)

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -541,13 +541,14 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		// /pipeline/ai-generate、/pipeline/ai-apply 比 /pipeline 多一段,不会被吞;均为写方法,过 auth + CSRF。
 		// 两路优雅降级(AI 未配 / clone 失败 / LLM 失败)均 HTTP 200,绝不 500、绝无明文密钥。
 		aiGenDeps := aiGenerateDeps{
-			analyzer: o.aiAnalyzer,
-			aiSvc:    aiSvc,
-			projects: p,
-			pipes:    pl,
-			settings: ps,
-			triggers: t,
-			vault:    v,
+			analyzer:    o.aiAnalyzer,
+			aiSvc:       aiSvc,
+			projects:    p,
+			pipes:       pl,
+			settings:    ps,
+			triggers:    t,
+			vault:       v,
+			customNodes: o.customNodes,
 		}
 		ar.Post("/projects/{id}/pipeline/ai-generate", makeAIGenerateHandler(aiGenDeps))
 		ar.Post("/projects/{id}/pipeline/ai-apply", makeAIApplyHandler(aiGenDeps))

--- a/internal/httpapi/runs.go
+++ b/internal/httpapi/runs.go
@@ -57,6 +57,7 @@ type triggerInfo struct {
 type stepDTO struct {
 	ID         string  `json:"id"`
 	Name       string  `json:"name"`
+	Stage      string  `json:"stage,omitempty"` // 所属阶段名(节点级分组;空 = 未分组)
 	Status     string  `json:"status"`
 	StartedAt  *string `json:"startedAt"`
 	FinishedAt *string `json:"finishedAt"`
@@ -111,6 +112,7 @@ func toRunDetailDTO(r *run.Run, artifacts []run.Artifact, targets []run.DeployTa
 		steps = append(steps, stepDTO{
 			ID:         st.ID,
 			Name:       st.Name,
+			Stage:      st.Stage,
 			Status:     st.Status,
 			StartedAt:  rfc3339Ptr(st.StartedAt),
 			FinishedAt: rfc3339Ptr(st.FinishedAt),

--- a/internal/notify/feishu.go
+++ b/internal/notify/feishu.go
@@ -1,0 +1,173 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// 飞书自定义机器人投递。
+//
+// 与通用 webhook 渠道的关键区别(也是后者发不进飞书的根因):
+//   - 报文形状:飞书要 {"msg_type":"text","content":{"text":...}},而非通用 webhook 的
+//     {title,body,fields};发错形状飞书返回 HTTP 200 但 body 内 code=19002「params error」。
+//   - 成功判定:飞书**即便参数错误也回 HTTP 200**,故绝不能只看 HTTP 状态码,必须解析返回
+//     JSON 的 code 字段(0=成功,非 0=失败,人读 msg 透出)。
+//
+// 可选签名:机器人若开启「签名校验」,配置时填密钥(走 vault 加密)。投递按飞书规范算
+// timestamp + sign 注入 body;未配密钥则不带签名(与机器人未开校验一致)。
+
+// feishuTextBody 是飞书文本消息体(开启签名时另带 timestamp/sign)。
+type feishuTextBody struct {
+	Timestamp string `json:"timestamp,omitempty"`
+	Sign      string `json:"sign,omitempty"`
+	MsgType   string `json:"msg_type"`
+	Content   struct {
+		Text string `json:"text"`
+	} `json:"content"`
+}
+
+// feishuResp 是飞书机器人返回体(只取判定/人读所需字段)。
+type feishuResp struct {
+	Code          int    `json:"code"`
+	Msg           string `json:"msg"`
+	StatusCode    int    `json:"StatusCode"`
+	StatusMessage string `json:"StatusMessage"`
+}
+
+// sendFeishu 经注入的 *http.Client POST 文本消息到飞书机器人 webhook。
+//   - SSRF 收口:投递前再校验一次 URL(与保存时一致;CheckRedirect 每跳复校)。
+//   - 超时:注入 client.Timeout 兜底 + 另套 8s context。
+//   - 成功判定:HTTP 2xx **且** 返回 JSON code==0(飞书参数错也回 200,必须看 code)。
+//   - sealed 非空:解密为签名密钥,按飞书规范算 timestamp+sign。
+func (s *service) sendFeishu(ctx context.Context, ch *Channel, sealed []byte, payload Payload) error {
+	target := ch.Config.URL
+	if !validWebhookURL(target) {
+		return fmt.Errorf("飞书 webhook 地址不被允许:仅 http/https,且不可指向云元数据/链路本地地址")
+	}
+
+	var body feishuTextBody
+	body.MsgType = "text"
+	body.Content.Text = feishuText(payload)
+
+	// 可选签名:机器人开启「签名校验」时,配置里存了密钥(密文)。
+	if len(sealed) > 0 {
+		secret, err := s.openSecret(sealed)
+		if err != nil {
+			return fmt.Errorf("飞书签名密钥不可用:保险库未配置或密文损坏")
+		}
+		if strings.TrimSpace(secret) != "" {
+			ts := strconv.FormatInt(time.Now().Unix(), 10)
+			sign, serr := feishuSign(ts, secret)
+			if serr != nil {
+				return fmt.Errorf("飞书签名计算失败")
+			}
+			body.Timestamp = ts
+			body.Sign = sign
+		}
+	}
+
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("飞书载荷序列化失败")
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, target, bytes.NewReader(raw))
+	if err != nil {
+		return fmt.Errorf("飞书请求构造失败:地址可能非法")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "Pipewright-notify/1")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return mapWebhookTransportError(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxWebhookRespBytes))
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("飞书接收端返回非 2xx 状态:HTTP %d", resp.StatusCode)
+	}
+
+	// 飞书参数错误也回 HTTP 200,必须解析 code 才能判定真成功(否则误报成功、群里收不到)。
+	var fr feishuResp
+	if err := json.Unmarshal(respBody, &fr); err != nil {
+		// 无法解析返回体:无从确认投递结果,按失败处理(绝不乐观)。
+		return fmt.Errorf("飞书返回体无法解析,投递结果未知")
+	}
+	if fr.Code != 0 || fr.StatusCode != 0 {
+		msg := strings.TrimSpace(fr.Msg)
+		if msg == "" {
+			msg = strings.TrimSpace(fr.StatusMessage)
+		}
+		code := fr.Code
+		if code == 0 {
+			code = fr.StatusCode
+		}
+		if msg == "" {
+			return fmt.Errorf("飞书机器人拒收:code=%d", code)
+		}
+		return fmt.Errorf("飞书机器人拒收:code=%d %s", code, msg)
+	}
+	return nil
+}
+
+// feishuText 把通知载荷拼成飞书文本消息正文(标题 + 正文 + 结构化字段)。
+func feishuText(p Payload) string {
+	var b strings.Builder
+	if t := strings.TrimSpace(p.Title); t != "" {
+		b.WriteString(t)
+	}
+	if body := strings.TrimSpace(p.Body); body != "" {
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(body)
+	}
+	if len(p.Fields) > 0 {
+		keys := make([]string, 0, len(p.Fields))
+		for k := range p.Fields {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys) // 稳定顺序(map 迭代无序,避免投递文案抖动)
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		for _, k := range keys {
+			b.WriteString("\n")
+			b.WriteString(k)
+			b.WriteString(": ")
+			b.WriteString(p.Fields[k])
+		}
+	}
+	if b.Len() == 0 {
+		return "(空通知)" // 飞书 text 不可为空
+	}
+	return b.String()
+}
+
+// feishuSign 按飞书规范算签名:stringToSign = "{timestamp}\n{secret}",
+// sign = base64(HMAC-SHA256(key=stringToSign, message=empty))。
+func feishuSign(timestamp, secret string) (string, error) {
+	stringToSign := timestamp + "\n" + secret
+	h := hmac.New(sha256.New, []byte(stringToSign))
+	if _, err := h.Write([]byte{}); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/notify/feishu_test.go
+++ b/internal/notify/feishu_test.go
@@ -1,0 +1,172 @@
+package notify
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// 飞书机器人成功:返回 {code:0} → Test 成功;POST 体须是 {msg_type:text,content:{text}}。
+func TestFeishuSendSuccess(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		gotBody []byte
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		gotBody = body
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"StatusCode":0,"StatusMessage":"success","code":0,"msg":"success","data":{}}`))
+	}))
+	defer srv.Close()
+
+	s, _, _ := newSvc(t, srv.Client())
+	ch, err := s.Create(ctx(), CreateInput{
+		Name: "ops-feishu", Type: TypeFeishu, Enabled: true,
+		Config: Config{URL: srv.URL + "/open-apis/bot/v2/hook/abc"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	res, err := s.Test(ctx(), ch.ID)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("飞书 test 应成功: %+v", res)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	var sent feishuTextBody
+	if err := json.Unmarshal(gotBody, &sent); err != nil {
+		t.Fatalf("POST 体应为合法 JSON: %s", gotBody)
+	}
+	if sent.MsgType != "text" {
+		t.Fatalf("msg_type 应为 text,得 %q", sent.MsgType)
+	}
+	if !strings.Contains(sent.Content.Text, "测试通知") {
+		t.Fatalf("content.text 应含测试标题: %q", sent.Content.Text)
+	}
+	if sent.Sign != "" || sent.Timestamp != "" {
+		t.Fatalf("未配密钥不应带签名: %+v", sent)
+	}
+}
+
+// 关键回归守卫:飞书参数错误**也回 HTTP 200**,但 body 内 code!=0。
+// 必须解析 code 判失败(否则误报成功、群里收不到)——这正是通用 webhook 渠道发不进飞书的坑。
+func TestFeishuRejectedHTTP200ButCodeNonZero(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK) // 注意:HTTP 200
+		_, _ = w.Write([]byte(`{"code":19002,"data":{},"msg":"params error, msg_type need"}`))
+	}))
+	defer srv.Close()
+
+	s, _, _ := newSvc(t, srv.Client())
+	ch, _ := s.Create(ctx(), CreateInput{
+		Name: "bad", Type: TypeFeishu, Enabled: true,
+		Config: Config{URL: srv.URL + "/hook"},
+	})
+	res, err := s.Test(ctx(), ch.ID)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	if res.OK {
+		t.Fatalf("飞书 code!=0 应判失败(不可因 HTTP 200 误报成功)")
+	}
+	if !strings.Contains(res.Error, "19002") || !strings.Contains(res.Error, "params error") {
+		t.Fatalf("错误应人读含 code 与 msg: %q", res.Error)
+	}
+}
+
+// 飞书 webhook 地址必填。
+func TestFeishuRequiresURL(t *testing.T) {
+	s, _, _ := newSvc(t, http.DefaultClient)
+	if _, err := s.Create(ctx(), CreateInput{Name: "x", Type: TypeFeishu, Enabled: true}); err != ErrInvalidConfig {
+		t.Fatalf("飞书缺 URL 应 ErrInvalidConfig,得: %v", err)
+	}
+}
+
+// 飞书地址同样过 SSRF 收口(拒云元数据)。
+func TestFeishuSSRFBlocked(t *testing.T) {
+	s, _, _ := newSvc(t, http.DefaultClient)
+	_, err := s.Create(ctx(), CreateInput{
+		Name: "evil", Type: TypeFeishu, Enabled: true,
+		Config: Config{URL: "http://169.254.169.254/hook"},
+	})
+	if err != ErrSSRFBlocked {
+		t.Fatalf("飞书 169.254 应被 SSRF 拒绝,得: %v", err)
+	}
+}
+
+// 配了签名密钥 → POST 体带 timestamp + sign,且 sign 与规范算法一致。
+func TestFeishuSignsWhenSecretConfigured(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		gotBody []byte
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		gotBody = body
+		mu.Unlock()
+		_, _ = w.Write([]byte(`{"code":0,"msg":"success"}`))
+	}))
+	defer srv.Close()
+
+	const secret = "my-sign-secret"
+	s, _, _ := newSvc(t, srv.Client())
+	ch, err := s.Create(ctx(), CreateInput{
+		Name: "signed", Type: TypeFeishu, Enabled: true,
+		Config: Config{URL: srv.URL + "/hook"}, Secret: secret,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	res, err := s.Test(ctx(), ch.ID)
+	if err != nil || !res.OK {
+		t.Fatalf("带签名应成功: %+v err=%v", res, err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	var sent feishuTextBody
+	if err := json.Unmarshal(gotBody, &sent); err != nil {
+		t.Fatalf("POST 体非法: %s", gotBody)
+	}
+	if sent.Timestamp == "" || sent.Sign == "" {
+		t.Fatalf("配密钥应带 timestamp+sign: %+v", sent)
+	}
+	want, _ := feishuSign(sent.Timestamp, secret)
+	if sent.Sign != want {
+		t.Fatalf("sign 与规范算法不一致: got %q want %q", sent.Sign, want)
+	}
+}
+
+// 文本拼装:标题 + 正文 + 字段(字段按 key 稳定排序)。
+func TestFeishuText(t *testing.T) {
+	got := feishuText(Payload{
+		Title:  "部署成功",
+		Body:   "aireboot @ staging",
+		Fields: map[string]string{"status": "success", "branch": "main"},
+	})
+	for _, want := range []string{"部署成功", "aireboot @ staging", "branch: main", "status: success"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("文本应含 %q,得:\n%s", want, got)
+		}
+	}
+	// 稳定排序:branch 在 status 前。
+	if strings.Index(got, "branch:") > strings.Index(got, "status:") {
+		t.Fatalf("字段应按 key 排序: %s", got)
+	}
+	if feishuText(Payload{}) != "(空通知)" {
+		t.Fatalf("空载荷应回占位文本")
+	}
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -411,8 +411,10 @@ func (s *service) deliver(ctx context.Context, ch *Channel, sealed []byte, paylo
 		return s.sendWebhook(ctx, ch, payload)
 	case TypeEmail:
 		return s.sendEmail(ctx, ch, sealed, payload)
+	case TypeFeishu:
+		return s.sendFeishu(ctx, ch, sealed, payload)
 	default:
-		// wecom / dingtalk / feishu:本期占位,人读提示(绝不 panic)。
+		// wecom / dingtalk:本期占位,人读提示(绝不 panic)。
 		return fmt.Errorf("该渠道类型(%s)暂未实现发送(not_implemented),敬请后续版本支持", ch.Type)
 	}
 }
@@ -515,6 +517,9 @@ func normalizeConfig(t string, c Config) Config {
 			To:       strings.TrimSpace(c.To),
 			Username: strings.TrimSpace(c.Username),
 		}
+	case TypeFeishu:
+		// 飞书自定义机器人:复用 URL 字段存 webhook hook 地址(签名密钥走 vault Secret)。
+		return Config{URL: strings.TrimSpace(c.URL)}
 	default:
 		return Config{}
 	}
@@ -536,8 +541,17 @@ func validateConfig(t string, c Config) error {
 			return ErrInvalidConfig
 		}
 		return nil
+	case TypeFeishu:
+		// 飞书机器人 webhook 地址必填,且过同一套 SSRF 收口(拒云元数据/链路本地)。
+		if c.URL == "" {
+			return ErrInvalidConfig
+		}
+		if !validWebhookURL(c.URL) {
+			return ErrSSRFBlocked
+		}
+		return nil
 	default:
-		// wecom/dingtalk/feishu:本期占位,不强制 config(保存合法)。
+		// wecom/dingtalk:本期占位,不强制 config(保存合法)。
 		return nil
 	}
 }

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -280,7 +280,7 @@ func TestEmailNoPasswordNoAuth(t *testing.T) {
 
 func TestPlaceholderTypesSaveButSendNotImplemented(t *testing.T) {
 	s, _, _ := newSvc(t, http.DefaultClient)
-	for _, ty := range []string{TypeWecom, TypeDingtalk, TypeFeishu} {
+	for _, ty := range []string{TypeWecom, TypeDingtalk} {
 		ch, err := s.Create(ctx(), CreateInput{Name: ty, Type: ty, Enabled: true})
 		if err != nil {
 			t.Fatalf("占位 type %s 应保存合法: %v", ty, err)

--- a/internal/notify/template.go
+++ b/internal/notify/template.go
@@ -335,6 +335,13 @@ func (s *service) matchTemplate(ctx context.Context, event, channelID string) *T
 // placeholderRE 匹配 {{name}} 占位(name 为字母数字与下划线;两侧可有空格)。
 var placeholderRE = regexp.MustCompile(`\{\{\s*([A-Za-z0-9_]+)\s*\}\}`)
 
+// RenderText 用 TemplateVars 对一段含 {{占位}} 的文本做纯文本替换(导出供 build 包的
+// notify 节点内联模板渲染复用;占位名同 TemplateVars.asMap,未知占位 → 空串)。
+// 与 RenderPayload 共用同一套占位语义,**绝不执行用户模板**(无 RCE)。
+func RenderText(tpl string, vars TemplateVars) string {
+	return renderTemplate(tpl, vars.asMap())
+}
+
 // renderTemplate 纯文本替换占位:{{name}} → vars[name];未知占位 → 空串。
 // **不执行任何用户模板**(无 text/template、无函数、无 RCE)——仅正则替换字符串。
 func renderTemplate(tpl string, vars map[string]string) string {

--- a/internal/notify/template_test.go
+++ b/internal/notify/template_test.go
@@ -258,3 +258,18 @@ func TestRouteEventVarsRendersConfiguredTemplate(t *testing.T) {
 		t.Fatalf("rendered body missing: %s", got)
 	}
 }
+
+// RenderText:导出给 notify 节点内联模板复用;占位替换、未知占位 → 空、空模板 → 空。
+func TestRenderText(t *testing.T) {
+	vars := TemplateVars{Project: "demo", Branch: "main", Commit: "abc1234", Status: "success", RunID: "r-1"}
+	got := RenderText("部署 {{project}} @ {{branch}}/{{commit}} = {{status}}", vars)
+	if got != "部署 demo @ main/abc1234 = success" {
+		t.Fatalf("unexpected render: %q", got)
+	}
+	if RenderText("{{unknown}}x", vars) != "x" {
+		t.Fatalf("unknown placeholder should render empty")
+	}
+	if RenderText("", vars) != "" {
+		t.Fatalf("empty template should render empty")
+	}
+}

--- a/internal/run/concurrency_test.go
+++ b/internal/run/concurrency_test.go
@@ -37,7 +37,7 @@ func (g *gatedRunner) Run(ctx context.Context, _ *Run, sink StepSink) error {
 	g.mu.Lock()
 	g.cur--
 	g.mu.Unlock()
-	if err := sink.Plan(ctx, []string{"s"}); err != nil {
+	if err := sink.Plan(ctx, []StepDecl{{Name: "s"}}); err != nil {
 		return err
 	}
 	_ = sink.StepRunning(ctx, 0)

--- a/internal/run/pool.go
+++ b/internal/run/pool.go
@@ -518,20 +518,24 @@ type dbStepSink struct {
 	runID   string
 	stepIDs []string
 	names   []string
+	stages  []string // 各 step 所属阶段名(节点级分组;与 names/stepIDs 同序)
 	// masker 在日志行落库/出网前脱敏(AC-SEC-04);nil 则不脱敏(纯单测可省)。
 	masker *mask.Masker
 }
 
-func (d *dbStepSink) Plan(ctx context.Context, names []string) error {
-	d.names = names
-	d.stepIDs = make([]string, len(names))
-	for i, name := range names {
+func (d *dbStepSink) Plan(ctx context.Context, steps []StepDecl) error {
+	d.names = make([]string, len(steps))
+	d.stages = make([]string, len(steps))
+	d.stepIDs = make([]string, len(steps))
+	for i, st := range steps {
+		d.names[i] = st.Name
+		d.stages[i] = st.Stage
 		id := uuid.NewString()
 		d.stepIDs[i] = id
 		_, err := d.svc.db.ExecContext(ctx,
-			`INSERT INTO run_steps (id, run_id, name, status, ordinal, started_at, finished_at)
-			 VALUES (?, ?, ?, ?, ?, NULL, NULL)`,
-			id, d.runID, name, StepPending, i,
+			`INSERT INTO run_steps (id, run_id, name, stage, status, ordinal, started_at, finished_at)
+			 VALUES (?, ?, ?, ?, ?, ?, NULL, NULL)`,
+			id, d.runID, st.Name, st.Stage, StepPending, i,
 		)
 		if err != nil {
 			return fmt.Errorf("run: insert step: %w", err)
@@ -651,7 +655,7 @@ func (d *dbStepSink) reconcile(runFinal string) {
 
 	// 用后台 ctx:取消场景下派生 ctx 已 Done,校正仍须持久化。
 	rows, err := d.svc.db.QueryContext(context.Background(),
-		`SELECT id, name, ordinal FROM run_steps
+		`SELECT id, name, COALESCE(stage, ''), ordinal FROM run_steps
 		 WHERE run_id = ? AND status NOT IN (?, ?, ?)`,
 		d.runID, StepSuccess, StepFailed, StepSkipped)
 	if err != nil {
@@ -661,12 +665,13 @@ func (d *dbStepSink) reconcile(runFinal string) {
 	type pending struct {
 		id      string
 		name    string
+		stage   string
 		ordinal int
 	}
 	var stuck []pending
 	for rows.Next() {
 		var p pending
-		if err := rows.Scan(&p.id, &p.name, &p.ordinal); err != nil {
+		if err := rows.Scan(&p.id, &p.name, &p.stage, &p.ordinal); err != nil {
 			log.Printf("[run] run %s: reconcile scan step failed: %v", d.runID, err)
 			_ = rows.Close()
 			return
@@ -690,6 +695,7 @@ func (d *dbStepSink) reconcile(runFinal string) {
 			Step: Step{
 				ID:         p.id,
 				Name:       p.name,
+				Stage:      p.stage,
 				Status:     target,
 				Ordinal:    p.ordinal,
 				FinishedAt: &now,
@@ -701,9 +707,13 @@ func (d *dbStepSink) reconcile(runFinal string) {
 // publish 经事件总线发布一个 step 事件(携带步骤快照,无日志正文)。
 func (d *dbStepSink) publish(ordinal int, status string, started, finished *time.Time) {
 	name := ""
+	stage := ""
 	id := ""
 	if ordinal >= 0 && ordinal < len(d.names) {
 		name = d.names[ordinal]
+	}
+	if ordinal >= 0 && ordinal < len(d.stages) {
+		stage = d.stages[ordinal]
 	}
 	if ordinal >= 0 && ordinal < len(d.stepIDs) {
 		id = d.stepIDs[ordinal]
@@ -715,6 +725,7 @@ func (d *dbStepSink) publish(ordinal int, status string, started, finished *time
 		Step: Step{
 			ID:         id,
 			Name:       name,
+			Stage:      stage,
 			Status:     status,
 			Ordinal:    ordinal,
 			StartedAt:  started,

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -122,13 +122,24 @@ type Trigger struct {
 }
 
 // Step 是穿珠时间线节点(运行步骤)。
+//
+// 节点级粒度(Story:运行详情下沉到 job 级):每个 step = 流水线里的一个 job(节点),
+// Stage 记其所属阶段名,供前端按「阶段 → 节点」两级聚合(进度图阶段框 + 步骤详情分组)。
+// 旧数据 / 非 DAG runner 的 step 其 Stage 可能为空(前端回退为单级展示)。
 type Step struct {
 	ID         string
 	Name       string
+	Stage      string // 所属阶段名(节点级分组;空 = 未分组,前端单级回退)
 	Status     string // pending|running|success|failed|skipped
 	Ordinal    int
 	StartedAt  *time.Time
 	FinishedAt *time.Time
+}
+
+// StepDecl 是 Plan 声明一个步骤(节点)的入参:节点名 + 所属阶段名。
+type StepDecl struct {
+	Name  string
+	Stage string
 }
 
 // Run 是一次流水线运行的领域模型。Steps 按 Ordinal 升序。

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -128,7 +128,7 @@ func TestConcurrentRunsIndependent(t *testing.T) {
 type branchRunner struct{}
 
 func (branchRunner) Run(ctx context.Context, r *Run, sink StepSink) error {
-	if err := sink.Plan(ctx, []string{"step1", "step2"}); err != nil {
+	if err := sink.Plan(ctx, []StepDecl{{Name: "step1"}, {Name: "step2"}}); err != nil {
 		return err
 	}
 	for i := 0; i < 2; i++ {
@@ -221,7 +221,7 @@ func TestCancelRunning(t *testing.T) {
 type blockingRunner struct{ gate chan struct{} }
 
 func (b *blockingRunner) Run(ctx context.Context, _ *Run, sink StepSink) error {
-	if err := sink.Plan(ctx, []string{"long"}); err != nil {
+	if err := sink.Plan(ctx, []StepDecl{{Name: "long"}}); err != nil {
 		return err
 	}
 	_ = sink.StepRunning(ctx, 0)
@@ -359,7 +359,7 @@ func TestReconcileHangingSteps(t *testing.T) {
 type hangingRunner struct{}
 
 func (hangingRunner) Run(ctx context.Context, _ *Run, sink StepSink) error {
-	if err := sink.Plan(ctx, []string{"hang"}); err != nil {
+	if err := sink.Plan(ctx, []StepDecl{{Name: "hang"}}); err != nil {
 		return err
 	}
 	_ = sink.StepRunning(ctx, 0)

--- a/internal/run/runner.go
+++ b/internal/run/runner.go
@@ -10,9 +10,9 @@ import (
 // 它声明步骤计划、置步骤运行/终态,由 worker 负责持久化 + 经事件总线发布。
 // 这样真实构建(3-3)只需实现 Runner、复用同一持久化/SSE 管道。
 type StepSink interface {
-	// Plan 声明本次运行的全部步骤名(按顺序);worker 据此落 run_steps(pending)。
-	// 必须在任何 StepRunning/StepDone 之前调用一次。
-	Plan(ctx context.Context, names []string) error
+	// Plan 声明本次运行的全部步骤(按顺序;每个 step = 一个 job 节点,带所属阶段名);
+	// worker 据此落 run_steps(pending)。必须在任何 StepRunning/StepDone 之前调用一次。
+	Plan(ctx context.Context, steps []StepDecl) error
 	// StepRunning 将第 ordinal 个步骤置为 running 并记录开始时刻。
 	StepRunning(ctx context.Context, ordinal int) error
 	// StepDone 将第 ordinal 个步骤置为终态(success|failed|skipped)并记录结束时刻。
@@ -203,7 +203,11 @@ func (s *StubRunner) Run(ctx context.Context, r *Run, sink StepSink) error {
 	if len(names) == 0 {
 		names = []string{"拉取源码", "构建镜像", "部署"}
 	}
-	if err := sink.Plan(ctx, names); err != nil {
+	decls := make([]StepDecl, len(names))
+	for i, n := range names {
+		decls[i] = StepDecl{Name: n} // 桩 runner 无阶段分组(Stage 留空 → 前端单级回退)
+	}
+	if err := sink.Plan(ctx, decls); err != nil {
 		return err
 	}
 	for i := range names {

--- a/internal/run/service.go
+++ b/internal/run/service.go
@@ -348,7 +348,7 @@ func (s *service) Get(ctx context.Context, id string) (*Run, error) {
 
 func (s *service) loadSteps(ctx context.Context, runID string) ([]Step, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, name, status, ordinal, started_at, finished_at
+		`SELECT id, name, COALESCE(stage, ''), status, ordinal, started_at, finished_at
 		 FROM run_steps WHERE run_id = ? ORDER BY ordinal ASC`, runID)
 	if err != nil {
 		return nil, fmt.Errorf("run: load steps: %w", err)
@@ -362,7 +362,7 @@ func (s *service) loadSteps(ctx context.Context, runID string) ([]Step, error) {
 			startedStr sql.NullString
 			finishStr  sql.NullString
 		)
-		if err := rows.Scan(&st.ID, &st.Name, &st.Status, &st.Ordinal, &startedStr, &finishStr); err != nil {
+		if err := rows.Scan(&st.ID, &st.Name, &st.Stage, &st.Status, &st.Ordinal, &startedStr, &finishStr); err != nil {
 			return nil, fmt.Errorf("run: scan step: %w", err)
 		}
 		if st.StartedAt, err = parseNullTime(startedStr); err != nil {

--- a/internal/store/migrations/0037_run_steps_stage.sql
+++ b/internal/store/migrations/0037_run_steps_stage.sql
@@ -1,0 +1,4 @@
+-- 运行步骤下沉到节点(job)级:run_steps 增 stage 列记录所属阶段名,
+-- 供运行详情按「阶段 → 节点」两级聚合(进度图阶段框 + 步骤详情分组)。
+-- 旧行 stage 为空串 → 前端回退为单级展示,无数据迁移负担。
+ALTER TABLE run_steps ADD COLUMN stage TEXT NOT NULL DEFAULT '';

--- a/web/src/api/aiGenerate.ts
+++ b/web/src/api/aiGenerate.ts
@@ -29,6 +29,10 @@ export interface AIProposalJob {
   name: string
   type: string
   summary: string
+  /** LLM 据仓库分析填好的可执行配置(命令/镜像/Dockerfile 路径/端口等);apply 时原样回传。 */
+  config?: Record<string, unknown>
+  /** 同阶段依赖的 job name(串行;如镜像依赖后端构建);空=并行。apply 时按 name 映射为 id。 */
+  needs?: string[]
 }
 
 export interface AIProposalStage {

--- a/web/src/api/runs.ts
+++ b/web/src/api/runs.ts
@@ -45,6 +45,8 @@ export interface ApprovalRecord {
 export interface RunStep {
   id: string
   name: string
+  /** 所属阶段名(节点级分组;空 = 未分组,前端单级回退)。 */
+  stage?: string
   status: StepStatus
   startedAt: string | null
   finishedAt: string | null

--- a/web/src/components/pipeline/AIGenerateWizard.vue
+++ b/web/src/components/pipeline/AIGenerateWizard.vue
@@ -422,13 +422,24 @@ watch(() => props.projectId, () => {
                         :key="job.id"
                         class="proposal-job"
                       >
-                        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                          <rect x="3" y="4" width="18" height="6" rx="1.5"/>
-                          <rect x="3" y="14" width="18" height="6" rx="1.5"/>
-                        </svg>
-                        <span class="job-name">{{ job.name }}</span>
-                        <span class="job-type">{{ job.type }}</span>
-                        <span v-if="job.summary" class="job-summary">— {{ job.summary }}</span>
+                        <div class="proposal-job-head">
+                          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                            <rect x="3" y="4" width="18" height="6" rx="1.5"/>
+                            <rect x="3" y="14" width="18" height="6" rx="1.5"/>
+                          </svg>
+                          <span class="job-name">{{ job.name }}</span>
+                          <span class="job-type">{{ job.type }}</span>
+                          <span v-if="job.summary" class="job-summary">— {{ job.summary }}</span>
+                        </div>
+                        <!-- 串/并:有 needs → 串行(显示依赖);无 needs → 与同阶段其它节点并行 -->
+                        <div v-if="job.needs && job.needs.length" class="job-needs">
+                          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+                          <span>串行 · 依赖 {{ job.needs.join('、') }}</span>
+                        </div>
+                        <div v-else class="job-needs job-needs--parallel">
+                          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><path d="M8 6v12M16 6v12"/></svg>
+                          <span>并行</span>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1263,13 +1274,31 @@ watch(() => props.projectId, () => {
 
 .proposal-job {
   display: flex;
-  align-items: center;
-  gap: 5px;
+  flex-direction: column;
+  gap: 2px;
   font-size: 0.76rem;
   color: var(--color-faint);
 }
 
+.proposal-job-head {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
 .proposal-job svg { color: var(--color-faint); flex-shrink: 0; }
+
+/* 串/并依赖指示:让预览体现节点编排(串行显依赖、并行显并行),不只是平铺列表。 */
+.job-needs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 16px;
+  font-size: 0.68rem;
+  color: var(--color-cyan);
+}
+.job-needs--parallel { color: var(--color-faint); }
+.job-needs svg { color: inherit; }
 
 .job-name {
   font-weight: 500;

--- a/web/src/components/pipeline/JobDrawer.vue
+++ b/web/src/components/pipeline/JobDrawer.vue
@@ -3,6 +3,7 @@ import { ref, computed, watch } from 'vue'
 import type { PipelineJob, PipelineStage } from '../../api/pipeline'
 import type { Credential } from '../../api/credentials'
 import type { Server } from '../../api/servers'
+import type { NotificationChannel } from '../../api/notifications'
 import {
   getJobTypeSpec,
   splitConfig,
@@ -28,6 +29,7 @@ const props = defineProps<{
   stage: PipelineStage
   credentials?: Credential[]
   servers?: Server[]
+  channels?: NotificationChannel[]
 }>()
 
 const emit = defineEmits<{
@@ -193,6 +195,18 @@ function credentialOptions(field: JobField): Credential[] {
   const all = props.credentials ?? []
   if (!field.credentialType) return all
   return all.filter((c) => c.type === field.credentialType)
+}
+
+const CHANNEL_TYPE_LABELS: Record<string, string> = {
+  webhook: 'Webhook',
+  email: '邮件',
+  feishu: '飞书',
+  wecom: '企业微信',
+  dingtalk: '钉钉',
+}
+
+function channelTypeLabel(type: string): string {
+  return CHANNEL_TYPE_LABELS[type] ?? type
 }
 
 // ─── Value get/set ────────────────────────────────────────────────────────────
@@ -501,6 +515,20 @@ async function confirmSave(): Promise<void> {
           <option value="">— 未选择 —</option>
           <option v-for="srv in (servers ?? [])" :key="srv.id" :value="srv.id">
             {{ srv.name }} · {{ srv.host }}
+          </option>
+        </select>
+
+        <!-- notification channel picker -->
+        <select
+          v-else-if="field.kind === 'channel'"
+          :value="fieldValue(field.key)"
+          class="drawer-select"
+          :aria-label="field.label"
+          @change="setField(field.key, ($event.target as HTMLSelectElement).value)"
+        >
+          <option value="">— 选择渠道 —</option>
+          <option v-for="ch in (channels ?? [])" :key="ch.id" :value="ch.id">
+            {{ ch.name }} · {{ channelTypeLabel(ch.type) }}{{ ch.enabled ? '' : '(已停用)' }}
           </option>
         </select>
 

--- a/web/src/components/pipeline/PipelineCanvas.vue
+++ b/web/src/components/pipeline/PipelineCanvas.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
 import type { PipelineStage, PipelineJob, StageKind } from '../../api/pipeline'
 import type { Credential } from '../../api/credentials'
 import type { Server } from '../../api/servers'
+import type { NotificationChannel } from '../../api/notifications'
 import StageColumn from './StageColumn.vue'
 import JobDrawer from './JobDrawer.vue'
 import StageDrawer from './StageDrawer.vue'
@@ -19,6 +20,7 @@ const props = defineProps<{
   yaml: string
   credentials?: Credential[]
   servers?: Server[]
+  channels?: NotificationChannel[]
 }>()
 
 const emit = defineEmits<{
@@ -398,6 +400,7 @@ function handleDrawerUpdate(patch: Partial<PipelineJob>): void {
       :stage="selectedStage"
       :credentials="props.credentials"
       :servers="props.servers"
+      :channels="props.channels"
       @close="closeDrawer"
       @update="handleDrawerUpdate"
       @change-type="requestChangeType"

--- a/web/src/components/pipeline/StageColumn.vue
+++ b/web/src/components/pipeline/StageColumn.vue
@@ -437,6 +437,21 @@ function resetDrag(): void {
   white-space: nowrap;
 }
 
+/* DAG mode: the column is as wide as the rank grid below; if the title keeps `flex:1`
+   it stretches across that whole width and dumps the action buttons to the far right
+   with an ugly empty gap in the middle. Pin the header content together at the left
+   (title takes only its own width; no auto-margin spacer) so it reads as one compact bar. */
+.stage-col--dag .stage-header {
+  width: fit-content;
+}
+.stage-col--dag .stage-name-text {
+  flex: 0 1 auto;
+  max-width: 220px;
+}
+.stage-col--dag .stage-add-job {
+  margin-left: 0;
+}
+
 .stage-deps-btn {
   display: inline-flex;
   align-items: center;

--- a/web/src/components/pipeline/jobConfigSchema.ts
+++ b/web/src/components/pipeline/jobConfigSchema.ts
@@ -26,6 +26,7 @@ export type FieldKind =
   | 'toggle'
   | 'credential'
   | 'server'
+  | 'channel'
 
 export interface SelectOption {
   value: string
@@ -464,24 +465,29 @@ export const JOB_TYPE_SPECS: Record<string, JobTypeSpec> = {
   notify: {
     type: 'notify',
     label: '通知',
-    description: '运行结束时发送通知',
+    description: '运行到此节点时发送通知',
     accent: 'cyan',
     category: 'notify',
     fields: [
       {
         key: 'channel',
         label: '通知渠道',
-        kind: 'text',
-        placeholder: '渠道 ID 或名称',
-        hint: '引用「通知」设置里已配置的渠道',
+        kind: 'channel',
+        hint: '从「通知」设置里已配置的渠道中选择;没有就先去设置里加一个',
       },
       {
-        key: 'events',
-        label: '触发事件',
+        key: 'titleTemplate',
+        label: '标题模板(可选)',
         kind: 'text',
-        monospace: true,
-        placeholder: 'success,failed',
-        hint: '逗号分隔;留空为全部终态',
+        placeholder: '部署成功:{{project}}',
+        hint: '留空用默认文案;支持占位 {{project}} {{branch}} {{commit}} {{status}} {{runId}}',
+      },
+      {
+        key: 'bodyTemplate',
+        label: '正文模板(可选)',
+        kind: 'textarea',
+        placeholder: '分支 {{branch}} @ {{commit}} 已执行到通知节点。',
+        hint: '留空用默认文案;同样支持 {{占位}},未知占位渲染为空',
       },
     ],
   },

--- a/web/src/components/pipeline/pipeline.css
+++ b/web/src/components/pipeline/pipeline.css
@@ -15,7 +15,8 @@
   background-color: var(--color-canvas);
   background-image: radial-gradient(oklch(100% 0 0 / 0.04) 1px, transparent 1px);
   background-size: 22px 22px;
-  padding: 34px 30px;
+  /* 上下内边距收窄(34→18):全幅画布把垂直空间让给节点,缓解「高度太窄」。 */
+  padding: 18px 30px;
   min-height: 0;
 }
 

--- a/web/src/components/run/DiagnosisPanel.vue
+++ b/web/src/components/run/DiagnosisPanel.vue
@@ -748,7 +748,10 @@ function confidenceLabel(level: DiagnosisDTO['confidence']): ConfLabel {
 /* ─── ready: two-column layout ──────────────────────────────────────────── */
 .dp-body--ready {
   display: grid;
-  grid-template-columns: 1.45fr 1fr;
+  /* minmax(0,…):fr 轨道默认 min-width:auto = 内容 min-content,修复脚本里的长 curl 行会把
+     左列撑爆、把右侧「原始日志证据」挤成只剩行号的窄条。置 0 让两列按 fr 比例收缩,长行交给
+     pre 自身 overflow-x 横向内滚 —— 小屏/窄容器下证据列不再被吞。 */
+  grid-template-columns: minmax(0, 1.45fr) minmax(0, 1fr);
   gap: 18px;
   align-items: start;
   padding: 20px;
@@ -765,6 +768,7 @@ function confidenceLabel(level: DiagnosisDTO['confidence']): ConfLabel {
   display: flex;
   flex-direction: column;
   gap: 14px;
+  min-width: 0; /* 允许列收缩到内容 min-content 之下(配合上面 minmax(0,…)) */
 }
 
 .dp-col-label {
@@ -874,6 +878,7 @@ function confidenceLabel(level: DiagnosisDTO['confidence']): ConfLabel {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  min-width: 0; /* 允许内部 pre 在收缩列里横向内滚而非撑宽 */
 }
 
 .dp-fixscript-head {
@@ -1096,17 +1101,19 @@ function confidenceLabel(level: DiagnosisDTO['confidence']): ConfLabel {
   overflow-x: auto;
 }
 
-/* Hit line: highlighted */
+/* Hit line: highlighted。终端恒为纯黑底,故用固定深红底 + 浅色字(不能用随主题翻转的
+   --color-red-soft/--color-text:浅色主题下它们是「浅底+近黑字」,贴黑终端=黑字黑底,
+   命中行文本看着像空的)。 */
 .dp-term-line--hit {
-  background: var(--color-red-soft);
+  background: oklch(48% 0.16 25 / 0.3);
 }
 
 .dp-term-line--hit .dp-term-ln {
-  color: var(--color-red);
+  color: oklch(74% 0.19 25);
 }
 
 .dp-term-line--hit .dp-term-code {
-  color: var(--color-text);
+  color: oklch(93% 0.03 25);
   font-weight: 500;
 }
 

--- a/web/src/components/run/RunStepList.vue
+++ b/web/src/components/run/RunStepList.vue
@@ -4,15 +4,56 @@
   纯展示组件:仅接收 steps prop,不自取数据。
 -->
 <script setup lang="ts">
-import type { RunStep } from '../../api/runs'
+import { computed } from 'vue'
+import type { RunStep, StepStatus } from '../../api/runs'
 
-defineProps<{
+const props = defineProps<{
   steps: RunStep[]
   /** 当前选中的步骤序号(用于高亮 + 过滤日志);null = 全部。 */
   selected?: number | null
 }>()
 
 const emit = defineEmits<{ select: [ordinal: number | null] }>()
+
+interface NodeRow {
+  step: RunStep
+  ordinal: number // 全局 step 序号(= 日志 stepOrdinal,用于过滤)
+}
+interface StageGroup {
+  stage: string
+  nodes: NodeRow[]
+  status: StepStatus
+}
+
+/** 任一失败→failed;任一运行→running;全跳过→skipped;全成功→success;否则 pending。 */
+function aggregate(nodes: NodeRow[]): StepStatus {
+  const ss = nodes.map((n) => n.step.status)
+  if (ss.some((s) => s === 'failed')) return 'failed'
+  if (ss.some((s) => s === 'running')) return 'running'
+  if (ss.length > 0 && ss.every((s) => s === 'success')) return 'success'
+  if (ss.length > 0 && ss.every((s) => s === 'skipped')) return 'skipped'
+  if (ss.some((s) => s === 'success')) return 'success'
+  return 'pending'
+}
+
+/** 是否启用节点级分组(任一 step 带 stage)。 */
+const grouped = computed(() => props.steps.some((s) => !!s.stage))
+
+/** 按阶段聚合(step 已按 ordinal 升序,同阶段连续)。 */
+const groups = computed<StageGroup[]>(() => {
+  const out: StageGroup[] = []
+  props.steps.forEach((step, ordinal) => {
+    const stage = step.stage || ''
+    let g = out[out.length - 1]
+    if (!g || g.stage !== stage) {
+      g = { stage, nodes: [], status: 'pending' }
+      out.push(g)
+    }
+    g.nodes.push({ step, ordinal })
+  })
+  for (const g of out) g.status = aggregate(g.nodes)
+  return out
+})
 
 function formatDuration(ms: number | null): string {
   if (ms === null) return '—'
@@ -39,37 +80,44 @@ function formatDuration(ms: number | null): string {
           <div class="step-info"><span class="step-name">全部日志</span></div>
         </button>
       </li>
-      <li
-        v-for="(step, idx) in steps"
-        :key="step.id"
-      >
-        <button
-          type="button"
-          class="step-row"
-          :class="[`step-row--${step.status}`, { 'step-row--selected': selected === idx }]"
-          @click="emit('select', idx)"
-        >
-        <div class="step-icon" :aria-label="step.status">
-          <svg v-if="step.status === 'success'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
-            <path d="M20 6 9 17l-5-5"/>
-          </svg>
-          <span v-else-if="step.status === 'running'" class="spinner spinner--amber" aria-hidden="true" />
-          <svg v-else-if="step.status === 'failed'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
-            <path d="m18 6-12 12M6 6l12 12"/>
-          </svg>
-          <svg v-else-if="step.status === 'skipped'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-            <path d="M13 17l5-5-5-5M6 17l5-5-5-5"/>
-          </svg>
-          <svg v-else width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-            <circle cx="12" cy="12" r="3"/>
-          </svg>
-        </div>
-        <div class="step-info">
-          <span class="step-name">{{ step.name }}</span>
-          <span v-if="step.durationMs !== null" class="step-dur mono">{{ formatDuration(step.durationMs) }}</span>
-        </div>
-        </button>
-      </li>
+
+      <template v-for="g in groups" :key="g.stage || '_'">
+        <!-- 阶段分组标题(节点级):阶段名 + 聚合状态点;无阶段名(旧数据)则不显示标题 -->
+        <li v-if="grouped && g.stage" class="stage-head" :class="`stage-head--${g.status}`">
+          <span class="stage-dot" :aria-label="g.status" />
+          <span class="stage-head-name">{{ g.stage }}</span>
+          <span class="stage-head-count">{{ g.nodes.length }} 节点</span>
+        </li>
+
+        <li v-for="n in g.nodes" :key="n.step.id">
+          <button
+            type="button"
+            class="step-row"
+            :class="[`step-row--${n.step.status}`, { 'step-row--selected': selected === n.ordinal, 'step-row--nested': grouped && g.stage }]"
+            @click="emit('select', n.ordinal)"
+          >
+            <div class="step-icon" :aria-label="n.step.status">
+              <svg v-if="n.step.status === 'success'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
+                <path d="M20 6 9 17l-5-5"/>
+              </svg>
+              <span v-else-if="n.step.status === 'running'" class="spinner spinner--amber" aria-hidden="true" />
+              <svg v-else-if="n.step.status === 'failed'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
+                <path d="m18 6-12 12M6 6l12 12"/>
+              </svg>
+              <svg v-else-if="n.step.status === 'skipped'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <path d="M13 17l5-5-5-5M6 17l5-5-5-5"/>
+              </svg>
+              <svg v-else width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <circle cx="12" cy="12" r="3"/>
+              </svg>
+            </div>
+            <div class="step-info">
+              <span class="step-name">{{ n.step.name }}</span>
+              <span v-if="n.step.durationMs !== null" class="step-dur mono">{{ formatDuration(n.step.durationMs) }}</span>
+            </div>
+          </button>
+        </li>
+      </template>
     </ul>
   </div>
 </template>
@@ -110,6 +158,38 @@ function formatDuration(ms: number | null): string {
 }
 
 .steps li { list-style: none; }
+
+/* 阶段分组标题(节点级):小标签 + 聚合状态点;节点行在其下缩进。 */
+.stage-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 10px 11px 4px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--color-dim);
+}
+.stage-head-name { text-transform: none; }
+.stage-head-count {
+  margin-left: auto;
+  font-size: 0.64rem;
+  font-weight: 400;
+  color: var(--color-faint);
+}
+.stage-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--color-faint);
+  flex-shrink: 0;
+}
+.stage-head--success .stage-dot { background: var(--color-green); }
+.stage-head--failed .stage-dot { background: var(--color-red); }
+.stage-head--running .stage-dot { background: var(--color-amber); }
+.stage-head--skipped .stage-dot { background: var(--color-faint); }
+/* 节点行在阶段标题下缩进,呈现「阶段 → 节点」两级。 */
+.step-row--nested { margin-left: 12px; }
 
 /* step-row 现在是按钮:点击切换「单步日志」过滤 */
 .step-row {

--- a/web/src/components/run/runDag.test.ts
+++ b/web/src/components/run/runDag.test.ts
@@ -81,6 +81,30 @@ describe('findStageForStep', () => {
   it('returns null for no match', () => {
     expect(findStageForStep(mkStep('x', 'checkout'), stages)).toBeNull()
   })
+
+  it('节点级:优先按 step.stage 精确归到同名阶段(节点名与阶段名不同也能归组)', () => {
+    const s = { ...mkStep('x', 'A'), stage: 'Build' }
+    expect(findStageForStep(s, stages)).toBe('s1')
+    // stage 精确优先于模糊名匹配:名为 deploy 但 stage=Build → 归 Build
+    const s2 = { ...mkStep('y', 'deploy'), stage: 'Build' }
+    expect(findStageForStep(s2, stages)).toBe('s1')
+  })
+})
+
+describe('buildRunStages 节点级分组', () => {
+  it('同阶段多节点按 step.stage 归到该阶段的 steps(供进度图展开 / 详情两级)', () => {
+    const stages = [mkStage('b', '构建')]
+    const steps: RunStep[] = [
+      { ...mkStep('a', 'A', 'success'), stage: '构建' },
+      { ...mkStep('bb', 'B', 'success'), stage: '构建' },
+      { ...mkStep('c', 'C', 'running'), stage: '构建' },
+    ]
+    const result = buildRunStages(steps, stages)
+    const build = result.find((s) => s.id === 'b')
+    expect(build).toBeTruthy()
+    expect(build!.steps.map((s) => s.name)).toEqual(['A', 'B', 'C'])
+    expect(build!.status).toBe('running') // 任一运行 → 阶段运行
+  })
 })
 
 // ─── buildRunStages ───────────────────────────────────────────────────────────

--- a/web/src/components/run/runDag.ts
+++ b/web/src/components/run/runDag.ts
@@ -70,6 +70,14 @@ export function findStageForStep(
   step: RunStep,
   stages: ReadonlyArray<PipelineStage>,
 ): string | null {
+  // 0. 节点级:step 自带所属阶段名(后端 run_steps.stage)时按阶段名精确归组,
+  //    一个阶段聚合其全部节点 step(进度图阶段框可展开看各节点)。最可靠,优先。
+  if (step.stage) {
+    const normStage = normalise(step.stage)
+    for (const s of stages) {
+      if (normalise(s.name) === normStage) return s.id
+    }
+  }
   const normStep = normalise(step.name)
   // 1. Exact name match (case-insensitive)
   for (const s of stages) {

--- a/web/src/views/ProjectPipeline.vue
+++ b/web/src/views/ProjectPipeline.vue
@@ -18,6 +18,7 @@ import {
 import { listCredentials, type Credential } from '../api/credentials'
 import { listProjects, type Project } from '../api/projects'
 import { listServers, type Server } from '../api/servers'
+import { listChannels, type NotificationChannel } from '../api/notifications'
 import { getValidation, type ValidationDTO, type IssueScope } from '../api/pipelineValidation'
 import { HttpError } from '../api/http'
 import PipelineCanvas from '../components/pipeline/PipelineCanvas.vue'
@@ -107,6 +108,7 @@ const editBuild    = ref<BuildConfig | null>(null)
 const editEnvs     = ref<Environment[]>([])
 const credentials  = ref<Credential[]>([])
 const servers      = ref<Server[]>([])
+const channels     = ref<NotificationChannel[]>([])
 
 function applySettings(dto: SettingsDTO): void {
   settings.value = dto
@@ -116,14 +118,16 @@ function applySettings(dto: SettingsDTO): void {
 
 async function loadSettings(): Promise<void> {
   try {
-    const [dto, creds, srvs] = await Promise.all([
+    const [dto, creds, srvs, chs] = await Promise.all([
       getSettings(projectId.value),
       listCredentials().catch(() => [] as Credential[]),
       listServers().catch(() => [] as Server[]),
+      listChannels().catch(() => [] as NotificationChannel[]),
     ])
     applySettings(dto)
     credentials.value = creds
     servers.value = srvs
+    channels.value = chs
   } catch {
     // Settings load failure is non-fatal for the canvas; the vars/envs tabs show
     // their own empty state until a successful save. Surfaced on save attempts.
@@ -528,6 +532,7 @@ async function loadProject(): Promise<void> {
             :yaml="pipeline.yaml"
             :credentials="credentials"
             :servers="servers"
+            :channels="channels"
             @update="handleCanvasUpdate"
           />
 
@@ -641,8 +646,11 @@ async function loadProject(): Promise<void> {
    * 增高,height:100% 无法解析成确定值),会导致抽屉撑满内容、被 overflow:hidden 链裁掉
    * 底部(后置步骤够不到)。这里按视口减去 .main-inner 的上下内边距锁定高度,使内部
    * overflow:auto/hidden 的滚动真正生效。
+   *
+   * 底部只留一小段呼吸位(而非整段 --main-pad-bottom):编辑器是全幅工作面板,把原本
+   * ~90px 的底部留白还给画布,缓解「画布高度太窄」。顶部仍减 --main-pad-top 对齐父内边距。
    */
-  height: calc(100vh - var(--main-pad-top) - var(--main-pad-bottom));
+  height: calc(100vh - var(--main-pad-top) - 20px);
   min-height: 0;
   gap: 0;
 }

--- a/web/src/views/settings/SettingsNotifications.vue
+++ b/web/src/views/settings/SettingsNotifications.vue
@@ -4,11 +4,12 @@
  *
  * Delivers:
  *   - Channel list (name / type / enabled / config summary)
- *   - Create / edit (type webhook | email + per-type fields)
+ *   - Create / edit (type webhook | email | feishu + per-type fields)
  *   - email SMTP password: WRITE-ONLY — never echoed; masked placeholder when stored
  *   - Test send with ok/latency/error result
  *   - Delete with confirm
- *   - wecom/dingtalk/feishu shown as "soon" placeholders (saveable, test=not_implemented)
+ *   - feishu: custom-bot webhook (url + optional sign secret); sends {msg_type,content}
+ *   - wecom/dingtalk shown as "soon" placeholders (saveable, test=not_implemented)
  *
  * Reuses: FormField / AppButton tokens from 1-6. No new UI libraries.
  * Animation: transform/opacity + prefers-reduced-motion. Sensitive fields never
@@ -73,9 +74,16 @@ const TYPES: TypeMeta[] = [
     glyphStyle: 'background:oklch(70% 0.14 250 / 0.16);color:oklch(62% 0.16 250)',
     implemented: true,
   },
+  {
+    id: 'feishu',
+    label: '飞书',
+    desc: '自定义机器人',
+    glyph: '飞',
+    glyphStyle: 'background:oklch(72% 0.15 200 / 0.16);color:oklch(56% 0.13 220)',
+    implemented: true,
+  },
   { id: 'wecom', label: '企业微信', desc: '即将支持', glyph: '企', glyphStyle: 'background:var(--color-inset);color:var(--color-faint)', implemented: false },
   { id: 'dingtalk', label: '钉钉', desc: '即将支持', glyph: '钉', glyphStyle: 'background:var(--color-inset);color:var(--color-faint)', implemented: false },
-  { id: 'feishu', label: '飞书', desc: '即将支持', glyph: '飞', glyphStyle: 'background:var(--color-inset);color:var(--color-faint)', implemented: false },
 ]
 
 function typeMeta(t: ChannelType): TypeMeta {
@@ -141,6 +149,7 @@ const saving = ref(false)
 
 const isEmail = computed(() => form.type === 'email')
 const isWebhook = computed(() => form.type === 'webhook')
+const isFeishu = computed(() => form.type === 'feishu')
 const selectedTypeMeta = computed(() => typeMeta(form.type))
 
 function resetForm(): void {
@@ -215,6 +224,11 @@ function validate(): boolean {
       fieldErrors.url = '请填写 Webhook 地址'
       ok = false
     }
+  } else if (isFeishu.value) {
+    if (!form.url.trim()) {
+      fieldErrors.url = '请填写飞书机器人 Webhook 地址'
+      ok = false
+    }
   } else if (isEmail.value) {
     if (!form.smtpHost.trim()) {
       fieldErrors.smtpHost = '请填写 SMTP 主机'
@@ -240,6 +254,12 @@ function validate(): boolean {
 function buildConfig(): ChannelConfigInput {
   if (isWebhook.value) {
     return { url: form.url.trim() }
+  }
+  if (isFeishu.value) {
+    // 飞书:url=机器人 webhook 地址;password=可选签名密钥(机器人开启「签名校验」时填)。
+    const cfg: ChannelConfigInput = { url: form.url.trim() }
+    if (form.password) cfg.password = form.password
+    return cfg
   }
   if (isEmail.value) {
     const cfg: ChannelConfigInput = {
@@ -860,6 +880,53 @@ function configSummary(ch: NotificationChannel): string {
                   </template>
                 </FormField>
               </div>
+
+              <!-- Feishu fields -->
+              <template v-else-if="isFeishu">
+                <div class="config-row">
+                  <FormField
+                    label="飞书机器人 Webhook 地址"
+                    field-id="nt-fs-url"
+                    :error="fieldErrors.url"
+                    hint="飞书群「设置 → 群机器人 → 自定义机器人」的 Webhook 地址(open.feishu.cn/open-apis/bot/v2/hook/…)"
+                    required
+                  >
+                    <template #default="{ fieldId, ariaDescribedby }">
+                      <input
+                        :id="fieldId"
+                        v-model="form.url"
+                        type="url"
+                        class="field-input field-input--mono"
+                        :class="{ 'field-input--error': fieldErrors.url }"
+                        placeholder="https://open.feishu.cn/open-apis/bot/v2/hook/…"
+                        :aria-describedby="ariaDescribedby"
+                        :disabled="saving"
+                        @input="fieldErrors.url = ''"
+                      />
+                    </template>
+                  </FormField>
+                </div>
+                <div class="config-row">
+                  <FormField
+                    label="签名密钥(可选)"
+                    field-id="nt-fs-secret"
+                    :hint="hasStoredPassword ? '已配置 ••••(留空则保留)' : '仅当机器人开启「签名校验」时填写;写入后绝不回显'"
+                  >
+                    <template #default="{ fieldId, ariaDescribedby }">
+                      <input
+                        :id="fieldId"
+                        v-model="form.password"
+                        type="password"
+                        class="field-input field-input--mono"
+                        :placeholder="hasStoredPassword ? '已配置 ••••(留空不变)' : '机器人未开启签名校验则留空'"
+                        autocomplete="new-password"
+                        :aria-describedby="ariaDescribedby"
+                        :disabled="saving"
+                      />
+                    </template>
+                  </FormField>
+                </div>
+              </template>
 
               <!-- Email fields -->
               <template v-else-if="isEmail">


### PR DESCRIPTION
本分支汇集本轮通知 / 运行详情 / AI 生成 / 画布与诊断 UX 多项改进(4 个文件互不重叠的提交,便于分块审)。后端 `go vet`/`go test ./...` 全过、`gofmt` 净;前端 `typecheck`/`lint`(0 err)/`vitest`(311)全过;真 docker-in-docker 走页面亲验(含 AI 完全生成流水线 → 部署成功、actuator UP)。

## 1. feat(notify) 原生飞书渠道 + 通知节点渠道下拉/模板
- `internal/notify` 落 `TypeFeishu`:发 `{msg_type,content}` 正确格式 + **校验返回 JSON 的 `code`**(修「飞书参数错也回 HTTP 200 被误判成功」),可选签名密钥。
- 通知节点(画布):渠道由自由文本 → **已配渠道下拉**;新增**标题/正文模板**(`{{vars}}`,`notify.RenderText` 服务端渲染,纯文本替换无 RCE)。

## 2. feat(run) 运行详情下沉到节点(job)级 + DAG 失败日志捕获
- `run_steps` 阶段级 → **job 级**(迁移 `0037` 加 `stage` 列;`Plan([]StepDecl)`);日志靠 `stepOrdinal` 天然按节点分流。进度图按阶段聚合可展开看节点,步骤详情「阶段→节点」两级、各节点日志可点。
- 修真 bug:**DAG 执行器此前从不写 `failure_log`** → 失败 run 的 AI 诊断恒「无失败日志」;新增 `tapSink` 捕获日志尾部落 `failure_log`。

## 3. feat(ai) 仓库分析 monorepo 化 + 动态节点目录 + 配置/串并行填充
- 仓库分析下钻子目录(monorepo `backend/`/`frontend/` 不再「未识别」)。
- 把**全部可用节点(内置 + 复用库自定义节点)**作为工具清单喂 LLM;让 LLM **填好每个节点可执行 config**(命令/镜像/Dockerfile 路径/端口/健康 URL)并用 **`needs` 表达串/并**(修 applySelectedStages 此前硬置空 config + 无依赖);提案预览标「并行 / 串行·依赖 X」。
- 诊断面板:小屏证据列被挤窄(`minmax(0,…)`)、命中行黑底黑字(改固定浅色)双修。

## 4. fix(pipeline) 画布阶段头拉伸/高度 + 通知渠道接入
- DAG 阶段头 `fit-content` 不再横跨拉伸(消除中间空隙);画布回收底部留白、高度更舒展。

🤖 Generated with [Claude Code](https://claude.com/claude-code)