### PR TITLE
feat(server-status): 内存对齐宿主面板口径 + swap + 物理内存缓存 + 自动刷新

### DIFF
--- a/internal/httpapi/server_metrics.go
+++ b/internal/httpapi/server_metrics.go
@@ -47,6 +47,11 @@ var (
 	cmdFreeBytes  = []string{"free", "-b"}
 	cmdDfBytes    = []string{"df", "-B1", "/"}
 	cmdDfKiB      = []string{"df", "-k", "/"}
+	// 物理/分配内存(SMBIOS Type 17 内存设备容量之和)。`free` 的 MemTotal 是内核
+	// **可用**总量(已扣固件/内核保留),通常略小于物理装机量;dmidecode 读 SMBIOS
+	// 得「物理/分配」总量,与 PVE 等宿主面板显示的总量一致。需 root;非 root / 无
+	// dmidecode / 虚拟化未暴露 SMBIOS → 采集失败 → physicalTotalBytes 为 0(不展示)。
+	cmdDmidecodeMem = []string{"dmidecode", "-t", "17"}
 )
 
 // cpuMetric / memoryMetric / diskMetric 是各维度指标 DTO(冻结契约字段形状)。
@@ -57,8 +62,16 @@ type cpuMetric struct {
 }
 
 type memoryMetric struct {
-	UsedBytes  int64 `json:"usedBytes"`
-	TotalBytes int64 `json:"totalBytes"`
+	UsedBytes int64 `json:"usedBytes"` // 不含可回收页缓存(进程真实占用 / 内存压力口径)
+	// 含页缓存(total - free);与 cgroup 总用量 / PVE 等容器面板的「已用」一致。
+	UsedWithCacheBytes int64 `json:"usedWithCacheBytes"`
+	TotalBytes         int64 `json:"totalBytes"` // free 的 MemTotal:内核**可用**总量
+	// 物理/分配总量(dmidecode SMBIOS);0 表示采集不到。通常 ≥ TotalBytes,与宿主
+	// 面板(PVE 等)显示的总量一致,用作「含缓存」口径的分母以对齐其百分比。
+	PhysicalTotalBytes int64 `json:"physicalTotalBytes"`
+	// 交换分区 used/total(free 的 Swap 行);SwapTotalBytes 为 0 表示未配置 swap。
+	SwapUsedBytes  int64 `json:"swapUsedBytes"`
+	SwapTotalBytes int64 `json:"swapTotalBytes"`
 }
 
 type diskMetric struct {
@@ -175,11 +188,65 @@ func collectMemory(ctx context.Context, svc target.Service, id string) *memoryMe
 	if err != nil {
 		return nil
 	}
-	used, total, ok := parseFreeBytes(out)
+	used, usedWithCache, total, ok := parseFreeBytes(out)
 	if !ok {
 		return nil
 	}
-	return &memoryMetric{UsedBytes: used, TotalBytes: total}
+	m := &memoryMetric{UsedBytes: used, UsedWithCacheBytes: usedWithCache, TotalBytes: total}
+	// Swap 与内存来自同一份 `free -b`:解析 Swap 行(未配置 swap → 0/0)。
+	if su, st, sok := parseSwapBytes(out); sok {
+		m.SwapUsedBytes, m.SwapTotalBytes = su, st
+	}
+	// 物理/分配总量:静态硬件量,经 host 级缓存避免每次轮询都跑一次 SSH dmidecode。
+	m.PhysicalTotalBytes = cachedPhysicalTotal(ctx, svc, id, total)
+	return m
+}
+
+// ─── 物理内存缓存 ──────────────────────────────────────────────────────────────
+//
+// dmidecode 取的物理/分配内存是静态量(不随负载变),但采集页可能每 10s 轮询一次。
+// 按 serverID 缓存:成功值(>0)长期复用;失败(非 root / 无 dmidecode / SSH 抖动)缓存
+// 一个冷却期,避免对失败主机每轮都重拨 SSH。进程重启即清空,自然容纳极少见的换内存。
+type physMemEntry struct {
+	bytes    int64 // >0:已知物理总量;0:探测过但取不到
+	probedAt time.Time
+}
+
+var (
+	physMemMu    sync.Mutex
+	physMemCache = map[string]physMemEntry{}
+)
+
+// physMemRetryCooldown:对「取不到」的主机多久重试一次 dmidecode(成功值不受此限,永久缓存)。
+const physMemRetryCooldown = 10 * time.Minute
+
+// cachedPhysicalTotal 返回该主机物理/分配内存(字节),0 表示取不到。memTotal 用于
+// 合理性校验(物理量应 ≥ 内核可用量)。SSH 调用在不持锁时进行,不串行化各主机。
+func cachedPhysicalTotal(ctx context.Context, svc target.Service, id string, memTotal int64) int64 {
+	now := time.Now()
+
+	physMemMu.Lock()
+	if e, hit := physMemCache[id]; hit {
+		// 成功值永久有效;失败值在冷却期内复用(不重拨)。
+		if e.bytes > 0 || now.Sub(e.probedAt) < physMemRetryCooldown {
+			physMemMu.Unlock()
+			return e.bytes
+		}
+	}
+	physMemMu.Unlock()
+
+	// 探测(不持锁):dmidecode 需 root,失败一律记 0,绝不连累已成功的 free 口径。
+	var phys int64
+	if dmiOut, dmiErr := runMetricCmd(ctx, svc, id, cmdDmidecodeMem); dmiErr == nil {
+		if p, pok := parseDmidecodeMemBytes(dmiOut); pok && p >= memTotal {
+			phys = p
+		}
+	}
+
+	physMemMu.Lock()
+	physMemCache[id] = physMemEntry{bytes: phys, probedAt: now}
+	physMemMu.Unlock()
+	return phys
 }
 
 // collectDisk 取根分区 used/total(字节)。`df -B1 /` 优先;macOS 不识别 -B1 → 回退 `df -k /`
