### PR TITLE
feat(web): 全局概览 dashboard 作为新首页(bento + 真数据)

### DIFF
--- a/web/src/components/dashboard/DashAlerts.vue
+++ b/web/src/components/dashboard/DashAlerts.vue
@@ -1,0 +1,208 @@
+<script setup lang="ts">
+/**
+ * DashAlerts — 概览页「异常告警 + AI 诊断」(presentational)。
+ * 上:最近资源异常告警(磁盘/内存/CPU 越阈)。下:AI 失败诊断闭环准确率。
+ */
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import type { AnomalyAlert } from '../../api/anomaly'
+import type { DiagnosisStats } from '../../api/settings'
+
+const props = defineProps<{
+  alerts: AnomalyAlert[]
+  diagnosis: DiagnosisStats | null
+  loading: boolean
+}>()
+
+const router = useRouter()
+
+const recent = computed(() => props.alerts.slice(0, 4))
+
+const accuracyPct = computed(() => {
+  const a = props.diagnosis?.accuracy
+  return a === null || a === undefined ? null : Math.round(a * 100)
+})
+
+function fmtAgo(rfc: string): string {
+  const t = new Date(rfc).getTime()
+  if (Number.isNaN(t)) return ''
+  const m = Math.floor(Math.max(0, Date.now() - t) / 60000)
+  if (m < 60) return `${m}m前`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h前`
+  return `${Math.floor(h / 24)}d前`
+}
+</script>
+
+<template>
+  <section class="card alerts" aria-labelledby="dash-alerts-h">
+    <header class="card-head">
+      <h2 id="dash-alerts-h" class="card-title">告警与 AI 诊断</h2>
+      <button class="card-link" type="button" @click="router.push('/anomaly')">异常检测 →</button>
+    </header>
+
+    <div v-if="loading" class="al-skeleton" aria-busy="true">
+      <span v-for="i in 3" :key="i" class="sk-row" />
+    </div>
+
+    <template v-else>
+      <!-- 异常告警 -->
+      <div class="al-block">
+        <div class="al-sub">资源异常</div>
+        <p v-if="!recent.length" class="al-none">无异常 · 各机资源均在阈值内 ✓</p>
+        <ul v-else class="al-list" role="list">
+          <li v-for="a in recent" :key="a.id" class="al-row">
+            <span class="al-icon" :class="a.metric" aria-hidden="true" />
+            <span class="al-msg">{{ a.message }}</span>
+            <span class="al-srv">{{ a.serverName }}</span>
+            <span class="al-time">{{ fmtAgo(a.at) }}</span>
+          </li>
+        </ul>
+      </div>
+
+      <!-- AI 诊断准确率 -->
+      <div class="al-block diag">
+        <div class="al-sub">AI 失败诊断闭环</div>
+        <div v-if="(diagnosis?.totalFeedback ?? 0) === 0" class="al-none">暂无诊断反馈 · 对失败诊断点 👍/👎 后,准确率会沉淀于此。</div>
+        <div v-else class="diag-row">
+          <div class="diag-acc">
+            <span class="diag-acc-val">{{ accuracyPct ?? '—' }}<span class="diag-acc-unit">%</span></span>
+            <span class="diag-acc-label">准确率</span>
+          </div>
+          <div class="diag-counts">
+            <span class="diag-up">👍 {{ diagnosis?.thumbsUp ?? 0 }}</span>
+            <span class="diag-down">👎 {{ diagnosis?.thumbsDown ?? 0 }}</span>
+            <span class="diag-total">共 {{ diagnosis?.totalFeedback ?? 0 }} 次反馈</span>
+          </div>
+          <button class="card-link" type="button" @click="router.push('/settings/diagnosis-stats')">详情 →</button>
+        </div>
+      </div>
+    </template>
+  </section>
+</template>
+
+<style scoped>
+.al-block {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.al-block.diag {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px dashed var(--color-border);
+}
+.al-sub {
+  font-size: var(--text-micro);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-faint);
+}
+.al-none {
+  font-size: var(--text-caption);
+  color: var(--color-text-soft);
+  margin: 0;
+}
+.al-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.al-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  gap: 9px;
+  padding: 6px 2px;
+}
+.al-icon {
+  width: 7px;
+  height: 7px;
+  border-radius: 2px;
+  background: var(--color-amber);
+}
+.al-icon.disk {
+  background: var(--color-red);
+}
+.al-icon.memory {
+  background: var(--color-amber);
+}
+.al-icon.cpu {
+  background: var(--color-cyan);
+}
+.al-msg {
+  font-size: var(--text-caption);
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.al-srv {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  white-space: nowrap;
+}
+.al-time {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+.diag-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+.diag-acc {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  line-height: 1;
+}
+.diag-acc-val {
+  font-size: var(--text-kpi);
+  font-weight: 800;
+  color: var(--color-success);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+.diag-acc-unit {
+  font-size: var(--text-body);
+  margin-left: 1px;
+}
+.diag-acc-label {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  margin-top: 3px;
+}
+.diag-counts {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: var(--text-caption);
+  color: var(--color-text-soft);
+  flex: 1;
+}
+.diag-total {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+}
+.al-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.sk-row {
+  height: 30px;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(90deg, var(--color-inset), var(--color-surface-hover), var(--color-inset));
+  background-size: 200% 100%;
+  animation: dash-shimmer 1.3s ease-in-out infinite;
+}
+@keyframes dash-shimmer {
+  to {
+    background-position: -200% 0;
+  }
+}
+</style>

--- a/web/src/components/dashboard/DashEnvironments.vue
+++ b/web/src/components/dashboard/DashEnvironments.vue
@@ -1,0 +1,171 @@
+<script setup lang="ts">
+/**
+ * DashEnvironments — 概览页「环境部署态」(presentational)。
+ * 跨项目聚合每个环境的当前激活部署(最近一次全成功),显示项目·环境·commit·分支·时间。
+ */
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import type { EnvDeployment } from '../../api/environments'
+
+export interface DashEnvEntry {
+  projectId: string
+  projectName: string
+  environment: string
+  active: EnvDeployment | null
+}
+
+const props = defineProps<{
+  entries: DashEnvEntry[]
+  loading: boolean
+}>()
+
+const router = useRouter()
+
+const rows = computed(() => props.entries.slice(0, 8))
+
+function fmtAgo(rfc: string): string {
+  const t = new Date(rfc).getTime()
+  if (Number.isNaN(t)) return ''
+  const m = Math.floor(Math.max(0, Date.now() - t) / 60000)
+  if (m < 60) return `${m}m前`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h前`
+  return `${Math.floor(h / 24)}d前`
+}
+</script>
+
+<template>
+  <section class="card env" aria-labelledby="dash-env-h">
+    <header class="card-head">
+      <h2 id="dash-env-h" class="card-title">环境部署态</h2>
+      <button class="card-link" type="button" @click="router.push('/environments')">全部 →</button>
+    </header>
+
+    <div v-if="loading" class="env-skeleton" aria-busy="true">
+      <span v-for="i in 4" :key="i" class="sk-row" />
+    </div>
+
+    <p v-else-if="!rows.length" class="card-empty">尚无环境部署。配置「分支→环境」映射并完成部署后,各环境当前版本会显示在此。</p>
+
+    <ul v-else class="env-list" role="list">
+      <li v-for="e in rows" :key="e.projectId + e.environment" class="env-row">
+        <div class="env-id">
+          <span class="env-name">{{ e.environment }}</span>
+          <span class="env-proj">{{ e.projectName }}</span>
+        </div>
+        <template v-if="e.active">
+          <code class="env-commit">{{ e.active.commit.slice(0, 7) }}</code>
+          <span class="env-branch">{{ e.active.branch }}</span>
+          <span class="env-time">{{ fmtAgo(e.active.deployedAt) }}</span>
+          <span class="env-pill ok">已部署</span>
+        </template>
+        <span v-else class="env-pill none">未部署</span>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<style scoped>
+.env-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.env-row {
+  display: grid;
+  grid-template-columns: 1.4fr auto auto auto auto;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 4px;
+  border-bottom: 1px solid var(--color-border);
+}
+.env-row:last-child {
+  border-bottom: none;
+}
+.env-id {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+.env-name {
+  font-size: var(--text-caption);
+  font-weight: 700;
+  color: var(--color-text);
+  text-transform: capitalize;
+}
+.env-proj {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.env-commit {
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+  padding: 1px 6px;
+  border-radius: 5px;
+}
+.env-branch {
+  font-size: var(--text-micro);
+  color: var(--color-text-soft);
+  font-family: var(--font-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 110px;
+}
+.env-time {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+.env-pill {
+  font-size: var(--text-micro);
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+  white-space: nowrap;
+  justify-self: end;
+}
+.env-pill.ok {
+  color: var(--color-success);
+  background: var(--color-green-soft);
+}
+.env-pill.none {
+  color: var(--color-faint);
+  background: var(--color-inset);
+  grid-column: 2 / -1;
+}
+.env-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 0;
+}
+.sk-row {
+  height: 34px;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(90deg, var(--color-inset), var(--color-surface-hover), var(--color-inset));
+  background-size: 200% 100%;
+  animation: dash-shimmer 1.3s ease-in-out infinite;
+}
+@keyframes dash-shimmer {
+  to {
+    background-position: -200% 0;
+  }
+}
+@media (max-width: 720px) {
+  .env-row {
+    grid-template-columns: 1fr auto auto;
+  }
+  .env-branch,
+  .env-time {
+    display: none;
+  }
+}
+</style>

--- a/web/src/components/dashboard/DashRecentRuns.vue
+++ b/web/src/components/dashboard/DashRecentRuns.vue
@@ -1,0 +1,225 @@
+<script setup lang="ts">
+/**
+ * DashRecentRuns — 概览页「最近运行」feed(presentational)。
+ * 收最近若干条 RunListItem,渲染状态徽章 + 项目 + 触发源 + 耗时 + 相对时间。
+ * 整卡点击进运行列表;单条点击进该 run 详情。
+ */
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import type { RunListItem, RunStatus } from '../../api/runs'
+
+const props = defineProps<{
+  runs: RunListItem[]
+  loading: boolean
+}>()
+
+const router = useRouter()
+
+// RunStatus → { label, tone };tone 映射到语义色(成功/失败/进行/等待/回滚)。
+const STATUS: Record<RunStatus, { label: string; tone: string }> = {
+  queued: { label: '排队', tone: 'idle' },
+  running: { label: '进行中', tone: 'run' },
+  waiting_approval: { label: '待审批', tone: 'wait' },
+  success: { label: '成功', tone: 'ok' },
+  failed: { label: '失败', tone: 'err' },
+  partial_failed: { label: '部分失败', tone: 'warn' },
+  rolled_back: { label: '已回滚', tone: 'roll' },
+}
+
+const items = computed(() => props.runs.slice(0, 10))
+
+function fmtDuration(ms: number | null): string {
+  if (ms === null || ms < 0) return '—'
+  const s = Math.round(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m${s % 60 ? ` ${s % 60}s` : ''}`
+  return `${Math.floor(m / 60)}h ${m % 60}m`
+}
+
+function fmtAgo(rfc: string): string {
+  const t = new Date(rfc).getTime()
+  if (Number.isNaN(t)) return ''
+  const diff = Math.max(0, Date.now() - t)
+  const m = Math.floor(diff / 60000)
+  if (m < 1) return '刚刚'
+  if (m < 60) return `${m} 分钟前`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h} 小时前`
+  return `${Math.floor(h / 24)} 天前`
+}
+</script>
+
+<template>
+  <section class="card runs" aria-labelledby="dash-runs-h">
+    <header class="card-head">
+      <h2 id="dash-runs-h" class="card-title">最近运行</h2>
+      <button class="card-link" type="button" @click="router.push('/runs')">全部 →</button>
+    </header>
+
+    <div v-if="loading" class="runs-skeleton" aria-busy="true">
+      <span v-for="i in 5" :key="i" class="sk-row" />
+    </div>
+
+    <p v-else-if="!items.length" class="card-empty">暂无运行记录。接入项目并触发流水线后,这里会显示最近的构建/部署。</p>
+
+    <ul v-else class="runs-list" role="list">
+      <li v-for="r in items" :key="r.id">
+        <button class="run-row" type="button" @click="router.push(`/runs/${r.id}`)">
+          <span class="run-badge" :class="`t-${STATUS[r.status].tone}`">
+            <span class="run-dot" aria-hidden="true" />
+            {{ STATUS[r.status].label }}
+          </span>
+          <span class="run-project">{{ r.projectName }}</span>
+          <span class="run-trigger">{{ r.trigger?.branch ?? '' }}</span>
+          <span class="run-dur">{{ fmtDuration(r.durationMs) }}</span>
+          <span class="run-ago">{{ fmtAgo(r.createdAt) }}</span>
+        </button>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<style scoped>
+.runs {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.runs-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+.run-row {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 96px 1fr auto auto auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 8px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+  transition: background var(--duration-fast);
+}
+.run-row:hover {
+  background: var(--color-surface-hover);
+}
+.runs-list li:last-child .run-row {
+  border-bottom: none;
+}
+.run-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: var(--text-micro);
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+  white-space: nowrap;
+  justify-self: start;
+}
+.run-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.t-ok {
+  color: var(--color-success);
+  background: var(--color-green-soft);
+}
+.t-err {
+  color: var(--color-danger);
+  background: var(--color-danger-soft);
+}
+.t-run {
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+}
+.t-run .run-dot {
+  animation: dash-pulse 1.4s ease-out infinite;
+}
+.t-wait {
+  color: var(--color-amber);
+  background: var(--color-amber-soft);
+}
+.t-warn {
+  color: var(--color-amber);
+  background: var(--color-amber-soft);
+}
+.t-roll {
+  color: var(--color-dim);
+  background: var(--color-inset);
+}
+.t-idle {
+  color: var(--color-faint);
+  background: var(--color-inset);
+}
+.run-project {
+  font-size: var(--text-caption);
+  font-weight: 600;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.run-trigger {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  font-family: var(--font-mono);
+}
+.run-dur {
+  font-size: var(--text-micro);
+  color: var(--color-text-soft);
+  font-variant-numeric: tabular-nums;
+}
+.run-ago {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  white-space: nowrap;
+}
+.runs-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 0;
+}
+.sk-row {
+  height: 38px;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(90deg, var(--color-inset), var(--color-surface-hover), var(--color-inset));
+  background-size: 200% 100%;
+  animation: dash-shimmer 1.3s ease-in-out infinite;
+}
+@keyframes dash-shimmer {
+  to {
+    background-position: -200% 0;
+  }
+}
+@keyframes dash-pulse {
+  0% {
+    box-shadow: 0 0 0 0 currentColor;
+    opacity: 1;
+  }
+  100% {
+    box-shadow: 0 0 0 5px transparent;
+    opacity: 0.7;
+  }
+}
+@media (max-width: 720px) {
+  .run-row {
+    grid-template-columns: 84px 1fr auto;
+  }
+  .run-trigger,
+  .run-dur {
+    display: none;
+  }
+}
+</style>

--- a/web/src/components/dashboard/DashServers.vue
+++ b/web/src/components/dashboard/DashServers.vue
@@ -1,0 +1,247 @@
+<script setup lang="ts">
+/**
+ * DashServers — 概览页「服务器健康」(presentational)。
+ * 每台机一张紧凑卡:可达性 + 内存/磁盘使用率条 + CPU 负载。不可达显错误态。
+ */
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import type { Server, ServerMetrics } from '../../api/servers'
+
+const props = defineProps<{
+  servers: Server[]
+  metrics: ServerMetrics[]
+  loading: boolean
+}>()
+
+const router = useRouter()
+
+interface Row {
+  id: string
+  name: string
+  host: string
+  reachable: boolean
+  error: string
+  load: string
+  memPct: number | null
+  memText: string
+  diskPct: number | null
+  diskText: string
+}
+
+const rows = computed<Row[]>(() =>
+  props.servers.map((s) => {
+    const m = props.metrics.find((x) => x.serverId === s.id)
+    const mem = m?.memory
+    const disk = m?.disk
+    return {
+      id: s.id,
+      name: s.name,
+      host: s.host,
+      reachable: m?.reachable ?? false,
+      error: m?.error ?? '',
+      load: m?.cpu?.loadavg1 != null ? m.cpu.loadavg1.toFixed(2) : '—',
+      memPct: mem && mem.totalBytes > 0 ? Math.round((mem.usedBytes / mem.totalBytes) * 100) : null,
+      memText: mem ? `${fmtGB(mem.usedBytes)} / ${fmtGB(mem.totalBytes)}` : '—',
+      diskPct: disk && disk.totalBytes > 0 ? Math.round((disk.usedBytes / disk.totalBytes) * 100) : null,
+      diskText: disk ? `${fmtGB(disk.usedBytes)} / ${fmtGB(disk.totalBytes)}` : '—',
+    }
+  }),
+)
+
+function fmtGB(bytes: number): string {
+  const gb = bytes / 1024 ** 3
+  return gb >= 10 ? `${Math.round(gb)}G` : `${gb.toFixed(1)}G`
+}
+
+// 使用率 → 色调(<70 正常 / 70-85 偏高 / >85 危险)。
+function tone(pct: number | null): string {
+  if (pct === null) return 'na'
+  if (pct >= 85) return 'err'
+  if (pct >= 70) return 'warn'
+  return 'ok'
+}
+</script>
+
+<template>
+  <section class="card srv" aria-labelledby="dash-srv-h">
+    <header class="card-head">
+      <h2 id="dash-srv-h" class="card-title">服务器健康</h2>
+      <button class="card-link" type="button" @click="router.push('/server-status')">全部 →</button>
+    </header>
+
+    <div v-if="loading" class="srv-grid">
+      <span v-for="i in 2" :key="i" class="sk-card" />
+    </div>
+
+    <p v-else-if="!rows.length" class="card-empty">尚未登记服务器。在「服务器」页添加目标机后,这里显示实时 CPU/内存/磁盘。</p>
+
+    <div v-else class="srv-grid">
+      <article v-for="r in rows" :key="r.id" class="srv-card" :class="{ down: !r.reachable }">
+        <div class="srv-top">
+          <span class="srv-name">{{ r.name }}</span>
+          <span class="srv-state" :class="r.reachable ? 'up' : 'down'">
+            <span class="srv-dot" aria-hidden="true" />
+            {{ r.reachable ? '在线' : '离线' }}
+          </span>
+        </div>
+        <div class="srv-host">{{ r.host }}</div>
+
+        <template v-if="r.reachable">
+          <div class="srv-metric">
+            <div class="srv-metric-head"><span>内存</span><span class="srv-metric-val">{{ r.memPct ?? '—' }}%</span></div>
+            <div class="srv-bar"><span class="srv-fill" :class="tone(r.memPct)" :style="{ width: (r.memPct ?? 0) + '%' }" /></div>
+            <div class="srv-metric-sub">{{ r.memText }}</div>
+          </div>
+          <div class="srv-metric">
+            <div class="srv-metric-head"><span>磁盘</span><span class="srv-metric-val">{{ r.diskPct ?? '—' }}%</span></div>
+            <div class="srv-bar"><span class="srv-fill" :class="tone(r.diskPct)" :style="{ width: (r.diskPct ?? 0) + '%' }" /></div>
+            <div class="srv-metric-sub">{{ r.diskText }}</div>
+          </div>
+          <div class="srv-load">负载 <strong>{{ r.load }}</strong></div>
+        </template>
+        <p v-else class="srv-err">{{ r.error || '无法连接' }}</p>
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.srv-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+  gap: 12px;
+}
+.srv-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+  background: var(--color-surface);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.srv-card.down {
+  background: var(--color-danger-soft);
+  border-color: var(--color-red-line, var(--color-danger));
+}
+.srv-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.srv-name {
+  font-size: var(--text-caption);
+  font-weight: 700;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.srv-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--text-micro);
+  font-weight: 600;
+  white-space: nowrap;
+}
+.srv-state.up {
+  color: var(--color-success);
+}
+.srv-state.down {
+  color: var(--color-danger);
+}
+.srv-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.srv-state.up .srv-dot {
+  animation: dash-blink 1.6s ease-in-out infinite;
+}
+.srv-host {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  font-family: var(--font-mono);
+  margin-top: -4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.srv-metric-head {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--text-micro);
+  color: var(--color-text-soft);
+}
+.srv-metric-val {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--color-text);
+}
+.srv-bar {
+  height: 6px;
+  border-radius: 999px;
+  background: var(--color-inset);
+  overflow: hidden;
+  margin: 3px 0;
+}
+.srv-fill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  transition: width var(--duration-normal) var(--ease-out-expo, ease);
+}
+.srv-fill.ok {
+  background: var(--color-green);
+}
+.srv-fill.warn {
+  background: var(--color-amber);
+}
+.srv-fill.err {
+  background: var(--color-red);
+}
+.srv-fill.na {
+  background: var(--color-faint);
+}
+.srv-metric-sub {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  font-variant-numeric: tabular-nums;
+}
+.srv-load {
+  font-size: var(--text-micro);
+  color: var(--color-text-soft);
+}
+.srv-load strong {
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text);
+}
+.srv-err {
+  font-size: var(--text-micro);
+  color: var(--color-danger);
+  margin: 0;
+}
+.sk-card {
+  height: 130px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(90deg, var(--color-inset), var(--color-surface-hover), var(--color-inset));
+  background-size: 200% 100%;
+  animation: dash-shimmer 1.3s ease-in-out infinite;
+}
+@keyframes dash-shimmer {
+  to {
+    background-position: -200% 0;
+  }
+}
+@keyframes dash-blink {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+</style>

--- a/web/src/components/dashboard/dashboard.css
+++ b/web/src/components/dashboard/dashboard.css
@@ -1,0 +1,54 @@
+/* 概览页共享卡片骨架。用 .dashboard 父级前缀收束作用域(不泄漏全局,
+   也避免与 CronPanel/RunnerPanel 等组件各自 scoped 的 .card-head/.card-title 冲突)。
+   各 widget 用 .card / .card-head / .card-title / .card-link / .card-empty,样式在此统一。 */
+
+.dashboard .card {
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4) var(--space-5);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 8px 24px -18px rgba(0, 0, 0, 0.16);
+}
+
+.dashboard .card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: var(--space-3);
+}
+
+.dashboard .card-title {
+  font-size: var(--text-heading);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--color-text);
+}
+
+.dashboard .card-link {
+  background: none;
+  border: none;
+  padding: 2px 4px;
+  font-size: var(--text-micro);
+  font-weight: 600;
+  color: var(--color-primary);
+  cursor: pointer;
+  white-space: nowrap;
+  border-radius: var(--radius-sm);
+  transition: color var(--duration-fast);
+}
+.dashboard .card-link:hover {
+  color: var(--color-primary-press);
+}
+.dashboard .card-link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+
+.dashboard .card-empty {
+  font-size: var(--text-caption);
+  color: var(--color-text-soft);
+  margin: 0;
+  padding: var(--space-2) 0;
+  line-height: 1.6;
+}

