### PR TITLE
feat(vault): 新增 SSH 密码凭据类型(ssh_password)

### DIFF
--- a/internal/vault/masker.go
+++ b/internal/vault/masker.go
@@ -30,6 +30,9 @@ func mask(credType, secret string) string {
 		return maskSSHKey(secret)
 	case TypeRegistry:
 		return maskRegistry(secret)
+	case TypeSSHPassword:
+		// 密码:全打点,绝不暴露任何字符(不留尾部)。
+		return maskDots
 	default:
 		return maskDots
 	}

--- a/internal/vault/masker_test.go
+++ b/internal/vault/masker_test.go
@@ -38,6 +38,20 @@ func TestMaskSSHKey(t *testing.T) {
 	}
 }
 
+// TestMaskSSHPassword 验证 ssh_password 掩码:全打点,绝不暴露任何字符(含尾部),且类型校验通过。
+func TestMaskSSHPassword(t *testing.T) {
+	got := mask(TypeSSHPassword, "19980528")
+	if got != maskDots {
+		t.Fatalf("ssh_password 应全打点, got %q", got)
+	}
+	if strings.Contains(got, "1998") || strings.Contains(got, "0528") {
+		t.Fatalf("ssh_password 掩码泄露明文: %q", got)
+	}
+	if err := validateType(TypeSSHPassword); err != nil {
+		t.Fatalf("validateType(ssh_password) 应通过, got %v", err)
+	}
+}
+
 // TestMaskShortGitTokenFullyDotted 验证短 token 全打点,绝不暴露任何前缀/尾部(=明文)。
 func TestMaskShortGitToken(t *testing.T) {
 	got := mask(TypeGitToken, "ab_cdef") // 7 字符 < 阈值

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -21,9 +21,10 @@ import (
 
 // 凭据类型枚举(DB 存 snake_case 字串;JSON camelCase 字段)。
 const (
-	TypeGitToken = "git_token"
-	TypeSSHKey   = "ssh_key"
-	TypeRegistry = "registry"
+	TypeGitToken    = "git_token"
+	TypeSSHKey      = "ssh_key"
+	TypeRegistry    = "registry"
+	TypeSSHPassword = "ssh_password" // SSH 登录密码(非 PEM);SSH 层据 looksLikePEM 自动按密码认证
 )
 
 // 领域错误。错误体永不含明文/密文/master key。
@@ -115,7 +116,7 @@ func (s *service) configured() bool { return s.key != nil }
 // validateType 校验类型枚举。
 func validateType(t string) error {
 	switch t {
-	case TypeGitToken, TypeSSHKey, TypeRegistry:
+	case TypeGitToken, TypeSSHKey, TypeRegistry, TypeSSHPassword:
 		return nil
 	default:
 		return ErrInvalidType

--- a/web/src/api/credentials.ts
+++ b/web/src/api/credentials.ts
@@ -13,7 +13,7 @@
 
 import { http } from './http'
 
-export type CredentialType = 'git_token' | 'ssh_key' | 'registry'
+export type CredentialType = 'git_token' | 'ssh_key' | 'ssh_password' | 'registry'
 
 export interface Credential {
   id: string

--- a/web/src/views/settings/SettingsServers.vue
+++ b/web/src/views/settings/SettingsServers.vue
@@ -30,7 +30,7 @@ const loadState = ref<LoadState>('idle')
 const loadError = ref('')
 const servers = ref<Server[]>([])
 
-// SSH credentials available to bind (type ssh_key only).
+// SSH credentials available to bind (ssh_key private key, or ssh_password login password).
 const sshCredentials = ref<Credential[]>([])
 
 // ─── add / edit modal ───────────────────────────────────────────────────────
@@ -126,7 +126,7 @@ async function loadServers(): Promise<void> {
   try {
     const [srv, creds] = await Promise.all([listServers(), listCredentials()])
     servers.value = srv
-    sshCredentials.value = creds.filter((c) => c.type === 'ssh_key')
+    sshCredentials.value = creds.filter((c) => c.type === 'ssh_key' || c.type === 'ssh_password')
     loadState.value = 'idle'
   } catch (err) {
     if (err instanceof HttpError) {
@@ -348,7 +348,7 @@ async function handleTest(s: Server): Promise<void> {
 
     <!-- ─── no-credential hint ────────────────────────────────────────────────── -->
     <div v-if="loadState === 'idle' && !hasSSHCredentials" class="banner banner--warn" role="status">
-      <span>尚无 SSH 凭据。请先到「凭据保险库」添加一条 ssh_key 类型凭据,再登记服务器。</span>
+      <span>尚无 SSH 凭据。请先到「凭据保险库」添加一条「SSH 私钥」或「SSH 密码」凭据,再登记服务器。</span>
     </div>
 
     <!-- ─── load error banner ─────────────────────────────────────────────────── -->

--- a/web/src/views/settings/SettingsVault.vue
+++ b/web/src/views/settings/SettingsVault.vue
@@ -160,6 +160,7 @@ function relativeTime(isoStr: string | null): string {
 const typeLabels: Record<CredentialType, string> = {
   git_token: 'Git 令牌',
   ssh_key: 'SSH 私钥',
+  ssh_password: 'SSH 密码',
   registry: '镜像仓库',
 }
 
@@ -489,6 +490,11 @@ async function copyReference(c: Credential): Promise<void> {
             <svg v-else-if="cred.type === 'ssh_key'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9">
               <path d="M4 17l6-6-6-6M12 19h8"/>
             </svg>
+            <!-- ssh_password(锁) -->
+            <svg v-else-if="cred.type === 'ssh_password'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9">
+              <rect x="4" y="11" width="16" height="9" rx="2"/>
+              <path d="M8 11V7a4 4 0 0 1 8 0v4"/>
+            </svg>
             <!-- registry -->
             <svg v-else width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9">
               <rect x="3" y="3" width="8" height="8" rx="1"/>
@@ -663,7 +669,7 @@ async function copyReference(c: Credential): Promise<void> {
             <label class="field-label" for="cred-type">类型</label>
             <div class="segmented" role="group" aria-label="凭据类型">
               <button
-                v-for="opt in (['git_token', 'ssh_key', 'registry'] as CredentialType[])"
+                v-for="opt in (['git_token', 'ssh_key', 'ssh_password', 'registry'] as CredentialType[])"
                 :key="opt"
                 type="button"
                 class="seg-item"
@@ -723,7 +729,7 @@ async function copyReference(c: Credential): Promise<void> {
               class="field-input field-input--mono"
               :class="{ 'field-input--error': formErrors.secret }"
               type="password"
-              :placeholder="modalMode === 'add' ? '粘贴令牌内容…' : '留空保持当前密钥不变'"
+              :placeholder="modalMode === 'add' ? (form.type === 'ssh_password' ? '输入 SSH 登录密码…' : '粘贴令牌内容…') : '留空保持当前密钥不变'"
               :disabled="formSubmitting"
               :aria-invalid="formErrors.secret ? 'true' : undefined"
               :aria-describedby="formErrors.secret ? 'cred-secret-err' : undefined"
@@ -731,7 +737,8 @@ async function copyReference(c: Credential): Promise<void> {
               @input="formErrors.secret = ''"
             />
             <span v-if="formErrors.secret" id="cred-secret-err" class="field-error" role="alert">{{ formErrors.secret }}</span>
-            <span class="field-hint">密钥写入后不可读出，界面仅展示掩码值</span>
+            <span v-if="form.type === 'ssh_password'" class="field-hint">SSH 登录用户名在「登记服务器」时填写;此处仅存密码。写入后不可读出,仅展示掩码。</span>
+            <span v-else class="field-hint">密钥写入后不可读出，界面仅展示掩码值</span>
           </div>
 
           <!-- Footer -->


### PR DESCRIPTION
## 背景
真机用部署好的 Pipewright(104)去连另一台服务器(103,root + **密码**),发现凭据库只有 Git 令牌 / SSH 私钥 / 镜像仓库,**没有 SSH 密码**类型 —— 无法用密码登记服务器。

## 改动
- `vault`:新增 `TypeSSHPassword = "ssh_password"`,`validateType` 放行;`masker` 对密码**全打点**(不留尾部,绝不泄露)。
- 前端:`SettingsVault.vue` 加「SSH 密码」类型(按钮/锁图标/占位/提示);`SettingsServers.vue` 服务器绑定凭据过滤纳入 `ssh_password`,空态提示更新;`credentials.ts` 类型联合更新。
- 新增 `TestMaskSSHPassword`(掩码全打点 + 类型校验)。

## 为何底层无需改
SSH 连接层(`internal/target`)**早已**据 `looksLikePEM` 自动判私钥 vs 口令认证(`ssh.PublicKeys` / `ssh.Password`),密码凭据存进去即可被正确用作口令 —— 本 PR 只补「类型 + 掩码 + UI」。

## 验证
gofmt 空 · `go vet`/`go build`/`go test ./internal/vault/` 通过(含新测试) · 前端 `typecheck` 通过、`lint` 0 错误。

🤖 Generated with [Claude Code](https://claude.com/claude-code)