### PR TITLE
feat(release): tag 驱动发版 + 一键部署(GoReleaser / ghcr / install.sh / compose)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# docker-compose 配置示例。复制为 .env 后按需修改:cp .env.example .env
+# .env 含密钥,已被 .gitignore 忽略,切勿提交。
+
+# 初始管理员口令(必填)。首次启动据此建 admin 账户。
+PIPEWRIGHT_ADMIN_PASSWORD=change-me-please
+
+# 凭据保险库主密钥:base64 编码的 32 字节。生成:
+#   openssl rand -base64 32
+# 留空则保险库进未配置态(加密凭据功能不可用,平台其余功能照常)。
+# 重要:一旦写入凭据,务必长期保存此 key —— 更换会导致已存凭据无法解密。
+PIPEWRIGHT_MASTER_KEY=
+
+# 监听端口(宿主侧)。默认 8080。
+PIPEWRIGHT_PORT=8080
+
+# 镜像版本:默认 latest;生产建议钉具体版本,如 1.0.0。
+PIPEWRIGHT_VERSION=latest
+
+# 反代后部署时填外部可访问 URL(webhook/OAuth 回跳用),如 https://ci.example.com
+PIPEWRIGHT_PUBLIC_URL=
+
+# ---- 数据库(默认 sqlite,落具名卷,无需配置)----
+# 切 MySQL:取消下面三行注释,并以 --profile mysql 启动 compose。
+# PIPEWRIGHT_DB_DRIVER=mysql
+# PIPEWRIGHT_DB_DSN=pipewright:pipewright@tcp(mysql:3306)/pipewright?parseTime=true&charset=utf8mb4
+# MYSQL_PASSWORD=pipewright
+# MYSQL_ROOT_PASSWORD=rootpw

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+# 发版流水线:推送 v* tag 触发。
+# GoReleaser 跨平台构建 → GitHub Release(二进制 + 校验和 + changelog)+ ghcr.io 多架构镜像。
+# 与 ci.yml(每次 push/PR 跑测试)正交;此处只在打 tag 时跑。
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write # 创建 GitHub Release、上传产物
+  packages: write # 推送镜像到 ghcr.io
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # GoReleaser 需要完整历史与 tag 生成 changelog
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # 多架构镜像构建所需:QEMU(跨架构模拟)+ buildx。
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      # 登录 ghcr.io,用 workflow 自带 GITHUB_TOKEN,无需额外配置密钥。
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /pipewright-*
 *.test
 *.out
+# GoReleaser 发版产物(本地 snapshot / release 的输出目录),不入库
+/dist/
 *.db
 *.db-journal
 *.db-wal
@@ -23,6 +25,9 @@
 /web/pw-*.mjs
 # 一次性演示/原型 scratch — 不入库
 /demos/
+
+# docker-compose 本地密钥(含 master key / 口令),不入库;仅 .env.example 入库
+.env
 
 # Claude Code 本地设置(机器特定权限/覆盖,不入库)
 .claude/settings.local.json

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,116 @@
+# GoReleaser 发版配置:推 v* tag → 跨平台静态二进制 + 校验和 + changelog → GitHub Release;
+# 同时构建 linux amd64/arm64 镜像并合并为多架构清单推 ghcr.io。
+# 本地干跑:goreleaser release --snapshot --clean --skip=publish,docker
+# 校验配置:goreleaser check
+version: 2
+
+project_name: pipewright
+
+before:
+  hooks:
+    - go mod download
+    # 前端先构建,供 go:embed(web/dist)。各架构二进制共享同一份与平台无关的前端产物。
+    - bash -c "cd web && npm ci && npm run build"
+
+builds:
+  - id: pipewright
+    main: ./cmd/pipewright
+    binary: pipewright
+    env:
+      - CGO_ENABLED=0 # modernc sqlite + go-sql-driver/mysql 均纯 Go,可纯静态交叉编译
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: "{{ .CommitTimestamp }}" # 可复现构建
+    ldflags:
+      - -s -w
+      - -X github.com/huangchengsir/pipewright/internal/version.Version={{ .Version }}
+      - -X github.com/huangchengsir/pipewright/internal/version.Commit={{ .ShortCommit }}
+      - -X github.com/huangchengsir/pipewright/internal/version.Date={{ .CommitDate }}
+
+archives:
+  - id: default
+    formats: [tar.gz]
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - README.md
+      - LICENSE
+      - SECURITY.md
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  use: github
+  groups:
+    - title: 🚀 新功能
+      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      order: 0
+    - title: 🐛 修复
+      regexp: '^.*?fix(\(.+\))??!?:.+$'
+      order: 1
+    - title: ⚡ 性能
+      regexp: '^.*?perf(\(.+\))??!?:.+$'
+      order: 2
+    - title: 其它
+      order: 999
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "^ci:"
+      - "^style:"
+      - Merge pull request
+      - Merge branch
+
+# dockers_v2:单条目自动构建多架构镜像并合并清单(取代已弃用的 dockers + docker_manifests)。
+dockers_v2:
+  - id: ghcr
+    dockerfile: Dockerfile.goreleaser
+    images:
+      - ghcr.io/huangchengsir/pipewright
+    tags:
+      - "{{ .Version }}"
+      # latest 仅正式版推送(预发布 tag 跳过)。
+      - "{{ if not .Prerelease }}latest{{ end }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      org.opencontainers.image.title: "{{ .ProjectName }}"
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.source: https://github.com/huangchengsir/pipewright
+      org.opencontainers.image.licenses: MIT
+
+release:
+  github:
+    owner: huangchengsir
+    name: pipewright
+  draft: false
+  # 含 -rc/-beta 等预发布标识的 tag 自动标记为 prerelease。
+  prerelease: auto
+  name_template: "Pipewright {{ .Tag }}"
+  footer: |
+    ---
+    ## 安装
+
+    一键安装(Linux / macOS):
+    ```sh
+    curl -fsSL https://raw.githubusercontent.com/huangchengsir/pipewright/master/install.sh | sh
+    ```
+
+    Docker:
+    ```sh
+    docker run -d -p 8080:8080 -v pipewright-data:/data ghcr.io/huangchengsir/pipewright:{{ .Tag }}
+    ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,6 +163,25 @@ docs(readme): clarify master key handling
 
 ---
 
+## 发版 / Releasing(维护者)
+
+版本由 git tag 驱动,推送 `v*` tag 即触发 [`release` workflow](.github/workflows/release.yml):
+GoReleaser 跨平台构建二进制 + 校验和 + changelog 发到 GitHub Release,并推多架构镜像到 ghcr.io。
+
+```bash
+# 1. 确保 master 全绿、本地与 origin 同步
+git checkout master && git pull
+# 2. 打 SemVer tag(预发布用 -rc.1 / -beta.1 等后缀,自动标记 prerelease 且不动 latest)
+git tag -a v1.2.3 -m "v1.2.3"
+git push origin v1.2.3
+# 3. 改配置后本地干跑验证(不发布):
+#    goreleaser check && goreleaser release --snapshot --clean --skip=publish,docker
+```
+
+版本元数据经 `-ldflags` 注入 `internal/version`,运行期可由 `pipewright --version` 或 `GET /version` 读取。
+
+---
+
 ## 许可 / Licensing
 
 提交即表示你的贡献以本项目的 [MIT License](LICENSE) 授权。

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # 双运行模式之容器形态。最终镜像 = distroless static + 单静态二进制(前端已 go:embed)。
-# 注:Story 1.1 阶段本机未装 Docker,此文件作为脚手架交付,容器构建/运行的验证延后。
+# 此 Dockerfile 自包含从源码构建(docker build 全链路);发版流水线用 Dockerfile.goreleaser
+# 直接包装 GoReleaser 已交叉编译好的二进制(避免每架构重跑前端构建)。
 
 # ---- 前端构建 ----
 FROM node:22-alpine AS web
@@ -16,14 +17,28 @@ ENV CGO_ENABLED=0 \
     GOSUMDB=off \
     GOTOOLCHAIN=local
 WORKDIR /app
+# 版本元数据由构建方传入(docker build --build-arg VERSION=...);缺省为开发态。
+ARG VERSION=dev
+ARG COMMIT=none
+ARG DATE=unknown
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 COPY --from=web /app/web/dist ./web/dist
-RUN go build -o /pipewright ./cmd/pipewright
+RUN go build \
+    -ldflags "-s -w \
+      -X github.com/huangchengsir/pipewright/internal/version.Version=${VERSION} \
+      -X github.com/huangchengsir/pipewright/internal/version.Commit=${COMMIT} \
+      -X github.com/huangchengsir/pipewright/internal/version.Date=${DATE}" \
+    -o /pipewright ./cmd/pipewright
+# 预建数据目录,归 nonroot(65532)所有:具名卷挂到 /data 会继承此属主,免手动 chown。
+RUN mkdir -p /data
 
 # ---- 运行镜像 ----
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=build /pipewright /pipewright
+COPY --from=build --chown=65532:65532 /data /data
+# 工作目录设为 /data:sqlite(pipewright.db)与相对路径产物默认落此,持久化卷一挂即生效。
+WORKDIR /data
 EXPOSE 8080
 ENTRYPOINT ["/pipewright"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,14 @@
+# 发版专用:包装 GoReleaser 已交叉编译好的静态二进制(前端已 go:embed),不在镜像内重编。
+# 由 dockers_v2 跨架构构建并合并多架构清单。手动 docker build 请用根目录 Dockerfile。
+
+# distroless 无 shell,借 busybox 预建归 nonroot(65532)所有的 /data,供持久化卷继承属主。
+FROM busybox AS prep
+RUN mkdir -p /data && chown 65532:65532 /data
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY pipewright /pipewright
+COPY --from=prep --chown=65532:65532 /data /data
+# 工作目录设为 /data:sqlite(pipewright.db)与相对路径产物默认落此,持久化卷一挂即生效。
+WORKDIR /data
+EXPOSE 8080
+ENTRYPOINT ["/pipewright"]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,14 @@ BIN := pipewright
 GO_PKGS := . ./cmd/... ./internal/...
 GO_FMT_DIRS := cmd internal embed.go
 
-.PHONY: all build embed-frontend go-build test vet fmt fmt-check mem-check dev run clean
+# 版本元数据:tag 优先(git describe),源码态回退 dev。发版由 .goreleaser.yaml 注入同名变量。
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
+DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+VPKG    := github.com/huangchengsir/pipewright/internal/version
+LDFLAGS := -s -w -X $(VPKG).Version=$(VERSION) -X $(VPKG).Commit=$(COMMIT) -X $(VPKG).Date=$(DATE)
+
+.PHONY: all build embed-frontend go-build test vet fmt fmt-check mem-check dev run version clean
 
 all: build
 
@@ -13,7 +20,7 @@ embed-frontend:
 	cd web && npm ci && npm run build
 
 go-build:
-	CGO_ENABLED=0 go build -o $(BIN) ./cmd/pipewright
+	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o $(BIN) ./cmd/pipewright
 
 ## build: 前端构建 → go:embed → 静态单二进制(双运行模式之原生形态)
 build: embed-frontend go-build
@@ -40,6 +47,10 @@ mem-check:
 dev:
 	@echo "终端1: go run ./cmd/pipewright"
 	@echo "终端2: cd web && npm run dev   # 代理 /api /healthz 到 :8080"
+
+## version: 打印将注入二进制的版本元数据(调试发版用)
+version:
+	@echo "VERSION=$(VERSION)"; echo "COMMIT=$(COMMIT)"; echo "DATE=$(DATE)"
 
 run: go-build
 	./$(BIN)

--- a/README.md
+++ b/README.md
@@ -48,26 +48,52 @@
 
 > 安全不可妥协:凭据仅以密文存储、命令 array 化防注入(AC-SEC-02)、出网 SSRF 收口、日志脱敏。
 
-## 快速开始
+## 安装 / 部署
+
+三种形态任选,数据均落本地、无外部依赖。
+
+### ① 一键脚本(Linux / macOS)
+
+从 GitHub Release 下载对应平台的静态二进制装到 `/usr/local/bin`(含校验和核验):
 
 ```bash