--- a/web/src/layouts/AppShell.vue
+++ b/web/src/layouts/AppShell.vue
@@ -2,6 +2,7 @@
 import type { Component } from 'vue'
 import { useRoute } from 'vue-router'
 import {
+  Dashboard,
   GitBranch,
   GitFork,
   ChartBar,
@@ -26,6 +27,7 @@ interface NavItem {
 }
 
 const navItems: NavItem[] = [
+  { name: 'dashboard',     to: '/dashboard',     icon: Dashboard, label: '概览',  ariaLabel: '概览' },
   { name: 'projects',      to: '/projects',      icon: GitBranch,  label: '项目',  ariaLabel: '项目' },
   { name: 'runs',          to: '/runs',          icon: GitFork,    label: '运行',  ariaLabel: '运行' },
   // FR-8-13: 复用库(流水线模板 + 变量组)。

--- a/web/src/layouts/AppShell.vue
+++ b/web/src/layouts/AppShell.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Component } from 'vue'
+import { ref } from 'vue'
 import { useRoute } from 'vue-router'
 import {
   Dashboard,
@@ -12,6 +13,7 @@ import {
   Settings,
   Stack2,
   Rocket,
+  ChevronRight,
 } from '@vicons/tabler'
 import { NIcon } from 'naive-ui'
 import ThemeToggle from '../components/ThemeToggle.vue'
@@ -57,16 +59,27 @@ function isActive(item: NavItem): boolean {
   }
   return route.path.startsWith(item.to)
 }
+
+// 侧栏展开/收起:固定按钮切换,状态持久化到 localStorage(刷新/重开保持)。
+const STORAGE_KEY = 'pipewright_sidebar_expanded'
+const expanded = ref(localStorage.getItem(STORAGE_KEY) === '1')
+function toggleExpanded(): void {
+  expanded.value = !expanded.value
+  localStorage.setItem(STORAGE_KEY, expanded.value ? '1' : '0')
+}
 </script>
 
 <template>
-  <div class="app-shell">
+  <div class="app-shell" :class="{ 'is-expanded': expanded }">
     <!-- Left rail navigation -->
     <nav class="rail" aria-label="主导航">
-      <!-- Brand mark -->
-      <router-link to="/" class="brand-mark" aria-label="Pipewright 主页">
-        <span class="mono">p&gt;</span>
-      </router-link>
+      <!-- 顶部:品牌 -->
+      <div class="rail-head">
+        <router-link to="/" class="brand" aria-label="Pipewright 主页">
+          <span class="brand-mark mono">p&gt;</span>
+          <span class="brand-name">Pipewright</span>
+        </router-link>
+      </div>
 
       <!-- Primary navigation items -->
       <ul class="nav-list" role="list">
@@ -78,8 +91,8 @@ function isActive(item: NavItem): boolean {
             :aria-label="item.ariaLabel"
             :aria-current="isActive(item) ? 'page' : undefined"
           >
-            <n-icon :component="item.icon" :size="20" />
-            <span class="sr-only">{{ item.label }}</span>
+            <n-icon class="nav-icon" :component="item.icon" :size="20" />
+            <span class="nav-label">{{ item.label }}</span>
           </router-link>
         </li>
       </ul>
@@ -95,10 +108,21 @@ function isActive(item: NavItem): boolean {
         :aria-label="settingsItem.ariaLabel"
         :aria-current="isActive(settingsItem) ? 'page' : undefined"
       >
-        <n-icon :component="settingsItem.icon" :size="20" />
-        <span class="sr-only">{{ settingsItem.label }}</span>
+        <n-icon class="nav-icon" :component="settingsItem.icon" :size="20" />
+        <span class="nav-label">{{ settingsItem.label }}</span>
       </router-link>
     </nav>
+
+    <!-- 边缘切换:骑在侧栏右缘、与品牌齐平的圆形按钮(随 --rail-width 平移)。 -->
+    <button
+      class="rail-edge-toggle"
+      type="button"
+      :aria-label="expanded ? '收起侧栏' : '展开侧栏'"
+      :aria-pressed="expanded"
+      @click="toggleExpanded"
+    >
+      <n-icon class="toggle-chevron" :class="{ flipped: expanded }" :component="ChevronRight" :size="16" />
+    </button>
 
     <!-- Main content area -->
     <main class="main-area" id="main-content">
@@ -120,6 +144,12 @@ function isActive(item: NavItem): boolean {
      超长内容只在各自容器内(终端横向滚动)处理,布局自适应窗口。 */
   grid-template-columns: var(--rail-width) minmax(0, 1fr);
   min-height: 100vh;
+  position: relative; /* 作为边缘切换按钮的定位上下文 */
+  transition: grid-template-columns var(--duration-normal) var(--ease-out-expo, ease);
+}
+/* 展开态:覆盖 --rail-width,grid 主区与 active 指示条偏移随之自适应。 */
+.app-shell.is-expanded {
+  --rail-width: 212px;
 }
 
 /* ——— Rail ——— */
@@ -134,12 +164,38 @@ function isActive(item: NavItem): boolean {
   gap: 6px;
   border-right: 1px solid var(--color-border);
   background-color: var(--color-bg);
-  /* Slightly above bg to separate rail from content at a glance */
   z-index: 10;
   overflow: hidden;
 }
+.is-expanded .rail {
+  align-items: stretch;
+  padding: 20px 12px;
+}
 
-/* Brand mark */
+/* 顶部头区:品牌 + 切换。收起态纵向叠放(logo 上、箭头下);展开态横向一行(品牌左、箭头右)。 */
+.rail-head {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 18px;
+  flex-shrink: 0;
+}
+.is-expanded .rail-head {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  padding-left: 4px;
+}
+
+/* Brand */
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  flex-shrink: 0;
+}
 .brand-mark {
   width: 30px;
   height: 30px;
@@ -151,15 +207,25 @@ function isActive(item: NavItem): boolean {
   font-family: var(--font-mono);
   font-weight: 700;
   font-size: 0.78rem;
-  margin-bottom: 18px;
   box-shadow: 0 4px 14px var(--color-primary-soft);
-  text-decoration: none;
   transition: box-shadow var(--duration-fast);
   flex-shrink: 0;
 }
-
-.brand-mark:hover {
+.brand:hover .brand-mark {
   box-shadow: 0 6px 20px var(--color-primary-soft);
+}
+.brand-name {
+  font-size: var(--text-body);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  /* 收起时隐藏文字(无障碍名仍由 brand 的 aria-label 提供)。 */
+  display: none;
+}
+.is-expanded .brand-name {
+  display: inline;
 }
 
 /* Nav list */
@@ -170,6 +236,9 @@ function isActive(item: NavItem): boolean {
   gap: 4px;
   width: 100%;
   align-items: center;
+}
+.is-expanded .nav-list {
+  align-items: stretch;
 }
 
 /* Nav item */
@@ -182,37 +251,106 @@ function isActive(item: NavItem): boolean {
   place-items: center;
   color: var(--color-faint);
   text-decoration: none;
+  background: none;
+  border: none;
+  cursor: pointer;
   transition:
     color var(--duration-fast),
     background-color var(--duration-fast);
-  cursor: pointer;
 }
-
+.is-expanded .nav-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 12px;
+  padding: 0 12px;
+}
+.nav-icon {
+  flex-shrink: 0;
+}
 .nav-item:hover {
   color: var(--color-text);
   background-color: var(--color-border);
 }
-
 .nav-item:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
 
-/* Active state: electric blue + 2.5px left bar */
+.nav-label {
+  font-size: var(--text-label);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  display: none;
+}
+.is-expanded .nav-label {
+  display: inline;
+}
+
+/* Active state */
 .nav-item--active {
   color: var(--color-primary);
 }
-
+.is-expanded .nav-item--active {
+  background: var(--color-primary-soft);
+  font-weight: 600;
+}
 .nav-item--active::before {
   content: "";
   position: absolute;
-  /* Extends to the left edge of the rail */
+  /* 收起态:指示条贴在 rail 左缘(图标水平居中,据 rail 宽度回推偏移)。 */
   left: calc(-1 * (var(--rail-width) / 2 - 20px + 1px));
   top: 9px;
   bottom: 9px;
   width: 2.5px;
   border-radius: 2px;
   background: var(--color-primary);
+}
+/* 展开态:指示条贴在条目自身左缘(条目左对齐、占满宽度)。 */
+.is-expanded .nav-item--active::before {
+  left: 0;
+  top: 6px;
+  bottom: 6px;
+}
+
+/* 边缘切换:骑在侧栏右缘、与品牌行齐平的圆形按钮。随 --rail-width 平移(展开/收起都跟手)。 */
+.rail-edge-toggle {
+  position: absolute;
+  top: 23px; /* 与顶部品牌 mark 垂直居中对齐 */
+  left: calc(var(--rail-width) - 13px); /* 圆心落在 rail 右缘分割线上 */
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  color: var(--color-dim);
+  cursor: pointer;
+  z-index: 30;
+  box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.14);
+  transition:
+    left var(--duration-normal) var(--ease-out-expo, ease),
+    color var(--duration-fast),
+    border-color var(--duration-fast),
+    box-shadow var(--duration-fast);
+}
+.rail-edge-toggle:hover {
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+  box-shadow: 0 4px 12px -2px var(--color-primary-soft);
+}
+.rail-edge-toggle:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+.toggle-chevron {
+  transition: transform var(--duration-normal) var(--ease-out-expo, ease);
+}
+.toggle-chevron.flipped {
+  transform: rotate(180deg);
 }
 
 .rail-spacer {

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -6,6 +6,7 @@ const Login       = () => import('../views/Login.vue')
 const AppShell    = () => import('../layouts/AppShell.vue')
 // Story 1-7: first-run onboarding guide
 const Onboarding  = () => import('../views/Onboarding.vue')
+const Dashboard   = () => import('../views/Dashboard.vue')
 const Projects    = () => import('../views/Projects.vue')
 const Runs        = () => import('../views/Runs.vue')
 // FR-8-13: 复用库(流水线模板 + 变量组)
@@ -90,7 +91,8 @@ const router = createRouter({
       meta: { requiresAuth: true },
       children: [
         // 首页:概览仪表盘尚未建,暂重定向到项目页(避免落到占位页)。
-        { path: '', name: 'overview', redirect: { name: 'projects' } },
+        { path: '', name: 'overview', redirect: { name: 'dashboard' } },
+        { path: 'dashboard', name: 'dashboard', component: Dashboard },
         // Story 1-7: first-run onboarding guide (inside shell, auth-required)
         { path: 'onboarding', name: 'onboarding', component: Onboarding },
         { path: 'projects', name: 'projects', component: Projects },

--- a/web/src/views/Dashboard.vue
+++ b/web/src/views/Dashboard.vue
@@ -1,0 +1,428 @@
+<script setup lang="ts">
+/**
+ * Dashboard — 全局概览首页(container)。
+ *
+ * 并行(Promise.allSettled,单点失败不拖垮整页)拉取真实数据:运行 / 项目 / 服务器 + 指标 /
+ * DORA / 异常告警 / AI 诊断 / 各项目环境部署,派生 KPI 并以 bento 网格组织各 presentational widget。
+ * 无数据各 widget 自行降级到空状态(自托管首启即可用,不白屏)。
+ */
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+
+import { listRuns, type RunListItem } from '../api/runs'
+import { listProjects, type Project } from '../api/projects'
+import { listServers, getAllServerMetrics, type Server, type ServerMetrics } from '../api/servers'
+import { listEnvironmentDeployments } from '../api/environments'
+import { getDoraMetrics, type DoraMetrics, formatFrequency, formatDuration, formatPercent } from '../api/metrics'
+import { listAnomalyAlerts, type AnomalyAlert } from '../api/anomaly'
+import { getDiagnosisStats, type DiagnosisStats } from '../api/settings'
+
+import DashRecentRuns from '../components/dashboard/DashRecentRuns.vue'
+import DashServers from '../components/dashboard/DashServers.vue'
+import DashEnvironments, { type DashEnvEntry } from '../components/dashboard/DashEnvironments.vue'
+import DashAlerts from '../components/dashboard/DashAlerts.vue'
+import DoraMetricCard from '../components/metrics/DoraMetricCard.vue'
+import '../components/dashboard/dashboard.css'
+
+const router = useRouter()
+
+const loading = ref(true)
+const refreshing = ref(false)
+
+const runs = ref<RunListItem[]>([])
+const runsTotal = ref(0)
+const runningTotal = ref(0)
+const projects = ref<Project[]>([])
+const servers = ref<Server[]>([])
+const serverMetrics = ref<ServerMetrics[]>([])
+const dora = ref<DoraMetrics | null>(null)
+const alerts = ref<AnomalyAlert[]>([])
+const diagnosis = ref<DiagnosisStats | null>(null)
+const envEntries = ref<DashEnvEntry[]>([])
+
+/** allSettled 取值助手:fulfilled 返回值,否则 fallback。 */
+function val<T>(r: PromiseSettledResult<T>, fallback: T): T {
+  return r.status === 'fulfilled' ? r.value : fallback
+}
+
+async function load(isRefresh = false): Promise<void> {
+  if (isRefresh) refreshing.value = true
+  else loading.value = true
+
+  const [recentR, runningR, projectsR, serversR, metricsR, doraR, alertsR, diagR] = await Promise.allSettled([
+    listRuns({ pageSize: 12 }),
+    listRuns({ status: 'running', pageSize: 1 }),
+    listProjects(),
+    listServers(),
+    getAllServerMetrics(),
+    getDoraMetrics({}),
+    listAnomalyAlerts({ limit: 6 }),
+    getDiagnosisStats(),
+  ])
+
+  const recent = val(recentR, { items: [], page: 1, total: 0 })
+  runs.value = recent.items
+  runsTotal.value = recent.total
+  runningTotal.value = val(runningR, { items: [], page: 1, total: 0 }).total
+  projects.value = val(projectsR, [])
+  servers.value = val(serversR, [])
+  serverMetrics.value = val(metricsR, [])
+  dora.value = doraR.status === 'fulfilled' ? doraR.value : null
+  alerts.value = val(alertsR, [])
+  diagnosis.value = diagR.status === 'fulfilled' ? diagR.value : null
+
+  // 环境:逐项目拉部署时间线并聚合(自托管项目数少,并行可控)。
+  const envResults = await Promise.allSettled(
+    projects.value.map((p) =>
+      listEnvironmentDeployments(p.id).then((timelines) =>
+        timelines.map<DashEnvEntry>((t) => ({
+          projectId: p.id,
+          projectName: p.name,
+          environment: t.environment,
+          active: t.active,
+        })),
+      ),
+    ),
+  )
+  const flat = envResults.flatMap((r) => (r.status === 'fulfilled' ? r.value : []))
+  // 已部署的(有 active)按部署时间倒序在前,未部署的在后。
+  flat.sort((a, b) => {
+    const ta = a.active ? new Date(a.active.deployedAt).getTime() : 0
+    const tb = b.active ? new Date(b.active.deployedAt).getTime() : 0
+    return tb - ta
+  })
+  envEntries.value = flat
+
+  loading.value = false
+  refreshing.value = false
+}
+
+// ─── KPI 派生 ───────────────────────────────────────────────
+const successRate = computed<number | null>(() => {
+  const terminal = runs.value.filter((r) =>
+    ['success', 'failed', 'partial_failed', 'rolled_back'].includes(r.status),
+  )
+  if (!terminal.length) return null
+  const ok = terminal.filter((r) => r.status === 'success').length
+  return Math.round((ok / terminal.length) * 100)
+})
+const serversOnline = computed(() => serverMetrics.value.filter((m) => m.reachable).length)
+
+const kpis = computed(() => [
+  { label: '项目', value: String(projects.value.length), to: '/projects', accent: 'primary' },
+  { label: '运行总数', value: String(runsTotal.value), to: '/runs', accent: 'neutral' },
+  {
+    label: '近期成功率',
+    value: successRate.value === null ? '—' : `${successRate.value}%`,
+    suffix: successRate.value === null ? '' : '近 12 次',
+    to: '/runs',
+    accent: successRate.value === null ? 'neutral' : successRate.value >= 90 ? 'ok' : successRate.value >= 70 ? 'warn' : 'err',
+  },
+  { label: '进行中', value: String(runningTotal.value), to: '/runs', accent: runningTotal.value > 0 ? 'run' : 'neutral' },
+  {
+    label: '服务器在线',
+    value: servers.value.length ? `${serversOnline.value}/${servers.value.length}` : '0',
+    to: '/server-status',
+    accent: servers.value.length && serversOnline.value < servers.value.length ? 'warn' : 'ok',
+  },
+])
+
+// ─── DORA 4 卡(复用 DoraMetricCard)─────────────────────────
+const doraTrend = computed(() => dora.value?.trend ?? [])
+const deployTrend = computed(() => doraTrend.value.map((p) => p.deployments))
+const cfrTrend = computed(() => doraTrend.value.map((p) => p.changeFailureRate))
+
+onMounted(load)
+</script>
+
+<template>
+  <div class="dashboard">
+    <header class="dash-header">
+      <div>
+        <h1 class="dash-title">概览</h1>
+        <p class="dash-sub">CI/CD · 部署 · 运维 全局态</p>
+      </div>
+      <div class="dash-actions">
+        <button class="dash-ghost" type="button" :disabled="refreshing" @click="load(true)">
+          <svg class="dash-refresh-icon" :class="{ spin: refreshing }" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M1 4v6h6M23 20v-6h-6" /><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+          </svg>
+          刷新
+        </button>
+        <button class="dash-primary" type="button" @click="router.push('/projects')">＋ 新建项目</button>
+      </div>
+    </header>
+
+    <!-- KPI 行 -->
+    <section class="kpi-row" aria-label="关键指标">
+      <button v-for="k in kpis" :key="k.label" class="kpi" :class="`kpi--${k.accent}`" type="button" @click="router.push(k.to)">
+        <span class="kpi-label">{{ k.label }}</span>
+        <strong class="kpi-value">{{ k.value }}</strong>
+        <span v-if="k.suffix" class="kpi-suffix">{{ k.suffix }}</span>
+      </button>
+    </section>
+
+    <!-- bento 网格 -->
+    <div class="bento">
+      <div class="bento-runs"><DashRecentRuns :runs="runs" :loading="loading" /></div>
+      <div class="bento-env"><DashEnvironments :entries="envEntries" :loading="loading" /></div>
+      <div class="bento-srv"><DashServers :servers="servers" :metrics="serverMetrics" :loading="loading" /></div>
+      <div class="bento-alerts"><DashAlerts :alerts="alerts" :diagnosis="diagnosis" :loading="loading" /></div>
+
+      <section class="card bento-dora" aria-labelledby="dash-dora-h">
+        <header class="card-head">
+          <h2 id="dash-dora-h" class="card-title">DORA 指标 <span class="dora-window">{{ dora?.window ?? '30d' }}</span></h2>
+          <button class="card-link" type="button" @click="router.push('/metrics/dora')">详情 →</button>
+        </header>
+        <div v-if="loading" class="dora-skeleton"><span v-for="i in 4" :key="i" /></div>
+        <div v-else-if="dora" class="dora-grid">
+          <DoraMetricCard
+            title="部署频率" subtitle="Deployment Frequency"
+            :display="dora.metrics.deploymentFrequency.sampleCount ? formatFrequency(dora.deploymentFrequency) : '—'"
+            :caption="`${dora.windowDays} 天内 ${dora.totalDeployments} 次部署`"
+            :band="dora.metrics.deploymentFrequency.band" :sampleCount="dora.metrics.deploymentFrequency.sampleCount" :trend="deployTrend"
+          />
+          <DoraMetricCard
+            title="变更前置时长" subtitle="Lead Time"
+            :display="dora.metrics.leadTime.sampleCount ? formatDuration(dora.leadTimeSeconds) : '—'"
+            caption="提交到部署的中位时长"
+            :band="dora.metrics.leadTime.band" :sampleCount="dora.metrics.leadTime.sampleCount" :trend="deployTrend"
+          />
+          <DoraMetricCard
+            title="变更失败率" subtitle="Change Failure Rate"
+            :display="dora.metrics.changeFailureRate.sampleCount ? formatPercent(dora.changeFailureRate) : '—'"
+            :caption="`${dora.failedDeployments}/${dora.totalDeployments} 次部署失败`"
+            :band="dora.metrics.changeFailureRate.band" :sampleCount="dora.metrics.changeFailureRate.sampleCount" :trend="cfrTrend"
+          />
+          <DoraMetricCard
+            title="平均恢复时长" subtitle="MTTR"
+            :display="dora.metrics.mttr.sampleCount ? formatDuration(dora.mttrSeconds) : '—'"
+            caption="失败到恢复的中位时长"
+            :band="dora.metrics.mttr.band" :sampleCount="dora.metrics.mttr.sampleCount" :trend="cfrTrend"
+          />
+        </div>
+        <p v-else class="card-empty">暂无 DORA 数据。完成若干次部署后,四项工程效能指标会在此汇总。</p>
+      </section>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+.dash-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding-bottom: var(--space-2);
+}
+.dash-title {
+  font-size: var(--text-display);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
+}
+.dash-sub {
+  font-size: var(--text-body);
+  color: var(--color-faint);
+  margin-top: 2px;
+}
+.dash-actions {
+  display: flex;
+  gap: 10px;
+  flex: none;
+}
+.dash-ghost,
+.dash-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  font-size: var(--text-label);
+  font-weight: 600;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--duration-fast), transform var(--duration-fast);
+}
+.dash-ghost {
+  color: var(--color-text-soft);
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+}
+.dash-ghost:hover:not(:disabled) {
+  background: var(--color-surface-hover);
+}
+.dash-ghost:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+.dash-primary {
+  color: #fff;
+  background: var(--color-primary);
+  border: none;
+}
+.dash-primary:hover {
+  background: var(--color-primary-press);
+  transform: translateY(-1px);
+}
+.dash-refresh-icon.spin {
+  animation: dash-spin 0.8s linear infinite;
+}
+@keyframes dash-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* KPI 行 */
+.kpi-row {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 12px;
+}
+.kpi {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px 18px;
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  text-align: left;
+  overflow: hidden;
+  transition: transform var(--duration-fast), box-shadow var(--duration-fast), border-color var(--duration-fast);
+}
+.kpi::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--accent, var(--color-border-strong));
+}
+.kpi:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px -16px rgba(0, 0, 0, 0.3);
+  border-color: var(--color-border-strong);
+}
+.kpi--primary {
+  --accent: var(--color-primary);
+}
+.kpi--ok {
+  --accent: var(--color-green);
+}
+.kpi--warn {
+  --accent: var(--color-amber);
+}
+.kpi--err {
+  --accent: var(--color-red);
+}
+.kpi--run {
+  --accent: var(--color-cyan);
+}
+.kpi--neutral {
+  --accent: var(--color-border-strong);
+}
+.kpi-label {
+  font-size: var(--text-micro);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-faint);
+}
+.kpi-value {
+  font-size: var(--text-kpi);
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+.kpi-suffix {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+}
+
+/* bento 网格 */
+.bento {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 16px;
+}
+.bento-runs {
+  grid-column: 1;
+}
+.bento-env {
+  grid-column: 2;
+}
+.bento-srv {
+  grid-column: 1;
+}
+.bento-alerts {
+  grid-column: 2;
+}
+.bento-dora {
+  grid-column: 1 / -1;
+}
+.dora-window {
+  font-size: var(--text-micro);
+  font-weight: 600;
+  color: var(--color-faint);
+  font-family: var(--font-mono);
+  margin-left: 4px;
+}
+.dora-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+.dora-skeleton {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+.dora-skeleton span {
+  height: 150px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(90deg, var(--color-inset), var(--color-surface-hover), var(--color-inset));
+  background-size: 200% 100%;
+  animation: dash-shimmer 1.3s ease-in-out infinite;
+}
+@keyframes dash-shimmer {
+  to {
+    background-position: -200% 0;
+  }
+}
+
+@media (max-width: 1080px) {
+  .kpi-row {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .bento {
+    grid-template-columns: 1fr;
+  }
+  .bento-runs,
+  .bento-env,
+  .bento-srv,
+  .bento-alerts,
+  .bento-dora {
+    grid-column: 1;
+  }
+  .dora-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+@media (max-width: 560px) {
+  .kpi-row {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .dora-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>


### PR DESCRIPTION
## 目标
之前登录后落地是「项目列表」,缺一个聚合全局态的概览首页。本 PR 新增 bento 概览 dashboard 作为新首页(用户要求)。

## 实现(纯前端,复用现有 API,零后端改动)
- `views/Dashboard.vue`:`Promise.allSettled` 并行拉 runs / projects / servers+metrics / dora / anomaly / diagnosis + 各项目 environments 聚合,单点失败不拖垮整页。
- **KPI 行**:项目 / 运行总数 / 近期成功率 / 进行中 / 服务器在线(语义色左条 + 可点钻取)。
- **bento 网格 widget**(`components/dashboard/`):
  - DashRecentRuns — 最近运行状态徽章 feed
  - DashServers — 各机内存/磁盘使用率条 + 在线态 + 负载
  - DashEnvironments — 跨项目各环境当前激活版本
  - DashAlerts — 资源异常告警 + AI 诊断准确率
  - DORA — 复用 `DoraMetricCard` 四指标
- 共享卡片骨架 `dashboard.css` 以 `.dashboard` 父级前缀收束作用域(不泄漏全局,不与 CronPanel/RunnerPanel 的 scoped `.card-*` 冲突)。
- 路由 `/` → dashboard、新增 `/dashboard`,侧栏顶部加「概览」;onboarding 首启引导不受影响。
- 各 widget 自带骨架/空状态 → 自托管首启即可用、不白屏。

## 验证
- typecheck / lint(新文件 0 问题)/ 311 前端测试 / 构建全绿。
- 真二进制登录直达 `/dashboard` 渲染正常,KPI + 各 widget 空状态优雅降级(browser-use 实测)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)