### PR TITLE
fix(install): SELinux restorecon + 下载断点重试/卡死检测(真机部署暴露)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -114,6 +114,14 @@ else
 	err "${INSTALL_DIR} 不可写且无 sudo。可设 INSTALL_DIR=\$HOME/.local/bin 重试。"
 fi
 
+# SELinux(RHEL/CentOS/Rocky/Fedora 系,强制模式):二进制经临时目录 mv 进来会带上 user_tmp_t
+# 类型,systemd(init_t)无权执行它 → 装为服务后起不来(AVC denied execute)。重置为该路径
+# 的默认上下文(/usr/local/bin → bin_t),systemd 即可执行。非 SELinux 系统无 restorecon,跳过。
+if command -v restorecon >/dev/null 2>&1; then
+	restorecon "${INSTALL_DIR}/${BIN}" 2>/dev/null ||
+		sudo restorecon "${INSTALL_DIR}/${BIN}" 2>/dev/null || true
+fi
+
 info "完成 ✓  $("${INSTALL_DIR}/${BIN}" --version 2>/dev/null || echo "${BIN} ${TAG}")"
 
 # ── 可选:装为 systemd 服务 ──────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -34,11 +34,16 @@ err() {
 
 # 依赖检查:下载器与校验工具。
 if command -v curl >/dev/null 2>&1; then
-	DL="curl -fsSL"
-	DL_O="curl -fsSL -o"
+	# 大文件直连在部分网络(如 CN)易卡死;加断点重试 + 卡死检测:
+	#   --retry 3 --retry-delay 2  瞬时错误自动重试
+	#   --speed-time 30 --speed-limit 2048  速率 30s 持续 <2KB/s 判定 stall → 中止并触发重试
+	# 仍下不动时,设 https_proxy / all_proxy 走代理(curl 自动识别该环境变量)。
+	DL="curl -fsSL --retry 3 --retry-delay 2 --connect-timeout 20"
+	DL_O="curl -fsSL --retry 3 --retry-delay 2 --connect-timeout 20 --speed-time 30 --speed-limit 2048 -o"
 elif command -v wget >/dev/null 2>&1; then
-	DL="wget -qO-"
-	DL_O="wget -qO"
+	# wget:同样加重试 + 读超时(30s 无数据即断,配 --tries 重试),避免无限 hang。
+	DL="wget -qO- --tries=3 --timeout=30"
+	DL_O="wget -q --tries=3 --read-timeout=30 -O"
 else
 	err "需要 curl 或 wget。"
 fi


### PR DESCRIPTION
真机把 Pipewright 二进制部署到 **CentOS Stream 9(SELinux enforcing)+ CN 网络**的 server-104,一键脚本暴露两个真 bug:

## 1. SELinux 拦执行 → 服务崩溃重启
`install.sh` 经临时目录 `mv` 二进制进 `/usr/local/bin`,文件带上 `user_tmp_t` 类型;SELinux 强制模式下 systemd(`init_t`)**无权 execute** 该类型 → `SETUP_SERVICE` 装成服务后无限崩溃重启:
```
audit: avc: denied { execute } for comm="(pipewright)" ... tcontext=...:user_tmp_t tclass=file
```
**修**:安装后 `restorecon` 重置为路径默认上下文(`/usr/local/bin` → `bin_t`)。非 SELinux 系统无该命令,自动跳过。

## 2. 大文件直连卡死 → 无限 hang
~45MB 二进制直连 GitHub 在 CN 网络 stall,`curl -fsSL` 无超时 → **无限 hang**(实测部署时被迫 Ctrl+C、改设 https_proxy 才下得动)。
**修**:下载器加断点重试 + 卡死检测 —— curl `--retry 3 --speed-time 30 --speed-limit 2048`(速率持续 30s <2KB/s 即中止重试),wget `--read-timeout=30 --tries=3`;stall 时快速失败重试而非 hang,注释提示可设代理。

## 验证
- `sh -n install.sh` 通过。
- SELinux 问题:CentOS Stream 9 上复现,`restorecon` 后 `ls -Z` 变 `bin_t`、服务正常 execute。

> 注:这两个修复改的是 `install.sh`(从 raw master 实时拉取),合并后即时生效,无需等发版。

🤖 Generated with [Claude Code](https://claude.com/claude-code)