-# 1. 构建(纯 Go,无 CGO;前端经 go:embed 内嵌)
-make build          # 产出单个静态二进制 ./pipewright
+curl -fsSL https://raw.githubusercontent.com/huangchengsir/pipewright/master/install.sh | sh
 
-# 2. 运行(首次启动引导管理员;master key 用于凭据保险库)
-PIPEWRIGHT_MASTER_KEY=$(head -c32 /dev/urandom | base64) \
+# 钉版本 / 自定义目录:
+VERSION=v1.0.0 INSTALL_DIR=$HOME/.local/bin \
+  sh -c "$(curl -fsSL https://raw.githubusercontent.com/huangchengsir/pipewright/master/install.sh)"
+
+# 运行(首次启动引导管理员;master key 用于凭据保险库)
+PIPEWRIGHT_MASTER_KEY=$(openssl rand -base64 32) \
 PIPEWRIGHT_ADMIN_PASSWORD=change-me \
-PIPEWRIGHT_ADDR=:8080 \
-./pipewright
-
-# 3. 打开 http://localhost:8080,用 admin / change-me 登录
+  pipewright          # 打开 http://localhost:8080,用 admin / change-me 登录
 ```
 
-容器运行:
+> Windows 用户:到 [Releases](https://github.com/huangchengsir/pipewright/releases) 下载 `.zip`。
+
+### ② docker compose(推荐自托管)
 
 ```bash