@@ -256,17 +323,23 @@ func parseInt(s string) (int, bool) {
 	return v, true
 }
 
-// parseFreeBytes 解析 `free -b` 输出,取 Mem 行的 total/used(字节)。
+// parseFreeBytes 解析 `free -b` 输出,取 Mem 行的 total 与两种「已使用」口径(字节)。
 // 形如:
 //
 //	              total        used        free      shared  buff/cache   available
-//	Mem:    17179869184  4123456789  ...
+//	Mem:    17179869184   2854748160   706924544  ...
 //
-// 取 Mem 行的第 1 列 total、第 2 列 used。容错:列不足/非数字 → false。
-func parseFreeBytes(s string) (used, total int64, ok bool) {
+// 返回两口径(均常见、各有用途,不绑定任何虚拟化平台):
+//   - used:free 的「used」列(第 2 列)—— **不含可回收页缓存**,反映进程真实占用 /
+//     内存压力(htop、node_exporter 同口径)。
+//   - usedWithCache:total - free(= used + buff/cache)—— **含页缓存**,与 cgroup 总用量 /
+//     PVE 等容器面板的「已用」一致(它们把页缓存算进已用)。
+//
+// 取 Mem 行第 1 列 total、第 2 列 used、第 3 列 free。容错:列不足/非数字/越界 → false。
+func parseFreeBytes(s string) (used, usedWithCache, total int64, ok bool) {
 	for _, line := range strings.Split(s, "\n") {
 		fields := strings.Fields(line)
-		if len(fields) < 3 {
+		if len(fields) < 4 {
 			continue
 		}
 		if !strings.HasPrefix(strings.ToLower(fields[0]), "mem") {
@@ -274,12 +347,102 @@ func parseFreeBytes(s string) (used, total int64, ok bool) {
 		}
 		t, err1 := strconv.ParseInt(fields[1], 10, 64)
 		u, err2 := strconv.ParseInt(fields[2], 10, 64)
-		if err1 != nil || err2 != nil || t <= 0 || u < 0 {
+		f, err3 := strconv.ParseInt(fields[3], 10, 64)
+		if err1 != nil || err2 != nil || err3 != nil || t <= 0 || u < 0 || f < 0 || f > t {
+			return 0, 0, 0, false
+		}
+		return u, t - f, t, true
+	}
+	return 0, 0, 0, false
+}
+
+// parseSwapBytes 解析 `free -b` 的 Swap 行,取 total/used(字节)。形如:
+//
+//	Swap:    2147483648    536870912   1610612736
+//
+// 取第 1 列 total、第 2 列 used。无 Swap 行(部分系统)或列不足/非数字 → false;
+// total=0(未配置 swap)仍算成功(used/total 均 0,UI 据此不渲染 swap 行)。
+func parseSwapBytes(s string) (used, total int64, ok bool) {
+	for _, line := range strings.Split(s, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		if !strings.HasPrefix(strings.ToLower(fields[0]), "swap") {
+			continue
+		}
+		t, err1 := strconv.ParseInt(fields[1], 10, 64)
+		u, err2 := strconv.ParseInt(fields[2], 10, 64)
+		if err1 != nil || err2 != nil || t < 0 || u < 0 {
 			return 0, 0, false
 		}
 		return u, t, true
 	}
 	return 0, 0, false
+}
+
+// parseDmidecodeMemBytes 解析 `dmidecode -t 17` 输出,累加各「已装」内存设备的 Size
+// 得物理/分配总量(字节)。形如:
+//
+//	Memory Device
+//	        Size: 8 GiB
+//	Memory Device
+//	        Size: No Module Installed
+//
+// 单位大小写不敏感,兼容 dmidecode 各版本写法:kB/MB/GB/TB(十进制千)与 KiB/MiB/GiB/TiB
+// (二进制 1024)。"No Module Installed" / "Unknown" / 非数字 → 跳过该设备。
+// 一个有效 Size 都没有 → false(交由上层留 0、不展示)。
+func parseDmidecodeMemBytes(s string) (int64, bool) {
+	var total int64
+	found := false
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "Size:") {
+			continue
+		}
+		fields := strings.Fields(strings.TrimPrefix(line, "Size:"))
+		if len(fields) < 2 {
+			continue // "No Module Installed"/"Unknown" 等 → 跳过
+		}
+		n, err := strconv.ParseInt(fields[0], 10, 64)
+		if err != nil || n <= 0 {
+			continue
+		}
+		mult, uok := memUnitMultiplier(fields[1])
+		if !uok {
+			continue
+		}
+		total += n * mult
+		found = true
+	}
+	if !found || total <= 0 {
+		return 0, false
+	}
+	return total, true
+}
+
+// memUnitMultiplier 把内存单位换算为字节倍数。二进制单位(KiB/MiB/...)按 1024 进位,
+// 十进制单位(kB/MB/...)按 1000 进位;dmidecode 现版本用二进制(GiB),旧版用 MB/GB。
+func memUnitMultiplier(unit string) (int64, bool) {
+	switch strings.ToLower(unit) {
+	case "kb":
+		return 1000, true
+	case "mb":
+		return 1000 * 1000, true
+	case "gb":
+		return 1000 * 1000 * 1000, true
+	case "tb":
+		return 1000 * 1000 * 1000 * 1000, true
+	case "kib":
+		return 1024, true
+	case "mib":
+		return 1024 * 1024, true
+	case "gib":
+		return 1024 * 1024 * 1024, true
+	case "tib":
+		return 1024 * 1024 * 1024 * 1024, true
+	}
+	return 0, false
 }
 
 // parseDf 解析 `df` 输出的根分区行,取 total(第 2 列)/ used(第 3 列),乘以 unit 化为字节。

--- a/internal/httpapi/server_metrics_test.go
+++ b/internal/httpapi/server_metrics_test.go
@@ -56,15 +56,61 @@ func TestParseFreeBytes(t *testing.T) {
 	out := "              total        used        free      shared  buff/cache   available\n" +
 		"Mem:    17179869184  4123456789  1000000000   100000   500000000  12000000000\n" +
 		"Swap:    2147483648           0  2147483648\n"
-	used, total, ok := parseFreeBytes(out)
-	if !ok || total != 17179869184 || used != 4123456789 {
-		t.Fatalf("parseFreeBytes = %d,%d,%v", used, total, ok)
+	used, usedWithCache, total, ok := parseFreeBytes(out)
+	// used = 「used」列(不含缓存);usedWithCache = total - free(含页缓存)。
+	if !ok || total != 17179869184 || used != 4123456789 || usedWithCache != 17179869184-1000000000 {
+		t.Fatalf("parseFreeBytes = %d,%d,%d,%v", used, usedWithCache, total, ok)
 	}
-	if _, _, ok := parseFreeBytes(""); ok {
+	if _, _, _, ok := parseFreeBytes(""); ok {
 		t.Fatalf("empty should be false")
 	}
-	if _, _, ok := parseFreeBytes("no mem line here\n"); ok {
+	if _, _, _, ok := parseFreeBytes("no mem line here\n"); ok {
 		t.Fatalf("no Mem line should be false")
+	}
+}
+
+func TestParseSwapBytes(t *testing.T) {
+	out := "" +
+		"              total        used        free\n" +
+		"Mem:    8054091776  2855583744  1000000000\n" +
+		"Swap:   2147483648   536870912  1610612736\n"
+	used, total, ok := parseSwapBytes(out)
+	if !ok || total != 2147483648 || used != 536870912 {
+		t.Fatalf("parseSwapBytes = %d,%d,%v", used, total, ok)
+	}
+	// 未配置 swap:total=0 仍算成功。
+	if u, tt, ok := parseSwapBytes("Swap:   0   0   0\n"); !ok || u != 0 || tt != 0 {
+		t.Fatalf("zero swap should be ok with 0/0, got %d,%d,%v", u, tt, ok)
+	}
+	// 无 Swap 行 → false。
+	if _, _, ok := parseSwapBytes("Mem:  1 2 3\n"); ok {
+		t.Fatalf("no swap line should be false")
+	}
+}
+
+func TestParseDmidecodeMemBytes(t *testing.T) {
+	// 现版本 dmidecode:二进制单位 GiB;含一个未装设备(应跳过)。
+	out := "" +
+		"Memory Device\n\tSize: 8 GiB\n\tLocator: DIMM 0\n" +
+		"Memory Device\n\tSize: No Module Installed\n\tLocator: DIMM 1\n"
+	got, ok := parseDmidecodeMemBytes(out)
+	if !ok || got != 8*1024*1024*1024 {
+		t.Fatalf("parseDmidecodeMemBytes(GiB) = %d,%v want %d", got, ok, int64(8*1024*1024*1024))
+	}
+
+	// 旧版 dmidecode:十进制 MB,多条相加。
+	out2 := "\tSize: 4096 MB\n\tSize: 4096 MB\n"
+	got2, ok2 := parseDmidecodeMemBytes(out2)
+	if !ok2 || got2 != 2*4096*1000*1000 {
+		t.Fatalf("parseDmidecodeMemBytes(MB) = %d,%v", got2, ok2)
+	}
+
+	// 全部未装 / 空 → false(上层留 0 不展示)。
+	if _, ok := parseDmidecodeMemBytes("Memory Device\n\tSize: No Module Installed\n"); ok {
+		t.Fatalf("no installed module should be false")
+	}
+	if _, ok := parseDmidecodeMemBytes(""); ok {
+		t.Fatalf("empty should be false")
 	}
 }
 

--- a/web/src/api/servers.ts
+++ b/web/src/api/servers.ts
@@ -227,8 +227,17 @@ export interface CpuMetric {
 
 /** Memory used/total in bytes. */
 export interface MemoryMetric {
+  /** 进程真实占用,**不含**可回收页缓存(htop/node_exporter 同口径,反映内存压力)。 */
   usedBytes: number
+  /** total - free,**含**页缓存;与 cgroup 总用量 / 容器面板的「已用」一致(口径之一,不绑定平台)。 */
+  usedWithCacheBytes: number
+  /** free 的 MemTotal:内核**可用**总量(已扣固件/内核保留)。 */
   totalBytes: number
+  /** 物理/分配总量(dmidecode SMBIOS);0 表示采集不到(非 root / 无 dmidecode / 虚拟化未暴露)。 */
+  physicalTotalBytes: number
+  /** 交换分区 used/total(free 的 Swap 行);swapTotalBytes 为 0 表示未配置 swap。 */
+  swapUsedBytes: number
+  swapTotalBytes: number
 }
 
 /** Disk used/total in bytes for a mount path (root `/`). */

--- a/web/src/components/ops/ServerMetricsCard.vue
+++ b/web/src/components/ops/ServerMetricsCard.vue
@@ -55,9 +55,31 @@ function humanBytes(n: number): string {
 const memPercent = computed(() =>
   props.metrics.memory ? pct(props.metrics.memory.usedBytes, props.metrics.memory.totalBytes) : null,
 )
+/**
+ * 「含缓存」口径的分母:有物理/分配总量时优先用它(对齐宿主面板如 PVE 的总量),
+ * 否则回退 free 的可用总量。physicalTotalBytes 为 0 表示采集不到。
+ */
+const memCacheTotal = computed(() => {
+  const m = props.metrics.memory
+  if (!m) return null
+  return m.physicalTotalBytes > 0 ? m.physicalTotalBytes : m.totalBytes
+})
+/** 含页缓存(total - free)/ 物理总量 —— 与 cgroup / 宿主面板「已用」百分比一致。 */
+const memCachePercent = computed(() =>
+  props.metrics.memory && memCacheTotal.value
+    ? pct(props.metrics.memory.usedWithCacheBytes, memCacheTotal.value)
+    : null,
+)
 const diskPercent = computed(() =>
   props.metrics.disk ? pct(props.metrics.disk.usedBytes, props.metrics.disk.totalBytes) : null,
 )
+
+/** 交换分区用量(swapTotalBytes 为 0 → 未配置,不渲染)。 */
+const swapPercent = computed(() => {
+  const m = props.metrics.memory
+  if (!m || m.swapTotalBytes <= 0) return null
+  return pct(m.swapUsedBytes, m.swapTotalBytes)
+})
 
 /** CPU 负载相对核数的健康着色(无核数则不着色)。 */
 const loadVariant = computed<ProgressVariant>(() => {
@@ -134,8 +156,35 @@ const loadText = computed(() => {
               {{ humanBytes(metrics.memory.usedBytes) }} / {{ humanBytes(metrics.memory.totalBytes) }}
               <span class="metric-pct">({{ memPercent.toFixed(0) }}%)</span>
             </span>
+            <span
+              v-if="memCachePercent !== null && memCacheTotal !== null"
+              class="metric-sub metric-sub--cache"
+              title="含页缓存口径(total − free)/ 总量:页缓存计入已用,与 cgroup / 宿主面板(如 PVE)的「已用」一致。总量优先取物理/分配内存,取不到则用内核可用总量。"
+            >
+              含缓存 {{ humanBytes(metrics.memory.usedWithCacheBytes) }} /
+              {{ humanBytes(memCacheTotal) }}
+              <span class="metric-pct">({{ memCachePercent.toFixed(0) }}%)</span>
+              <span v-if="metrics.memory.physicalTotalBytes > 0" class="metric-tag">物理</span>
+            </span>
           </template>
           <span v-else class="metric-num metric-num--na">不可用</span>
+        </dd>
+      </div>
+
+      <!-- Swap(仅在配置了 swap 时显示) -->
+      <div v-if="swapPercent !== null && metrics.memory" class="metric-row">
+        <dt class="metric-row__label">交换</dt>
+        <dd class="metric-row__value">
+          <ProgressBar
+            :value="swapPercent"
+            :variant="usageVariant(swapPercent)"
+            :label="`交换使用 ${swapPercent.toFixed(0)}%`"
+          />
+          <span class="metric-sub">
+            {{ humanBytes(metrics.memory.swapUsedBytes) }} /
+            {{ humanBytes(metrics.memory.swapTotalBytes) }}
+            <span class="metric-pct">({{ swapPercent.toFixed(0) }}%)</span>
+          </span>
         </dd>
       </div>
 
@@ -287,6 +336,20 @@ const loadText = computed(() => {
 }
 .metric-pct {
   color: var(--color-faint);
+}
+.metric-sub--cache {
+  color: var(--color-faint);
+  cursor: help;
+}
+.metric-tag {
+  margin-left: 4px;
+  padding: 0 5px;
+  border-radius: var(--rounded-sm, 4px);
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: var(--color-dim);
+  background: var(--color-inset);
+  vertical-align: 1px;
 }
 
 .metrics-card__foot {

--- a/web/src/views/ServerStatus.vue
+++ b/web/src/views/ServerStatus.vue
@@ -10,7 +10,7 @@
   这是一个**新增**的总览入口,不动 4-1 SettingsServers CRUD、6-2 日志入口。
 -->
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { getAllServerMetrics, listServers, type ServerMetrics, type Server } from '../api/servers'
 import { HttpError } from '../api/http'
 import ServerMetricsCard from '../components/ops/ServerMetricsCard.vue'
@@ -73,8 +73,45 @@ async function loadServerNames(): Promise<Map<string, string>> {
   return m
 }
 
+// ─── 自动刷新 ────────────────────────────────────────────────────────────────
+// 指标实时、不落库,这里定时轮询(stale-while-revalidate:旧数据留屏、后台静默重取)。
+// 标签页隐藏时暂停(省 SSH;终端常在新标签开,这页可能被晾在后台),回到前台立即补一次。
+const REFRESH_INTERVAL_MS = 12_000
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+function startPolling(): void {
+  if (pollTimer !== null) return
+  pollTimer = setInterval(() => {
+    // 上一轮还在飞 / 出错重试中就跳过这拍,避免叠请求。
+    if (loadState.value !== 'loading') void load()
+  }, REFRESH_INTERVAL_MS)
+}
+
+function stopPolling(): void {
+  if (pollTimer !== null) {
+    clearInterval(pollTimer)
+    pollTimer = null
+  }
+}
+
+function onVisibilityChange(): void {
+  if (document.hidden) {
+    stopPolling()
+  } else {
+    void load() // 回前台立即补一次,再恢复轮询
+    startPolling()
+  }
+}
+
 onMounted(() => {
   void load()
+  startPolling()
+  document.addEventListener('visibilitychange', onVisibilityChange)
+})
+
+onUnmounted(() => {
+  stopPolling()
+  document.removeEventListener('visibilitychange', onVisibilityChange)
 })
 </script>
 
@@ -88,6 +125,7 @@ onMounted(() => {
           <span v-if="totalCount > 0" class="view-sub__count">
             · {{ reachableCount }}/{{ totalCount }} 可达
           </span>
+          <span class="view-sub__count">· 每 12 秒自动刷新</span>
         </p>
       </div>
       <AppButton variant="default" :loading="loadState === 'loading'" @click="load">


### PR DESCRIPTION
## 概要
服务器状态页指标增强,对齐 PVE 等宿主面板的内存口径,并补 swap、自动刷新。

## 改动
- **内存「含缓存」口径**:`total − free`(含页缓存),与 cgroup / 宿主面板「已用」一致;主行仍按进程占用(不含可回收缓存)着色,反映真实压力。
- **物理/分配总量**:`dmidecode -t 17`(SMBIOS)取物理内存做含缓存口径分母,百分比与宿主面板一致;按 host 缓存(静态量,失败 10min 冷却),不每轮重拨 SSH。
- **Swap 指标**:复用同一份 `free -b` 的 Swap 行,仅在配置 swap 时显示。
- **自动刷新**:服务器状态页每 12s 轮询,页面隐藏暂停、回前台立即补刷。

## 容错
dmidecode 需 root / 可能未装 / 虚拟化未暴露 SMBIOS → 静默留 0 不展示「物理」,绝不连累已成功的 `free` 口径。

## 验证
- `go build/vet/test` + `gofmt` 干净;新增 `parseSwapBytes` / `parseDmidecodeMemBytes` 单测
- 前端 `typecheck` / `lint`(0 错)/ `test` 311 通过
- 真机(server-104 over SSH)端到端验过:含缓存 6.85 / 物理 8.00 GiB = PVE 一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)