### PR TITLE
feat(version): 检查更新在 API 限流时退回网页站重定向解析

### DIFF
--- a/internal/version/update.go
+++ b/internal/version/update.go
@@ -68,6 +68,68 @@ func NewChecker() *Checker {
 // apiBase 允许测试把请求打到本地 stub server;生产为空时用 GitHub 公网 API。
 var apiBase = ""
 
+// htmlBase 允许测试把重定向兜底打到本地 stub server;生产为空时用 github.com 网页站。
+var htmlBase = ""
+
+// resolveLatestViaRedirect 不走 API,改读 github.com/<repo>/releases/latest 的 302 重定向
+// (会跳到 /releases/tag/<tag>),从 Location 解析出最新 tag。用于 API 被限流(常见 403)或
+// 不可达时兜底 —— 实测部分网络(如 CN)下 api.github.com 403 但 github.com 网页站可达。
+// 局限:只拿得到 tag 与 release 页 URL,拿不到 notes / 发布时间。
+func (c *Checker) resolveLatestViaRedirect(ctx context.Context) (tag, htmlURL string, err error) {
+	base := htmlBase
+	if base == "" {
+		base = "https://github.com"
+	}
+	u := fmt.Sprintf("%s/%s/releases/latest", base, c.repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return "", "", err
+	}
+	req.Header.Set("User-Agent", "pipewright/"+Version)
+	// 不跟随重定向:停在 302 读 Location 即可(避免下载整页 HTML)。
+	noRedir := &http.Client{
+		Timeout:       c.client.Timeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	resp, err := noRedir.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	const marker = "/releases/tag/"
+	loc := resp.Header.Get("Location")
+	i := strings.LastIndex(loc, marker)
+	if i < 0 {
+		return "", "", fmt.Errorf("无重定向 tag(状态 %d)", resp.StatusCode)
+	}
+	tag = strings.Trim(loc[i+len(marker):], "/")
+	if tag == "" {
+		return "", "", fmt.Errorf("重定向 tag 为空")
+	}
+	htmlURL = loc
+	if strings.HasPrefix(loc, "/") {
+		htmlURL = base + loc
+	}
+	return tag, htmlURL, nil
+}
+
+// tryRedirectFallback 在 API 受限/不可达时改用重定向解析最新 tag。成功则填好 out(清空
+// CheckError、按需置 UpdateAvailable)并返回 true;失败返回 false,由调用方保留原 CheckError。
+func (c *Checker) tryRedirectFallback(ctx context.Context, out *UpdateInfo, cur string) bool {
+	tag, htmlURL, err := c.resolveLatestViaRedirect(ctx)
+	if err != nil || tag == "" {
+		return false
+	}
+	out.Latest = tag
+	out.ReleaseURL = htmlURL
+	out.CheckError = ""
+	if isComparable(cur) && CompareVersions(tag, cur) > 0 {
+		out.UpdateAvailable = true
+	}
+	return true
+}
+
 // Check 返回更新信息。命中未过期缓存则直接返回;否则查 GitHub。
 // 网络/解析失败不返回 error —— 而是在 UpdateInfo.CheckError 里带上原因(始终附当前版本),
 // 让上层端点稳定返回 200、前端优雅降级。
@@ -114,6 +176,10 @@ func (c *Checker) fetch(ctx context.Context) UpdateInfo {
 
 	resp, err := c.client.Do(req)
 	if err != nil {
+		// API 不可达:尝试网页站重定向兜底(可能 API 域被挡而网页站可达)。
+		if c.tryRedirectFallback(ctx, &out, cur) {
+			return out
+		}
 		out.CheckError = "无法连接 GitHub(网络不可达?)"
 		return out
 	}
@@ -127,6 +193,10 @@ func (c *Checker) fetch(ctx context.Context) UpdateInfo {
 		out.CheckError = ""
 		return out
 	case http.StatusForbidden, http.StatusTooManyRequests:
+		// API 限流(CN 网络常见):退回网页站重定向解析,绕开 API。
+		if c.tryRedirectFallback(ctx, &out, cur) {
+			return out
+		}
 		out.CheckError = "GitHub API 限流,请稍后再试"
 		return out
 	default:

--- a/internal/version/update_test.go
+++ b/internal/version/update_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -54,11 +55,13 @@ func TestIsComparable(t *testing.T) {
 func newStubChecker(t *testing.T, current string, h http.HandlerFunc) (*Checker, func()) {
 	t.Helper()
 	srv := httptest.NewServer(h)
-	prevBase, prevVer := apiBase, Version
+	prevBase, prevHTML, prevVer := apiBase, htmlBase, Version
 	apiBase = srv.URL
+	htmlBase = srv.URL // 同一 stub 兼当网页站,避免重定向兜底打到真实 github.com
 	Version = current
 	cleanup := func() {
 		apiBase = prevBase
+		htmlBase = prevHTML
 		Version = prevVer
 		srv.Close()
 	}
@@ -132,6 +135,30 @@ func TestCheck_RateLimitedReportsError(t *testing.T) {
 	defer done()
 	if info := c.Check(context.Background()); info.CheckError == "" {
 		t.Errorf("403 should surface a checkError")
+	}
+}
+
+// API 限流(403)时,退回网页站 /releases/latest 的 302 重定向解析出最新 tag。
+func TestCheck_RateLimitFallsBackToRedirect(t *testing.T) {
+	c, done := newStubChecker(t, "v1.0.0", func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/repos/"):
+			w.WriteHeader(http.StatusForbidden) // API 限流
+		case strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			w.Header().Set("Location", "/owner/repo/releases/tag/v1.2.0")
+			w.WriteHeader(http.StatusFound) // 网页站 302 → tag
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer done()
+
+	info := c.Check(context.Background())
+	if info.CheckError != "" {
+		t.Fatalf("重定向兜底应清空 checkError,实得 %q", info.CheckError)
+	}
+	if info.Latest != "v1.2.0" || !info.UpdateAvailable {
+		t.Errorf("应经重定向得到 latest=v1.2.0 updateAvailable=true,实得 %+v", info)
 	}
 }
 


### PR DESCRIPTION
## 背景

应用内「设置 → 系统 → 检查更新」查 `api.github.com/repos/<repo>/releases/latest`。该未鉴权 API **限速 60 次/小时/IP**,部分网络(实测 CN)下**直接 403**,导致检查永远「GitHub API 限流」。而 release **下载站 / 网页站(github.com)在同一网络下可达**(自更新的二进制下载就走 github.com)。

配套 #96 在 `install.sh` 取版本时已加了同样的重定向兜底;本 PR 给**应用内检查器**补齐,使二进制部署在这类网络下也能可靠「检查更新」。

## 改动

- API 返回 **403 / 429** 或**连接失败**时,退回读 `github.com/<repo>/releases/latest` 的 **302 重定向**(跳 `/releases/tag/<tag>`),从 `Location` 解析最新 tag。
- `resolveLatestViaRedirect`(不跟随重定向、只读 Location)+ `tryRedirectFallback`(成功填好结果并清空 `CheckError`)。
- 局限:重定向只拿得到 **tag 与 release 页 URL**,无 notes / 发布时间 —— 可接受(仍能判断有无更新并跳转)。
- `htmlBase` 变量便于测试注入;测试 helper 同步把网页站指向 stub(避免打真实 github.com);新增「403 → 重定向兜底成功」用例。

## 自测

- `gofmt -l` 空,`go vet ./internal/version/` 通过,`go build ./...` OK。
- `go test ./internal/version/` 全过(含新用例 + 原 403→CheckError 用例)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)