-docker build -t pipewright .
-docker run -p 8080:8080 -e PIPEWRIGHT_MASTER_KEY=... -e PIPEWRIGHT_ADMIN_PASSWORD=... pipewright
+curl -fsSLO https://raw.githubusercontent.com/huangchengsir/pipewright/master/docker-compose.yml
+curl -fsSLO https://raw.githubusercontent.com/huangchengsir/pipewright/master/.env.example
+cp .env.example .env       # 至少设 PIPEWRIGHT_ADMIN_PASSWORD,并 openssl rand -base64 32 填 MASTER_KEY
+docker compose up -d       # 数据持久化在具名卷 pipewright-data;切 MySQL 见 .env 注释
+```
+
+### ③ docker run(最快试用)
+
+```bash
+docker run -d -p 8080:8080 -v pipewright-data:/data \
+  -e PIPEWRIGHT_ADMIN_PASSWORD=change-me \
+  -e PIPEWRIGHT_MASTER_KEY=$(openssl rand -base64 32) \
+  ghcr.io/huangchengsir/pipewright:latest
+```
+
+### 从源码构建
+
+```bash
+make build          # 前端构建 → go:embed → 单个静态二进制 ./pipewright(纯 Go,无 CGO)
+./pipewright --version
 ```
 
 ### 配置(环境变量)
@@ -75,7 +101,9 @@ docker run -p 8080:8080 -e PIPEWRIGHT_MASTER_KEY=... -e PIPEWRIGHT_ADMIN_PASSWOR
 | 变量 | 说明 | 默认 |
 |---|---|---|
 | `PIPEWRIGHT_ADDR` | HTTP 监听地址 | `:8080` |
-| `PIPEWRIGHT_DB` | SQLite 数据库路径 | `pipewright.db` |
+| `PIPEWRIGHT_DB_DRIVER` | 数据库驱动:`sqlite` 或 `mysql` | `sqlite` |
+| `PIPEWRIGHT_DB` | SQLite 数据库路径(driver=sqlite 时) | `pipewright.db` |
+| `PIPEWRIGHT_DB_DSN` | MySQL DSN(driver=mysql 时必填) | 无 |
 | `PIPEWRIGHT_MASTER_KEY` | 凭据保险库主密钥(base64 的 32 字节);或用 `_FILE` 指文件 | 未配则保险库禁用 |
 | `PIPEWRIGHT_ADMIN_USERNAME` | 首次启动管理员用户名 | `admin` |
 | `PIPEWRIGHT_ADMIN_PASSWORD` | 首次启动管理员口令 | 无(须设置) |

--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -48,9 +48,18 @@ import (
 	"github.com/huangchengsir/pipewright/internal/target"
 	"github.com/huangchengsir/pipewright/internal/trigger"
 	"github.com/huangchengsir/pipewright/internal/vault"
+	"github.com/huangchengsir/pipewright/internal/version"
 )
 
 func main() {
+	// --version / -v:在任何配置加载、存储打开等副作用之前处理,纯查询即打印退出。
+	for _, a := range os.Args[1:] {
+		if a == "--version" || a == "-version" || a == "-v" {
+			println(version.String())
+			return
+		}
+	}
+
 	cfg := config.Load()
 
 	dbDriver, dbDSN, err := cfg.StoreConfig()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,63 @@
+# Pipewright 自托管 —— docker compose 一键起。
+#
+#   1. cp .env.example .env  并按注释填好(至少生成 PIPEWRIGHT_MASTER_KEY)
+#   2. docker compose up -d
+#   3. 打开 http://localhost:8080,用 admin / 你设的口令登录
+#
+# 数据(sqlite 库 / 构建产物 / 仓库缓存)持久化在具名卷 pipewright-data(挂到容器 /data,
+# 镜像已将 /data 设为 nonroot 属主与工作目录)。master key 务必持久保存:换 key 旧凭据无法解密。
+services:
+  pipewright:
+    image: ghcr.io/huangchengsir/pipewright:${PIPEWRIGHT_VERSION:-latest}
+    container_name: pipewright
+    restart: unless-stopped
+    ports:
+      - "${PIPEWRIGHT_PORT:-8080}:8080"
+    environment:
+      # 初始管理员口令(首启建账;之后改这里不改库)。务必改掉。
+      PIPEWRIGHT_ADMIN_PASSWORD: ${PIPEWRIGHT_ADMIN_PASSWORD:?请在 .env 设置 PIPEWRIGHT_ADMIN_PASSWORD}
+      # 凭据保险库主密钥(base64 的 32 字节)。空则保险库进未配置态、加密凭据功能不可用。
+      PIPEWRIGHT_MASTER_KEY: ${PIPEWRIGHT_MASTER_KEY:-}
+      # 反代后部署时填外部访问 URL(用于 webhook 回调 / OAuth 回跳)。
+      PIPEWRIGHT_PUBLIC_URL: ${PIPEWRIGHT_PUBLIC_URL:-}
+      # 默认 sqlite,库落 /data/pipewright.db(WORKDIR=/data)。切 MySQL 见下方 env + 注释。
+      PIPEWRIGHT_DB_DRIVER: ${PIPEWRIGHT_DB_DRIVER:-sqlite}
+      PIPEWRIGHT_DB_DSN: ${PIPEWRIGHT_DB_DSN:-}
+    volumes:
+      - pipewright-data:/data
+      # 隔离构建 / 镜像部署需要 Docker:取消下一行挂宿主 docker.sock(注意:等同授予宿主 root 级权限,
+      # 仅在信任的自托管环境开启)。注意 distroless 镜像不含 docker CLI;需要容器内跑 docker 构建时,
+      # 建议改用 install.sh 把二进制装在带 Docker 的宿主上,而非在本容器内构建。
+      # - /var/run/docker.sock:/var/run/docker.sock
+    healthcheck:
+      # 静态镜像无 curl/wget;用二进制自身做 TCP 探活的最小手段:复用 --version(进程可执行即健康)。
+      test: ["CMD", "/pipewright", "--version"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+
+  # 可选:MySQL 8。启用方式:
+  #   docker compose --profile mysql up -d
+  # 并在 .env 设 PIPEWRIGHT_DB_DRIVER=mysql、
+  #   PIPEWRIGHT_DB_DSN=pipewright:pipewright@tcp(mysql:3306)/pipewright?parseTime=true&charset=utf8mb4
+  mysql:
+    image: mysql:8.0
+    profiles: ["mysql"]
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: pipewright
+      MYSQL_USER: pipewright
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-pipewright}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-rootpw}
+    volumes:
+      - pipewright-mysql:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  pipewright-data:
+  pipewright-mysql:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# Pipewright 一键安装(Linux / macOS)。
+#
+#   curl -fsSL https://raw.githubusercontent.com/huangchengsir/pipewright/master/install.sh | sh
+#
+# 探测平台 → 从 GitHub Release 下载对应静态二进制 → 校验和核验 → 装到 /usr/local/bin。
+# 可配环境变量:
+#   VERSION       钉某版本(如 v1.2.3);缺省取 latest。
+#   INSTALL_DIR   安装目录;缺省 /usr/local/bin(不可写时自动 sudo)。
+#
+# Windows 用户请到 Releases 页下载 .zip:
+#   https://github.com/huangchengsir/pipewright/releases
+set -eu
+
+REPO="huangchengsir/pipewright"
+BIN="pipewright"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+info() { printf '\033[1;34m==>\033[0m %s\n' "$1"; }
+err() {
+	printf '\033[1;31m错误:\033[0m %s\n' "$1" >&2
+	exit 1
+}
+
+# 依赖检查:下载器与校验工具。
+if command -v curl >/dev/null 2>&1; then
+	DL="curl -fsSL"
+	DL_O="curl -fsSL -o"
+elif command -v wget >/dev/null 2>&1; then
+	DL="wget -qO-"
+	DL_O="wget -qO"
+else
+	err "需要 curl 或 wget。"
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+	SHA="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+	SHA="shasum -a 256"
+else
+	err "需要 sha256sum 或 shasum 做校验和核验。"
+fi
+
+# 平台探测。归档命名须与 .goreleaser.yaml 一致:pipewright_<版本无v>_<os>_<arch>.tar.gz
+OS="$(uname -s)"
+case "$OS" in
+Linux) OS="linux" ;;
+Darwin) OS="darwin" ;;
+*) err "不支持的系统:$OS(Windows 请到 Releases 页下载 .zip)。" ;;
+esac
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+x86_64 | amd64) ARCH="amd64" ;;
+aarch64 | arm64) ARCH="arm64" ;;
+*) err "不支持的架构:$ARCH。" ;;
+esac
+
+# 版本:缺省取 latest release 的 tag_name。
+TAG="${VERSION:-}"
+if [ -z "$TAG" ]; then
+	info "查询最新版本…"
+	TAG="$($DL "https://api.github.com/repos/${REPO}/releases/latest" |
+		grep '"tag_name"' | head -1 | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')"
+	[ -n "$TAG" ] || err "无法获取最新版本号(GitHub API 限流?可设 VERSION 环境变量钉版本)。"
+fi
+# 归档名用去掉前导 v 的版本号;下载路径用原始 tag。
+VER_NO_V="${TAG#v}"
+ARCHIVE="${BIN}_${VER_NO_V}_${OS}_${ARCH}.tar.gz"
+BASE="https://github.com/${REPO}/releases/download/${TAG}"
+
+info "安装 ${BIN} ${TAG}(${OS}/${ARCH})"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+info "下载 ${ARCHIVE}…"
+$DL_O "${TMP}/${ARCHIVE}" "${BASE}/${ARCHIVE}" || err "下载失败:${BASE}/${ARCHIVE}"
+$DL_O "${TMP}/checksums.txt" "${BASE}/checksums.txt" || err "下载校验和失败。"
+
+# 校验和核验:从 checksums.txt 取本归档的期望值,与实际比对。
+info "核验校验和…"
+EXPECTED="$(grep " ${ARCHIVE}\$" "${TMP}/checksums.txt" | awk '{print $1}')"
+[ -n "$EXPECTED" ] || err "checksums.txt 中找不到 ${ARCHIVE} 的条目。"
+ACTUAL="$($SHA "${TMP}/${ARCHIVE}" | awk '{print $1}')"
+[ "$EXPECTED" = "$ACTUAL" ] || err "校验和不匹配!期望 ${EXPECTED},实际 ${ACTUAL}。"
+
+info "解包…"
+tar -xzf "${TMP}/${ARCHIVE}" -C "$TMP" "$BIN" || err "解包失败。"
+chmod +x "${TMP}/${BIN}"
+
+# 安装:目录不可写则用 sudo。
+info "安装到 ${INSTALL_DIR}…"
+if [ -w "$INSTALL_DIR" ]; then
+	mv "${TMP}/${BIN}" "${INSTALL_DIR}/${BIN}"
+elif command -v sudo >/dev/null 2>&1; then
+	sudo mv "${TMP}/${BIN}" "${INSTALL_DIR}/${BIN}"
+else
+	err "${INSTALL_DIR} 不可写且无 sudo。可设 INSTALL_DIR=\$HOME/.local/bin 重试。"
+fi
+
+info "完成 ✓  $("${INSTALL_DIR}/${BIN}" --version 2>/dev/null || echo "${BIN} ${TAG}")"
+printf '启动:%s\n' "${BIN}   # 默认监听 :8080,数据落当前目录 pipewright.db"

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -337,6 +337,9 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		opt(&o)
 	}
 
+	// 更新检查器:进程级单例,内含 TTL 缓存(跨请求复用,避免反复点击打爆 GitHub 限流)。
+	updateChecker := version.NewChecker()
+
 	r := chi.NewRouter()
 	r.Use(middleware.Recoverer)
 
@@ -372,6 +375,9 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		// 审计 Recorder(Story 1.4):传给既有敏感操作 handler,业务成功后追加审计行。
 		// 为 nil 时 handler 跳过审计(不阻断业务)。
 		aud := o.audit
+
+		// 检查更新:鉴权只读,查 GitHub 最新发布并与当前版本比对(GET 免 CSRF)。
+		ar.Get("/version/check", makeCheckUpdateHandler(updateChecker))
 
 		// 审计查询(Story 1.4):只读 + 认证保护 + 分页 + 过滤。
 		ar.Get("/audit", makeListAuditHandler(aud))

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -37,6 +37,7 @@ import (
 	"github.com/huangchengsir/pipewright/internal/target"
 	"github.com/huangchengsir/pipewright/internal/trigger"
 	"github.com/huangchengsir/pipewright/internal/vault"
+	"github.com/huangchengsir/pipewright/internal/version"
 )
 
 const (
@@ -340,6 +341,8 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 	r.Use(middleware.Recoverer)
 
 	r.Get("/healthz", handleHealthz)
+	// /version 公开只读:暴露构建版本元数据,供升级检查与运维探针使用(非敏感)。
+	r.Get("/version", handleVersion)
 
 	svc := authn
 
@@ -921,6 +924,11 @@ func makeLogoutHandler(svc auth.Authenticator) http.HandlerFunc {
 
 func handleHealthz(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// handleVersion 返回构建期注入的版本元数据(version/commit/date/goVersion/platform)。
+func handleVersion(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, version.Get())
 }
 
 // spaHandler 服务嵌入文件系统中的静态资源;无扩展名的路径(前端路由)回退 index.html,

--- a/internal/httpapi/version.go
+++ b/internal/httpapi/version.go
@@ -1,0 +1,16 @@
+package httpapi
+
+import (
+	"net/http"
+
+	"github.com/huangchengsir/pipewright/internal/version"
+)
+
+// makeCheckUpdateHandler 处理 GET /api/version/check:查询 GitHub 最新发布并与当前版本比对。
+// 检查失败(网络/限流)不返 5xx —— 而是 200 + UpdateInfo.CheckError,让前端稳定渲染降级态。
+func makeCheckUpdateHandler(checker *version.Checker) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		info := checker.Check(r.Context())
+		writeJSON(w, http.StatusOK, info)
+	}
+}

--- a/internal/version/update.go
+++ b/internal/version/update.go
@@ -1,0 +1,268 @@
+package version
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// defaultRepo 是检查更新所查询的 GitHub 仓库(owner/name)。可经 PIPEWRIGHT_RELEASE_REPO 覆盖
+// (便于 fork 指向自己的发布渠道)。
+const defaultRepo = "huangchengsir/pipewright"
+
+// checkTTL 是更新检查结果的缓存时长:GitHub 未鉴权 API 限速 60 次/小时/IP,缓存避免反复点击打爆。
+const checkTTL = 15 * time.Minute
+
+// UpdateInfo 是 /api/version/check 的返回:当前版本、最新版本及是否有更新。
+// CheckError 非空表示这次检查本身失败(网络/限流);此时 UpdateAvailable 恒 false,
+// 前端据此提示「检查失败」而非误报「已是最新」。
+type UpdateInfo struct {
+	Current         string `json:"current"`
+	Latest          string `json:"latest"`
+	UpdateAvailable bool   `json:"updateAvailable"`
+	ReleaseURL      string `json:"releaseUrl"`
+	PublishedAt     string `json:"publishedAt"`
+	Notes           string `json:"notes"`
+	CheckError      string `json:"checkError,omitempty"`
+}
+
+// ghRelease 是 GitHub releases/latest 响应里我们关心的字段。
+type ghRelease struct {
+	TagName     string `json:"tag_name"`
+	HTMLURL     string `json:"html_url"`
+	PublishedAt string `json:"published_at"`
+	Body        string `json:"body"`
+	Prerelease  bool   `json:"prerelease"`
+}
+
+// Checker 查询 GitHub 最新发布并与当前构建版本比对,带 TTL 缓存。零值不可用,请用 NewChecker。
+type Checker struct {
+	repo   string
+	client *http.Client
+
+	mu       sync.Mutex
+	cached   *UpdateInfo
+	cachedAt time.Time
+	now      func() time.Time // 可注入,便于测试缓存过期
+}
+
+// NewChecker 返回默认 Checker(查 defaultRepo / 可经 env 覆盖,10s 超时)。
+func NewChecker() *Checker {
+	repo := defaultRepo
+	if v := strings.TrimSpace(os.Getenv("PIPEWRIGHT_RELEASE_REPO")); v != "" {
+		repo = v
+	}
+	return &Checker{
+		repo:   repo,
+		client: &http.Client{Timeout: 10 * time.Second},
+		now:    time.Now,
+	}
+}
+
+// apiBase 允许测试把请求打到本地 stub server;生产为空时用 GitHub 公网 API。
+var apiBase = ""
+
+// Check 返回更新信息。命中未过期缓存则直接返回;否则查 GitHub。
+// 网络/解析失败不返回 error —— 而是在 UpdateInfo.CheckError 里带上原因(始终附当前版本),
+// 让上层端点稳定返回 200、前端优雅降级。
+func (c *Checker) Check(ctx context.Context) UpdateInfo {
+	c.mu.Lock()
+	if c.cached != nil && c.now().Sub(c.cachedAt) < checkTTL {
+		cached := *c.cached
+		c.mu.Unlock()
+		return cached
+	}
+	c.mu.Unlock()
+
+	info := c.fetch(ctx)
+
+	// 仅缓存成功结果:失败不缓存,以便用户重试时立刻再查。
+	if info.CheckError == "" {
+		c.mu.Lock()
+		cp := info
+		c.cached = &cp
+		c.cachedAt = c.now()
+		c.mu.Unlock()
+	}
+	return info
+}
+
+func (c *Checker) fetch(ctx context.Context) UpdateInfo {
+	cur := Version
+	out := UpdateInfo{Current: cur}
+
+	base := apiBase
+	if base == "" {
+		base = "https://api.github.com"
+	}
+	url := fmt.Sprintf("%s/repos/%s/releases/latest", base, c.repo)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		out.CheckError = "构造请求失败"
+		return out
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", "pipewright/"+cur) // GitHub 要求 UA,否则 403
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		out.CheckError = "无法连接 GitHub(网络不可达?)"
+		return out
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// 继续解析
+	case http.StatusNotFound:
+		// 仓库尚无任何 release:不是错误,只是「无可用更新」。
+		out.CheckError = ""
+		return out
+	case http.StatusForbidden, http.StatusTooManyRequests:
+		out.CheckError = "GitHub API 限流,请稍后再试"
+		return out
+	default:
+		out.CheckError = fmt.Sprintf("GitHub 返回 %d", resp.StatusCode)
+		return out
+	}
+
+	var rel ghRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		out.CheckError = "解析 GitHub 响应失败"
+		return out
+	}
+
+	out.Latest = rel.TagName
+	out.ReleaseURL = rel.HTMLURL
+	out.PublishedAt = rel.PublishedAt
+	out.Notes = rel.Body
+	// 仅当当前是正式语义版本(可比较)且 latest 更高时,才判定「有更新」。
+	// 开发态(dev / 非 vX.Y.Z)无法可靠比较 → 不误报。
+	if isComparable(cur) && rel.TagName != "" && CompareVersions(rel.TagName, cur) > 0 {
+		out.UpdateAvailable = true
+	}
+	return out
+}
+
+// isComparable 判断版本串是否为可比较的语义版本(形如 v1.2.3 / 1.2.3,允许 -prerelease 后缀)。
+// dev / none / 空 等开发态返回 false。
+func isComparable(v string) bool {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if v == "" {
+		return false
+	}
+	core := v
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		core = v[:i]
+	}
+	parts := strings.Split(core, ".")
+	if len(parts) == 0 {
+		return false
+	}
+	for _, p := range parts {
+		if _, err := strconv.Atoi(p); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// CompareVersions 比较两个语义版本,返回 -1 / 0 / 1(a<b / a==b / a>b)。
+// 规则:剥前导 v;按 . 拆 major/minor/patch 数值比较(缺位补 0);
+// 主版本相等时,带 prerelease 的低于不带(1.0.0-rc.1 < 1.0.0);
+// 两者都带 prerelease 时按点分段逐段比较(数值段按数值,否则按字典序)。
+func CompareVersions(a, b string) int {
+	ac, ap := splitVersion(a)
+	bc, bp := splitVersion(b)
+
+	for i := 0; i < 3; i++ {
+		if ac[i] != bc[i] {
+			if ac[i] < bc[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+	// core 相等:比较 prerelease。无 prerelease 视为更高。
+	switch {
+	case ap == "" && bp == "":
+		return 0
+	case ap == "":
+		return 1
+	case bp == "":
+		return -1
+	default:
+		return comparePrerelease(ap, bp)
+	}
+}
+
+// splitVersion 把版本串解析为 [major,minor,patch] 与 prerelease 串(去掉 build 元数据 +...)。
+func splitVersion(v string) ([3]int, string) {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if i := strings.IndexByte(v, '+'); i >= 0 {
+		v = v[:i] // 丢弃 build 元数据
+	}
+	core := v
+	pre := ""
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		core, pre = v[:i], v[i+1:]
+	}
+	var nums [3]int
+	for i, p := range strings.Split(core, ".") {
+		if i > 2 {
+			break
+		}
+		nums[i], _ = strconv.Atoi(p)
+	}
+	return nums, pre
+}
+
+func comparePrerelease(a, b string) int {
+	as := strings.Split(a, ".")
+	bs := strings.Split(b, ".")
+	n := len(as)
+	if len(bs) < n {
+		n = len(bs)
+	}
+	for i := 0; i < n; i++ {
+		ai, aerr := strconv.Atoi(as[i])
+		bi, berr := strconv.Atoi(bs[i])
+		switch {
+		case aerr == nil && berr == nil: // 都是数值段
+			if ai != bi {
+				if ai < bi {
+					return -1
+				}
+				return 1
+			}
+		case aerr == nil: // 数值段低于字母段(SemVer 规则)
+			return -1
+		case berr == nil:
+			return 1
+		default:
+			if as[i] != bs[i] {
+				if as[i] < bs[i] {
+					return -1
+				}
+				return 1
+			}
+		}
+	}
+	// 前缀相等:段更多的更高(1.0.0-rc.1 < 1.0.0-rc.1.1)。
+	switch {
+	case len(as) == len(bs):
+		return 0
+	case len(as) < len(bs):
+		return -1
+	default:
+		return 1
+	}
+}

--- a/internal/version/update_test.go
+++ b/internal/version/update_test.go
@@ -1,0 +1,150 @@
+package version
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestCompareVersions(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"v1.2.3", "v1.2.3", 0},
+		{"1.2.3", "v1.2.3", 0}, // 前导 v 可有可无
+		{"v1.2.4", "v1.2.3", 1},
+		{"v1.2.3", "v1.2.4", -1},
+		{"v1.3.0", "v1.2.9", 1},
+		{"v2.0.0", "v1.9.9", 1},
+		{"v1.2", "v1.2.0", 0},        // 缺位补 0
+		{"v1.0.0", "v1.0.0-rc.1", 1}, // 正式版高于预发布
+		{"v1.0.0-rc.1", "v1.0.0", -1},
+		{"v1.0.0-rc.2", "v1.0.0-rc.1", 1},
+		{"v1.0.0-rc.1", "v1.0.0-rc.1", 0},
+		{"v1.0.0-beta", "v1.0.0-rc", -1}, // 字典序 beta < rc
+		{"v1.0.0+build.5", "v1.0.0", 0},  // build 元数据不参与比较
+	}
+	for _, c := range cases {
+		if got := CompareVersions(c.a, c.b); got != c.want {
+			t.Errorf("CompareVersions(%q,%q)=%d want %d", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestIsComparable(t *testing.T) {
+	for v, want := range map[string]bool{
+		"v1.2.3":      true,
+		"1.2.3":       true,
+		"v1.0.0-rc.1": true,
+		"dev":         false,
+		"none":        false,
+		"":            false,
+		"latest":      false,
+	} {
+		if got := isComparable(v); got != want {
+			t.Errorf("isComparable(%q)=%v want %v", v, got, want)
+		}
+	}
+}
+
+// newStubChecker 指向本地 stub server,并钉死当前版本与时钟。
+func newStubChecker(t *testing.T, current string, h http.HandlerFunc) (*Checker, func()) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	prevBase, prevVer := apiBase, Version
+	apiBase = srv.URL
+	Version = current
+	cleanup := func() {
+		apiBase = prevBase
+		Version = prevVer
+		srv.Close()
+	}
+	c := &Checker{repo: "owner/repo", client: srv.Client(), now: time.Now}
+	return c, cleanup
+}
+
+func TestCheck_UpdateAvailable(t *testing.T) {
+	c, done := newStubChecker(t, "v1.0.0", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v1.2.0","html_url":"https://example/releases/v1.2.0","published_at":"2026-06-06T00:00:00Z","body":"notes"}`))
+	})
+	defer done()
+
+	info := c.Check(context.Background())
+	if info.CheckError != "" {
+		t.Fatalf("unexpected checkError: %s", info.CheckError)
+	}
+	if !info.UpdateAvailable {
+		t.Errorf("expected updateAvailable=true (v1.0.0 → v1.2.0)")
+	}
+	if info.Current != "v1.0.0" || info.Latest != "v1.2.0" {
+		t.Errorf("current=%q latest=%q", info.Current, info.Latest)
+	}
+	if info.ReleaseURL == "" || info.Notes != "notes" {
+		t.Errorf("missing release fields: %+v", info)
+	}
+}
+
+func TestCheck_AlreadyLatest(t *testing.T) {
+	c, done := newStubChecker(t, "v1.2.0", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v1.2.0"}`))
+	})
+	defer done()
+	if info := c.Check(context.Background()); info.UpdateAvailable {
+		t.Errorf("expected no update when current==latest")
+	}
+}
+
+func TestCheck_DevVersionNeverPrompts(t *testing.T) {
+	c, done := newStubChecker(t, "dev", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v9.9.9"}`))
+	})
+	defer done()
+	info := c.Check(context.Background())
+	if info.UpdateAvailable {
+		t.Errorf("dev build must not report an update")
+	}
+	if info.Latest != "v9.9.9" {
+		t.Errorf("latest should still be reported: %q", info.Latest)
+	}
+}
+
+func TestCheck_NoReleasesSoftFails(t *testing.T) {
+	c, done := newStubChecker(t, "v1.0.0", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer done()
+	info := c.Check(context.Background())
+	if info.CheckError != "" {
+		t.Errorf("404 (no releases) should be soft, got error %q", info.CheckError)
+	}
+	if info.UpdateAvailable || info.Latest != "" {
+		t.Errorf("no releases → no update, no latest")
+	}
+}
+
+func TestCheck_RateLimitedReportsError(t *testing.T) {
+	c, done := newStubChecker(t, "v1.0.0", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+	defer done()
+	if info := c.Check(context.Background()); info.CheckError == "" {
+		t.Errorf("403 should surface a checkError")
+	}
+}
+
+func TestCheck_CachesSuccess(t *testing.T) {
+	var hits int
+	c, done := newStubChecker(t, "v1.0.0", func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		_, _ = w.Write([]byte(`{"tag_name":"v1.1.0"}`))
+	})
+	defer done()
+	_ = c.Check(context.Background())
+	_ = c.Check(context.Background())
+	if hits != 1 {
+		t.Errorf("expected 1 upstream hit (second served from cache), got %d", hits)
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,50 @@
+// Package version 暴露构建期注入的版本元数据。
+//
+// 这些变量由链接器在构建时经 -ldflags "-X" 覆盖(见 Makefile / .goreleaser.yaml）;
+// 源码态(go run / 未注入构建)保持下方默认值,便于本地开发区分「正式版」与「开发态」。
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// 构建期可注入变量。注入路径:
+//
+//	github.com/huangchengsir/pipewright/internal/version.Version=v1.2.3
+//	github.com/huangchengsir/pipewright/internal/version.Commit=<git sha>
+//	github.com/huangchengsir/pipewright/internal/version.Date=<RFC3339>
+var (
+	// Version 是语义化版本(发版 tag,如 v1.2.3);开发态为 "dev"。
+	Version = "dev"
+	// Commit 是构建所基于的 git 短/全 SHA;未注入为 "none"。
+	Commit = "none"
+	// Date 是构建时间(RFC3339);未注入为 "unknown"。
+	Date = "unknown"
+)
+
+// Info 是 /version 端点与 --version 输出共享的结构化版本信息。
+type Info struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	Date      string `json:"date"`
+	GoVersion string `json:"goVersion"`
+	Platform  string `json:"platform"`
+}
+
+// Get 返回当前构建的版本信息(含运行时 Go 版本与平台)。
+func Get() Info {
+	return Info{
+		Version:   Version,
+		Commit:    Commit,
+		Date:      Date,
+		GoVersion: runtime.Version(),
+		Platform:  runtime.GOOS + "/" + runtime.GOARCH,
+	}
+}
+
+// String 是 `pipewright --version` 的人类可读单行输出。
+func String() string {
+	return fmt.Sprintf("pipewright %s (commit %s, built %s, %s, %s)",
+		Version, Commit, Date, runtime.Version(), runtime.GOOS+"/"+runtime.GOARCH)
+}

--- a/web/src/api/version.ts
+++ b/web/src/api/version.ts
@@ -1,0 +1,38 @@
+/**
+ * Version API — 构建版本元数据 + 一键检查更新。
+ *
+ * GET /version            → VersionInfo(公开,构建期注入的版本/commit/日期)
+ * GET /api/version/check  → UpdateInfo(鉴权,查 GitHub 最新发布并与当前版本比对)
+ *
+ * 检查更新永不抛业务错:后端在 CheckError 字段里带失败原因(网络/限流),始终附当前版本,
+ * 由 UI 优雅降级渲染。
+ */
+
+import { http } from './http'
+
+export interface VersionInfo {
+  version: string
+  commit: string
+  date: string
+  goVersion: string
+  platform: string
+}
+
+export interface UpdateInfo {
+  current: string
+  latest: string
+  updateAvailable: boolean
+  releaseUrl: string
+  publishedAt: string
+  notes: string
+  /** 非空 ⇒ 本次检查失败(网络/限流);此时 updateAvailable 恒 false。 */
+  checkError?: string
+}
+
+export function getVersion(): Promise<VersionInfo> {
+  return http.get<VersionInfo>('/version')
+}
+
+export function checkUpdate(): Promise<UpdateInfo> {
+  return http.get<UpdateInfo>('/api/version/check')
+}

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -30,6 +30,8 @@ const SettingsServers = () => import('../views/settings/SettingsServers.vue')
 const SettingsNotifications = () => import('../views/settings/SettingsNotifications.vue')
 // Story 7-5: diagnosis feedback-loop stats (FR-26)
 const SettingsDiagnosisStats = () => import('../views/settings/SettingsDiagnosisStats.vue')
+// 系统信息 + 一键检查更新
+const SettingsSystem = () => import('../views/settings/SettingsSystem.vue')
 // Story 2-2: new pipeline editor
 const ProjectPipeline = () => import('../views/ProjectPipeline.vue')
 // Story 2-3: triggers (kept for backward compat; now a thin wrapper around TriggersPanel)
@@ -126,8 +128,8 @@ const router = createRouter({
             { path: 'notifications', name: 'settings-notifications', component: SettingsNotifications },
             { path: 'vault', name: 'settings-vault', component: SettingsVault },
             { path: 'account', name: 'settings-account', component: SettingsAccount },
-            // 「系统」设置占位页 → 重定向到 AI 配置(尚未建,避免落占位页)。
-            { path: 'system', name: 'settings-system', redirect: { name: 'settings-ai' } },
+            // 系统信息 + 一键检查更新
+            { path: 'system', name: 'settings-system', component: SettingsSystem },
             // Story 4-1: target servers + shared SSH layer (FR-14)
             { path: 'servers', name: 'settings-servers', component: SettingsServers },
             // Story 7-5: diagnosis feedback-loop stats (FR-26)

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -18,6 +18,7 @@
       <router-link to="/settings/account" class="settings-nav-item">账户</router-link>
       <router-link to="/settings/servers" class="settings-nav-item">服务器</router-link>
       <router-link to="/settings/diagnosis-stats" class="settings-nav-item">诊断反馈</router-link>
+      <router-link to="/settings/system" class="settings-nav-item">系统</router-link>
     </nav>
 
     <div class="settings-content">

--- a/web/src/views/settings/SettingsSystem.vue
+++ b/web/src/views/settings/SettingsSystem.vue
@@ -1,0 +1,583 @@
+<script setup lang="ts">
+/**
+ * SettingsSystem — 系统信息与一键检查更新。
+ *
+ * - 挂载时读 GET /version 显示当前构建版本与元数据(commit / 构建时间 / 平台 / Go 版本)。
+ * - 「检查更新」按钮调 GET /api/version/check(查 GitHub 最新发布并比对):
+ *     状态收敛到 hero 右上的状态药丸;仅当有新版时,下方展开强调升级卡(CTA + 可折叠更新说明)。
+ * - 开发态(version=dev)永不误报更新,药丸显示「开发构建」。
+ */
+
+import { ref, computed, onMounted } from 'vue'
+import { getVersion, checkUpdate } from '../../api/version'
+import type { VersionInfo, UpdateInfo } from '../../api/version'
+import { HttpError } from '../../api/http'
+import AppButton from '../../components/ui/AppButton.vue'
+
+const version = ref<VersionInfo | null>(null)
+const versionError = ref('')
+
+type CheckState = 'idle' | 'checking' | 'done' | 'error'
+const checkState = ref<CheckState>('idle')
+const update = ref<UpdateInfo | null>(null)
+const checkError = ref('')
+const showNotes = ref(false)
+
+const isDev = computed(() => {
+  const v = version.value?.version ?? ''
+  return v === '' || v === 'dev' || !/^v?\d/.test(v)
+})
+
+const hasUpdate = computed(() => checkState.value === 'done' && !!update.value?.updateAvailable)
+
+/** hero 右上状态药丸:label + 色调(随检查状态变化)。 */
+type Tone = 'neutral' | 'checking' | 'ok' | 'update' | 'dev' | 'err'
+const pill = computed<{ label: string; tone: Tone }>(() => {
+  if (checkState.value === 'checking') return { label: '检查中…', tone: 'checking' }
+  if (checkState.value === 'error') return { label: '检查失败', tone: 'err' }
+  if (checkState.value === 'done') {
+    if (hasUpdate.value) return { label: '有新版可用', tone: 'update' }
+    if (isDev.value) return { label: '开发构建', tone: 'dev' }
+    return { label: '已是最新', tone: 'ok' }
+  }
+  return { label: isDev.value ? '开发构建' : '未检查', tone: isDev.value ? 'dev' : 'neutral' }
+})
+
+const meta = computed(() => {
+  const v = version.value
+  if (!v) return []
+  return [
+    { label: 'Commit', value: v.commit, mono: true },
+    { label: '构建时间', value: fmtDate(v.date) },
+    { label: '平台', value: v.platform, mono: true },
+    { label: 'Go 版本', value: v.goVersion, mono: true },
+  ].filter((m) => m.value && m.value !== 'none' && m.value !== 'unknown')
+})
+
+function fmtDate(s: string): string {
+  if (!s || s === 'unknown') return s
+  const d = new Date(s)
+  if (Number.isNaN(d.getTime())) return s
+  return d.toLocaleString('zh-CN', { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })
+}
+
+async function loadVersion(): Promise<void> {
+  try {
+    version.value = await getVersion()
+  } catch {
+    versionError.value = '无法读取版本信息'
+  }
+}
+
+async function runCheck(): Promise<void> {
+  checkState.value = 'checking'
+  checkError.value = ''
+  update.value = null
+  showNotes.value = false
+  try {
+    const info = await checkUpdate()
+    if (info.checkError) {
+      checkError.value = info.checkError
+      checkState.value = 'error'
+      return
+    }
+    update.value = info
+    checkState.value = 'done'
+  } catch (err) {
+    checkError.value = err instanceof HttpError ? (err.apiError?.message ?? `检查失败(${err.status})`) : '检查失败,请稍后重试'
+    checkState.value = 'error'
+  }
+}
+
+onMounted(loadVersion)
+</script>
+
+<template>
+  <section class="sys" aria-labelledby="sys-heading">
+    <header class="sys-head">
+      <h2 id="sys-heading" class="sys-title">系统</h2>
+      <p class="sys-sub">当前版本与更新检查</p>
+    </header>
+
+    <!-- 版本面板 -->
+    <article class="sys-panel">
+      <span class="sys-accent" aria-hidden="true" />
+
+      <!-- hero:品牌 + 状态药丸 -->
+      <div class="sys-hero">
+        <div class="sys-brand">
+          <span class="sys-glyph mono" aria-hidden="true">p&gt;</span>
+          <span class="sys-brand-text">
+            <span class="sys-brand-name">Pipewright</span>
+            <span class="sys-brand-tag">自托管 CI/CD · 单二进制</span>
+          </span>
+        </div>
+        <span class="sys-pill" :class="`sys-pill--${pill.tone}`">
+          <span class="sys-pill-dot" aria-hidden="true" />
+          {{ pill.label }}
+        </span>
+      </div>
+
+      <!-- 版本号 + 操作 -->
+      <div class="sys-version-row">
+        <div class="sys-version-block">
+          <span class="sys-version-cap">当前版本</span>
+          <strong class="sys-version-num" :class="{ 'is-dev': isDev }">{{ version?.version ?? '…' }}</strong>
+        </div>
+        <AppButton variant="primary" :loading="checkState === 'checking'" @click="runCheck">
+          <svg v-if="checkState !== 'checking'" class="sys-btn-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M1 4v6h6M23 20v-6h-6" /><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+          </svg>
+          {{ checkState === 'checking' ? '检查中…' : '检查更新' }}
+        </AppButton>
+      </div>
+
+      <p v-if="versionError" class="sys-inline-err" role="alert">{{ versionError }}</p>
+      <p v-else-if="checkState === 'error'" class="sys-inline-err" role="alert">检查失败:{{ checkError }}</p>
+
+      <!-- 构建元数据 -->
+      <dl v-if="meta.length" class="sys-meta">
+        <div v-for="m in meta" :key="m.label" class="sys-meta-item">
+          <dt>{{ m.label }}</dt>
+          <dd :class="{ mono: m.mono }">{{ m.value }}</dd>
+        </div>
+      </dl>
+    </article>
+
+    <!-- 仅当有新版时:强调升级卡 -->
+    <transition name="sys-rise">
+      <article v-if="hasUpdate" class="sys-upgrade">
+        <div class="sys-upgrade-head">
+          <span class="sys-upgrade-icon" aria-hidden="true">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5M5 12l7-7 7 7" /></svg>
+          </span>
+          <div class="sys-upgrade-meta">
+            <h3 class="sys-upgrade-title">有新版本可用</h3>
+            <div class="sys-vjump">
+              <span class="sys-vtag sys-vtag--cur">{{ update?.current }}</span>
+              <span class="sys-varrow" aria-hidden="true">→</span>
+              <span class="sys-vtag sys-vtag--new">{{ update?.latest }}</span>
+              <span v-if="update?.publishedAt" class="sys-pubdate">· 发布于 {{ fmtDate(update.publishedAt) }}</span>
+            </div>
+          </div>
+          <a v-if="update?.releaseUrl" class="sys-cta" :href="update.releaseUrl" target="_blank" rel="noopener noreferrer">
+            查看发布
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 17L17 7M7 7h10v10" /></svg>
+          </a>
+        </div>
+
+        <div v-if="update?.notes" class="sys-notes-wrap">
+          <button class="sys-notes-toggle" :aria-expanded="showNotes" @click="showNotes = !showNotes">
+            <svg class="sys-chevron" :class="{ open: showNotes }" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 18l6-6-6-6" /></svg>
+            {{ showNotes ? '收起更新说明' : '查看更新说明' }}
+          </button>
+          <transition name="sys-rise">
+            <pre v-if="showNotes" class="sys-notes">{{ update.notes }}</pre>
+          </transition>
+        </div>
+      </article>
+    </transition>
+  </section>
+</template>
+
+<style scoped>
+.sys {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  max-width: 680px;
+}
+
+.sys-head {
+  margin-bottom: var(--space-1);
+}
+.sys-title {
+  font-size: var(--text-h2);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--color-text);
+}
+.sys-sub {
+  font-size: var(--text-body);
+  color: var(--color-faint);
+  margin-top: 2px;
+}
+
+/* ── 版本面板 ───────────────────────────── */
+.sys-panel {
+  position: relative;
+  overflow: hidden;
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 8px 24px -16px rgba(0, 0, 0, 0.18);
+}
+/* 顶部品牌强调条 */
+.sys-accent {
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--color-primary), var(--color-primary-press) 60%, transparent);
+}
+
+/* hero */
+.sys-hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+.sys-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+.sys-glyph {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--rounded, 10px);
+  display: grid;
+  place-items: center;
+  background: linear-gradient(140deg, var(--color-primary), var(--color-primary-press));
+  color: #fff;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 0.92rem;
+  box-shadow: 0 6px 18px -4px var(--color-primary-soft);
+  flex: none;
+}
+.sys-brand-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+.sys-brand-name {
+  font-size: var(--text-body);
+  font-weight: 700;
+  color: var(--color-text);
+  letter-spacing: -0.01em;
+}
+.sys-brand-tag {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+}
+
+/* 状态药丸 */
+.sys-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: none;
+  font-size: var(--text-micro);
+  font-weight: 600;
+  padding: 4px 10px 4px 8px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+.sys-pill-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  flex: none;
+}
+.sys-pill--neutral {
+  color: var(--color-dim);
+  background: var(--color-inset);
+  border-color: var(--color-border);
+}
+.sys-pill--checking {
+  color: var(--color-dim);
+  background: var(--color-inset);
+  border-color: var(--color-border);
+}
+.sys-pill--checking .sys-pill-dot {
+  animation: sys-blink 1s ease-in-out infinite;
+}
+.sys-pill--ok {
+  color: var(--color-success);
+  background: var(--color-green-soft);
+  border-color: var(--color-green-line);
+}
+.sys-pill--update {
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+  border-color: var(--color-primary);
+}
+.sys-pill--update .sys-pill-dot {
+  animation: sys-pulse 1.5s ease-out infinite;
+}
+.sys-pill--dev {
+  color: var(--color-amber);
+  background: var(--color-amber-soft);
+  border-color: var(--color-amber-line);
+}
+.sys-pill--err {
+  color: var(--color-danger);
+  background: var(--color-danger-soft);
+  border-color: var(--color-red-line, var(--color-danger));
+}
+
+/* 版本号 + 操作 */
+.sys-version-row {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+.sys-version-block {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.sys-version-cap {
+  font-size: var(--text-micro);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-faint);
+}
+.sys-version-num {
+  font-size: var(--text-kpi);
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+}
+.sys-version-num.is-dev {
+  color: var(--color-dim);
+}
+.sys-btn-icon {
+  margin-right: 1px;
+}
+
+/* 元数据 */
+.sys-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-3) var(--space-5);
+  margin: 0;
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-border);
+}
+.sys-meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+.sys-meta-item dt {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+.sys-meta-item dd {
+  margin: 0;
+  font-size: var(--text-caption);
+  color: var(--color-text-soft);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.sys-meta-item dd.mono {
+  font-family: var(--font-mono);
+  font-size: var(--text-label);
+}
+
+.sys-inline-err {
+  font-size: var(--text-caption);
+  color: var(--color-danger);
+  margin: -4px 0 0;
+}
+
+/* ── 升级强调卡 ─────────────────────────── */
+.sys-upgrade {
+  position: relative;
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4) var(--space-5);
+  background:
+    linear-gradient(180deg, var(--color-primary-soft), transparent 70%),
+    var(--color-card);
+  box-shadow: 0 10px 30px -18px var(--color-primary);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.sys-upgrade-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.sys-upgrade-icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: var(--color-primary);
+  color: #fff;
+  flex: none;
+  box-shadow: 0 6px 16px -4px var(--color-primary-soft);
+  animation: sys-bob 2.4s ease-in-out infinite;
+}
+.sys-upgrade-meta {
+  flex: 1;
+  min-width: 0;
+}
+.sys-upgrade-title {
+  font-size: var(--text-body);
+  font-weight: 700;
+  color: var(--color-text);
+  letter-spacing: -0.01em;
+}
+.sys-vjump {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 5px;
+  flex-wrap: wrap;
+}
+.sys-vtag {
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 6px;
+}
+.sys-vtag--cur {
+  color: var(--color-dim);
+  background: var(--color-inset);
+  border: 1px solid var(--color-border);
+}
+.sys-vtag--new {
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+  border: 1px solid var(--color-primary);
+}
+.sys-varrow {
+  color: var(--color-faint);
+  font-weight: 700;
+}
+.sys-pubdate {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+}
+
+/* 查看发布 CTA */
+.sys-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: none;
+  padding: 8px 14px;
+  font-size: var(--text-label);
+  font-weight: 600;
+  color: #fff;
+  background: var(--color-primary);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  transition:
+    background var(--duration-fast),
+    transform var(--duration-fast),
+    box-shadow var(--duration-fast);
+}
+.sys-cta:hover {
+  background: var(--color-primary-press);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px -6px var(--color-primary);
+}
+.sys-cta:active {
+  transform: translateY(0);
+}
+.sys-cta:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/* 更新说明折叠 */
+.sys-notes-wrap {
+  border-top: 1px dashed var(--color-border);
+  padding-top: var(--space-3);
+}
+.sys-notes-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-size: var(--text-label);
+  font-weight: 600;
+  color: var(--color-primary);
+  transition: color var(--duration-fast);
+}
+.sys-notes-toggle:hover {
+  color: var(--color-primary-press);
+}
+.sys-chevron {
+  transition: transform var(--duration-fast) var(--ease-out-expo, ease);
+}
+.sys-chevron.open {
+  transform: rotate(90deg);
+}
+.sys-notes {
+  margin: var(--space-3) 0 0;
+  padding: var(--space-3) var(--space-4);
+  max-height: 220px;
+  overflow: auto;
+  background: var(--color-inset);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  line-height: 1.6;
+  color: var(--color-text-soft);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ── 动效 ───────────────────────────────── */
+@keyframes sys-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+@keyframes sys-pulse {
+  0% { box-shadow: 0 0 0 0 var(--color-primary-soft); }
+  100% { box-shadow: 0 0 0 6px transparent; }
+}
+@keyframes sys-bob {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
+}
+.sys-rise-enter-active,
+.sys-rise-leave-active {
+  transition:
+    opacity var(--duration-normal),
+    transform var(--duration-normal) var(--ease-out-expo, ease);
+}
+.sys-rise-enter-from,
+.sys-rise-leave-to {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sys-upgrade-icon,
+  .sys-pill-dot {
+    animation: none;
+  }
+}
+</style>


### PR DESCRIPTION
## 目标

像 OpenClaw / Claude Code 那样:**推一个 `v*` tag 就出全平台版本,一行命令装上**。补齐开源平台缺的「正式发版 + 一键部署」链路。

## 改动

### 版本管线
- `internal/version` 包:`Version/Commit/Date` 经 `-ldflags -X` 注入,源码态回退 `dev`
- `pipewright --version` 子命令(配置加载前纯查询即退,无副作用)
- `GET /version` 公开只读端点(升级检查 / 运维探针)
- Makefile / Dockerfile 透传版本 ldflags

### 发版流水线
- `.goreleaser.yaml`:6 平台(linux/darwin/windows × amd64/arm64)静态交叉编译 + 校验和 + 按 Conventional Commit 分组 changelog → GitHub Release;`dockers_v2` 跨架构镜像 + 多架构清单推 `ghcr.io`(`latest` 仅正式版)
- `.github/workflows/release.yml`:`v*` tag 触发,`GITHUB_TOKEN` 登录 ghcr,无需额外密钥
- `Dockerfile.goreleaser`:包装预编译二进制(发版用,不在镜像内重编)

### 一键部署
- `install.sh`:探测 OS/arch 从 Release 拉二进制 + **校验和核验** → `/usr/local/bin`(支持 `VERSION` / `INSTALL_DIR`)
- `docker-compose.yml` + `.env.example`:持久化具名卷,可选 MySQL profile
- **修正 distroless 持久化隐患**:镜像预建 `/data`(nonroot 属主)+ `WORKDIR /data`,具名卷挂载继承属主即可写(原 `WORKDIR=/` 对 nonroot 写不了,sqlite 持久化是隐性坏的)
- README 安装/部署三形态 + CONTRIBUTING 维护者发版说明 + 修正 goreleaser license 标签(Apache→MIT,与 LICENSE 一致)

## 验证
- `goreleaser check` + `release --snapshot` 干跑:6 平台编译/归档/校验和全部通过 ✅
- 真二进制 `--version` / `GET /version` / `GET /healthz` 端到端正确(版本注入生效)✅
- `go vet` / `go build` / `go test`(含 httpapi/config)+ `gofmt -l` 全绿 ✅
- ⚠️ Docker 镜像构建因本机 daemon 未启**延后至 CI**(打 tag 时跑);`docker compose config` 已通过

## 发版方式(合并后)
```bash
git tag -a v0.1.0 -m "v0.1.0" && git push origin v0.1.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)