### PR TITLE
feat(install): install.sh 可选装 systemd 服务 + latest 重定向兜底

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ PIPEWRIGHT_ADMIN_PASSWORD=change-me \
   pipewright          # 打开 http://localhost:8080,用 admin / change-me 登录
 ```
 
+**推荐:装为 systemd 服务**(开机自启 + 崩溃重启 + 一键自更新可用;Linux,需 root)。脚本会自动持久化 master key 到 `/etc/pipewright/master.key`、数据落 `/var/lib/pipewright`、配置写 `/etc/pipewright/pipewright.env`:
+
+```bash
+SETUP_SERVICE=1 sh -c "$(curl -fsSL https://raw.githubusercontent.com/huangchengsir/pipewright/master/install.sh)"
+# 状态 / 日志:systemctl status pipewright  ·  journalctl -u pipewright -f
+# 改端口等:编辑 /etc/pipewright/pipewright.env 后 systemctl restart pipewright
+
+# 用 MySQL 而非默认 SQLite(DSN 为 go-sql-driver 格式,parseTime=true 必带):
+SETUP_SERVICE=1 PIPEWRIGHT_DB_DRIVER=mysql \
+  PIPEWRIGHT_DB_DSN='user:pw@tcp(host:3306)/pipewright?parseTime=true&charset=utf8mb4' \
+  sh -c "$(curl -fsSL https://raw.githubusercontent.com/huangchengsir/pipewright/master/install.sh)"
+```
+
 > Windows 用户:到 [Releases](https://github.com/huangchengsir/pipewright/releases) 下载 `.zip`。
 
 ### ② docker compose(推荐自托管)
@@ -103,7 +116,7 @@ make build          # 前端构建 → go:embed → 单个静态二进制 ./pipe
 
 打开 **设置 → 系统**,点「检查更新」查最新发布;有新版时:
 
-- **二进制部署**:点「立即更新」即自动下载新版 + 校验和核验 + 替换 + 重启(需对二进制文件有写权限;装在 `$HOME/.local/bin` 免 sudo)。
+- **二进制部署**:点「立即更新」即自动下载新版 + 校验和核验 + 替换 + 重启(需对二进制文件有写权限;装在 `$HOME/.local/bin` 免 sudo,或用 `SETUP_SERVICE=1` 装的 root systemd 服务亦满足)。
 - **Docker 部署**:容器不替换自身镜像,按提示在宿主执行 `docker compose pull && docker compose up -d`(数据卷保留)。
 
 ### 配置(环境变量)

--- a/install.sh
+++ b/install.sh
@@ -5,9 +5,16 @@
 #
 # 探测平台 → 从 GitHub Release 下载对应静态二进制 → 校验和核验 → 装到 /usr/local/bin。
 # 可配环境变量:
-#   VERSION         钉某版本(如 v1.2.3);缺省取 latest。
+#   VERSION         钉某版本(如 v1.2.3);缺省取 latest(API 被限流时自动退回重定向解析)。
 #   INSTALL_DIR     安装目录;缺省 /usr/local/bin(不可写时自动 sudo)。
 #   INSTALL_DOCKER  =1 时,Linux 下若缺 Docker 自动经官方 get.docker.com 安装(隔离构建/容器部署需要)。
+#   SETUP_SERVICE   =1 装为 systemd 服务(开机自启 + 崩溃重启 + 自更新可用;Linux,需 root);=0 强制跳过;
+#                   缺省在交互式终端下询问。会持久化 master key 到 /etc/pipewright/master.key、
+#                   数据落 /var/lib/pipewright,配置写 /etc/pipewright/pipewright.env。
+#   PIPEWRIGHT_ADDR 监听地址(装服务时写入 env 文件);缺省 :8080。
+#   PIPEWRIGHT_DB_DRIVER / PIPEWRIGHT_DB_DSN
+#                   装服务时选 DB 后端:缺省 sqlite(数据落 /var/lib/pipewright);
+#                   传 mysql + DSN(user:pw@tcp(host:3306)/db?parseTime=true&charset=utf8mb4)则用 MySQL。
 #
 # Windows 用户请到 Releases 页下载 .zip:
 #   https://github.com/huangchengsir/pipewright/releases
@@ -16,6 +23,7 @@ set -eu
 REPO="huangchengsir/pipewright"
 BIN="pipewright"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+SERVICE_INSTALLED=0
 
 info() { printf '\033[1;34m==>\033[0m %s\n' "$1"; }
 warn() { printf '\033[1;33m提示:\033[0m %s\n' "$1" >&2; }
@@ -62,8 +70,13 @@ esac
 TAG="${VERSION:-}"
 if [ -z "$TAG" ]; then
 	info "查询最新版本…"
-	TAG="$($DL "https://api.github.com/repos/${REPO}/releases/latest" |
+	# 先走 API;若被限流(常见 403)或网络失败,退回 /releases/latest 的重定向解析,绕开 API。
+	TAG="$($DL "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null |
 		grep '"tag_name"' | head -1 | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')"
+	if [ -z "$TAG" ] && command -v curl >/dev/null 2>&1; then
+		EFF="$(curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.com/${REPO}/releases/latest" 2>/dev/null || true)"
+		case "$EFF" in */releases/tag/*) TAG="${EFF##*/tag/}" ;; esac
+	fi
 	[ -n "$TAG" ] || err "无法获取最新版本号(GitHub API 限流?可设 VERSION 环境变量钉版本)。"
 fi
 # 归档名用去掉前导 v 的版本号;下载路径用原始 tag。
@@ -102,6 +115,117 @@ else
 fi
 
 info "完成 ✓  $("${INSTALL_DIR}/${BIN}" --version 2>/dev/null || echo "${BIN} ${TAG}")"
+
+# ── 可选:装为 systemd 服务 ──────────────────────────────────────────
+# 「部署平台」需要开机自启 + 崩溃重启,且自更新(二进制自替换 + syscall.Exec 自重启)要求
+# 进程对 ${INSTALL_DIR} 有写权限 —— 故服务以 root 运行。本函数幂等:重装复用已有 master key /
+# env 文件,不覆盖用户改动,升级不丢保险库。
+setup_service() {
+	SUDO=""
+	if [ "$(id -u)" -ne 0 ]; then
+		command -v sudo >/dev/null 2>&1 || err "安装 systemd 服务需 root 权限,且未找到 sudo。"
+		SUDO="sudo"
+	fi
+
+	CONF_DIR=/etc/pipewright
+	DATA_DIR=/var/lib/pipewright
+	KEY_FILE="${CONF_DIR}/master.key"
+	ENV_FILE="${CONF_DIR}/pipewright.env"
+	UNIT=/etc/systemd/system/pipewright.service
+	ADDR="${PIPEWRIGHT_ADDR:-:8080}"
+
+	info "配置 systemd 服务…"
+	$SUDO mkdir -p "$CONF_DIR" "$DATA_DIR"
+
+	# master key:已存在则复用(升级不丢保险库),否则生成 32 字节(base64)。
+	if [ -s "$KEY_FILE" ]; then
+		info "复用已有 master key:${KEY_FILE}"
+	else
+		info "生成凭据保险库 master key:${KEY_FILE}"
+		head -c 32 /dev/urandom | base64 | tr -d '\n' | $SUDO tee "$KEY_FILE" >/dev/null
+		$SUDO chmod 600 "$KEY_FILE"
+	fi
+
+	# DB 后端:默认 SQLite(数据落 ${DATA_DIR});传入 PIPEWRIGHT_DB_DRIVER=mysql + PIPEWRIGHT_DB_DSN
+	# 则用 MySQL(DSN 为 go-sql-driver 格式,如 user:pw@tcp(host:3306)/db?parseTime=true&charset=utf8mb4)。
+	DB_DRIVER="${PIPEWRIGHT_DB_DRIVER:-sqlite}"
+	if [ "$DB_DRIVER" = "mysql" ] && [ -z "${PIPEWRIGHT_DB_DSN:-}" ]; then
+		err "PIPEWRIGHT_DB_DRIVER=mysql 需同时提供 PIPEWRIGHT_DB_DSN(go-sql-driver DSN,parseTime=true 必带)。"
+	fi
+
+	# env 文件:不存在才写(保留用户后续改动);改后 systemctl restart pipewright 生效。
+	if [ ! -f "$ENV_FILE" ]; then
+		{
+			echo '# Pipewright 运行配置(systemd EnvironmentFile);改后 systemctl restart pipewright 生效。'
+			echo "PIPEWRIGHT_ADDR=${ADDR}"
+			echo "PIPEWRIGHT_MASTER_KEY_FILE=${KEY_FILE}"
+			if [ "$DB_DRIVER" = "mysql" ]; then
+				echo 'PIPEWRIGHT_DB_DRIVER=mysql'
+				echo "PIPEWRIGHT_DB_DSN=${PIPEWRIGHT_DB_DSN}"
+			else
+				echo "PIPEWRIGHT_DB=${DATA_DIR}/pipewright.db"
+			fi
+		} | $SUDO tee "$ENV_FILE" >/dev/null
+		$SUDO chmod 600 "$ENV_FILE"
+	fi
+
+	# systemd unit。User=root:自更新须写 ${INSTALL_DIR}、隔离构建须用 docker、SSH 部署须读密钥。
+	# 自更新经 syscall.Exec 自替换映像(同 PID),systemd 无感,与 Restart=always 不冲突。
+	printf '%s\n' \
+		'[Unit]' \
+		'Description=Pipewright CI/CD 平台' \
+		'After=network-online.target docker.service' \
+		'Wants=network-online.target' \
+		'' \
+		'[Service]' \
+		'Type=simple' \
+		'User=root' \
+		"WorkingDirectory=${DATA_DIR}" \
+		"EnvironmentFile=${ENV_FILE}" \
+		"ExecStart=${INSTALL_DIR}/${BIN}" \
+		'Restart=always' \
+		'RestartSec=3' \
+		'' \
+		'[Install]' \
+		'WantedBy=multi-user.target' |
+		$SUDO tee "$UNIT" >/dev/null
+
+	$SUDO systemctl daemon-reload
+	$SUDO systemctl enable pipewright >/dev/null 2>&1 || true
+	$SUDO systemctl restart pipewright
+
+	SERVICE_INSTALLED=1
+	info "服务已启动并设为开机自启。"
+	printf '  状态:%s\n' "systemctl status pipewright"
+	printf '  日志:%s\n' "journalctl -u pipewright -f"
+	printf '  访问:http://<本机IP>%s  (首次登录后在引导页设置管理员账号)\n' "$ADDR"
+}
+
+# 决定是否装服务:SETUP_SERVICE=1 装 / =0 跳过 / 交互式询问 / 非交互且未设则给提示。
+maybe_setup_service() {
+	[ "$OS" = "linux" ] || return 0
+	if ! command -v systemctl >/dev/null 2>&1; then
+		[ "${SETUP_SERVICE:-}" = "1" ] && warn "未检测到 systemd(systemctl),跳过服务安装。"
+		return 0
+	fi
+
+	do_svc=0
+	case "${SETUP_SERVICE:-}" in
+	1) do_svc=1 ;;
+	0) do_svc=0 ;;
+	*)
+		if [ -t 0 ]; then
+			printf '  装为 systemd 服务?开机自启 + 崩溃重启 + 自更新可用(以 root 运行)。[Y/n] ' >&2
+			read -r ans
+			case "$ans" in n | N | no | NO) do_svc=0 ;; *) do_svc=1 ;; esac
+		else
+			warn "如需开机自启 + 自更新,重跑时加 SETUP_SERVICE=1(装为 systemd 服务)。"
+		fi
+		;;
+	esac
+
+	[ "$do_svc" = "1" ] && setup_service
+}
 
 # ── Docker 运行时检测 ────────────────────────────────────────────────
 # 「隔离构建 / 容器部署」需要 Docker;控制台 / SSH 部署 / AI 诊断不需要。
@@ -146,5 +270,11 @@ check_docker() {
 	fi
 }
 check_docker
+maybe_setup_service
 
-printf '启动:%s\n' "${BIN}   # 默认监听 :8080,数据落当前目录 pipewright.db"
+if [ "$SERVICE_INSTALLED" = "1" ]; then
+	info "完成 ✓  Pipewright 已作为 systemd 服务运行(开机自启 + 自更新可用)。"
+else
+	printf '启动:%s\n' "${BIN}   # 默认监听 :8080,数据落当前目录 pipewright.db"
+	printf '提示:%s\n' "如需开机自启 + 自更新,可重跑并加 SETUP_SERVICE=1 装为 systemd 服务。"
+fi


### PR DESCRIPTION
## 背景

要把 Pipewright 以**二进制方式部署到服务器、用其内置「自动更新」**,跑实际部署时发现 `install.sh` 只负责把二进制丢到 `/usr/local/bin`,对「部署成一个能自启 + 自更新的服务」有几处缺口:

1. **不建 systemd 服务** → 没有开机自启 / 崩溃重启,得手动前台跑。
2. **不持久化 master key** → 不设 `PIPEWRIGHT_MASTER_KEY` 时保险库进「未配置」态(SSH 凭据 / AI key 都存不了),且**不是随机生成**。
3. **DB 落 CWD** → systemd 起且无 WorkingDirectory 时会把 `pipewright.db` 写到根目录。
4. **取 latest 走会被限流的 API** → 实测 CN 网络下 `api.github.com/.../releases/latest` 直连和代理**都回 403**,导致 `curl|sh` 直接失败(虽可 `VERSION=` 绕过)。

## 改动

- **`SETUP_SERVICE=1` 可选装 systemd 服务**(Linux,需 root,幂等):
  - 持久化 master key → `/etc/pipewright/master.key`(600)
  - 数据目录 `/var/lib/pipewright`,配置 `/etc/pipewright/pipewright.env`(600)
  - 写 `pipewright.service`(`User=root` / `WorkingDirectory` / `EnvironmentFile` / `Restart=always`)→ `daemon-reload` + `enable` + `start`
  - 重装复用已有 key/env,**升级不丢保险库**
  - `User=root` 理由:自更新须写 `/usr/local/bin`、隔离构建须用 docker、SSH 部署须读密钥;自更新经 `syscall.Exec` 自替换映像(**同 PID**),systemd 无感,与 `Restart=always` **不冲突**
  - 门控对齐既有 `INSTALL_DOCKER` 风格:`=1` 装 / `=0` 跳过 / 交互式询问 / 非交互给提示
- **latest 兜底**:API 失败(限流 403 / 网络)时退回 `/releases/latest` 的重定向解析,绕开匿名 API 限流。
- README 安装段补 systemd 服务用法。

## 自测

- `sh -n install.sh` 语法通过。
- 重定向兜底实测解析出 `v1.0.0`(绕开 403)。
- env / unit 文件内容、master key(base64 32B = 44 字符)生成正确。
- 真机正式部署待本 PR 合并后用改版脚本进行(故意不在 PR 前手动污染目标机)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)