### PR TITLE
fix(version): 检查更新兜底也从 releases.atom 补出更新说明

### DIFF
--- a/internal/version/update.go
+++ b/internal/version/update.go
@@ -3,9 +3,12 @@ package version
 import (
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
+	"html"
 	"net/http"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -124,10 +127,77 @@ func (c *Checker) tryRedirectFallback(ctx context.Context, out *UpdateInfo, cur 
 	out.Latest = tag
 	out.ReleaseURL = htmlURL
 	out.CheckError = ""
+	// 走 atom feed(非限流 API)补 release 说明 —— API 限流时仍能给用户看更新内容。
+	// 拿不到不影响主流程(说明留空,前端不显示「查看更新说明」)。
+	out.Notes = c.fetchReleaseNotes(ctx, tag)
 	if isComparable(cur) && CompareVersions(tag, cur) > 0 {
 		out.UpdateAvailable = true
 	}
 	return true
+}
+
+// fetchReleaseNotes 从 github.com 的 releases.atom(RSS,不走会限流的 api.github.com)取指定
+// tag 的 release 正文,去 HTML 标签转纯文本(前端 <pre> 直接展示)。失败返回空串。
+func (c *Checker) fetchReleaseNotes(ctx context.Context, tag string) string {
+	base := htmlBase
+	if base == "" {
+		base = "https://github.com"
+	}
+	u := fmt.Sprintf("%s/%s/releases.atom", base, c.repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("User-Agent", "pipewright/"+Version)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	var feed struct {
+		Entries []struct {
+			ID      string `xml:"id"`
+			Content string `xml:"content"`
+		} `xml:"entry"`
+	}
+	if err := xml.NewDecoder(resp.Body).Decode(&feed); err != nil {
+		return ""
+	}
+	for _, e := range feed.Entries {
+		// id 形如 tag:github.com,2008:Repository/<repoID>/<tag>
+		if strings.HasSuffix(e.ID, "/"+tag) {
+			return htmlToText(e.Content)
+		}
+	}
+	return ""
+}
+
+var (
+	reBlockEnd = regexp.MustCompile(`(?i)</(h[1-6]|p|div|li|ul|ol|tr|pre)>`)
+	reListItem = regexp.MustCompile(`(?i)<li[^>]*>`)
+	reHr       = regexp.MustCompile(`(?i)<hr\s*/?>`)
+	reAnyTag   = regexp.MustCompile(`<[^>]+>`)
+)
+
+// htmlToText 把 release notes 的 HTML 粗略转纯文本:块级标签转换行、li 加项目符号、去其余标签、
+// 解实体、压多余空行。用于 <pre> 展示(非渲染 HTML/Markdown),够读即可。
+func htmlToText(h string) string {
+	h = reListItem.ReplaceAllString(h, "• ")
+	h = reHr.ReplaceAllString(h, "\n———\n")
+	h = reBlockEnd.ReplaceAllString(h, "\n")
+	h = reAnyTag.ReplaceAllString(h, "")
+	h = html.UnescapeString(h)
+	lines := strings.Split(h, "\n")
+	out := make([]string, 0, len(lines))
+	for _, ln := range lines {
+		if ln = strings.TrimSpace(ln); ln != "" {
+			out = append(out, ln)
+		}
+	}
+	return strings.Join(out, "\n")
 }
 
 // Check 返回更新信息。命中未过期缓存则直接返回;否则查 GitHub。

--- a/internal/version/update_test.go
+++ b/internal/version/update_test.go
@@ -138,12 +138,23 @@ func TestCheck_RateLimitedReportsError(t *testing.T) {
 	}
 }
 
-// API 限流(403)时,退回网页站 /releases/latest 的 302 重定向解析出最新 tag。
+// API 限流(403)时,退回网页站 /releases/latest 的 302 重定向解析出最新 tag,
+// 并从 releases.atom(非限流)补出 release 说明。
 func TestCheck_RateLimitFallsBackToRedirect(t *testing.T) {
+	const atom = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>tag:github.com,2008:Repository/123/v1.2.0</id>
+    <title>Pipewright v1.2.0</title>
+    <content type="html">&lt;h2&gt;Changelog&lt;/h2&gt;&lt;ul&gt;&lt;li&gt;feat: 新增 SSH 密码凭据 (#100)&lt;/li&gt;&lt;/ul&gt;</content>
+  </entry>
+</feed>`
 	c, done := newStubChecker(t, "v1.0.0", func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.HasPrefix(r.URL.Path, "/repos/"):
 			w.WriteHeader(http.StatusForbidden) // API 限流
+		case strings.HasSuffix(r.URL.Path, "/releases.atom"):
+			_, _ = w.Write([]byte(atom))
 		case strings.HasSuffix(r.URL.Path, "/releases/latest"):
 			w.Header().Set("Location", "/owner/repo/releases/tag/v1.2.0")
 			w.WriteHeader(http.StatusFound) // 网页站 302 → tag
@@ -159,6 +170,21 @@ func TestCheck_RateLimitFallsBackToRedirect(t *testing.T) {
 	}
 	if info.Latest != "v1.2.0" || !info.UpdateAvailable {
 		t.Errorf("应经重定向得到 latest=v1.2.0 updateAvailable=true,实得 %+v", info)
+	}
+	if !strings.Contains(info.Notes, "SSH 密码凭据") || !strings.Contains(info.Notes, "• ") {
+		t.Errorf("应从 atom 补出 release 说明(去标签转纯文本 + li 转项目符号),实得 %q", info.Notes)
+	}
+}
+
+func TestHtmlToText(t *testing.T) {
+	got := htmlToText(`<h2>标题</h2><ul><li>第一条 <a href="x">#1</a></li><li>第二条</li></ul><hr><p>结尾 &amp; 收尾</p>`)
+	for _, want := range []string{"标题", "• 第一条 #1", "• 第二条", "结尾 & 收尾"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("htmlToText 缺 %q,实得:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "<") || strings.Contains(got, "href") {
+		t.Errorf("htmlToText 未去净标签: %q", got)
 	}
 }
 


### PR DESCRIPTION
真机(104,CN 网络)点「检查更新」,能查到新版可更新,但**没有更新说明** —— 因为 api.github.com 403、走 #97 的重定向兜底只拿得到版本号 tag、拿不到 release notes。

**修**:兜底时额外抓 `github.com/<repo>/releases.atom`(RSS feed,不走限流 API),按 `<id>.../<tag>` 匹配 entry,取 `<content>` 去 HTML 标签转纯文本(前端是 `<pre>{{notes}}` 纯文本渲染,正好对上)填入 `Notes`。拿不到为空、不影响主流程。

新增 `htmlToText` + atom 兜底单测;`go test ./internal/version/` 全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)