### PR TITLE
chore(install): 安装脚本检测 Docker + Linux 可选自动安装

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,17 +51,19 @@
 
 ## 安装 / 部署
 
-三种形态任选,数据均落本地、无外部依赖。
+三种形态任选,平台本体是单静态二进制、**运行时零依赖**(无需 Go/Node)。
+
+> **Docker 前置**:平台本体不依赖 Docker,但**「隔离构建 / 容器部署」需要 Docker**(没有则降级到桩 runner、不做真实构建)。控制台 / SSH 部署 / AI 诊断 / 通知不需要。一键脚本会**检测 Docker** 并在缺失时提示;Linux 下可 `INSTALL_DOCKER=1` 自动安装(经官方 get.docker.com),macOS 请装 Docker Desktop。
 
 ### ① 一键脚本(Linux / macOS)
 
-从 GitHub Release 下载对应平台的静态二进制装到 `/usr/local/bin`(含校验和核验):
+从 GitHub Release 下载对应平台的静态二进制装到 `/usr/local/bin`(含校验和核验 + Docker 检测):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/huangchengsir/pipewright/master/install.sh | sh
 
-# 钉版本 / 自定义目录:
-VERSION=v1.0.0 INSTALL_DIR=$HOME/.local/bin \
+# 钉版本 / 自定义目录 / Linux 顺带自动装 Docker:
+VERSION=v1.0.0 INSTALL_DIR=$HOME/.local/bin INSTALL_DOCKER=1 \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/huangchengsir/pipewright/master/install.sh)"
 
 # 运行(首次启动引导管理员;master key 用于凭据保险库)

--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,9 @@
 #
 # 探测平台 → 从 GitHub Release 下载对应静态二进制 → 校验和核验 → 装到 /usr/local/bin。
 # 可配环境变量:
-#   VERSION       钉某版本(如 v1.2.3);缺省取 latest。
-#   INSTALL_DIR   安装目录;缺省 /usr/local/bin(不可写时自动 sudo)。
+#   VERSION         钉某版本(如 v1.2.3);缺省取 latest。
+#   INSTALL_DIR     安装目录;缺省 /usr/local/bin(不可写时自动 sudo)。
+#   INSTALL_DOCKER  =1 时,Linux 下若缺 Docker 自动经官方 get.docker.com 安装(隔离构建/容器部署需要)。
 #
 # Windows 用户请到 Releases 页下载 .zip:
 #   https://github.com/huangchengsir/pipewright/releases
@@ -17,6 +18,7 @@ BIN="pipewright"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 
 info() { printf '\033[1;34m==>\033[0m %s\n' "$1"; }
+warn() { printf '\033[1;33m提示:\033[0m %s\n' "$1" >&2; }
 err() {
 	printf '\033[1;31m错误:\033[0m %s\n' "$1" >&2
 	exit 1
@@ -100,4 +102,49 @@ else
 fi
 
 info "完成 ✓  $("${INSTALL_DIR}/${BIN}" --version 2>/dev/null || echo "${BIN} ${TAG}")"
+
+# ── Docker 运行时检测 ────────────────────────────────────────────────
+# 「隔离构建 / 容器部署」需要 Docker;控制台 / SSH 部署 / AI 诊断不需要。
+# 缺失不致命(平台照常起),但隔离构建会降级到桩 runner —— 故给出明确提示 / 可选自动安装。
+check_docker() {
+	if command -v docker >/dev/null 2>&1; then
+		if docker info >/dev/null 2>&1; then
+			info "Docker 已就绪 ✓  隔离构建 / 容器部署可用"
+		else
+			warn "Docker 已安装但守护进程未运行。启动后隔离构建可用(Linux:sudo systemctl start docker)。"
+		fi
+		return
+	fi
+
+	warn "未检测到 Docker。平台可运行,但「隔离构建 / 容器部署」需要它(否则降级到桩 runner,不做真实构建)。"
+
+	# macOS:Docker Desktop 是 GUI 应用,无法命令行装,只提示。
+	if [ "$OS" != "linux" ]; then
+		printf '  macOS 请安装 Docker Desktop:https://www.docker.com/products/docker-desktop/\n' >&2
+		return
+	fi
+
+	# Linux:opt-in 自动装(INSTALL_DOCKER=1 或交互式确认)。官方 get.docker.com 仅支持 Linux。
+	do_install=0
+	if [ "${INSTALL_DOCKER:-}" = "1" ]; then
+		do_install=1
+	elif [ -t 0 ]; then
+		printf '  是否现在用官方脚本 get.docker.com 自动安装 Docker?[y/N] ' >&2
+		read -r ans
+		case "$ans" in y | Y | yes | YES) do_install=1 ;; esac
+	else
+		printf '  Linux 自动安装:重跑时加 INSTALL_DOCKER=1,或手动 curl -fsSL https://get.docker.com | sh\n' >&2
+	fi
+
+	if [ "$do_install" = "1" ]; then
+		info "经官方脚本安装 Docker(get.docker.com,需要 sudo 提权)…"
+		if $DL https://get.docker.com | sh; then
+			info "Docker 安装完成。建议:sudo systemctl enable --now docker;将当前用户加入 docker 组(sudo usermod -aG docker \"\$USER\")后重新登录免 sudo。"
+		else
+			warn "Docker 自动安装失败,请参考 https://docs.docker.com/engine/install/ 手动安装。"
+		fi
+	fi
+}
+check_docker
+
 printf '启动:%s\n' "${BIN}   # 默认监听 :8080,数据落当前目录 pipewright.db"


### PR DESCRIPTION
## 背景
一键 `install.sh` 此前只装静态二进制(运行时零依赖,无需 Go/Node)。但 Pipewright 的头牌功能**「隔离构建 / 容器部署」实际需要 Docker** —— 缺失时会降级到桩 runner、不做真实构建。脚本之前对此完全没提示,是个缺口。

## 改动
- 装完二进制后**检测 Docker**:已就绪 ✓ / 已装但 daemon 未起(提示启动)/ 未装。
- **未装且 Linux**:`INSTALL_DOCKER=1` 或交互式确认(`curl|sh` 管道无 TTY 时仅打印提示)后,经官方 `get.docker.com` 自动安装;装后提示 `enable --now` + 加 docker 组。
- **macOS**:Docker Desktop 无法命令行装,仅给下载链接。
- 全程**非致命**:Docker 缺失不影响二进制安装与平台启动(控制台 / SSH 部署 / AI 诊断 / 通知不依赖 Docker)。`get.docker.com` 下载复用脚本已选的 `$DL`(curl/wget 自适应)。
- README:把 Docker 标为隔离构建前置依赖 + 记 `INSTALL_DOCKER`。

## 不做的事
不自动装 Go/Node —— 它们只是构建期依赖,发布二进制是纯静态、前端已 `go:embed`,用户运行时一概不需要。

## 验证
`sh -n install.sh` 语法通过;Docker 检测分支逻辑本机实测(Docker 在跑 → 「已就绪 ✓」)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)