### PR TITLE
feat(containers): 容器管理(Portainer 式 + AI)—— 容器/镜像/Compose/卷/网络 + stats/inspect/清理/搜索批量 + AI 四件套

### DIFF
--- a/internal/ai/ai.go
+++ b/internal/ai/ai.go
@@ -143,6 +143,9 @@ type Service interface {
 	// CompleteCommand 据已输入命令前缀补全为一条完整命令(P2 智能补全;以前缀原样开头)。
 	// 脱敏铁律同上;未配 → ErrAINotConfigured(前端可退化为本地字典兜底)。短回包、低 max_tokens。
 	CompleteCommand(ctx context.Context, in CompleteCommandInput) (*CompletionResult, error)
+	// GenerateCompose 据中文需求生成 docker-compose.yml(容器管理「AI 生成 compose」)。
+	// 生成需 AI:未配 / 未启用 → ErrAINotConfigured。NL 出网前脱敏;输出去围栏 + 二次脱敏。
+	GenerateCompose(ctx context.Context, in GenerateComposeInput) (*ComposeResult, error)
 }
 
 // service 是 store + vault + 注入 http.Client 支撑的 Service 实现。

--- a/internal/ai/compose.go
+++ b/internal/ai/compose.go
@@ -1,0 +1,73 @@
+package ai
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/huangchengsir/pipewright/internal/mask"
+)
+
+// GenerateCompose:中文需求 → docker-compose.yml(容器管理「AI 生成 compose」)。
+// 与 CommandSuggest 一致——生成本就需要 AI:未配置/未启用 → ErrAINotConfigured。
+
+const composeGenMaxTokens = 1500
+
+// GenerateComposeInput 是生成 compose 的入参。
+type GenerateComposeInput struct {
+	NL     string       // 中文需求(如「nginx + redis,nginx 映射 8080,数据持久化」)
+	Masker *mask.Masker // 出网前脱敏(NL 经 Scrub)
+}
+
+// ComposeResult 是生成结果。
+type ComposeResult struct {
+	YAML        string    `json:"yaml"`
+	GeneratedAt time.Time `json:"generatedAt"`
+}
+
+// GenerateCompose 据中文需求生成一份 docker-compose.yml(纯 yaml,无围栏/解释)。
+func (s *service) GenerateCompose(ctx context.Context, in GenerateComposeInput) (*ComposeResult, error) {
+	masker := in.Masker
+	if masker == nil {
+		masker = mask.NewMasker()
+	}
+	nl := strings.TrimSpace(in.NL)
+	if nl == "" {
+		return nil, fmt.Errorf("%w: 请描述你想要的 compose", ErrGenerateFailed)
+	}
+
+	provider, baseURL, apiKey, err := s.resolveChatCreds(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	prompt := buildComposePrompt(masker, nl)
+	text, cerr := s.chatWithTokens(ctx, provider, baseURL, s.modelFor(ctx), apiKey, prompt, composeGenMaxTokens)
+	apiKey = "" // 明文用完即弃
+	_ = apiKey
+	if cerr != nil {
+		return nil, cerr
+	}
+
+	yaml := masker.Scrub(stripCodeFence(strings.TrimSpace(text)))
+	if yaml == "" {
+		return nil, fmt.Errorf("%w: 模型未产出 compose", ErrGenerateFailed)
+	}
+	return &ComposeResult{YAML: yaml, GeneratedAt: time.Now().UTC()}, nil
+}
+
+func buildComposePrompt(m *mask.Masker, nl string) string {
+	var b strings.Builder
+	b.WriteString("你是 Docker / Compose 专家。根据用户的中文需求,产出一份可直接用 `docker compose up -d` 部署的 docker-compose.yml。\n\n")
+	b.WriteString("## 用户需求\n")
+	b.WriteString(truncateRunes(m.Scrub(nl), maxNLChars))
+	b.WriteString("\n\n")
+	b.WriteString(`## 输出要求
+- **只输出 compose 文件本身的 YAML 内容**,不要任何解释文字、不要 markdown 代码块围栏(不要 ` + "```" + `)。
+- 使用 Compose 规范(顶层 services:,可含 volumes:/networks:);不写已废弃的 version 字段。
+- 镜像用明确 tag;端口、环境变量、卷挂载按需求给全;合理设置 restart 策略。
+- 绝不写入明文密钥 / token / 密码,需要凭据处用占位符或环境变量引用。
+`)
+	return b.String()
+}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -42,6 +42,7 @@ const (
 	ActionServiceOp          = "service_op"
 	ActionContainerCreate    = "container_create"
 	ActionImageOp            = "image_op"
+	ActionStackOp            = "stack_op"
 	ActionContainerTerminal  = "container_terminal"
 	ActionServerTerminal     = "server_terminal"
 	// 流水线模板 + 变量组(FR-8-13 复用基座)。

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -40,6 +40,7 @@ const (
 	ActionPasswordChange     = "password_change"
 	ActionSessionRevoke      = "session_revoke"
 	ActionServiceOp          = "service_op"
+	ActionContainerCreate    = "container_create"
 	ActionContainerTerminal  = "container_terminal"
 	ActionServerTerminal     = "server_terminal"
 	// 流水线模板 + 变量组(FR-8-13 复用基座)。

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -41,6 +41,7 @@ const (
 	ActionSessionRevoke      = "session_revoke"
 	ActionServiceOp          = "service_op"
 	ActionContainerCreate    = "container_create"
+	ActionImageOp            = "image_op"
 	ActionContainerTerminal  = "container_terminal"
 	ActionServerTerminal     = "server_terminal"
 	// 流水线模板 + 变量组(FR-8-13 复用基座)。

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -43,6 +43,8 @@ const (
 	ActionContainerCreate    = "container_create"
 	ActionImageOp            = "image_op"
 	ActionStackOp            = "stack_op"
+	ActionVolumeOp           = "volume_op"
+	ActionNetworkOp          = "network_op"
 	ActionContainerTerminal  = "container_terminal"
 	ActionServerTerminal     = "server_terminal"
 	// 流水线模板 + 变量组(FR-8-13 复用基座)。

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -45,6 +45,7 @@ const (
 	ActionStackOp            = "stack_op"
 	ActionVolumeOp           = "volume_op"
 	ActionNetworkOp          = "network_op"
+	ActionSystemPrune        = "system_prune"
 	ActionContainerTerminal  = "container_terminal"
 	ActionServerTerminal     = "server_terminal"
 	// 流水线模板 + 变量组(FR-8-13 复用基座)。

--- a/internal/httpapi/ai_command.go
+++ b/internal/httpapi/ai_command.go
@@ -116,6 +116,42 @@ func makeAICommandHandler(aiSvc ai.Service) http.HandlerFunc {
 	}
 }
 
+// makeAIComposeHandler 返回 POST /api/ai/compose handler(中文 → docker-compose.yml)。
+// 未配 AI → 200 + available=false(前端提示去设置配)。
+func makeAIComposeHandler(aiSvc ai.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if aiSvc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "AI 助手未初始化")
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+		var req struct {
+			NL string `json:"nl"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		if strings.TrimSpace(req.NL) == "" {
+			writeError(w, http.StatusBadRequest, "bad_request", "请描述你想要的 compose")
+			return
+		}
+		out, err := aiSvc.GenerateCompose(r.Context(), ai.GenerateComposeInput{NL: req.NL, Masker: mask.NewMasker()})
+		switch {
+		case err == nil:
+			writeJSON(w, http.StatusOK, map[string]any{
+				"available":   true,
+				"yaml":        out.YAML,
+				"generatedAt": out.GeneratedAt.UTC().Format(time.RFC3339),
+			})
+		case errors.Is(err, ai.ErrAINotConfigured):
+			writeJSON(w, http.StatusOK, map[string]any{"available": false, "reason": reasonAINotConfigured})
+		default:
+			writeJSON(w, http.StatusOK, map[string]any{"available": true, "yaml": "", "reason": "AI 生成 compose 失败:" + humanizeGenerateErr(err)})
+		}
+	}
+}
+
 // makeAICompleteHandler 返回 POST /api/ai/complete handler(P2 智能补全:前缀 → 完整命令)。
 // 未配 AI → 200 + available=false(前端退化为本地常用命令字典兜底)。
 func makeAICompleteHandler(aiSvc ai.Service) http.HandlerFunc {

--- a/internal/httpapi/ai_generate_test.go
+++ b/internal/httpapi/ai_generate_test.go
@@ -56,6 +56,9 @@ func (s *stubAIService) ExplainCommand(context.Context, ai.ExplainCommandInput) 
 func (s *stubAIService) CompleteCommand(context.Context, ai.CompleteCommandInput) (*ai.CompletionResult, error) {
 	return nil, ai.ErrAINotConfigured
 }
+func (s *stubAIService) GenerateCompose(context.Context, ai.GenerateComposeInput) (*ai.ComposeResult, error) {
+	return nil, ai.ErrAINotConfigured
+}
 
 // ---- stub analyzer ----
 

--- a/internal/httpapi/container_create.go
+++ b/internal/httpapi/container_create.go
@@ -1,0 +1,256 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/audit"
+	"github.com/huangchengsir/pipewright/internal/target"
+)
+
+// 新增容器(Portainer 式 docker run)。POST /api/servers/{id}/containers。
+//
+// AC-SEC-02 要害:所有参数严格白名单校验,命令一律 array 化
+// (`docker run -d [--name][--restart][-p][-e][-v] <image> [cmd...]`),经 target.Exec
+// 各参数 shell 转义后执行,**绝不拼 shell 字符串**。任一参数非法 → 400 invalid_create_spec,
+// 命令不构造、不执行。SSH/命令失败 → 200 + ok:false + 人读 error(绝无密钥),不 500。
+// 成功(命令成功投递)后写 append-only 审计(detail 脱敏:仅 image/name,不含 env 值)。
+
+var (
+	// 镜像引用:registry/repo:tag@digest 形态。首字符强制字母数字(禁 `-` 防 flag 注入),
+	// 其余为字母数字 + `._/:@-`(无任何 shell 元字符)。
+	reImageRef = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._/:@-]*$`)
+	// 端口映射:[ip:][hostPort:]containerPort[/tcp|/udp]。
+	rePortSpec = regexp.MustCompile(`^(\d{1,3}(\.\d{1,3}){3}:)?(\d{1,5}:)?\d{1,5}(/(tcp|udp))?$`)
+	// 环境变量名:首字符字母/下划线,其余字母数字下划线。
+	reEnvKey = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+	// 卷路径段(host 路径 / 命名卷 / 容器内路径):字母数字 + `._/@-`,无 shell 元字符。
+	reVolumeSeg = regexp.MustCompile(`^[\w/][\w./@-]*$`)
+)
+
+// restartPolicies 是允许的重启策略(docker 枚举)。
+var restartPolicies = map[string]bool{"no": true, "always": true, "unless-stopped": true, "on-failure": true}
+
+// createContainerRequest 是 POST /api/servers/{id}/containers 请求体(冻结契约)。
+type createContainerRequest struct {
+	Image   string   `json:"image"`             // 必填,如 nginx:latest
+	Name    string   `json:"name,omitempty"`    // 可选,容器名
+	Ports   []string `json:"ports,omitempty"`   // "8080:80" / "127.0.0.1:8080:80" / "80"
+	Env     []string `json:"env,omitempty"`     // "KEY=VALUE"
+	Volumes []string `json:"volumes,omitempty"` // "/host:/ctr" / "/host:/ctr:ro" / "vol:/ctr"
+	Restart string   `json:"restart,omitempty"` // no|always|unless-stopped|on-failure
+	Command string   `json:"command,omitempty"` // 可选,按空白拆成参数(不经 shell)
+}
+
+// createContainerDTO 是响应体(冻结契约)。
+type createContainerDTO struct {
+	ServerID    string `json:"serverId"`
+	OK          bool   `json:"ok"`
+	ContainerID string `json:"containerId"` // 成功时为新容器完整 ID
+	Error       string `json:"error"`       // ok=false 时人读(绝无密钥)
+}
+
+// validateCreateSpec 校验创建参数,合法返回 nil。AC-SEC-02:绝不放过可被当 flag / shell 解释的输入。
+func validateCreateSpec(req *createContainerRequest) error {
+	img := strings.TrimSpace(req.Image)
+	if img == "" {
+		return errors.New("镜像不能为空")
+	}
+	if len(img) > 256 || !reImageRef.MatchString(img) {
+		return errors.New("非法镜像引用")
+	}
+	req.Image = img
+
+	if req.Name != "" {
+		if len(req.Name) > 128 || !reDockerTgt.MatchString(req.Name) {
+			return errors.New("非法容器名(仅字母数字与 . _ -,且不以 - 开头)")
+		}
+	}
+	if req.Restart != "" && !restartPolicies[req.Restart] {
+		return errors.New("非法重启策略(no/always/unless-stopped/on-failure)")
+	}
+	if len(req.Ports) > 64 || len(req.Env) > 128 || len(req.Volumes) > 64 {
+		return errors.New("端口/环境变量/卷数量过多")
+	}
+	for _, p := range req.Ports {
+		if err := validatePortSpec(p); err != nil {
+			return err
+		}
+	}
+	for _, e := range req.Env {
+		if err := validateEnvSpec(e); err != nil {
+			return err
+		}
+	}
+	for _, v := range req.Volumes {
+		if err := validateVolumeSpec(v); err != nil {
+			return err
+		}
+	}
+	if len(req.Command) > 1024 {
+		return errors.New("command 过长")
+	}
+	for _, a := range strings.Fields(req.Command) {
+		// 命令参数同样禁止以 `-` 开头被当作 docker run 自身的 flag(image 之后才是容器命令,
+		// docker 已按位置区分,但稳妥起见仍禁 shell 元字符)。
+		if strings.ContainsAny(a, "`$;|&<>(){}\n\r") {
+			return errors.New("command 含非法字符")
+		}
+	}
+	return nil
+}
+
+func validatePortSpec(p string) error {
+	if !rePortSpec.MatchString(p) {
+		return fmt.Errorf("非法端口映射:%s", truncateLog(p, 64))
+	}
+	// 进一步校验每个端口号 ≤ 65535。
+	hostPart := p
+	if i := strings.IndexByte(hostPart, '/'); i >= 0 {
+		hostPart = hostPart[:i]
+	}
+	for _, seg := range strings.Split(hostPart, ":") {
+		if seg == "" || strings.Contains(seg, ".") {
+			continue // 跳过空段与 IP 段
+		}
+		if n, err := strconv.Atoi(seg); err != nil || n < 1 || n > 65535 {
+			return fmt.Errorf("端口号越界:%s", truncateLog(seg, 16))
+		}
+	}
+	return nil
+}
+
+func validateEnvSpec(e string) error {
+	i := strings.IndexByte(e, '=')
+	if i <= 0 {
+		return errors.New("环境变量须为 KEY=VALUE 形式")
+	}
+	key, val := e[:i], e[i+1:]
+	if !reEnvKey.MatchString(key) {
+		return fmt.Errorf("非法环境变量名:%s", truncateLog(key, 64))
+	}
+	if strings.ContainsAny(val, "\n\r\x00") {
+		return errors.New("环境变量值不能含换行或空字符")
+	}
+	if len(val) > 4096 {
+		return errors.New("环境变量值过长")
+	}
+	return nil
+}
+
+func validateVolumeSpec(v string) error {
+	parts := strings.Split(v, ":")
+	if len(parts) < 2 || len(parts) > 3 {
+		return fmt.Errorf("非法卷挂载:%s", truncateLog(v, 64))
+	}
+	if len(parts) == 3 {
+		if parts[2] != "ro" && parts[2] != "rw" {
+			return errors.New("卷模式仅支持 ro/rw")
+		}
+	}
+	for _, seg := range parts[:2] {
+		if seg == "" || !reVolumeSeg.MatchString(seg) {
+			return fmt.Errorf("非法卷路径段:%s", truncateLog(seg, 64))
+		}
+	}
+	return nil
+}
+
+// buildDockerRunCmd 构造 `docker run -d ...` 命令 array(不拼 shell)。调用前须先过 validateCreateSpec。
+func buildDockerRunCmd(req *createContainerRequest) []string {
+	cmd := []string{"docker", "run", "-d"}
+	if req.Name != "" {
+		cmd = append(cmd, "--name", req.Name)
+	}
+	if req.Restart != "" {
+		cmd = append(cmd, "--restart", req.Restart)
+	}
+	for _, p := range req.Ports {
+		cmd = append(cmd, "-p", p)
+	}
+	for _, e := range req.Env {
+		cmd = append(cmd, "-e", e)
+	}
+	for _, v := range req.Volumes {
+		cmd = append(cmd, "-v", v)
+	}
+	cmd = append(cmd, req.Image)
+	cmd = append(cmd, strings.Fields(req.Command)...)
+	return cmd
+}
+
+// makeCreateContainerHandler 返回 POST /api/servers/{id}/containers handler(认证 + CSRF;写操作)。
+func makeCreateContainerHandler(svc target.Service, aud audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+		var req createContainerRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		if err := validateCreateSpec(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_create_spec", "创建参数非法:"+err.Error())
+			return
+		}
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeServerError(w, err)
+			return
+		}
+
+		out := createContainerDTO{ServerID: id}
+		auditOp := func(ok bool) {
+			recordAudit(r.Context(), aud, audit.Entry{
+				Actor:      auditActor,
+				Action:     audit.ActionContainerCreate,
+				TargetType: audit.TargetServer,
+				TargetID:   id,
+				// detail 仅白名单结构化字段:image/name/ok(不含 env 值等敏感内容)。
+				Detail: map[string]any{"image": req.Image, "name": req.Name, "ok": ok},
+				IP:     clientIP(r),
+			})
+		}
+
+		res, err := svc.Exec(r.Context(), id, buildDockerRunCmd(&req))
+		if err != nil {
+			if errors.Is(err, target.ErrNotFound) {
+				writeServerError(w, err)
+				return
+			}
+			if errors.Is(err, target.ErrCredentialNotFound) || errors.Is(err, target.ErrVaultUnconfigured) {
+				auditOp(false)
+				writeServerError(w, err)
+				return
+			}
+			out.OK = false
+			out.Error = humanServiceError(err)
+			auditOp(false)
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		if res.ExitCode != 0 {
+			msg := strings.TrimSpace(res.Stderr)
+			if msg == "" {
+				msg = "docker run 以非零状态退出"
+			}
+			out.OK = false
+			out.Error = truncateLog(msg, 1024)
+		} else {
+			out.OK = true
+			out.ContainerID = strings.TrimSpace(res.Stdout)
+		}
+		auditOp(out.OK)
+		writeJSON(w, http.StatusOK, out)
+	}
+}

--- a/internal/httpapi/container_create_test.go
+++ b/internal/httpapi/container_create_test.go
@@ -1,0 +1,88 @@
+package httpapi
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestValidateCreateSpec_Valid(t *testing.T) {
+	req := &createContainerRequest{
+		Image:   "nginx:latest",
+		Name:    "web-1",
+		Ports:   []string{"8080:80", "127.0.0.1:9090:90/tcp", "443"},
+		Env:     []string{"FOO=bar", "TZ=Asia/Shanghai"},
+		Volumes: []string{"/data/web:/usr/share/nginx/html:ro", "myvol:/cache"},
+		Restart: "unless-stopped",
+		Command: "nginx -g daemon off;",
+	}
+	if err := validateCreateSpec(req); err == nil {
+		// command 含 ';' 应被拒
+		t.Fatalf("command with ';' should be rejected")
+	}
+	req.Command = "nginx"
+	if err := validateCreateSpec(req); err != nil {
+		t.Fatalf("valid spec rejected: %v", err)
+	}
+}
+
+func TestValidateCreateSpec_RejectsInjection(t *testing.T) {
+	cases := []struct {
+		name string
+		req  createContainerRequest
+	}{
+		{"image shell metachar", createContainerRequest{Image: "nginx; rm -rf /"}},
+		{"image flag injection", createContainerRequest{Image: "-v/etc:/etc"}},
+		{"empty image", createContainerRequest{Image: ""}},
+		{"name leading dash", createContainerRequest{Image: "nginx", Name: "-rf"}},
+		{"name shell char", createContainerRequest{Image: "nginx", Name: "a;b"}},
+		{"bad restart", createContainerRequest{Image: "nginx", Restart: "sometimes"}},
+		{"port out of range", createContainerRequest{Image: "nginx", Ports: []string{"99999:80"}}},
+		{"port non-numeric", createContainerRequest{Image: "nginx", Ports: []string{"abc:80"}}},
+		{"env bad key", createContainerRequest{Image: "nginx", Env: []string{"1FOO=bar"}}},
+		{"env no equals", createContainerRequest{Image: "nginx", Env: []string{"FOOBAR"}}},
+		{"env newline value", createContainerRequest{Image: "nginx", Env: []string{"FOO=a\nb"}}},
+		{"volume one part", createContainerRequest{Image: "nginx", Volumes: []string{"/onlyone"}}},
+		{"volume bad mode", createContainerRequest{Image: "nginx", Volumes: []string{"/a:/b:xx"}}},
+		{"volume shell char", createContainerRequest{Image: "nginx", Volumes: []string{"/a:/b;c"}}},
+	}
+	for _, tc := range cases {
+		req := tc.req
+		if err := validateCreateSpec(&req); err == nil {
+			t.Fatalf("%s: should be rejected but passed", tc.name)
+		}
+	}
+}
+
+func TestBuildDockerRunCmd(t *testing.T) {
+	req := &createContainerRequest{
+		Image:   "redis:latest",
+		Name:    "cache",
+		Ports:   []string{"6379:6379"},
+		Env:     []string{"X=1"},
+		Volumes: []string{"data:/data"},
+		Restart: "always",
+		Command: "redis-server --appendonly yes",
+	}
+	got := buildDockerRunCmd(req)
+	want := []string{
+		"docker", "run", "-d",
+		"--name", "cache",
+		"--restart", "always",
+		"-p", "6379:6379",
+		"-e", "X=1",
+		"-v", "data:/data",
+		"redis:latest",
+		"redis-server", "--appendonly", "yes",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildDockerRunCmd =\n%v\nwant\n%v", got, want)
+	}
+}
+
+func TestBuildDockerRunCmd_Minimal(t *testing.T) {
+	got := buildDockerRunCmd(&createContainerRequest{Image: "nginx"})
+	want := []string{"docker", "run", "-d", "nginx"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("minimal = %v, want %v", got, want)
+	}
+}

--- a/internal/httpapi/container_diagnose.go
+++ b/internal/httpapi/container_diagnose.go
@@ -1,0 +1,106 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/ai"
+	"github.com/huangchengsir/pipewright/internal/mask"
+	"github.com/huangchengsir/pipewright/internal/target"
+)
+
+// 容器 AI 诊断 / 看日志(AI moat)。POST /api/servers/{id}/containers/{containerId}/diagnose。
+//
+// 取该容器最近日志(docker logs)+ 状态摘要,喂给 ai.Diagnose 出「根因假说 + 置信度 + 修复
+// 建议 + 可粘贴修复脚本 + 证据行」。同一端点既服务「日志一键 AI 分析」也服务「异常容器一键
+// 诊断」(都是日志 → 诊断)。
+//
+// 铁律:
+//   - AC-SEC-02:containerId 严格白名单(reDockerTgt:首字符非 `-`、无 shell 元字符),命令 array 化。
+//   - 出网前脱敏:日志进 prompt 前经 Masker(ai.Diagnose 内部 Scrub)。
+//   - 优雅降级:AI 未配 / 超时 / 不可解析 → 200 + status=unavailable + 人读 reason,**绝不 500**。
+
+const diagnoseLogTail = "200"
+
+// makeContainerDiagnoseHandler 返回 POST /api/servers/{id}/containers/{containerId}/diagnose
+// (认证 + CSRF;读容器日志 + 调 AI)。
+func makeContainerDiagnoseHandler(svc target.Service, aiSvc ai.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		containerID := chi.URLParam(r, "containerId")
+		if !reDockerTgt.MatchString(containerID) || len(containerID) > 256 {
+			writeError(w, http.StatusBadRequest, "invalid_container_target", "容器名非法")
+			return
+		}
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeServerError(w, err)
+			return
+		}
+
+		// AI 未注入 → 直接降级 unavailable(不去读日志,省一次 SSH)。
+		if aiSvc == nil {
+			writeJSON(w, http.StatusOK, &ai.Diagnosis{
+				Status:      "unavailable",
+				Reason:      "AI 未配置,无法诊断。请到「设置 › AI」配置模型后重试。",
+				GeneratedAt: time.Now().UTC(),
+			})
+			return
+		}
+
+		cctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+
+		// 取日志(docker logs 同时走 stdout/stderr,合并)。失败不致命:空日志也能让 AI 据状态推断。
+		logText := fetchContainerLogs(cctx, svc, id, containerID)
+		if strings.TrimSpace(logText) == "" {
+			logText = "(该容器无日志输出)"
+		}
+
+		diag, err := aiSvc.Diagnose(cctx, ai.DiagnoseInput{
+			FailureLog:  logText,
+			StepName:    "容器 " + containerID,
+			ProjectName: "",
+			Masker:      mask.NewMasker(),
+		})
+		if err != nil || diag == nil {
+			// ai.Diagnose 仅极少内部错回 error;统一降级 unavailable(绝不 500 / 绝无密钥)。
+			writeJSON(w, http.StatusOK, &ai.Diagnosis{
+				Status:      "unavailable",
+				Reason:      "诊断暂不可用,请稍后重试。",
+				GeneratedAt: time.Now().UTC(),
+			})
+			return
+		}
+		writeJSON(w, http.StatusOK, diag)
+	}
+}
+
+// fetchContainerLogs 取容器最近 N 行日志(stdout+stderr 合并;失败返回空串,由调用方兜底)。
+func fetchContainerLogs(ctx context.Context, svc target.Service, serverID, containerID string) string {
+	res, err := svc.Exec(ctx, serverID, []string{"docker", "logs", "--tail", diagnoseLogTail, containerID})
+	if err != nil {
+		return ""
+	}
+	var b strings.Builder
+	if s := strings.TrimSpace(res.Stdout); s != "" {
+		b.WriteString(s)
+	}
+	if s := strings.TrimSpace(res.Stderr); s != "" {
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(s)
+	}
+	out := b.String()
+	if len(out) > 32<<10 {
+		out = out[len(out)-(32<<10):] // 取末尾 32KiB(最近日志最相关)
+	}
+	return out
+}

--- a/internal/httpapi/container_inspect.go
+++ b/internal/httpapi/container_inspect.go
@@ -1,0 +1,278 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/target"
+)
+
+// 容器详情(inspect):经界面查看目标机上某容器的精选元信息(镜像/命令/状态/重启策略/
+// 环境变量/挂载/网络/端口/标签),免去逐台 SSH 登录手敲 `docker inspect`。
+//
+// GET 只读 → 过 auth、豁免 CSRF。
+//
+// 安全(AC-SEC-02,与 6-3/6-4 同姿态):
+//   - containerId 经严格白名单 reDockerTgt(首字符 [\w] 防 flag 注入、无 shell 元字符防命令注入),
+//     >256 拒;
+//   - 命令一律 array 化(`docker inspect <containerId>`),经 target.Exec 各参数 shell 转义后执行,
+//     绝不拼 shell 字符串。
+//   - inspect 失败 / 容器不存在 / 解析失败 → 200 + reachable:false + 人读 error,**不 500**。
+//   - env 值可能含密钥:展示给已登录管理员,但**绝不记日志**(本 handler 不打印任何 inspect 输出)。
+
+// containerMountDTO 是单条挂载(精选 .Mounts 字段)。
+type containerMountDTO struct {
+	Source      string `json:"source"`
+	Destination string `json:"destination"`
+	Mode        string `json:"mode"`
+	RW          bool   `json:"rw"`
+}
+
+// containerNetworkDTO 是单个网络的接入信息(精选 .NetworkSettings.Networks)。
+type containerNetworkDTO struct {
+	Name      string `json:"name"`
+	IPAddress string `json:"ipAddress"`
+}
+
+// containerPortDTO 是单条端口映射(展开 .NetworkSettings.Ports)。
+// 未发布端口(映射为 null)仅含 containerPort;已发布则每个绑定一条。
+type containerPortDTO struct {
+	ContainerPort string `json:"containerPort"` // 如 "80/tcp"
+	HostIP        string `json:"hostIp,omitempty"`
+	HostPort      string `json:"hostPort,omitempty"`
+}
+
+// containerInspectDTO 是响应体(冻结契约)。reachable=false 时仅 error 有意义。
+type containerInspectDTO struct {
+	ServerID      string                `json:"serverId"`
+	ContainerID   string                `json:"containerId"`
+	Reachable     bool                  `json:"reachable"`
+	Error         string                `json:"error,omitempty"`
+	Image         string                `json:"image,omitempty"`
+	Command       string                `json:"command,omitempty"`
+	CreatedAt     string                `json:"createdAt,omitempty"`
+	State         string                `json:"state,omitempty"`
+	RestartPolicy string                `json:"restartPolicy,omitempty"`
+	Env           []string              `json:"env"`
+	Mounts        []containerMountDTO   `json:"mounts"`
+	Networks      []containerNetworkDTO `json:"networks"`
+	Ports         []containerPortDTO    `json:"ports"`
+	Labels        map[string]string     `json:"labels"`
+}
+
+// dockerInspectRaw 仅声明我们关心的字段,映射 `docker inspect` 数组元素;其余字段被忽略。
+type dockerInspectRaw struct {
+	Created string   `json:"Created"`
+	Path    string   `json:"Path"`
+	Args    []string `json:"Args"`
+	State   struct {
+		Status string `json:"Status"`
+	} `json:"State"`
+	Config struct {
+		Image  string            `json:"Image"`
+		Cmd    []string          `json:"Cmd"`
+		Env    []string          `json:"Env"`
+		Labels map[string]string `json:"Labels"`
+	} `json:"Config"`
+	HostConfig struct {
+		RestartPolicy struct {
+			Name string `json:"Name"`
+		} `json:"RestartPolicy"`
+	} `json:"HostConfig"`
+	Mounts []struct {
+		Source      string `json:"Source"`
+		Destination string `json:"Destination"`
+		Mode        string `json:"Mode"`
+		RW          bool   `json:"RW"`
+	} `json:"Mounts"`
+	NetworkSettings struct {
+		Networks map[string]struct {
+			IPAddress string `json:"IPAddress"`
+		} `json:"Networks"`
+		Ports map[string][]struct {
+			HostIP   string `json:"HostIp"`
+			HostPort string `json:"HostPort"`
+		} `json:"Ports"`
+	} `json:"NetworkSettings"`
+}
+
+// parseContainerInspect 解析 `docker inspect` 的原始输出(JSON 数组),取首元素并映射为精选 DTO。
+// 纯函数,便于单测。空数组 / 非法 JSON → 错误。
+func parseContainerInspect(output string) (containerInspectDTO, error) {
+	var arr []dockerInspectRaw
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &arr); err != nil {
+		return containerInspectDTO{}, errors.New("无法解析 docker inspect 输出")
+	}
+	if len(arr) == 0 {
+		return containerInspectDTO{}, errors.New("docker inspect 返回空")
+	}
+	return mapContainerInspect(arr[0]), nil
+}
+
+// mapContainerInspect 把原始 inspect 结构映射为精选 DTO(确定性顺序,便于前端稳定展示)。
+func mapContainerInspect(raw dockerInspectRaw) containerInspectDTO {
+	dto := containerInspectDTO{
+		Reachable:     true,
+		Image:         raw.Config.Image,
+		Command:       inspectCommand(raw),
+		CreatedAt:     raw.Created,
+		State:         raw.State.Status,
+		RestartPolicy: raw.HostConfig.RestartPolicy.Name,
+		Env:           []string{},
+		Mounts:        []containerMountDTO{},
+		Networks:      []containerNetworkDTO{},
+		Ports:         []containerPortDTO{},
+		Labels:        map[string]string{},
+	}
+
+	if len(raw.Config.Env) > 0 {
+		dto.Env = append(dto.Env, raw.Config.Env...)
+	}
+
+	for _, m := range raw.Mounts {
+		dto.Mounts = append(dto.Mounts, containerMountDTO{
+			Source:      m.Source,
+			Destination: m.Destination,
+			Mode:        m.Mode,
+			RW:          m.RW,
+		})
+	}
+
+	// 网络:map 无序 → 按网络名排序输出,展示稳定。
+	netNames := make([]string, 0, len(raw.NetworkSettings.Networks))
+	for name := range raw.NetworkSettings.Networks {
+		netNames = append(netNames, name)
+	}
+	sort.Strings(netNames)
+	for _, name := range netNames {
+		dto.Networks = append(dto.Networks, containerNetworkDTO{
+			Name:      name,
+			IPAddress: raw.NetworkSettings.Networks[name].IPAddress,
+		})
+	}
+
+	// 端口:map 无序 → 按容器端口键排序;每个绑定展开一条,未发布端口保留一条占位。
+	portKeys := make([]string, 0, len(raw.NetworkSettings.Ports))
+	for key := range raw.NetworkSettings.Ports {
+		portKeys = append(portKeys, key)
+	}
+	sort.Strings(portKeys)
+	for _, key := range portKeys {
+		bindings := raw.NetworkSettings.Ports[key]
+		if len(bindings) == 0 {
+			dto.Ports = append(dto.Ports, containerPortDTO{ContainerPort: key})
+			continue
+		}
+		for _, b := range bindings {
+			dto.Ports = append(dto.Ports, containerPortDTO{
+				ContainerPort: key,
+				HostIP:        b.HostIP,
+				HostPort:      b.HostPort,
+			})
+		}
+	}
+
+	if len(raw.Config.Labels) > 0 {
+		dto.Labels = raw.Config.Labels
+	}
+
+	return dto
+}
+
+// inspectCommand 取容器命令的可读表示:优先 .Config.Cmd(空格拼接),否则回退 .Path + .Args。
+func inspectCommand(raw dockerInspectRaw) string {
+	if len(raw.Config.Cmd) > 0 {
+		return strings.Join(raw.Config.Cmd, " ")
+	}
+	parts := make([]string, 0, len(raw.Args)+1)
+	if raw.Path != "" {
+		parts = append(parts, raw.Path)
+	}
+	parts = append(parts, raw.Args...)
+	return strings.Join(parts, " ")
+}
+
+// makeContainerInspectHandler 返回 GET /api/servers/{id}/containers/{containerId}/inspect handler。
+// GET 只读(过 auth、豁免 CSRF)。containerId 严格白名单 → 非法 400 invalid_container_target;
+// 服务器/凭据不存在等定位类错误走标准映射;inspect 失败/容器不存在/解析失败 → 200 + reachable:false。
+func makeContainerInspectHandler(svc target.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		containerID := chi.URLParam(r, "containerId")
+
+		// AC-SEC-02:容器 ID 严格白名单(首字符非 `-` 防 flag 注入、无 shell 元字符),>256 拒。
+		if containerID == "" || len(containerID) > 256 || !reDockerTgt.MatchString(containerID) {
+			writeError(w, http.StatusBadRequest, "invalid_container_target",
+				"非法容器 ID(仅允许字母数字与 . _ -,且不得以 - 开头)")
+			return
+		}
+
+		// 先确认服务器存在(404/422/503 在写任何 200 体之前)。
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeServerError(w, err)
+			return
+		}
+
+		out := containerInspectDTO{
+			ServerID:    id,
+			ContainerID: containerID,
+			Env:         []string{},
+			Mounts:      []containerMountDTO{},
+			Networks:    []containerNetworkDTO{},
+			Ports:       []containerPortDTO{},
+			Labels:      map[string]string{},
+		}
+
+		// 命令 array 化(绝不拼 shell):docker inspect <containerId>。
+		res, err := svc.Exec(r.Context(), id, []string{"docker", "inspect", containerID})
+		if err != nil {
+			// 凭据/保险库等定位类错误 → 标准映射;连接/认证/执行类 → 200 + reachable:false。
+			if errors.Is(err, target.ErrNotFound) ||
+				errors.Is(err, target.ErrCredentialNotFound) ||
+				errors.Is(err, target.ErrVaultUnconfigured) {
+				writeServerError(w, err)
+				return
+			}
+			out.Reachable = false
+			out.Error = humanServiceError(err)
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+
+		// 退出码非零(容器不存在 / docker 未装)→ reachable:false + stderr 人读,不 500。
+		if res.ExitCode != 0 {
+			msg := strings.TrimSpace(res.Stderr)
+			if msg == "" {
+				msg = strings.TrimSpace(res.Stdout)
+			}
+			if msg == "" {
+				msg = "容器不存在或 docker inspect 以非零状态退出"
+			}
+			out.Reachable = false
+			out.Error = truncateLog(msg, 1024)
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+
+		parsed, perr := parseContainerInspect(res.Stdout)
+		if perr != nil {
+			// 解析失败(输出非预期)→ reachable:false,绝不回显原始输出(可能含密钥)。
+			out.Reachable = false
+			out.Error = "解析容器信息失败:" + perr.Error()
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+
+		parsed.ServerID = id
+		parsed.ContainerID = containerID
+		writeJSON(w, http.StatusOK, parsed)
+	}
+}

--- a/internal/httpapi/container_inspect_test.go
+++ b/internal/httpapi/container_inspect_test.go
@@ -1,0 +1,174 @@
+package httpapi
+
+import "testing"
+
+// 一段贴近真实 `docker inspect <name>` 的输出片段(JSON 数组,仅保留我们关心的字段 + 少量噪声字段)。
+const sampleInspectJSON = `[
+  {
+    "Id": "9f1e2c3d4b5a6789abcdef0123456789abcdef0123456789abcdef0123456789",
+    "Created": "2026-06-01T08:30:00.123456789Z",
+    "Path": "docker-entrypoint.sh",
+    "Args": ["nginx", "-g", "daemon off;"],
+    "State": {
+      "Status": "running",
+      "Running": true,
+      "Pid": 12345
+    },
+    "Config": {
+      "Image": "nginx:1.27-alpine",
+      "Cmd": ["nginx", "-g", "daemon off;"],
+      "Env": [
+        "PATH=/usr/local/sbin:/usr/local/bin",
+        "NGINX_VERSION=1.27.0",
+        "DB_PASSWORD=s3cr3t"
+      ],
+      "Labels": {
+        "com.example.team": "platform",
+        "maintainer": "ops@example.com"
+      }
+    },
+    "HostConfig": {
+      "RestartPolicy": {
+        "Name": "unless-stopped",
+        "MaximumRetryCount": 0
+      }
+    },
+    "Mounts": [
+      {
+        "Type": "bind",
+        "Source": "/data/nginx/conf",
+        "Destination": "/etc/nginx/conf.d",
+        "Mode": "ro",
+        "RW": false
+      },
+      {
+        "Type": "volume",
+        "Name": "nginx-logs",
+        "Source": "/var/lib/docker/volumes/nginx-logs/_data",
+        "Destination": "/var/log/nginx",
+        "Mode": "z",
+        "RW": true
+      }
+    ],
+    "NetworkSettings": {
+      "Networks": {
+        "bridge": {
+          "IPAddress": "172.17.0.2",
+          "Gateway": "172.17.0.1"
+        },
+        "app-net": {
+          "IPAddress": "10.5.0.7"
+        }
+      },
+      "Ports": {
+        "80/tcp": [
+          {"HostIp": "0.0.0.0", "HostPort": "8080"}
+        ],
+        "443/tcp": null
+      }
+    }
+  }
+]`
+
+func TestParseContainerInspect_SelectedFields(t *testing.T) {
+	dto, err := parseContainerInspect(sampleInspectJSON)
+	if err != nil {
+		t.Fatalf("parseContainerInspect 失败: %v", err)
+	}
+
+	if !dto.Reachable {
+		t.Errorf("Reachable = false, 期望 true")
+	}
+	if dto.Image != "nginx:1.27-alpine" {
+		t.Errorf("Image = %q, 期望 nginx:1.27-alpine", dto.Image)
+	}
+	if dto.Command != "nginx -g daemon off;" {
+		t.Errorf("Command = %q, 期望 'nginx -g daemon off;'", dto.Command)
+	}
+	if dto.CreatedAt != "2026-06-01T08:30:00.123456789Z" {
+		t.Errorf("CreatedAt = %q", dto.CreatedAt)
+	}
+	if dto.State != "running" {
+		t.Errorf("State = %q, 期望 running", dto.State)
+	}
+	if dto.RestartPolicy != "unless-stopped" {
+		t.Errorf("RestartPolicy = %q, 期望 unless-stopped", dto.RestartPolicy)
+	}
+
+	// 环境变量原样保留(含密钥值 —— 后端不特殊处理,展示给已登录管理员)。
+	if len(dto.Env) != 3 {
+		t.Fatalf("Env 长度 = %d, 期望 3", len(dto.Env))
+	}
+	if dto.Env[2] != "DB_PASSWORD=s3cr3t" {
+		t.Errorf("Env[2] = %q, 期望 DB_PASSWORD=s3cr3t", dto.Env[2])
+	}
+
+	// 挂载。
+	if len(dto.Mounts) != 2 {
+		t.Fatalf("Mounts 长度 = %d, 期望 2", len(dto.Mounts))
+	}
+	m0 := dto.Mounts[0]
+	if m0.Source != "/data/nginx/conf" || m0.Destination != "/etc/nginx/conf.d" || m0.Mode != "ro" || m0.RW {
+		t.Errorf("Mounts[0] = %+v, 不符合预期", m0)
+	}
+	if !dto.Mounts[1].RW {
+		t.Errorf("Mounts[1].RW = false, 期望 true")
+	}
+
+	// 网络按名排序:app-net < bridge。
+	if len(dto.Networks) != 2 {
+		t.Fatalf("Networks 长度 = %d, 期望 2", len(dto.Networks))
+	}
+	if dto.Networks[0].Name != "app-net" || dto.Networks[0].IPAddress != "10.5.0.7" {
+		t.Errorf("Networks[0] = %+v, 期望 app-net/10.5.0.7", dto.Networks[0])
+	}
+	if dto.Networks[1].Name != "bridge" || dto.Networks[1].IPAddress != "172.17.0.2" {
+		t.Errorf("Networks[1] = %+v, 期望 bridge/172.17.0.2", dto.Networks[1])
+	}
+
+	// 端口按键排序:443/tcp(未发布,占位)< 80/tcp(发布到 0.0.0.0:8080)。
+	if len(dto.Ports) != 2 {
+		t.Fatalf("Ports 长度 = %d, 期望 2", len(dto.Ports))
+	}
+	if dto.Ports[0].ContainerPort != "443/tcp" || dto.Ports[0].HostPort != "" {
+		t.Errorf("Ports[0] = %+v, 期望 443/tcp 无绑定", dto.Ports[0])
+	}
+	if dto.Ports[1].ContainerPort != "80/tcp" || dto.Ports[1].HostIP != "0.0.0.0" || dto.Ports[1].HostPort != "8080" {
+		t.Errorf("Ports[1] = %+v, 期望 80/tcp -> 0.0.0.0:8080", dto.Ports[1])
+	}
+
+	// 标签。
+	if dto.Labels["com.example.team"] != "platform" {
+		t.Errorf("Labels[com.example.team] = %q, 期望 platform", dto.Labels["com.example.team"])
+	}
+}
+
+// 命令回退:无 Config.Cmd 时用 Path + Args 拼接。
+func TestParseContainerInspect_CommandFallback(t *testing.T) {
+	raw := `[{"Path":"/bin/myapp","Args":["--port","9000"],"Config":{"Image":"busybox"},"State":{"Status":"exited"}}]`
+	dto, err := parseContainerInspect(raw)
+	if err != nil {
+		t.Fatalf("parseContainerInspect 失败: %v", err)
+	}
+	if dto.Command != "/bin/myapp --port 9000" {
+		t.Errorf("Command = %q, 期望 '/bin/myapp --port 9000'", dto.Command)
+	}
+	if dto.State != "exited" {
+		t.Errorf("State = %q, 期望 exited", dto.State)
+	}
+	// 空集合应序列化为非 nil 切片/映射(前端不必判 null)。
+	if dto.Env == nil || dto.Mounts == nil || dto.Networks == nil || dto.Ports == nil || dto.Labels == nil {
+		t.Errorf("空集合不应为 nil: env=%v mounts=%v networks=%v ports=%v labels=%v",
+			dto.Env, dto.Mounts, dto.Networks, dto.Ports, dto.Labels)
+	}
+}
+
+// 空数组 / 非法 JSON → 错误(handler 据此回 reachable:false)。
+func TestParseContainerInspect_Errors(t *testing.T) {
+	if _, err := parseContainerInspect("[]"); err == nil {
+		t.Errorf("空数组应返回错误")
+	}
+	if _, err := parseContainerInspect("not-json"); err == nil {
+		t.Errorf("非法 JSON 应返回错误")
+	}
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -627,6 +627,10 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		// 新增容器(docker run) —— 写操作,过 auth + CSRF。参数严格白名单 + array 化,
 		// 非法 400 invalid_create_spec;SSH/命令失败人读不 500;成功后写审计(detail 仅 image/name)。
 		ar.Post("/servers/{id}/containers", makeCreateContainerHandler(sv, aud))
+		// 镜像管理 —— 列表(只读)+ 拉取/删除(写,过 CSRF + 审计)。镜像引用严格白名单 + array 化。
+		ar.Get("/servers/{id}/images", makeServerImagesHandler(sv))
+		ar.Post("/servers/{id}/images/pull", makeImagePullHandler(sv, aud))
+		ar.Post("/servers/{id}/images/remove", makeImageRemoveHandler(sv, aud))
 		// 服务操作 —— 重启/停止/启动(Story 6.3;FR-17,经 SSH 跑 systemctl/docker)。
 		// 复用 sv(4-1 装配)+ aud(1-4 装配),无需新服务。写操作 → 过 auth + CSRF。
 		// type/target/action 严格白名单(AC-SEC-02:首字符非 `-` 防 flag 注入、无 shell 元字符

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -646,6 +646,10 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		ar.Get("/servers/{id}/networks", makeServerNetworksHandler(sv))
 		ar.Post("/servers/{id}/networks/create", makeNetworkCreateHandler(sv, aud))
 		ar.Post("/servers/{id}/networks/remove", makeNetworkRemoveHandler(sv, aud))
+		// 网络详情:某网络上连着哪些容器 + 连接/断开。network 段白名单 + array 化。
+		ar.Get("/servers/{id}/networks/{network}/containers", makeNetworkContainersHandler(sv))
+		ar.Post("/servers/{id}/networks/{network}/connect", makeNetworkConnectHandler(sv, aud))
+		ar.Post("/servers/{id}/networks/{network}/disconnect", makeNetworkDisconnectHandler(sv, aud))
 		// 服务操作 —— 重启/停止/启动(Story 6.3;FR-17,经 SSH 跑 systemctl/docker)。
 		// 复用 sv(4-1 装配)+ aud(1-4 装配),无需新服务。写操作 → 过 auth + CSRF。
 		// type/target/action 严格白名单(AC-SEC-02:首字符非 `-` 防 flag 注入、无 shell 元字符

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -639,6 +639,13 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		// 容器 AI 诊断 / 看日志(AI moat):取容器日志 → ai.Diagnose 出根因+修复。复用 sv +
 		// o.aiSettings。出网前脱敏;AI 未配/失败 → 200 unavailable,绝不 500。比 {id} 多两段不被吞。
 		ar.Post("/servers/{id}/containers/{containerId}/diagnose", makeContainerDiagnoseHandler(sv, o.aiSettings))
+		// 数据卷 + 网络 —— 列表(只读)+ 创建/删除(写,过 CSRF + 审计)。名称白名单 + array 化。
+		ar.Get("/servers/{id}/volumes", makeServerVolumesHandler(sv))
+		ar.Post("/servers/{id}/volumes/create", makeVolumeCreateHandler(sv, aud))
+		ar.Post("/servers/{id}/volumes/remove", makeVolumeRemoveHandler(sv, aud))
+		ar.Get("/servers/{id}/networks", makeServerNetworksHandler(sv))
+		ar.Post("/servers/{id}/networks/create", makeNetworkCreateHandler(sv, aud))
+		ar.Post("/servers/{id}/networks/remove", makeNetworkRemoveHandler(sv, aud))
 		// 服务操作 —— 重启/停止/启动(Story 6.3;FR-17,经 SSH 跑 systemctl/docker)。
 		// 复用 sv(4-1 装配)+ aud(1-4 装配),无需新服务。写操作 → 过 auth + CSRF。
 		// type/target/action 严格白名单(AC-SEC-02:首字符非 `-` 防 flag 注入、无 shell 元字符

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -579,6 +579,7 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		ar.Post("/ai/command", makeAICommandHandler(aiSvc))
 		ar.Post("/ai/explain", makeAIExplainHandler(aiSvc))
 		ar.Post("/ai/complete", makeAICompleteHandler(aiSvc)) // P2 智能补全(前缀→完整命令)
+		ar.Post("/ai/compose", makeAIComposeHandler(aiSvc))   // 中文 → docker-compose.yml
 
 		// 只读源码读取(Story 3.6;FR-4 预埋,7-4 消费):go-git 浅克隆读 tree/blob。
 		// 复用已注入 projects(p)+ vault(v)取凭据 + 注入的 SourceReader。reader 为 nil → 503。

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -625,6 +625,13 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		// (type=docker)。chi 字面段 /servers/containers 优先于 {id},不会被吞。
 		ar.Get("/servers/containers", makeAllServerContainersHandler(sv))
 		ar.Get("/servers/{id}/containers", makeServerContainersHandler(sv))
+		// 容器实时资源 stats(docker stats --no-stream)。字面段 stats 不与 {id}/containers 冲突。
+		ar.Get("/servers/{id}/containers/stats", makeServerContainerStatsHandler(sv))
+		// 容器详情 inspect(docker inspect → 精选字段)。
+		ar.Get("/servers/{id}/containers/{containerId}/inspect", makeContainerInspectHandler(sv))
+		// 一键清理:磁盘占用(docker system df)+ prune(写,过 CSRF + 审计)。
+		ar.Get("/servers/{id}/system/df", makeSystemDfHandler(sv))
+		ar.Post("/servers/{id}/system/prune", makeSystemPruneHandler(sv, aud))
 		// 新增容器(docker run) —— 写操作,过 auth + CSRF。参数严格白名单 + array 化,
 		// 非法 400 invalid_create_spec;SSH/命令失败人读不 500;成功后写审计(detail 仅 image/name)。
 		ar.Post("/servers/{id}/containers", makeCreateContainerHandler(sv, aud))

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -636,6 +636,9 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		ar.Get("/servers/{id}/stacks", makeServerStacksHandler(sv))
 		ar.Post("/servers/{id}/stacks/deploy", makeStackDeployHandler(sv, aud))
 		ar.Post("/servers/{id}/stacks/action", makeStackActionHandler(sv, aud))
+		// 容器 AI 诊断 / 看日志(AI moat):取容器日志 → ai.Diagnose 出根因+修复。复用 sv +
+		// o.aiSettings。出网前脱敏;AI 未配/失败 → 200 unavailable,绝不 500。比 {id} 多两段不被吞。
+		ar.Post("/servers/{id}/containers/{containerId}/diagnose", makeContainerDiagnoseHandler(sv, o.aiSettings))
 		// 服务操作 —— 重启/停止/启动(Story 6.3;FR-17,经 SSH 跑 systemctl/docker)。
 		// 复用 sv(4-1 装配)+ aud(1-4 装配),无需新服务。写操作 → 过 auth + CSRF。
 		// type/target/action 严格白名单(AC-SEC-02:首字符非 `-` 防 flag 注入、无 shell 元字符

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -631,6 +631,11 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		ar.Get("/servers/{id}/images", makeServerImagesHandler(sv))
 		ar.Post("/servers/{id}/images/pull", makeImagePullHandler(sv, aud))
 		ar.Post("/servers/{id}/images/remove", makeImageRemoveHandler(sv, aud))
+		// Compose/Stacks —— 列表(只读)+ 部署(贴 yaml → up)+ start/stop/restart/down。
+		// 项目名严格白名单 + array 化;compose 内容经 Upload 落文件(非 shell 注入面)。写过 CSRF + 审计。
+		ar.Get("/servers/{id}/stacks", makeServerStacksHandler(sv))
+		ar.Post("/servers/{id}/stacks/deploy", makeStackDeployHandler(sv, aud))
+		ar.Post("/servers/{id}/stacks/action", makeStackActionHandler(sv, aud))
 		// 服务操作 —— 重启/停止/启动(Story 6.3;FR-17,经 SSH 跑 systemctl/docker)。
 		// 复用 sv(4-1 装配)+ aud(1-4 装配),无需新服务。写操作 → 过 auth + CSRF。
 		// type/target/action 严格白名单(AC-SEC-02:首字符非 `-` 防 flag 注入、无 shell 元字符

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -617,6 +617,13 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		// chi 字面段优先于 {id},/servers/metrics 不会被 /servers/{id} 吞。
 		ar.Get("/servers/metrics", makeAllServerMetricsHandler(sv))
 		ar.Get("/servers/{id}/metrics", makeServerMetricsHandler(sv))
+		// 容器管理列表/聚合(Portainer 式总览)——经 SSH 跑 `docker ps -a --format {{json .}}`
+		// 采集容器清单。复用 sv(4-1 装配,无新服务)。GET 只读 → 过 auth、豁免 CSRF。命令纯静态
+		// array、不接受任何用户输入(AC-SEC-02);某台不可达/无运行时 → reachable:false / runtime:""
+		// ,不 500。批量端点逐台并行有界、各自独立。容器**生命周期**写操作复用上面的 /service/action
+		// (type=docker)。chi 字面段 /servers/containers 优先于 {id},不会被吞。
+		ar.Get("/servers/containers", makeAllServerContainersHandler(sv))
+		ar.Get("/servers/{id}/containers", makeServerContainersHandler(sv))
 		// 服务操作 —— 重启/停止/启动(Story 6.3;FR-17,经 SSH 跑 systemctl/docker)。
 		// 复用 sv(4-1 装配)+ aud(1-4 装配),无需新服务。写操作 → 过 auth + CSRF。
 		// type/target/action 严格白名单(AC-SEC-02:首字符非 `-` 防 flag 注入、无 shell 元字符

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -624,6 +624,9 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		// (type=docker)。chi 字面段 /servers/containers 优先于 {id},不会被吞。
 		ar.Get("/servers/containers", makeAllServerContainersHandler(sv))
 		ar.Get("/servers/{id}/containers", makeServerContainersHandler(sv))
+		// 新增容器(docker run) —— 写操作,过 auth + CSRF。参数严格白名单 + array 化,
+		// 非法 400 invalid_create_spec;SSH/命令失败人读不 500;成功后写审计(detail 仅 image/name)。
+		ar.Post("/servers/{id}/containers", makeCreateContainerHandler(sv, aud))
 		// 服务操作 —— 重启/停止/启动(Story 6.3;FR-17,经 SSH 跑 systemctl/docker)。
 		// 复用 sv(4-1 装配)+ aud(1-4 装配),无需新服务。写操作 → 过 auth + CSRF。
 		// type/target/action 严格白名单(AC-SEC-02:首字符非 `-` 防 flag 注入、无 shell 元字符

--- a/internal/httpapi/run_diagnose_test.go
+++ b/internal/httpapi/run_diagnose_test.go
@@ -94,6 +94,9 @@ func (s *diagStubAI) CompleteCommand(_ context.Context, in ai.CompleteCommandInp
 	}
 	return nil, ai.ErrAINotConfigured
 }
+func (s *diagStubAI) GenerateCompose(context.Context, ai.GenerateComposeInput) (*ai.ComposeResult, error) {
+	return nil, ai.ErrAINotConfigured
+}
 
 // setupDiagnoseServer 构造带 auth + project + run(失败 runner,FailAt=0)+ stub AI 的 server。
 // 返回 server / client / csrf / projID / run.Service。

--- a/internal/httpapi/server_container_stats.go
+++ b/internal/httpapi/server_container_stats.go
@@ -1,0 +1,126 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/target"
+)
+
+// 容器实时资源 stats(Portainer 式):一次性采样 `docker stats --no-stream`。经 SSH 跑 docker,
+// 目标机零侵入。
+//
+// AC-SEC-02:命令是纯静态只读 array、不接受任何用户输入,不拼 shell。GET 只读 → 过 auth、
+// 豁免 CSRF;某台不可达/无 docker → reachable:false / runtime:"",绝不 500。
+
+// statsCmdTimeout:`docker stats --no-stream` 需先采两帧算 CPU 差值,可能比纯列表慢一点,给 20s。
+const statsCmdTimeout = 20 * time.Second
+
+// cmdContainerStats 是固定的只读采样命令(无用户输入)。
+var cmdContainerStats = []string{"docker", "stats", "--no-stream", "--format", "{{json .}}"}
+
+// containerStatDTO 是单个容器的实时资源样本(冻结契约)。
+type containerStatDTO struct {
+	Name     string `json:"name"`     // 容器名(docker stats 的 Name 字段)
+	CpuPerc  string `json:"cpuPerc"`  // CPU 百分比,如 "0.15%"
+	MemUsage string `json:"memUsage"` // 内存用量/上限,如 "12.5MiB / 1.94GiB"
+	MemPerc  string `json:"memPerc"`  // 内存百分比,如 "0.63%"
+	NetIO    string `json:"netIO"`    // 网络 IO,如 "1.2kB / 0B"
+	BlockIO  string `json:"blockIO"`  // 块设备 IO,如 "0B / 0B"
+}
+
+// serverContainerStatsDTO 是单台服务器容器 stats 响应体(冻结契约)。
+type serverContainerStatsDTO struct {
+	ServerID    string             `json:"serverId"`
+	Reachable   bool               `json:"reachable"`
+	Runtime     string             `json:"runtime"`
+	Error       string             `json:"error"`
+	Stats       []containerStatDTO `json:"stats"`
+	CollectedAt string             `json:"collectedAt"`
+}
+
+// dockerStatsLine 对应 `docker stats --format '{{json .}}'` 的逐行 JSON。
+type dockerStatsLine struct {
+	Name     string `json:"Name"`
+	CPUPerc  string `json:"CPUPerc"`
+	MemUsage string `json:"MemUsage"`
+	MemPerc  string `json:"MemPerc"`
+	NetIO    string `json:"NetIO"`
+	BlockIO  string `json:"BlockIO"`
+}
+
+// parseContainerStats 逐行解析 docker stats 的 JSON 输出;脏行(空/非 JSON)跳过。
+func parseContainerStats(out string) []containerStatDTO {
+	list := []containerStatDTO{}
+	if len(out) > imagesOutMax {
+		out = out[:imagesOutMax]
+	}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var p dockerStatsLine
+		if err := json.Unmarshal([]byte(line), &p); err != nil {
+			continue
+		}
+		list = append(list, containerStatDTO{
+			Name:     p.Name,
+			CpuPerc:  p.CPUPerc,
+			MemUsage: p.MemUsage,
+			MemPerc:  p.MemPerc,
+			NetIO:    p.NetIO,
+			BlockIO:  p.BlockIO,
+		})
+	}
+	return list
+}
+
+func collectServerContainerStats(ctx context.Context, svc target.Service, id string) (serverContainerStatsDTO, error) {
+	out := serverContainerStatsDTO{ServerID: id, Stats: []containerStatDTO{}, CollectedAt: time.Now().UTC().Format(time.RFC3339)}
+	cctx, cancel := context.WithTimeout(ctx, statsCmdTimeout)
+	defer cancel()
+
+	res, err := svc.Exec(cctx, id, cmdContainerStats)
+	if err != nil {
+		out.Reachable = false
+		out.Error = humanContainersError(err)
+		if isLocateError(err) {
+			return out, err
+		}
+		return out, nil
+	}
+	out.Reachable = true
+	if res.ExitCode != 0 {
+		out.Error = "未检测到容器运行时(docker 未安装或当前用户无权限)"
+		return out, nil
+	}
+	out.Runtime = "docker"
+	out.Stats = parseContainerStats(res.Stdout)
+	return out, nil
+}
+
+// makeServerContainerStatsHandler 返回 GET /api/servers/{id}/containers/stats(认证,只读)。
+func makeServerContainerStatsHandler(svc target.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeServerError(w, err)
+			return
+		}
+		out, locErr := collectServerContainerStats(r.Context(), svc, id)
+		if locErr != nil {
+			writeServerError(w, locErr)
+			return
+		}
+		writeJSON(w, http.StatusOK, out)
+	}
+}

--- a/internal/httpapi/server_container_stats_test.go
+++ b/internal/httpapi/server_container_stats_test.go
@@ -1,0 +1,35 @@
+package httpapi
+
+import "testing"
+
+func TestParseContainerStats(t *testing.T) {
+	out := `{"BlockIO":"0B / 0B","CPUPerc":"0.15%","Container":"abc","MemPerc":"0.63%","MemUsage":"12.5MiB / 1.94GiB","Name":"web","NetIO":"1.2kB / 0B","PIDs":"5"}
+{"BlockIO":"8.19kB / 0B","CPUPerc":"1.20%","Container":"def","MemPerc":"2.10%","MemUsage":"40MiB / 1.94GiB","Name":"redis","NetIO":"0B / 0B","PIDs":"4"}
+`
+	got := parseContainerStats(out)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Name != "web" || got[0].CpuPerc != "0.15%" || got[0].MemUsage != "12.5MiB / 1.94GiB" {
+		t.Fatalf("stat0 wrong: %+v", got[0])
+	}
+	if got[0].MemPerc != "0.63%" || got[0].NetIO != "1.2kB / 0B" || got[0].BlockIO != "0B / 0B" {
+		t.Fatalf("stat0 fields wrong: %+v", got[0])
+	}
+	if got[1].Name != "redis" || got[1].CpuPerc != "1.20%" {
+		t.Fatalf("stat1 wrong: %+v", got[1])
+	}
+}
+
+func TestParseContainerStats_SkipsGarbage(t *testing.T) {
+	got := parseContainerStats("garbage line\n{\"Name\":\"x\",\"CPUPerc\":\"0.00%\"}\n\n   \n")
+	if len(got) != 1 || got[0].Name != "x" {
+		t.Fatalf("want 1 valid stat, got %+v", got)
+	}
+}
+
+func TestParseContainerStats_Empty(t *testing.T) {
+	if got := parseContainerStats(""); len(got) != 0 {
+		t.Fatalf("want empty, got %+v", got)
+	}
+}

--- a/internal/httpapi/server_containers.go
+++ b/internal/httpapi/server_containers.go
@@ -1,0 +1,255 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/target"
+)
+
+// 容器管理 —— 列表/聚合(Portainer 式「统计所有服务器上的容器」入口能力)。
+//
+// 设计与 6-1(server_metrics.go)一脉相承:经 SSH 跑**固定白名单只读命令**采集,目标机
+// 零侵入(不装 agent、不开 Docker API socket)。容错纪律相同:
+//   - 某台不可达 / 认证失败 → 该台 reachable:false + 人读 error,**不 500**,不连累其它台。
+//   - 某台连得上但无容器运行时(docker 未装 / 当前用户无权限)→ runtime:"" + 人读 error,
+//     containers 空,仍 reachable:true(连接本身没问题)。
+//   - 批量端点逐台并行采集,有界并发(信号量防 N 台同时 SSH 打爆)。
+//
+// AC-SEC-02:采集命令是**纯静态命令 array**(`docker ps -a --format {{json .}}`),绝不接受
+// 任何用户输入拼接 —— 无注入面。容器**生命周期**(起停重启/暂停/kill/删除)复用既有
+// `POST /servers/{id}/service/action`(type=docker),那里已做严格白名单 + 审计。
+
+const (
+	// containersConcurrency 是批量采集的最大并发 SSH 数(有界,防打爆)。
+	containersConcurrency = 6
+	// containersCmdTimeout 是单台采集的整体超时。
+	containersCmdTimeout = 15 * time.Second
+	// containersOutMax 是 ps 输出解析前的截断上限(防超大输出撑爆内存;几百容器也远不及)。
+	containersOutMax = 4 << 20 // 4 MiB
+)
+
+// containerRuntimePref 是容器运行时探测优先级。**当前仅 docker 已实现**;命令形态高度一致,
+// 后续补 podman/nerdctl(containerd)只需在此 append + 适配个别 format 差异 —— 抽象已预留。
+var containerRuntimePref = []string{"docker"}
+
+// cmdContainerPS 构造列容器命令 array(不拼 shell)。`-a` 含已停止容器;`--no-trunc` 给完整
+// ID(生命周期操作用全 ID 无歧义);`--format {{json .}}` 每行一个 JSON 对象。
+func cmdContainerPS(bin string) []string {
+	return []string{bin, "ps", "-a", "--no-trunc", "--format", "{{json .}}"}
+}
+
+// containerDTO 是单个容器的展示 DTO(冻结契约字段形状)。
+type containerDTO struct {
+	ID        string `json:"id"`        // 完整容器 ID(FE 自行截短展示)
+	Names     string `json:"names"`     // 主名(已去前导 `/`)
+	Image     string `json:"image"`     // 镜像名:tag
+	State     string `json:"state"`     // running/exited/paused/created/restarting/dead/unknown
+	Status    string `json:"status"`    // 人读状态(如 "Up 2 hours" / "Exited (0) 3 days ago")
+	Ports     string `json:"ports"`     // 端口映射原文(如 "0.0.0.0:80->80/tcp")
+	CreatedAt string `json:"createdAt"` // 创建时间原文
+}
+
+// serverContainersDTO 是单台服务器的容器清单响应体(冻结契约)。
+//   - reachable:false 时 containers 空、error 人读非空(连接/认证/定位类失败)。
+//   - reachable:true 且 runtime:"" 时表示连得上但无容器运行时,error 人读说明。
+//   - reachable:true 且 runtime 非空时 containers 为实际清单,running/total 为计数。
+type serverContainersDTO struct {
+	ServerID    string         `json:"serverId"`
+	Reachable   bool           `json:"reachable"`
+	Runtime     string         `json:"runtime"` // "docker" | ""(未检测到)
+	Error       string         `json:"error"`
+	Containers  []containerDTO `json:"containers"`
+	Running     int            `json:"running"`
+	Total       int            `json:"total"`
+	CollectedAt string         `json:"collectedAt"`
+}
+
+// dockerPSLine 映射 `docker ps --format {{json .}}` 的逐行 JSON。仅取展示所需字段。
+// State 字段于 Docker 20.10+ 才有;旧版缺失 → 留空,由 deriveState 据 Status 回退推断。
+type dockerPSLine struct {
+	ID        string `json:"ID"`
+	Names     string `json:"Names"`
+	Image     string `json:"Image"`
+	State     string `json:"State"`
+	Status    string `json:"Status"`
+	Ports     string `json:"Ports"`
+	CreatedAt string `json:"CreatedAt"`
+}
+
+// parseContainers 解析 `docker ps -a --format {{json .}}` 的多行 JSON 为 DTO 切片。
+// 单行解析失败(格式异常)→ 跳过该行,不报错、不影响其它行(best-effort)。
+func parseContainers(out string) []containerDTO {
+	list := []containerDTO{}
+	if len(out) > containersOutMax {
+		out = out[:containersOutMax]
+	}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var p dockerPSLine
+		if err := json.Unmarshal([]byte(line), &p); err != nil {
+			continue
+		}
+		state := strings.ToLower(strings.TrimSpace(p.State))
+		if state == "" {
+			state = deriveState(p.Status)
+		}
+		list = append(list, containerDTO{
+			ID:        p.ID,
+			Names:     strings.TrimPrefix(p.Names, "/"),
+			Image:     p.Image,
+			State:     state,
+			Status:    p.Status,
+			Ports:     p.Ports,
+			CreatedAt: p.CreatedAt,
+		})
+	}
+	return list
+}
+
+// deriveState 在 ps 输出缺 State 字段(旧 Docker)时,据人读 Status 前缀推断容器状态。
+func deriveState(status string) string {
+	s := strings.TrimSpace(status)
+	switch {
+	case strings.HasPrefix(s, "Up") && strings.Contains(s, "(Paused)"):
+		return "paused"
+	case strings.HasPrefix(s, "Up"):
+		return "running"
+	case strings.HasPrefix(s, "Exited"):
+		return "exited"
+	case strings.HasPrefix(s, "Created"):
+		return "created"
+	case strings.HasPrefix(s, "Restarting"):
+		return "restarting"
+	case strings.HasPrefix(s, "Dead"):
+		return "dead"
+	default:
+		return "unknown"
+	}
+}
+
+// collectServerContainers 对单台服务器采集容器清单。永不返回 error 给批量端点用:
+// 不可达/无运行时均落到 DTO(reachable/runtime/error)。第二个返回值是「定位类」错误
+// (服务器/凭据不存在、保险库未配),仅供单台端点映射 404/422/503;批量端点忽略它。
+func collectServerContainers(ctx context.Context, svc target.Service, id string) (serverContainersDTO, error) {
+	out := serverContainersDTO{
+		ServerID:    id,
+		Containers:  []containerDTO{},
+		CollectedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, containersCmdTimeout)
+	defer cancel()
+
+	for _, bin := range containerRuntimePref {
+		res, err := svc.Exec(cctx, id, cmdContainerPS(bin))
+		if err != nil {
+			// SSH 层失败(连接/认证/定位)——对任何运行时都一样,直接判 reachable:false。
+			out.Reachable = false
+			out.Error = humanContainersError(err)
+			if isLocateError(err) {
+				return out, err
+			}
+			return out, nil
+		}
+		// 命令已投递 → 连接本身没问题。
+		out.Reachable = true
+		if res.ExitCode != 0 {
+			// 该运行时不存在 / 无权限(命令非零退出)→ 尝试下一个候选。
+			continue
+		}
+		out.Runtime = bin
+		out.Containers = parseContainers(res.Stdout)
+		out.Total = len(out.Containers)
+		for _, c := range out.Containers {
+			if c.State == "running" {
+				out.Running++
+			}
+		}
+		return out, nil
+	}
+
+	// 连得上但没有任何候选运行时可用。
+	out.Error = "未检测到容器运行时(docker 未安装,或当前用户无权限访问 docker)"
+	return out, nil
+}
+
+// humanContainersError 把领域错误映射为人读文案(绝不含凭据明文/内部栈)。
+func humanContainersError(err error) string {
+	switch {
+	case errors.Is(err, target.ErrAuth):
+		return "SSH 认证失败:密钥或口令无效,或无登录权限"
+	case errors.Is(err, target.ErrUnreachable):
+		return "无法连接服务器:端口未开放、主机不可达或超时"
+	case errors.Is(err, target.ErrInvalidCredential):
+		return "凭据不是可用的 SSH 私钥或口令"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "采集超时"
+	default:
+		return "采集容器清单失败:连接或命令执行错误"
+	}
+}
+
+// --- HTTP handlers ---
+
+// makeServerContainersHandler 返回 GET /api/servers/{id}/containers(认证,只读)。
+// 服务器不存在/凭据不存在/保险库未配 → 标准状态码;连接/采集失败 → 200 + reachable:false,不 500。
+func makeServerContainersHandler(svc target.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeServerError(w, err)
+			return
+		}
+		out, locErr := collectServerContainers(r.Context(), svc, id)
+		if locErr != nil {
+			writeServerError(w, locErr)
+			return
+		}
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+// makeAllServerContainersHandler 返回 GET /api/servers/containers(认证,只读;批量聚合)。
+// 逐台并行采集(有界并发),各自独立:某台失败仅该台 reachable:false,不连累其它台、不 500。
+func makeAllServerContainersHandler(svc target.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		servers, err := svc.List(r.Context())
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+			return
+		}
+
+		items := make([]serverContainersDTO, len(servers))
+		sem := make(chan struct{}, containersConcurrency)
+		var wg sync.WaitGroup
+		for i, srv := range servers {
+			wg.Add(1)
+			go func(i int, id string) {
+				defer wg.Done()
+				sem <- struct{}{}
+				defer func() { <-sem }()
+				items[i], _ = collectServerContainers(r.Context(), svc, id)
+			}(i, srv.ID)
+		}
+		wg.Wait()
+		writeJSON(w, http.StatusOK, map[string]any{"items": items})
+	}
+}

--- a/internal/httpapi/server_containers_test.go
+++ b/internal/httpapi/server_containers_test.go
@@ -1,0 +1,209 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/target"
+)
+
+// --- 纯解析单元测试 ---
+
+func TestParseContainers_WithStateField(t *testing.T) {
+	// Docker 20.10+ 的 `docker ps --format {{json .}}`:逐行 JSON,含 State 字段。
+	out := `{"ID":"abc123def456","Names":"web","Image":"nginx:latest","State":"running","Status":"Up 2 hours","Ports":"0.0.0.0:80->80/tcp","CreatedAt":"2026-06-01 10:00:00 +0800 CST"}
+{"ID":"def789","Names":"/db","Image":"mysql:8","State":"exited","Status":"Exited (0) 3 days ago","Ports":"","CreatedAt":"2026-05-28 09:00:00 +0800 CST"}
+`
+	got := parseContainers(out)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2: %+v", len(got), got)
+	}
+	if got[0].ID != "abc123def456" || got[0].Names != "web" || got[0].State != "running" {
+		t.Fatalf("c0 wrong: %+v", got[0])
+	}
+	if got[0].Image != "nginx:latest" || got[0].Ports != "0.0.0.0:80->80/tcp" {
+		t.Fatalf("c0 image/ports wrong: %+v", got[0])
+	}
+	// 前导 `/` 应去掉。
+	if got[1].Names != "db" || got[1].State != "exited" {
+		t.Fatalf("c1 wrong: %+v", got[1])
+	}
+}
+
+func TestParseContainers_OldDockerNoState(t *testing.T) {
+	// 旧 Docker 无 State 字段 → 据 Status 前缀推断。
+	out := `{"ID":"a1","Names":"running-one","Image":"img","Status":"Up 5 minutes","Ports":"","CreatedAt":""}
+{"ID":"a2","Names":"paused-one","Image":"img","Status":"Up 5 minutes (Paused)","Ports":"","CreatedAt":""}
+{"ID":"a3","Names":"stopped-one","Image":"img","Status":"Exited (137) 1 hour ago","Ports":"","CreatedAt":""}
+{"ID":"a4","Names":"created-one","Image":"img","Status":"Created","Ports":"","CreatedAt":""}`
+	got := parseContainers(out)
+	if len(got) != 4 {
+		t.Fatalf("len = %d, want 4", len(got))
+	}
+	want := []string{"running", "paused", "exited", "created"}
+	for i, w := range want {
+		if got[i].State != w {
+			t.Fatalf("c%d state = %q, want %q", i, got[i].State, w)
+		}
+	}
+}
+
+func TestParseContainers_SkipsGarbageLines(t *testing.T) {
+	out := "not json at all\n{\"ID\":\"ok\",\"Names\":\"good\",\"Status\":\"Up 1 second\"}\n   \n"
+	got := parseContainers(out)
+	if len(got) != 1 || got[0].ID != "ok" {
+		t.Fatalf("want 1 valid container, got %+v", got)
+	}
+}
+
+func TestDeriveState(t *testing.T) {
+	cases := map[string]string{
+		"Up 2 hours":            "running",
+		"Up 2 hours (Paused)":   "paused",
+		"Exited (0) 3 days ago": "exited",
+		"Created":               "created",
+		"Restarting (1) 2s ago": "restarting",
+		"Dead":                  "dead",
+		"some weird status":     "unknown",
+	}
+	for status, want := range cases {
+		if got := deriveState(status); got != want {
+			t.Fatalf("deriveState(%q) = %q, want %q", status, got, want)
+		}
+	}
+}
+
+// --- 集成测试:经真 HTTP 端点 + 假 dialer ---
+
+// dockerLikeDialer 模拟一台装了 docker 的服务器:`docker ps` 回显两个容器(一跑一停)。
+func dockerLikeDialer() cmdDialer {
+	return cmdDialer{fn: func(cmd []string) (*target.ExecResult, error) {
+		if len(cmd) >= 2 && cmd[0] == "docker" && cmd[1] == "ps" {
+			out := `{"ID":"c0full","Names":"web","Image":"nginx:latest","State":"running","Status":"Up 2 hours","Ports":"0.0.0.0:80->80/tcp","CreatedAt":"2026-06-01 10:00:00 +0800 CST"}
+{"ID":"c1full","Names":"db","Image":"mysql:8","State":"exited","Status":"Exited (0) 3 days ago","Ports":"","CreatedAt":"2026-05-28 09:00:00 +0800 CST"}
+`
+			return &target.ExecResult{Stdout: out, ExitCode: 0}, nil
+		}
+		return &target.ExecResult{Stderr: "command not found", ExitCode: 127}, nil
+	}}
+}
+
+// noDockerDialer 模拟连得上但没装 docker 的服务器:`docker ps` 命令找不到(127)。
+func noDockerDialer() cmdDialer {
+	return cmdDialer{fn: func(cmd []string) (*target.ExecResult, error) {
+		return &target.ExecResult{Stderr: "docker: command not found", ExitCode: 127}, nil
+	}}
+}
+
+func TestServerContainers_DockerPresent(t *testing.T) {
+	srv, client, csrf := setupServerAPI(t, dockerLikeDialer())
+	credID := newSSHCredAPI(t, client, srv.URL, csrf, "pw")
+	id := createServerAPI(t, client, srv.URL, csrf, credID)
+
+	resp, _ := client.Get(srv.URL + "/api/servers/" + id + "/containers")
+	raw, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, raw)
+	}
+	var out serverContainersDTO
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v: %s", err, raw)
+	}
+	if !out.Reachable || out.Runtime != "docker" {
+		t.Fatalf("want reachable+docker: %+v", out)
+	}
+	if out.Total != 2 || out.Running != 1 {
+		t.Fatalf("counts wrong: total=%d running=%d", out.Total, out.Running)
+	}
+	if out.Containers[0].Names != "web" || out.Containers[0].State != "running" {
+		t.Fatalf("c0 wrong: %+v", out.Containers[0])
+	}
+}
+
+func TestServerContainers_NoRuntime(t *testing.T) {
+	srv, client, csrf := setupServerAPI(t, noDockerDialer())
+	credID := newSSHCredAPI(t, client, srv.URL, csrf, "pw")
+	id := createServerAPI(t, client, srv.URL, csrf, credID)
+
+	resp, _ := client.Get(srv.URL + "/api/servers/" + id + "/containers")
+	raw, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, raw)
+	}
+	var out serverContainersDTO
+	_ = json.Unmarshal(raw, &out)
+	// 连得上(命令投递成功)但无运行时:reachable true、runtime 空、error 人读、容器空。
+	if !out.Reachable {
+		t.Fatalf("want reachable true (connection ok): %+v", out)
+	}
+	if out.Runtime != "" || out.Error == "" {
+		t.Fatalf("want empty runtime + human error: %+v", out)
+	}
+	if len(out.Containers) != 0 {
+		t.Fatalf("want no containers: %+v", out.Containers)
+	}
+}
+
+func TestAllServerContainers_BatchAggregate(t *testing.T) {
+	srv, client, csrf := setupServerAPI(t, dockerLikeDialer())
+	credID := newSSHCredAPI(t, client, srv.URL, csrf, "pw")
+	_ = createServerAPI(t, client, srv.URL, csrf, credID)
+	_ = createServerAPI(t, client, srv.URL, csrf, credID)
+
+	resp, _ := client.Get(srv.URL + "/api/servers/containers")
+	raw, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, raw)
+	}
+	var body struct {
+		Items []serverContainersDTO `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal: %v: %s", err, raw)
+	}
+	if len(body.Items) != 2 {
+		t.Fatalf("want 2 servers in aggregate, got %d", len(body.Items))
+	}
+	for _, it := range body.Items {
+		if it.Total != 2 || it.Running != 1 {
+			t.Fatalf("server %s counts wrong: %+v", it.ServerID, it)
+		}
+	}
+}
+
+// --- 生命周期 action 白名单扩展(docker pause/unpause/kill/rm) ---
+
+func TestValidateServiceParams_DockerLifecycleWidened(t *testing.T) {
+	ok := []string{"restart", "stop", "start", "pause", "unpause", "kill", "rm"}
+	for _, a := range ok {
+		if err := validateServiceParams("docker", "myapp", a); err != nil {
+			t.Fatalf("docker action %q should be valid: %v", a, err)
+		}
+	}
+	// systemd 不放宽:pause/kill/rm 仍非法。
+	for _, a := range []string{"pause", "unpause", "kill", "rm"} {
+		if err := validateServiceParams("systemd", "nginx.service", a); err == nil {
+			t.Fatalf("systemd action %q should be rejected", a)
+		}
+	}
+	// flag 注入仍被正则挡住。
+	if err := validateServiceParams("docker", "-rf", "rm"); err == nil {
+		t.Fatalf("container name starting with - must be rejected")
+	}
+}
+
+// buildServiceCmd 对新增 docker action 仍是 `docker <action> <name>`。
+func TestBuildServiceCmd_DockerNewActions(t *testing.T) {
+	for _, a := range []string{"pause", "unpause", "kill", "rm"} {
+		got := buildServiceCmd("docker", a, "myapp")
+		want := []string{"docker", a, "myapp"}
+		if len(got) != 3 || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+			t.Fatalf("buildServiceCmd docker %s = %v, want %v", a, got, want)
+		}
+	}
+}

--- a/internal/httpapi/server_images.go
+++ b/internal/httpapi/server_images.go
@@ -1,0 +1,245 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/audit"
+	"github.com/huangchengsir/pipewright/internal/target"
+)
+
+// 镜像管理(Portainer 式):列表 / 拉取 / 删除。经 SSH 跑 docker,目标机零侵入。
+//
+// AC-SEC-02:列表是静态只读命令;拉取/删除的镜像引用经严格白名单校验(首字符非 `-` 防 flag
+// 注入、无 shell 元字符),命令 array 化不拼 shell。写操作过 CSRF + 审计。
+
+const (
+	imagesCmdTimeout = 20 * time.Second // 列表/删除:只读或快操作
+	imagePullTimeout = 8 * time.Minute  // 拉取:大镜像 + 慢网络可能很久,给充裕超时
+	imagesOutMax     = 2 << 20
+)
+
+// reImageRef 已在 container_create.go 定义(镜像引用白名单)。删除可用镜像 ID(sha256 短/长)
+// 或 repo:tag —— 同一套 reImageRef 即可覆盖(十六进制 ID 也匹配 [A-Za-z0-9._/:@-])。
+
+var cmdImagesList = []string{"docker", "images", "--format", "{{json .}}"}
+
+// imageDTO 是单个镜像的展示 DTO(冻结契约)。
+type imageDTO struct {
+	ID           string `json:"id"`           // 镜像 ID(短)
+	Repository   string `json:"repository"`   // 仓库名(<none> 表示悬空)
+	Tag          string `json:"tag"`          // 标签
+	Size         string `json:"size"`         // 人读大小(如 "142MB")
+	CreatedSince string `json:"createdSince"` // 人读创建时长(如 "3 weeks ago")
+}
+
+// serverImagesDTO 是单台服务器镜像清单响应体(冻结契约)。
+type serverImagesDTO struct {
+	ServerID    string     `json:"serverId"`
+	Reachable   bool       `json:"reachable"`
+	Runtime     string     `json:"runtime"`
+	Error       string     `json:"error"`
+	Images      []imageDTO `json:"images"`
+	CollectedAt string     `json:"collectedAt"`
+}
+
+type dockerImageLine struct {
+	ID           string `json:"ID"`
+	Repository   string `json:"Repository"`
+	Tag          string `json:"Tag"`
+	Size         string `json:"Size"`
+	CreatedSince string `json:"CreatedSince"`
+}
+
+func parseImages(out string) []imageDTO {
+	list := []imageDTO{}
+	if len(out) > imagesOutMax {
+		out = out[:imagesOutMax]
+	}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var p dockerImageLine
+		if err := json.Unmarshal([]byte(line), &p); err != nil {
+			continue
+		}
+		list = append(list, imageDTO{
+			ID:           p.ID,
+			Repository:   p.Repository,
+			Tag:          p.Tag,
+			Size:         p.Size,
+			CreatedSince: p.CreatedSince,
+		})
+	}
+	return list
+}
+
+func collectServerImages(ctx context.Context, svc target.Service, id string) (serverImagesDTO, error) {
+	out := serverImagesDTO{ServerID: id, Images: []imageDTO{}, CollectedAt: time.Now().UTC().Format(time.RFC3339)}
+	cctx, cancel := context.WithTimeout(ctx, imagesCmdTimeout)
+	defer cancel()
+
+	res, err := svc.Exec(cctx, id, cmdImagesList)
+	if err != nil {
+		out.Reachable = false
+		out.Error = humanContainersError(err)
+		if isLocateError(err) {
+			return out, err
+		}
+		return out, nil
+	}
+	out.Reachable = true
+	if res.ExitCode != 0 {
+		out.Error = "未检测到容器运行时(docker 未安装或当前用户无权限)"
+		return out, nil
+	}
+	out.Runtime = "docker"
+	out.Images = parseImages(res.Stdout)
+	return out, nil
+}
+
+// makeServerImagesHandler 返回 GET /api/servers/{id}/images(认证,只读)。
+func makeServerImagesHandler(svc target.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeServerError(w, err)
+			return
+		}
+		out, locErr := collectServerImages(r.Context(), svc, id)
+		if locErr != nil {
+			writeServerError(w, locErr)
+			return
+		}
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+// imageActionRequest 是拉取/删除请求体。
+type imageActionRequest struct {
+	Image string `json:"image"`           // pull/rm 的镜像引用(repo:tag 或 ID)
+	Force bool   `json:"force,omitempty"` // rm 是否 -f
+}
+
+type imageActionDTO struct {
+	ServerID string `json:"serverId"`
+	Action   string `json:"action"`
+	Image    string `json:"image"`
+	OK       bool   `json:"ok"`
+	Output   string `json:"output"`
+	Error    string `json:"error"`
+}
+
+var reImageActionRef = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._/:@-]*$`)
+
+func validateImageActionRef(ref string) error {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return errors.New("镜像不能为空")
+	}
+	if len(ref) > 256 || !reImageActionRef.MatchString(ref) {
+		return errors.New("非法镜像引用")
+	}
+	return nil
+}
+
+// makeImagePullHandler 返回 POST /api/servers/{id}/images/pull(认证 + CSRF;写)。
+func makeImagePullHandler(svc target.Service, aud audit.Recorder) http.HandlerFunc {
+	return imageWriteHandler(svc, aud, "pull", imagePullTimeout, func(ref string, _ bool) []string {
+		return []string{"docker", "pull", ref}
+	})
+}
+
+// makeImageRemoveHandler 返回 POST /api/servers/{id}/images/remove(认证 + CSRF;写)。
+func makeImageRemoveHandler(svc target.Service, aud audit.Recorder) http.HandlerFunc {
+	return imageWriteHandler(svc, aud, "rm", imagesCmdTimeout, func(ref string, force bool) []string {
+		if force {
+			return []string{"docker", "rmi", "-f", ref}
+		}
+		return []string{"docker", "rmi", ref}
+	})
+}
+
+// imageWriteHandler 抽出拉取/删除共用骨架:校验 → array 化命令 → Exec → 审计 → 200/ok。
+func imageWriteHandler(svc target.Service, aud audit.Recorder, action string, timeout time.Duration, build func(ref string, force bool) []string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+		var req imageActionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		if err := validateImageActionRef(req.Image); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_image_ref", "镜像引用非法:"+err.Error())
+			return
+		}
+		req.Image = strings.TrimSpace(req.Image)
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeServerError(w, err)
+			return
+		}
+
+		out := imageActionDTO{ServerID: id, Action: action, Image: req.Image}
+		auditOp := func(ok bool) {
+			recordAudit(r.Context(), aud, audit.Entry{
+				Actor:      auditActor,
+				Action:     audit.ActionImageOp,
+				TargetType: audit.TargetServer,
+				TargetID:   id,
+				Detail:     map[string]any{"action": action, "image": req.Image, "ok": ok},
+				IP:         clientIP(r),
+			})
+		}
+
+		cctx, cancel := context.WithTimeout(r.Context(), timeout)
+		defer cancel()
+		res, err := svc.Exec(cctx, id, build(req.Image, req.Force))
+		if err != nil {
+			if errors.Is(err, target.ErrNotFound) {
+				writeServerError(w, err)
+				return
+			}
+			if errors.Is(err, target.ErrCredentialNotFound) || errors.Is(err, target.ErrVaultUnconfigured) {
+				auditOp(false)
+				writeServerError(w, err)
+				return
+			}
+			out.OK = false
+			out.Error = humanServiceError(err)
+			auditOp(false)
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		if res.ExitCode != 0 {
+			msg := strings.TrimSpace(res.Stderr)
+			if msg == "" {
+				msg = "docker " + action + " 以非零状态退出"
+			}
+			out.OK = false
+			out.Error = truncateLog(msg, 1024)
+			out.Output = truncateLog(strings.TrimSpace(res.Stdout), 2048)
+		} else {
+			out.OK = true
+			out.Output = truncateLog(strings.TrimSpace(res.Stdout), 2048)
+		}
+		auditOp(out.OK)
+		writeJSON(w, http.StatusOK, out)
+	}
+}

--- a/internal/httpapi/server_images_test.go
+++ b/internal/httpapi/server_images_test.go
@@ -1,0 +1,42 @@
+package httpapi
+
+import "testing"
+
+func TestParseImages(t *testing.T) {
+	out := `{"ID":"ad5fe409de38","Repository":"calciumion/new-api","Tag":"latest","Size":"232MB","CreatedSince":"7 weeks ago"}
+{"ID":"1f073813b641","Repository":"redis","Tag":"latest","Size":"202MB","CreatedSince":"2 months ago"}
+{"ID":"deadbeef0001","Repository":"<none>","Tag":"<none>","Size":"100MB","CreatedSince":"1 day ago"}
+`
+	got := parseImages(out)
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	if got[0].Repository != "calciumion/new-api" || got[0].Tag != "latest" || got[0].Size != "232MB" {
+		t.Fatalf("img0 wrong: %+v", got[0])
+	}
+	if got[2].Repository != "<none>" {
+		t.Fatalf("dangling repo wrong: %+v", got[2])
+	}
+}
+
+func TestParseImages_SkipsGarbage(t *testing.T) {
+	got := parseImages("garbage\n{\"ID\":\"x\",\"Repository\":\"a\",\"Tag\":\"b\"}\n\n")
+	if len(got) != 1 || got[0].ID != "x" {
+		t.Fatalf("want 1 valid image, got %+v", got)
+	}
+}
+
+func TestValidateImageActionRef(t *testing.T) {
+	ok := []string{"nginx", "nginx:latest", "calciumion/new-api:latest", "ad5fe409de38", "registry.io/repo:tag@sha256:abc"}
+	for _, r := range ok {
+		if err := validateImageActionRef(r); err != nil {
+			t.Fatalf("%q should be valid: %v", r, err)
+		}
+	}
+	bad := []string{"", "-rf", "nginx; rm -rf /", "a|b", "$(whoami)", "a b"}
+	for _, r := range bad {
+		if err := validateImageActionRef(r); err == nil {
+			t.Fatalf("%q should be rejected", r)
+		}
+	}
+}

--- a/internal/httpapi/server_ops.go
+++ b/internal/httpapi/server_ops.go
@@ -51,15 +51,22 @@ type serviceActionDTO struct {
 	Error    string `json:"error"`
 }
 
-// validateServiceParams 据 type 严格校验 target + 校验 action 枚举,合法返回 nil。
-// AC-SEC-02 要害:绝不放过可能被远端当 flag / shell 解释的危险输入。
-func validateServiceParams(typ, tgt, action string) error {
-	switch action {
-	case "restart", "stop", "start":
-		// ok
-	default:
-		return errors.New("非法 action(仅支持 restart/stop/start)")
+// systemdActions / dockerActions 是按 type 区分的 action 白名单(枚举)。
+//   - systemd:仅 restart/stop/start(单元生命周期)。
+//   - docker:容器生命周期更全 —— 起停重启 + 暂停/恢复 + kill + 删除(Portainer 式)。
+//     全部恰好是 `docker <action> <name>` 的合法子命令,无需特判;`rm` 不带 `-f`(运行中容器
+//     删除会失败 → ok:false,迫使先停再删,安全且留痕)。
+var (
+	systemdActions = map[string]bool{"restart": true, "stop": true, "start": true}
+	dockerActions  = map[string]bool{
+		"restart": true, "stop": true, "start": true,
+		"pause": true, "unpause": true, "kill": true, "rm": true,
 	}
+)
+
+// validateServiceParams 据 type 严格校验 target 与 action 枚举,合法返回 nil。
+// AC-SEC-02 要害:绝不放过可能被远端当 flag / shell 解释的危险输入。action 白名单按 type 区分。
+func validateServiceParams(typ, tgt, action string) error {
 	if tgt == "" {
 		return errors.New("target 不能为空")
 	}
@@ -68,10 +75,16 @@ func validateServiceParams(typ, tgt, action string) error {
 	}
 	switch typ {
 	case "systemd":
+		if !systemdActions[action] {
+			return errors.New("非法 action(systemd 仅支持 restart/stop/start)")
+		}
 		if !reSystemdUnit.MatchString(tgt) {
 			return errors.New("非法 systemd unit 名")
 		}
 	case "docker":
+		if !dockerActions[action] {
+			return errors.New("非法 action(docker 仅支持 restart/stop/start/pause/unpause/kill/rm)")
+		}
 		if !reDockerTgt.MatchString(tgt) {
 			return errors.New("非法 docker 容器名")
 		}

--- a/internal/httpapi/server_prune.go
+++ b/internal/httpapi/server_prune.go
@@ -1,0 +1,313 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/audit"
+	"github.com/huangchengsir/pipewright/internal/target"
+)
+
+// 容器管理 —— 一键清理(docker system df / prune)。
+//
+// 在界面看一台主机的 Docker 磁盘占用(各类型大小 + 可回收量),并一键清理停止的容器 /
+// 悬空镜像 / 无用卷 / 构建缓存 / 全部,免逐台 SSH 敲 `docker system prune`。
+//
+// AC-SEC-02 核心(要害):
+//   - df 采集命令是**纯静态命令 array**(`docker system df --format '{{json .}}'`),绝不接受任何
+//     用户输入拼接 —— 无注入面;
+//   - prune 的 scope 走**枚举白名单** {containers,images,volumes,builder,all},非法一律 400;
+//     命令一律 array 化(`docker <obj> prune -f`),经 target.Exec 各参数 shell 转义,**绝不拼 shell**;
+//   - all 走 `docker system prune -f`,**不加 `--volumes`**(避免误删数据卷),UI 文案明示 all 不含卷。
+//
+// 容错纪律:
+//   - df 只读、不过 CSRF:某台不可达/认证失败 → reachable:false + 人读 error,不 500;
+//     目标机未装 Docker / 守护进程不可用 → reachable:true + error,entries 空,不 500。
+//   - prune 写操作、过 CSRF + 审计(ActionSystemPrune):SSH/命令失败 → 200 + ok:false + 人读 error,
+//     不 500;成功投递后写 append-only 审计(detail 仅 scope/ok,无自由输出/凭据)。
+
+const (
+	// dfCmdTimeout 是 `docker system df` 的整体超时(只读、轻量)。
+	dfCmdTimeout = 15 * time.Second
+	// pruneCmdTimeout 是 prune 的整体超时(builder/全量清理在大主机上可能耗时,给足余量)。
+	pruneCmdTimeout = 120 * time.Second
+	// pruneOutMax 是命令 stdout 解析/回显前的截断上限(防超大输出撑爆内存)。
+	pruneOutMax = 64 * 1024
+)
+
+// cmdSystemDf 是 df 采集命令(AC-SEC-02:固定静态 array,绝不含任何用户输入)。
+// `--format '{{json .}}'` 逐行输出 JSON 对象,字段 Type/TotalCount/Active/Size/Reclaimable。
+var cmdSystemDf = []string{"docker", "system", "df", "--format", "{{json .}}"}
+
+// pruneScopes 是允许的清理范围 → 对应命令 array 的白名单(AC-SEC-02)。
+//   - containers → 删除所有已停止容器
+//   - images     → 删除悬空(dangling)镜像(**不做** image prune -a,避免误删在用镜像)
+//   - volumes    → 删除未被任何容器引用的卷
+//   - builder    → 清理构建缓存
+//   - all        → docker system prune(停止容器 + 悬空镜像 + 未用网络 + 构建缓存;**不含数据卷**)
+var pruneScopes = map[string][]string{
+	"containers": {"docker", "container", "prune", "-f"},
+	"images":     {"docker", "image", "prune", "-f"},
+	"volumes":    {"docker", "volume", "prune", "-f"},
+	"builder":    {"docker", "builder", "prune", "-f"},
+	"all":        {"docker", "system", "prune", "-f"},
+}
+
+// dfEntryDTO 是 `docker system df` 单行(单个对象类型)的结构化视图(冻结契约字段形状)。
+//   - Type ∈ {Images, Containers, "Local Volumes", "Build Cache"}
+//   - TotalCount/Active 为数量;Size/Reclaimable 为 docker 已人读化的串(如 "1.6GB"、"1.2GB (75%)")。
+type dfEntryDTO struct {
+	Type        string `json:"type"`
+	TotalCount  int    `json:"totalCount"`
+	Active      int    `json:"active"`
+	Size        string `json:"size"`
+	Reclaimable string `json:"reclaimable"`
+}
+
+// systemDfDTO 是 GET /system/df 响应体(冻结契约)。
+//   - reachable:false → SSH/连接/认证失败,entries 空,error 人读非空。
+//   - reachable:true 但 dockerAvailable:false → 目标机未装 Docker / 守护进程不可用,error 人读非空。
+//   - reachable:true 且 dockerAvailable:true → entries 为各类型占用,error 为空。
+type systemDfDTO struct {
+	ServerID        string       `json:"serverId"`
+	Reachable       bool         `json:"reachable"`
+	DockerAvailable bool         `json:"dockerAvailable"`
+	Entries         []dfEntryDTO `json:"entries"`
+	Error           string       `json:"error"`
+}
+
+// dfRawLine 是 `{{json .}}` 单行的原始形状。docker CLI 把 TotalCount/Active/Size/Reclaimable
+// 均序列化为**字符串**(底层是 formatter 的 String() 方法),故全用 string 接,再做转换。
+type dfRawLine struct {
+	Type        string `json:"Type"`
+	TotalCount  string `json:"TotalCount"`
+	Active      string `json:"Active"`
+	Size        string `json:"Size"`
+	Reclaimable string `json:"Reclaimable"`
+}
+
+// parseDf 解析 `docker system df --format '{{json .}}'` 的逐行 JSON 输出为 DTO 列表。
+// best-effort:坏行/空行跳过,不报错;计数字段解析失败归 0。无任何有效行 → 返回空切片。
+func parseDockerDf(stdout string) []dfEntryDTO {
+	out := make([]dfEntryDTO, 0, 4)
+	for _, line := range strings.Split(stdout, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var raw dfRawLine
+		if err := json.Unmarshal([]byte(line), &raw); err != nil {
+			continue
+		}
+		if raw.Type == "" {
+			continue
+		}
+		out = append(out, dfEntryDTO{
+			Type:        raw.Type,
+			TotalCount:  atoiSafe(raw.TotalCount),
+			Active:      atoiSafe(raw.Active),
+			Size:        raw.Size,
+			Reclaimable: raw.Reclaimable,
+		})
+	}
+	return out
+}
+
+// atoiSafe 把计数串转 int,失败归 0(docker 偶有 "N/A" 之类的占位)。
+func atoiSafe(s string) int {
+	n, err := strconv.Atoi(strings.TrimSpace(s))
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// validatePruneScope 校验 scope 是否在枚举白名单内(AC-SEC-02)。合法返回 nil。
+func validatePruneScope(scope string) error {
+	if _, ok := pruneScopes[scope]; !ok {
+		return errors.New("非法 scope(仅支持 containers/images/volumes/builder/all)")
+	}
+	return nil
+}
+
+// buildPruneCmd 据 scope 返回对应命令 array(不拼 shell)。调用前须先过 validatePruneScope;
+// 未命中白名单返回 nil。
+func buildPruneCmd(scope string) []string {
+	cmd, ok := pruneScopes[scope]
+	if !ok {
+		return nil
+	}
+	// 拷贝一份,避免调用方意外改动包级白名单切片。
+	out := make([]string, len(cmd))
+	copy(out, cmd)
+	return out
+}
+
+// systemPruneRequest 是 POST /system/prune 请求体(冻结契约)。
+type systemPruneRequest struct {
+	Scope string `json:"scope"`
+}
+
+// systemPruneDTO 是 POST /system/prune 响应体(冻结契约)。ok=false 时 error 为人读串(绝无凭据);
+// 成功时 output 为命令 stdout(含释放空间汇总,如 "Total reclaimed space: 1.2GB")。
+type systemPruneDTO struct {
+	ServerID string `json:"serverId"`
+	Scope    string `json:"scope"`
+	OK       bool   `json:"ok"`
+	Output   string `json:"output"`
+	Error    string `json:"error"`
+}
+
+// makeSystemDfHandler 返回 GET /api/servers/{id}/system/df(认证,只读 → 豁免 CSRF)。
+// 服务器不存在/凭据不存在/保险库未配 → 标准状态码;连接/认证失败 → 200 + reachable:false;
+// 未装 Docker → 200 + reachable:true + dockerAvailable:false。均不 500。
+func makeSystemDfHandler(svc target.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		// 先确认服务器存在(404 在写任何 200 体之前)。
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeServerError(w, err)
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(r.Context(), dfCmdTimeout)
+		defer cancel()
+
+		out := systemDfDTO{ServerID: id, Entries: []dfEntryDTO{}}
+		res, err := svc.Exec(ctx, id, cmdSystemDf)
+		if err != nil {
+			// 定位类错误(凭据不存在 / 保险库未配)→ 走标准映射(422/503),而非 reachable:false。
+			if isLocateError(err) {
+				writeServerError(w, err)
+				return
+			}
+			// 连接/认证类 → 200 + reachable:false + 人读 error,不 500。
+			out.Reachable = false
+			out.Error = humanServiceError(err)
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+
+		// SSH 可达。命令非零退出(未装 docker / 守护进程不可用 / 无权限)→ reachable:true +
+		// dockerAvailable:false + 人读 error,不 500。
+		out.Reachable = true
+		if res.ExitCode != 0 {
+			out.DockerAvailable = false
+			out.Error = "无法读取 Docker 磁盘占用:目标机未安装 Docker、守护进程不可用或当前用户无权限"
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+
+		stdout := res.Stdout
+		if len(stdout) > pruneOutMax {
+			stdout = stdout[:pruneOutMax]
+		}
+		out.DockerAvailable = true
+		out.Entries = parseDockerDf(stdout)
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+// makeSystemPruneHandler 返回 POST /api/servers/{id}/system/prune(认证 + CSRF;写操作)。
+// scope 严格枚举白名单 → 非法 400 invalid_prune_scope;服务器不存在 404;SSH/命令失败 →
+// 200 + ok:false + 人读 error,不 500;成功投递后写审计(ActionSystemPrune,detail 仅 scope/ok)。
+func makeSystemPruneHandler(svc target.Service, aud audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+		var req systemPruneRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+
+		// AC-SEC-02:scope 严格枚举白名单,非法一律 400(命令不构造、不执行)。
+		if err := validatePruneScope(req.Scope); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_prune_scope", "清理范围非法:"+err.Error())
+			return
+		}
+
+		// 先确认服务器存在(404 在写任何 200 体之前)。
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeServerError(w, err)
+			return
+		}
+
+		cmd := buildPruneCmd(req.Scope)
+		out := systemPruneDTO{ServerID: id, Scope: req.Scope}
+
+		// 审计 helper:写操作的**任何尝试**都留痕(NFR-8 取证)。detail 仅白名单结构化字段
+		// (scope/ok,无自由输出/凭据);Recorder 再过 Masker。
+		auditOp := func(ok bool) {
+			recordAudit(r.Context(), aud, audit.Entry{
+				Actor:      auditActor,
+				Action:     audit.ActionSystemPrune,
+				TargetType: audit.TargetServer,
+				TargetID:   id,
+				Detail:     map[string]any{"scope": req.Scope, "ok": ok},
+				IP:         clientIP(r),
+			})
+		}
+
+		ctx, cancel := context.WithTimeout(r.Context(), pruneCmdTimeout)
+		defer cancel()
+
+		res, err := svc.Exec(ctx, id, cmd)
+		if err != nil {
+			// 定位类错误:服务器不存在无可审计目标;凭据/vault 错误是对真实服务器的写尝试 → 留痕。
+			if errors.Is(err, target.ErrNotFound) {
+				writeServerError(w, err)
+				return
+			}
+			if errors.Is(err, target.ErrCredentialNotFound) ||
+				errors.Is(err, target.ErrVaultUnconfigured) {
+				auditOp(false)
+				writeServerError(w, err)
+				return
+			}
+			// 连接/认证/执行类 → 200 + ok:false + 人读 error,不 500。
+			out.OK = false
+			out.Error = humanServiceError(err)
+			auditOp(false)
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+
+		// 命令已投递。非零退出(未装 docker / 守护进程不可用 / 无权限)→ ok:false + stderr 人读。
+		if res.ExitCode != 0 {
+			msg := strings.TrimSpace(res.Stderr)
+			if msg == "" {
+				msg = strings.TrimSpace(res.Stdout)
+			}
+			if msg == "" {
+				msg = "清理命令以非零状态退出(目标机未装 Docker、守护进程不可用或无权限)"
+			}
+			out.OK = false
+			out.Output = truncateLog(strings.TrimSpace(res.Stdout), pruneOutMax)
+			out.Error = truncateLog(msg, 1024)
+		} else {
+			out.OK = true
+			out.Output = truncateLog(strings.TrimSpace(res.Stdout), pruneOutMax)
+		}
+
+		// 写操作受审计(NFR-8):命令已投递,按退出码记 ok 真伪。
+		auditOp(out.OK)
+
+		writeJSON(w, http.StatusOK, out)
+	}
+}

--- a/internal/httpapi/server_prune_test.go
+++ b/internal/httpapi/server_prune_test.go
@@ -1,0 +1,113 @@
+package httpapi
+
+import (
+	"testing"
+)
+
+// --- 纯函数:scope 枚举白名单校验(AC-SEC-02 要害) ---
+
+func TestValidatePruneScope(t *testing.T) {
+	cases := []struct {
+		name    string
+		scope   string
+		wantErr bool
+	}{
+		{"containers 合法", "containers", false},
+		{"images 合法", "images", false},
+		{"volumes 合法", "volumes", false},
+		{"builder 合法", "builder", false},
+		{"all 合法", "all", false},
+		// 非白名单 / 注入一律拒。
+		{"空 scope 拒", "", true},
+		{"未知 scope 拒", "networks", true},
+		{"大小写不匹配拒", "Containers", true},
+		{"image-all 不做拒", "images-all", true},
+		{"命令注入拒", "all;rm -rf /", true},
+		{"flag 注入拒", "--volumes", true},
+		{"带空格拒", "all ", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validatePruneScope(c.scope)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("validatePruneScope(%q) err=%v, wantErr=%v", c.scope, err, c.wantErr)
+			}
+		})
+	}
+}
+
+// --- 纯函数:命令 array 构造(不拼 shell;all 不加 --volumes) ---
+
+func TestBuildPruneCmd(t *testing.T) {
+	cases := []struct {
+		scope string
+		want  []string
+	}{
+		{"containers", []string{"docker", "container", "prune", "-f"}},
+		{"images", []string{"docker", "image", "prune", "-f"}},
+		{"volumes", []string{"docker", "volume", "prune", "-f"}},
+		{"builder", []string{"docker", "builder", "prune", "-f"}},
+		{"all", []string{"docker", "system", "prune", "-f"}},
+	}
+	for _, c := range cases {
+		got := buildPruneCmd(c.scope)
+		if !equalStrSlice(got, c.want) {
+			t.Fatalf("buildPruneCmd(%q) = %v, want %v", c.scope, got, c.want)
+		}
+	}
+	// AC-SEC-02:all 绝不含 --volumes(避免误删数据卷)。
+	for _, arg := range buildPruneCmd("all") {
+		if arg == "--volumes" {
+			t.Fatalf("buildPruneCmd(\"all\") 不应包含 --volumes(会误删数据卷)")
+		}
+	}
+	// 非白名单返回 nil(不构造命令)。
+	if got := buildPruneCmd("networks"); got != nil {
+		t.Fatalf("buildPruneCmd(非法) = %v, want nil", got)
+	}
+}
+
+// --- 纯函数:解析 `docker system df --format '{{json .}}'` 逐行 JSON ---
+
+func TestParseDockerDf(t *testing.T) {
+	// docker CLI 把 TotalCount/Active/Size/Reclaimable 序列化为字符串。
+	stdout := `{"Active":"2","Reclaimable":"1.2GB (75%)","Size":"1.6GB","TotalCount":"5","Type":"Images"}
+{"Active":"1","Reclaimable":"0B (0%)","Size":"20MB","TotalCount":"3","Type":"Containers"}
+{"Active":"0","Reclaimable":"500MB","Size":"500MB","TotalCount":"4","Type":"Local Volumes"}
+{"Active":"0","Reclaimable":"800MB","Size":"800MB","TotalCount":"10","Type":"Build Cache"}`
+
+	got := parseDockerDf(stdout)
+	if len(got) != 4 {
+		t.Fatalf("parseDf 返回 %d 条,want 4", len(got))
+	}
+
+	images := got[0]
+	if images.Type != "Images" || images.TotalCount != 5 || images.Active != 2 ||
+		images.Size != "1.6GB" || images.Reclaimable != "1.2GB (75%)" {
+		t.Fatalf("Images 行解析错: %+v", images)
+	}
+	if got[2].Type != "Local Volumes" || got[2].TotalCount != 4 {
+		t.Fatalf("Local Volumes 行解析错: %+v", got[2])
+	}
+	if got[3].Type != "Build Cache" || got[3].TotalCount != 10 {
+		t.Fatalf("Build Cache 行解析错: %+v", got[3])
+	}
+}
+
+func TestParseDockerDfTolerantOfJunk(t *testing.T) {
+	// 空行 / 坏 JSON / 缺 Type / "N/A" 计数:best-effort 跳过坏行、计数归 0,不 panic。
+	stdout := "\n  \nnot-json\n{\"Type\":\"\"}\n{\"Type\":\"Images\",\"TotalCount\":\"N/A\",\"Active\":\"\",\"Size\":\"1GB\",\"Reclaimable\":\"1GB\"}\n"
+	got := parseDockerDf(stdout)
+	if len(got) != 1 {
+		t.Fatalf("parseDf 应只保留 1 条有效行,得 %d 条: %+v", len(got), got)
+	}
+	if got[0].Type != "Images" || got[0].TotalCount != 0 || got[0].Active != 0 {
+		t.Fatalf("坏计数应归 0: %+v", got[0])
+	}
+}
+
+func TestParseDockerDfEmpty(t *testing.T) {
+	if got := parseDockerDf(""); len(got) != 0 {
+		t.Fatalf("parseDockerDf(\"\") = %v, want 空", got)
+	}
+}

--- a/internal/httpapi/server_stacks.go
+++ b/internal/httpapi/server_stacks.go
@@ -1,0 +1,351 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/audit"
+	"github.com/huangchengsir/pipewright/internal/target"
+)
+
+// Compose / Stacks 管理(Portainer 式)。经 SSH 跑 `docker compose`(v2 插件),目标机零侵入。
+//
+// AC-SEC-02:列表只读;项目名经严格白名单(reDockerTgt:首字符非 `-`、无 shell 元字符、无 `/`
+// 不能路径穿越),命令 array 化不拼 shell。部署的 compose 内容经 Upload 以**文件**落到受管目录
+// (非 shell 注入面),再 `docker compose -f <path> up -d`。写操作过 CSRF + 审计(detail 仅
+// 项目名 + 动作,不含 compose 内容)。
+
+const (
+	stacksCmdTimeout = 20 * time.Second
+	stacksUpTimeout  = 8 * time.Minute // up 可能拉镜像 + 构建,给充裕超时
+	// stacksBaseDir 是受管 compose 目录基址。部署时在其下按项目名建子目录存 docker-compose.yml,
+	// 使 `compose ls` 可见、后续可重新 up。需运行 SSH 用户对该目录可写(root 默认可)。
+	stacksBaseDir   = "/opt/pipewright/stacks"
+	composeFileName = "docker-compose.yml"
+	composeMaxBytes = 512 << 10 // 512 KiB compose 上限
+)
+
+var cmdComposeLs = []string{"docker", "compose", "ls", "--all", "--format", "json"}
+
+// stackDTO 是单个 compose 项目的展示 DTO(冻结契约)。
+type stackDTO struct {
+	Name        string `json:"name"`
+	Status      string `json:"status"`      // 如 "running(2)" / "exited(1)"
+	ConfigFiles string `json:"configFiles"` // compose 文件路径
+}
+
+type serverStacksDTO struct {
+	ServerID    string     `json:"serverId"`
+	Reachable   bool       `json:"reachable"`
+	Runtime     string     `json:"runtime"`
+	Error       string     `json:"error"`
+	Stacks      []stackDTO `json:"stacks"`
+	CollectedAt string     `json:"collectedAt"`
+}
+
+// composeLsLine 映射 `docker compose ls --format json` 的元素(JSON 数组)。
+type composeLsLine struct {
+	Name        string `json:"Name"`
+	Status      string `json:"Status"`
+	ConfigFiles string `json:"ConfigFiles"`
+}
+
+func parseStacks(out string) []stackDTO {
+	list := []stackDTO{}
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return list
+	}
+	var arr []composeLsLine
+	if err := json.Unmarshal([]byte(out), &arr); err != nil {
+		// 个别 docker 版本逐行 JSON;回退逐行解析。
+		for _, line := range strings.Split(out, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			var p composeLsLine
+			if json.Unmarshal([]byte(line), &p) == nil && p.Name != "" {
+				list = append(list, stackDTO{Name: p.Name, Status: p.Status, ConfigFiles: p.ConfigFiles})
+			}
+		}
+		return list
+	}
+	for _, p := range arr {
+		list = append(list, stackDTO{Name: p.Name, Status: p.Status, ConfigFiles: p.ConfigFiles})
+	}
+	return list
+}
+
+func collectServerStacks(ctx context.Context, svc target.Service, id string) (serverStacksDTO, error) {
+	out := serverStacksDTO{ServerID: id, Stacks: []stackDTO{}, CollectedAt: time.Now().UTC().Format(time.RFC3339)}
+	cctx, cancel := context.WithTimeout(ctx, stacksCmdTimeout)
+	defer cancel()
+
+	res, err := svc.Exec(cctx, id, cmdComposeLs)
+	if err != nil {
+		out.Reachable = false
+		out.Error = humanContainersError(err)
+		if isLocateError(err) {
+			return out, err
+		}
+		return out, nil
+	}
+	out.Reachable = true
+	if res.ExitCode != 0 {
+		// docker 未装 / 无 compose 插件 / 无权限。
+		out.Error = "未检测到 docker compose(需 docker 与 compose v2 插件,且当前用户有权限)"
+		return out, nil
+	}
+	out.Runtime = "docker"
+	out.Stacks = parseStacks(res.Stdout)
+	return out, nil
+}
+
+// makeServerStacksHandler 返回 GET /api/servers/{id}/stacks(认证,只读)。
+func makeServerStacksHandler(svc target.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeServerError(w, err)
+			return
+		}
+		out, locErr := collectServerStacks(r.Context(), svc, id)
+		if locErr != nil {
+			writeServerError(w, locErr)
+			return
+		}
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+// stackActionRequest 是 update/down/start/stop/restart 请求体。
+type stackActionRequest struct {
+	Name       string `json:"name"`
+	Action     string `json:"action"`               // start|stop|restart|down|update
+	ConfigFile string `json:"configFile,omitempty"` // action=update 必填:compose ls 给的配置文件路径
+}
+
+type stackDTOResult struct {
+	ServerID string `json:"serverId"`
+	Name     string `json:"name"`
+	Action   string `json:"action"`
+	OK       bool   `json:"ok"`
+	Output   string `json:"output"`
+	Error    string `json:"error"`
+}
+
+var stackActions = map[string]bool{"start": true, "stop": true, "restart": true, "down": true, "update": true}
+
+// composeFileArgs 把 compose ls 给的 ConfigFile(可能逗号分隔多文件)拆成 `-f <path>` 参数对。
+// 每个路径须以 `/` 开头(绝对路径,杜绝被当 flag 注入)、无控制字符;经 array 传参不拼 shell。
+func composeFileArgs(configFile string) ([]string, error) {
+	var args []string
+	for _, p := range strings.Split(configFile, ",") {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if len(p) > 512 || !strings.HasPrefix(p, "/") || strings.ContainsAny(p, "\n\r\x00") {
+			return nil, errors.New("非法 compose 文件路径")
+		}
+		args = append(args, "-f", p)
+	}
+	if len(args) == 0 {
+		return nil, errors.New("缺少 compose 文件路径(该 Stack 无可用配置,无法更新)")
+	}
+	return args, nil
+}
+
+// makeStackActionHandler 返回 POST /api/servers/{id}/stacks/action(认证 + CSRF;写)。
+// 对已有项目按 project name(标签)操作,无需 compose 文件。
+func makeStackActionHandler(svc target.Service, aud audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+		var req stackActionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		if !reDockerTgt.MatchString(req.Name) || len(req.Name) > 128 {
+			writeError(w, http.StatusBadRequest, "invalid_stack", "项目名非法")
+			return
+		}
+		if !stackActions[req.Action] {
+			writeError(w, http.StatusBadRequest, "invalid_stack", "非法动作(start/stop/restart/down)")
+			return
+		}
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeServerError(w, err)
+			return
+		}
+
+		// 构造命令 + 超时:
+		//   - update:`docker compose -p <name> -f <cfg>... up -d --pull always`(拉新镜像 + 重建,
+		//     即「升级」);需 compose ls 给的配置文件路径,给 up 的长超时。
+		//   - 其余:`docker compose -p <name> <action>`(down/start/stop/restart 按项目标签操作)。
+		var cmd []string
+		timeout := stacksCmdTimeout
+		if req.Action == "update" {
+			fileArgs, err := composeFileArgs(req.ConfigFile)
+			if err != nil {
+				writeError(w, http.StatusBadRequest, "invalid_stack", err.Error())
+				return
+			}
+			cmd = append([]string{"docker", "compose", "-p", req.Name}, fileArgs...)
+			cmd = append(cmd, "up", "-d", "--pull", "always")
+			timeout = stacksUpTimeout
+		} else {
+			cmd = []string{"docker", "compose", "-p", req.Name, req.Action}
+		}
+		out := stackDTOResult{ServerID: id, Name: req.Name, Action: req.Action}
+		auditOp := func(ok bool) {
+			recordAudit(r.Context(), aud, audit.Entry{
+				Actor: auditActor, Action: audit.ActionStackOp, TargetType: audit.TargetServer, TargetID: id,
+				Detail: map[string]any{"name": req.Name, "action": req.Action, "ok": ok}, IP: clientIP(r),
+			})
+		}
+		cctx, cancel := context.WithTimeout(r.Context(), timeout)
+		defer cancel()
+		res, err := svc.Exec(cctx, id, cmd)
+		if err != nil {
+			if errors.Is(err, target.ErrNotFound) {
+				writeServerError(w, err)
+				return
+			}
+			if errors.Is(err, target.ErrCredentialNotFound) || errors.Is(err, target.ErrVaultUnconfigured) {
+				auditOp(false)
+				writeServerError(w, err)
+				return
+			}
+			out.OK = false
+			out.Error = humanServiceError(err)
+			auditOp(false)
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		if res.ExitCode != 0 {
+			msg := strings.TrimSpace(res.Stderr)
+			if msg == "" {
+				msg = "docker compose " + req.Action + " 以非零状态退出"
+			}
+			out.OK = false
+			out.Error = truncateLog(msg, 1024)
+		} else {
+			out.OK = true
+			out.Output = truncateLog(strings.TrimSpace(res.Stdout), 2048)
+		}
+		auditOp(out.OK)
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+// stackDeployRequest 是部署(贴 compose yaml → up -d)请求体。
+type stackDeployRequest struct {
+	Name    string `json:"name"`
+	Compose string `json:"compose"` // 完整 docker-compose.yml 文本
+}
+
+// makeStackDeployHandler 返回 POST /api/servers/{id}/stacks/deploy(认证 + CSRF;写)。
+// mkdir 受管目录 → Upload compose 文件 → `docker compose -p <name> -f <path> up -d`。
+func makeStackDeployHandler(svc target.Service, aud audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+		var req stackDeployRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		if !reDockerTgt.MatchString(req.Name) || len(req.Name) > 128 {
+			writeError(w, http.StatusBadRequest, "invalid_stack", "项目名非法(仅字母数字与 . _ -,不以 - 开头)")
+			return
+		}
+		compose := strings.TrimSpace(req.Compose)
+		if compose == "" {
+			writeError(w, http.StatusBadRequest, "invalid_stack", "compose 内容不能为空")
+			return
+		}
+		if len(compose) > composeMaxBytes {
+			writeError(w, http.StatusBadRequest, "invalid_stack", "compose 内容过大")
+			return
+		}
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeServerError(w, err)
+			return
+		}
+
+		// 受管目录:基址 + 项目名(name 正则已排除 `/` 与前导 `.`,无路径穿越)。
+		dir := stacksBaseDir + "/" + req.Name
+		composePath := dir + "/" + composeFileName
+		out := stackDTOResult{ServerID: id, Name: req.Name, Action: "deploy"}
+		auditOp := func(ok bool) {
+			recordAudit(r.Context(), aud, audit.Entry{
+				Actor: auditActor, Action: audit.ActionStackOp, TargetType: audit.TargetServer, TargetID: id,
+				Detail: map[string]any{"name": req.Name, "action": "deploy", "ok": ok}, IP: clientIP(r),
+			})
+		}
+
+		cctx, cancel := context.WithTimeout(r.Context(), stacksUpTimeout)
+		defer cancel()
+
+		// 1) 建目录。
+		if res, err := svc.Exec(cctx, id, []string{"mkdir", "-p", dir}); err != nil {
+			out.Error = humanServiceError(err)
+			auditOp(false)
+			writeJSON(w, http.StatusOK, out)
+			return
+		} else if res.ExitCode != 0 {
+			out.Error = "创建受管目录失败:" + truncateLog(strings.TrimSpace(res.Stderr), 256)
+			auditOp(false)
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		// 2) 写 compose 文件(字节流,非 shell)。
+		if err := svc.Upload(cctx, id, strings.NewReader(compose), composePath); err != nil {
+			out.Error = "写入 compose 文件失败:" + humanServiceError(err)
+			auditOp(false)
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		// 3) up -d。
+		res, err := svc.Exec(cctx, id, []string{"docker", "compose", "-p", req.Name, "-f", composePath, "up", "-d"})
+		if err != nil {
+			out.Error = humanServiceError(err)
+			auditOp(false)
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		if res.ExitCode != 0 {
+			msg := strings.TrimSpace(res.Stderr)
+			if msg == "" {
+				msg = "docker compose up 以非零状态退出"
+			}
+			out.OK = false
+			out.Error = truncateLog(msg, 1024)
+		} else {
+			out.OK = true
+			out.Output = truncateLog(strings.TrimSpace(res.Stdout)+"\n"+strings.TrimSpace(res.Stderr), 2048)
+		}
+		auditOp(out.OK)
+		writeJSON(w, http.StatusOK, out)
+	}
+}

--- a/internal/httpapi/server_stacks_test.go
+++ b/internal/httpapi/server_stacks_test.go
@@ -1,0 +1,63 @@
+package httpapi
+
+import "testing"
+
+func TestParseStacks_JSONArray(t *testing.T) {
+	out := `[{"Name":"web","Status":"running(2)","ConfigFiles":"/opt/pipewright/stacks/web/docker-compose.yml"},{"Name":"db","Status":"exited(1)","ConfigFiles":"/x/docker-compose.yml"}]`
+	got := parseStacks(out)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Name != "web" || got[0].Status != "running(2)" {
+		t.Fatalf("stack0 wrong: %+v", got[0])
+	}
+}
+
+func TestParseStacks_LineDelimitedFallback(t *testing.T) {
+	out := "{\"Name\":\"a\",\"Status\":\"running(1)\"}\n{\"Name\":\"b\",\"Status\":\"exited(0)\"}\n"
+	got := parseStacks(out)
+	if len(got) != 2 || got[1].Name != "b" {
+		t.Fatalf("fallback parse wrong: %+v", got)
+	}
+}
+
+func TestParseStacks_Empty(t *testing.T) {
+	if got := parseStacks("  \n"); len(got) != 0 {
+		t.Fatalf("want empty, got %+v", got)
+	}
+	if got := parseStacks("[]"); len(got) != 0 {
+		t.Fatalf("want empty for [], got %+v", got)
+	}
+}
+
+func TestStackActionWhitelist(t *testing.T) {
+	for _, a := range []string{"start", "stop", "restart", "down", "update"} {
+		if !stackActions[a] {
+			t.Fatalf("%q should be allowed", a)
+		}
+	}
+	for _, a := range []string{"up", "rm", "kill", "exec", ""} {
+		if stackActions[a] {
+			t.Fatalf("%q should NOT be allowed", a)
+		}
+	}
+}
+
+func TestComposeFileArgs(t *testing.T) {
+	// 单文件。
+	got, err := composeFileArgs("/opt/pipewright/stacks/x/docker-compose.yml")
+	if err != nil || len(got) != 2 || got[0] != "-f" || got[1] != "/opt/pipewright/stacks/x/docker-compose.yml" {
+		t.Fatalf("single = %v, err=%v", got, err)
+	}
+	// 多文件(逗号分隔)→ 多个 -f。
+	got, err = composeFileArgs("/a/docker-compose.yml,/a/override.yml")
+	if err != nil || len(got) != 4 {
+		t.Fatalf("multi = %v, err=%v", got, err)
+	}
+	// 非法:相对路径 / flag 注入 / 空。
+	for _, bad := range []string{"", "relative/path.yml", "-rf", "/a\nb.yml"} {
+		if _, err := composeFileArgs(bad); err == nil {
+			t.Fatalf("%q should be rejected", bad)
+		}
+	}
+}

--- a/internal/httpapi/server_volnet.go
+++ b/internal/httpapi/server_volnet.go
@@ -1,0 +1,263 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/audit"
+	"github.com/huangchengsir/pipewright/internal/target"
+)
+
+// 数据卷 + 网络管理(Portainer 式):列表 / 创建 / 删除。经 SSH 跑 docker,目标机零侵入。
+// AC-SEC-02:名称严格白名单(reDockerTgt:首字符非 `-`、无 shell 元字符),命令 array 化。
+// 列表只读;创建/删除写,过 CSRF + 审计。
+
+const volnetCmdTimeout = 15 * time.Second
+
+// ─── 数据卷 ───────────────────────────────────────────────────────────────────
+
+type volumeDTO struct {
+	Name   string `json:"name"`
+	Driver string `json:"driver"`
+}
+type serverVolumesDTO struct {
+	ServerID    string      `json:"serverId"`
+	Reachable   bool        `json:"reachable"`
+	Runtime     string      `json:"runtime"`
+	Error       string      `json:"error"`
+	Volumes     []volumeDTO `json:"volumes"`
+	CollectedAt string      `json:"collectedAt"`
+}
+type dockerVolumeLine struct {
+	Name   string `json:"Name"`
+	Driver string `json:"Driver"`
+}
+
+func parseVolumes(out string) []volumeDTO {
+	list := []volumeDTO{}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var p dockerVolumeLine
+		if json.Unmarshal([]byte(line), &p) == nil && p.Name != "" {
+			list = append(list, volumeDTO{Name: p.Name, Driver: p.Driver})
+		}
+	}
+	return list
+}
+
+func makeServerVolumesHandler(svc target.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeServerError(w, err)
+			return
+		}
+		out := serverVolumesDTO{ServerID: id, Volumes: []volumeDTO{}, CollectedAt: time.Now().UTC().Format(time.RFC3339)}
+		cctx, cancel := context.WithTimeout(r.Context(), volnetCmdTimeout)
+		defer cancel()
+		res, err := svc.Exec(cctx, id, []string{"docker", "volume", "ls", "--format", "{{json .}}"})
+		if err != nil {
+			out.Reachable = false
+			out.Error = humanContainersError(err)
+			if isLocateError(err) {
+				writeServerError(w, err)
+				return
+			}
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		out.Reachable = true
+		if res.ExitCode != 0 {
+			out.Error = "未检测到容器运行时(docker 未安装或当前用户无权限)"
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		out.Runtime = "docker"
+		out.Volumes = parseVolumes(res.Stdout)
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+// ─── 网络 ─────────────────────────────────────────────────────────────────────
+
+type networkDTO struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Driver string `json:"driver"`
+	Scope  string `json:"scope"`
+}
+type serverNetworksDTO struct {
+	ServerID    string       `json:"serverId"`
+	Reachable   bool         `json:"reachable"`
+	Runtime     string       `json:"runtime"`
+	Error       string       `json:"error"`
+	Networks    []networkDTO `json:"networks"`
+	CollectedAt string       `json:"collectedAt"`
+}
+type dockerNetworkLine struct {
+	ID     string `json:"ID"`
+	Name   string `json:"Name"`
+	Driver string `json:"Driver"`
+	Scope  string `json:"Scope"`
+}
+
+func parseNetworks(out string) []networkDTO {
+	list := []networkDTO{}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var p dockerNetworkLine
+		if json.Unmarshal([]byte(line), &p) == nil && p.Name != "" {
+			list = append(list, networkDTO{ID: p.ID, Name: p.Name, Driver: p.Driver, Scope: p.Scope})
+		}
+	}
+	return list
+}
+
+func makeServerNetworksHandler(svc target.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeServerError(w, err)
+			return
+		}
+		out := serverNetworksDTO{ServerID: id, Networks: []networkDTO{}, CollectedAt: time.Now().UTC().Format(time.RFC3339)}
+		cctx, cancel := context.WithTimeout(r.Context(), volnetCmdTimeout)
+		defer cancel()
+		res, err := svc.Exec(cctx, id, []string{"docker", "network", "ls", "--format", "{{json .}}"})
+		if err != nil {
+			out.Reachable = false
+			out.Error = humanContainersError(err)
+			if isLocateError(err) {
+				writeServerError(w, err)
+				return
+			}
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		out.Reachable = true
+		if res.ExitCode != 0 {
+			out.Error = "未检测到容器运行时(docker 未安装或当前用户无权限)"
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		out.Runtime = "docker"
+		out.Networks = parseNetworks(res.Stdout)
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+// ─── 写操作(创建/删除卷与网络)共用骨架 ────────────────────────────────────────
+
+type volnetActionRequest struct {
+	Name string `json:"name"`
+}
+type volnetActionDTO struct {
+	ServerID string `json:"serverId"`
+	Action   string `json:"action"`
+	Name     string `json:"name"`
+	OK       bool   `json:"ok"`
+	Error    string `json:"error"`
+}
+
+// volnetWriteHandler 抽出 volume/network 的 create/rm 共用骨架。
+func volnetWriteHandler(svc target.Service, aud audit.Recorder, auditAction, label string, build func(name string) []string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+		var req volnetActionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		if !reDockerTgt.MatchString(req.Name) || len(req.Name) > 128 {
+			writeError(w, http.StatusBadRequest, "invalid_name", "名称非法(仅字母数字与 . _ -,不以 - 开头)")
+			return
+		}
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeServerError(w, err)
+			return
+		}
+		out := volnetActionDTO{ServerID: id, Action: label, Name: req.Name}
+		auditOp := func(ok bool) {
+			recordAudit(r.Context(), aud, audit.Entry{
+				Actor: auditActor, Action: auditAction, TargetType: audit.TargetServer, TargetID: id,
+				Detail: map[string]any{"action": label, "name": req.Name, "ok": ok}, IP: clientIP(r),
+			})
+		}
+		cctx, cancel := context.WithTimeout(r.Context(), volnetCmdTimeout)
+		defer cancel()
+		res, err := svc.Exec(cctx, id, build(req.Name))
+		if err != nil {
+			if errors.Is(err, target.ErrNotFound) {
+				writeServerError(w, err)
+				return
+			}
+			if errors.Is(err, target.ErrCredentialNotFound) || errors.Is(err, target.ErrVaultUnconfigured) {
+				auditOp(false)
+				writeServerError(w, err)
+				return
+			}
+			out.OK = false
+			out.Error = humanServiceError(err)
+			auditOp(false)
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		if res.ExitCode != 0 {
+			msg := strings.TrimSpace(res.Stderr)
+			if msg == "" {
+				msg = "命令以非零状态退出"
+			}
+			out.OK = false
+			out.Error = truncateLog(msg, 1024)
+		} else {
+			out.OK = true
+		}
+		auditOp(out.OK)
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+func makeVolumeCreateHandler(svc target.Service, aud audit.Recorder) http.HandlerFunc {
+	return volnetWriteHandler(svc, aud, audit.ActionVolumeOp, "create", func(name string) []string {
+		return []string{"docker", "volume", "create", name}
+	})
+}
+func makeVolumeRemoveHandler(svc target.Service, aud audit.Recorder) http.HandlerFunc {
+	return volnetWriteHandler(svc, aud, audit.ActionVolumeOp, "rm", func(name string) []string {
+		return []string{"docker", "volume", "rm", name}
+	})
+}
+func makeNetworkCreateHandler(svc target.Service, aud audit.Recorder) http.HandlerFunc {
+	return volnetWriteHandler(svc, aud, audit.ActionNetworkOp, "create", func(name string) []string {
+		return []string{"docker", "network", "create", name}
+	})
+}
+func makeNetworkRemoveHandler(svc target.Service, aud audit.Recorder) http.HandlerFunc {
+	return volnetWriteHandler(svc, aud, audit.ActionNetworkOp, "rm", func(name string) []string {
+		return []string{"docker", "network", "rm", name}
+	})
+}

--- a/internal/httpapi/server_volnet.go
+++ b/internal/httpapi/server_volnet.go
@@ -165,6 +165,160 @@ func makeServerNetworksHandler(svc target.Service) http.HandlerFunc {
 	}
 }
 
+// ─── 网络详情:某网络上连着哪些容器 + 连接/断开 ─────────────────────────────────
+
+type netContainerDTO struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	IPv4 string `json:"ipv4"`
+}
+type networkContainersDTO struct {
+	ServerID   string            `json:"serverId"`
+	Network    string            `json:"network"`
+	Reachable  bool              `json:"reachable"`
+	Error      string            `json:"error"`
+	Containers []netContainerDTO `json:"containers"`
+}
+
+// docker network inspect 的 .Containers 是 map[容器ID]{Name,IPv4Address,...}。
+type inspectNetContainer struct {
+	Name        string `json:"Name"`
+	IPv4Address string `json:"IPv4Address"`
+}
+
+func parseNetworkContainers(out string) []netContainerDTO {
+	list := []netContainerDTO{}
+	out = strings.TrimSpace(out)
+	if out == "" || out == "null" {
+		return list
+	}
+	var m map[string]inspectNetContainer
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		return list
+	}
+	for id, c := range m {
+		short := id
+		if len(short) > 12 {
+			short = short[:12]
+		}
+		list = append(list, netContainerDTO{ID: short, Name: c.Name, IPv4: c.IPv4Address})
+	}
+	return list
+}
+
+// makeNetworkContainersHandler 返回 GET /api/servers/{id}/networks/{network}/containers(认证,只读)。
+func makeNetworkContainersHandler(svc target.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		network := chi.URLParam(r, "network")
+		if !reDockerTgt.MatchString(network) || len(network) > 128 {
+			writeError(w, http.StatusBadRequest, "invalid_name", "网络名非法")
+			return
+		}
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeServerError(w, err)
+			return
+		}
+		out := networkContainersDTO{ServerID: id, Network: network, Containers: []netContainerDTO{}}
+		cctx, cancel := context.WithTimeout(r.Context(), volnetCmdTimeout)
+		defer cancel()
+		res, err := svc.Exec(cctx, id, []string{"docker", "network", "inspect", network, "--format", "{{json .Containers}}"})
+		if err != nil {
+			out.Reachable = false
+			out.Error = humanContainersError(err)
+			if isLocateError(err) {
+				writeServerError(w, err)
+				return
+			}
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		out.Reachable = true
+		if res.ExitCode != 0 {
+			out.Error = "读取网络详情失败:" + truncateLog(strings.TrimSpace(res.Stderr), 256)
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		out.Containers = parseNetworkContainers(res.Stdout)
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+// netAttachRequest 是 connect/disconnect 请求体。
+type netAttachRequest struct {
+	Container string `json:"container"`
+}
+
+// makeNetworkConnectHandler / makeNetworkDisconnectHandler:把容器连到 / 移出某网络。
+func makeNetworkConnectHandler(svc target.Service, aud audit.Recorder) http.HandlerFunc {
+	return networkAttachHandler(svc, aud, "connect")
+}
+func makeNetworkDisconnectHandler(svc target.Service, aud audit.Recorder) http.HandlerFunc {
+	return networkAttachHandler(svc, aud, "disconnect")
+}
+
+func networkAttachHandler(svc target.Service, aud audit.Recorder, action string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		network := chi.URLParam(r, "network")
+		if !reDockerTgt.MatchString(network) || len(network) > 128 {
+			writeError(w, http.StatusBadRequest, "invalid_name", "网络名非法")
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+		var req netAttachRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		if !reDockerTgt.MatchString(req.Container) || len(req.Container) > 256 {
+			writeError(w, http.StatusBadRequest, "invalid_name", "容器名非法")
+			return
+		}
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeServerError(w, err)
+			return
+		}
+		out := volnetActionDTO{ServerID: id, Action: action, Name: network}
+		auditOp := func(ok bool) {
+			recordAudit(r.Context(), aud, audit.Entry{
+				Actor: auditActor, Action: audit.ActionNetworkOp, TargetType: audit.TargetServer, TargetID: id,
+				Detail: map[string]any{"action": action, "network": network, "container": req.Container, "ok": ok}, IP: clientIP(r),
+			})
+		}
+		cctx, cancel := context.WithTimeout(r.Context(), volnetCmdTimeout)
+		defer cancel()
+		res, err := svc.Exec(cctx, id, []string{"docker", "network", action, network, req.Container})
+		if err != nil {
+			if errors.Is(err, target.ErrNotFound) {
+				writeServerError(w, err)
+				return
+			}
+			out.OK = false
+			out.Error = humanServiceError(err)
+			auditOp(false)
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		if res.ExitCode != 0 {
+			out.OK = false
+			out.Error = truncateLog(strings.TrimSpace(res.Stderr), 1024)
+		} else {
+			out.OK = true
+		}
+		auditOp(out.OK)
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
 // ─── 写操作(创建/删除卷与网络)共用骨架 ────────────────────────────────────────
 
 type volnetActionRequest struct {

--- a/internal/httpapi/server_volnet_test.go
+++ b/internal/httpapi/server_volnet_test.go
@@ -13,6 +13,25 @@ func TestParseVolumes(t *testing.T) {
 	}
 }
 
+func TestParseNetworkContainers(t *testing.T) {
+	out := `{"abc123def456789":{"Name":"redis","IPv4Address":"172.18.0.2/16"},"ffff0001":{"Name":"web","IPv4Address":"172.18.0.3/16"}}`
+	got := parseNetworkContainers(out)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	byName := map[string]netContainerDTO{}
+	for _, c := range got {
+		byName[c.Name] = c
+	}
+	if byName["redis"].IPv4 != "172.18.0.2/16" || byName["redis"].ID != "abc123def456" {
+		t.Fatalf("redis wrong: %+v", byName["redis"])
+	}
+	// null / 空 → 空切片。
+	if len(parseNetworkContainers("null")) != 0 || len(parseNetworkContainers("")) != 0 {
+		t.Fatalf("null/empty should be empty")
+	}
+}
+
 func TestParseNetworks(t *testing.T) {
 	out := "{\"ID\":\"abc\",\"Name\":\"bridge\",\"Driver\":\"bridge\",\"Scope\":\"local\"}\n{\"ID\":\"def\",\"Name\":\"host\",\"Driver\":\"host\",\"Scope\":\"local\"}\n"
 	got := parseNetworks(out)

--- a/internal/httpapi/server_volnet_test.go
+++ b/internal/httpapi/server_volnet_test.go
@@ -1,0 +1,22 @@
+package httpapi
+
+import "testing"
+
+func TestParseVolumes(t *testing.T) {
+	out := "{\"Name\":\"new-api_pg_data\",\"Driver\":\"local\"}\n{\"Name\":\"cache\",\"Driver\":\"local\"}\n"
+	got := parseVolumes(out)
+	if len(got) != 2 || got[0].Name != "new-api_pg_data" || got[0].Driver != "local" {
+		t.Fatalf("parseVolumes wrong: %+v", got)
+	}
+	if len(parseVolumes("garbage\n")) != 0 {
+		t.Fatalf("garbage should yield empty")
+	}
+}
+
+func TestParseNetworks(t *testing.T) {
+	out := "{\"ID\":\"abc\",\"Name\":\"bridge\",\"Driver\":\"bridge\",\"Scope\":\"local\"}\n{\"ID\":\"def\",\"Name\":\"host\",\"Driver\":\"host\",\"Scope\":\"local\"}\n"
+	got := parseNetworks(out)
+	if len(got) != 2 || got[0].Name != "bridge" || got[1].Driver != "host" {
+		t.Fatalf("parseNetworks wrong: %+v", got)
+	}
+}

--- a/web/src/api/aiOps.ts
+++ b/web/src/api/aiOps.ts
@@ -72,3 +72,17 @@ export async function completeCommand(
 ): Promise<CompleteCommandResponse> {
   return http.post<CompleteCommandResponse>('/api/ai/complete', { partial, context }, { signal })
 }
+
+export interface GenerateComposeResponse {
+  /** false = AI 未配置。 */
+  available: boolean
+  /** 生成的 docker-compose.yml(纯 yaml,无围栏);失败/未配时为空。 */
+  yaml?: string
+  /** 降级原因(人读)。 */
+  reason?: string
+}
+
+/** 中文需求 → docker-compose.yml(容器管理「AI 生成 compose」)。 */
+export async function generateCompose(nl: string): Promise<GenerateComposeResponse> {
+  return http.post<GenerateComposeResponse>('/api/ai/compose', { nl })
+}

--- a/web/src/api/containers.ts
+++ b/web/src/api/containers.ts
@@ -159,3 +159,58 @@ export async function pullImage(id: string, image: string): Promise<ImageActionR
 export async function removeImage(id: string, image: string, force = false): Promise<ImageActionResult> {
   return http.post<ImageActionResult>(`/api/servers/${id}/images/remove`, { image, force })
 }
+
+// ─── Compose / Stacks ────────────────────────────────────────────────────────
+
+/** One compose project as reported by `docker compose ls`. */
+export interface StackInfo {
+  name: string
+  /** e.g. `running(2)` / `exited(1)`. */
+  status: string
+  /** Path(s) to the compose file(s). */
+  configFiles: string
+}
+
+export interface ServerStacks {
+  serverId: string
+  reachable: boolean
+  runtime: string
+  error: string
+  stacks: StackInfo[]
+  collectedAt: string
+}
+
+export type StackAction = 'start' | 'stop' | 'restart' | 'down' | 'update'
+
+export interface StackActionResult {
+  serverId: string
+  name: string
+  action: string
+  ok: boolean
+  output: string
+  error: string
+}
+
+/** List compose projects on a server (docker compose ls). */
+export async function getServerStacks(id: string): Promise<ServerStacks> {
+  return http.get<ServerStacks>(`/api/servers/${id}/stacks`)
+}
+
+/** Deploy a stack from compose yaml (docker compose up -d). */
+export async function deployStack(id: string, name: string, compose: string): Promise<StackActionResult> {
+  return http.post<StackActionResult>(`/api/servers/${id}/stacks/deploy`, { name, compose })
+}
+
+/**
+ * Act on an existing compose project (by project name).
+ * `update` re-applies the compose file with `up -d --pull always`(拉新镜像 + 重建 = 升级);
+ * it needs `configFile`(来自 stack 列表的 configFiles)。其余动作按项目标签操作,无需文件。
+ */
+export async function stackAction(
+  id: string,
+  name: string,
+  action: StackAction,
+  configFile?: string,
+): Promise<StackActionResult> {
+  return http.post<StackActionResult>(`/api/servers/${id}/stacks/action`, { name, action, configFile })
+}

--- a/web/src/api/containers.ts
+++ b/web/src/api/containers.ts
@@ -281,6 +281,33 @@ export interface ServerNetworks {
 export async function getServerNetworks(id: string): Promise<ServerNetworks> {
   return http.get<ServerNetworks>(`/api/servers/${id}/networks`)
 }
+
+/** One container attached to a network. */
+export interface NetworkContainer {
+  id: string
+  name: string
+  ipv4: string
+}
+export interface NetworkContainers {
+  serverId: string
+  network: string
+  reachable: boolean
+  error: string
+  containers: NetworkContainer[]
+}
+
+/** List which containers are attached to a given network (docker network inspect). */
+export async function getNetworkContainers(id: string, network: string): Promise<NetworkContainers> {
+  return http.get<NetworkContainers>(`/api/servers/${id}/networks/${encodeURIComponent(network)}/containers`)
+}
+/** Attach a container to a network (docker network connect). */
+export async function connectNetwork(id: string, network: string, container: string): Promise<VolNetActionResult> {
+  return http.post<VolNetActionResult>(`/api/servers/${id}/networks/${encodeURIComponent(network)}/connect`, { container })
+}
+/** Detach a container from a network (docker network disconnect). */
+export async function disconnectNetwork(id: string, network: string, container: string): Promise<VolNetActionResult> {
+  return http.post<VolNetActionResult>(`/api/servers/${id}/networks/${encodeURIComponent(network)}/disconnect`, { container })
+}
 export async function createNetwork(id: string, name: string): Promise<VolNetActionResult> {
   return http.post<VolNetActionResult>(`/api/servers/${id}/networks/create`, { name })
 }

--- a/web/src/api/containers.ts
+++ b/web/src/api/containers.ts
@@ -72,3 +72,43 @@ export async function getAllContainers(): Promise<ServerContainers[]> {
 export async function getServerContainers(id: string): Promise<ServerContainers> {
   return http.get<ServerContainers>(`/api/servers/${id}/containers`)
 }
+
+/** Restart policy for a new container (docker `--restart`). */
+export type RestartPolicy = 'no' | 'always' | 'unless-stopped' | 'on-failure'
+
+/**
+ * Spec for creating (and running) a new container — maps to `docker run -d`.
+ * Every field is strictly validated server-side (AC-SEC-02) and the command is
+ * built as an argv array, never a shell string.
+ */
+export interface CreateContainerInput {
+  /** Image reference, e.g. `nginx:latest`. Required. */
+  image: string
+  name?: string
+  /** Port mappings, e.g. `["8080:80", "127.0.0.1:9090:90/tcp"]`. */
+  ports?: string[]
+  /** Env vars as `KEY=VALUE`. */
+  env?: string[]
+  /** Volume mounts, e.g. `["/host:/ctr", "/host:/ctr:ro", "vol:/ctr"]`. */
+  volumes?: string[]
+  restart?: RestartPolicy
+  /** Optional container command; split on whitespace into args (no shell). */
+  command?: string
+}
+
+export interface CreateContainerResult {
+  serverId: string
+  ok: boolean
+  /** Full container ID on success. */
+  containerId: string
+  /** Human-readable error when ok is false. Never a secret. */
+  error: string
+}
+
+/** Create and run a new container on a server (docker run -d). */
+export async function createContainer(
+  serverId: string,
+  input: CreateContainerInput,
+): Promise<CreateContainerResult> {
+  return http.post<CreateContainerResult>(`/api/servers/${serverId}/containers`, input)
+}

--- a/web/src/api/containers.ts
+++ b/web/src/api/containers.ts
@@ -196,6 +196,39 @@ export async function getServerStacks(id: string): Promise<ServerStacks> {
   return http.get<ServerStacks>(`/api/servers/${id}/stacks`)
 }
 
+// ─── AI 诊断 / 看日志 ─────────────────────────────────────────────────────────
+
+export interface DiagnosisEvidence {
+  line: number
+  text: string
+  highlight: boolean
+}
+
+/** AI 容器诊断结果。status≠ready 时只有 reason 有意义。 */
+export interface ContainerDiagnosis {
+  status: 'ready' | 'unavailable' | 'pending'
+  reason: string
+  hypothesis: string
+  confidence: 'high' | 'medium' | 'low' | ''
+  alternateCauses: string[]
+  fixSuggestions: string[]
+  /** 可直接粘贴的修复脚本/补丁片段;空串表示模型未给。 */
+  fixScript: string
+  evidence: DiagnosisEvidence[]
+  generatedAt: string
+}
+
+/**
+ * 让 AI 分析/诊断一个容器:取其最近日志 → 根因假说 + 修复建议 + 修复脚本。
+ * AI 未配置 / 失败 → status=unavailable + reason(不报错)。
+ */
+export async function diagnoseContainer(serverId: string, name: string): Promise<ContainerDiagnosis> {
+  return http.post<ContainerDiagnosis>(
+    `/api/servers/${serverId}/containers/${encodeURIComponent(name)}/diagnose`,
+    {},
+  )
+}
+
 /** Deploy a stack from compose yaml (docker compose up -d). */
 export async function deployStack(id: string, name: string, compose: string): Promise<StackActionResult> {
   return http.post<StackActionResult>(`/api/servers/${id}/stacks/deploy`, { name, compose })

--- a/web/src/api/containers.ts
+++ b/web/src/api/containers.ts
@@ -1,0 +1,74 @@
+/**
+ * Container management API client.
+ *
+ * GET /api/servers/containers       → { items: ServerContainers[] }  (batch aggregate; read-only)
+ * GET /api/servers/:id/containers   → ServerContainers               (single host; read-only)
+ *
+ * Containers are collected over SSH by running `docker ps -a --format {{json .}}`
+ * on each registered host — the target machine stays agentless (no Docker API
+ * socket exposed). Per-host fault isolation: an unreachable host or a host with
+ * no container runtime never 500s and never affects the others.
+ *
+ * Container LIFECYCLE (start/stop/restart/pause/unpause/kill/rm) reuses the
+ * existing `serviceAction(id, { type: 'docker', ... })` endpoint in `servers.ts`
+ * — see ServiceAction there. Interactive container terminals reuse
+ * `openContainerTerminal` (WebSocket). Container logs reuse the server logs
+ * endpoint with `source: 'docker'`.
+ */
+
+import { http } from './http'
+
+/** One container as reported by `docker ps -a`. */
+export interface ContainerInfo {
+  /** Full container ID (the UI shortens it for display). */
+  id: string
+  /** Primary name (leading `/` already stripped). */
+  names: string
+  /** Image reference, e.g. `nginx:latest`. */
+  image: string
+  /** Normalised lifecycle state. */
+  state: ContainerState
+  /** Human status line, e.g. `Up 2 hours` / `Exited (0) 3 days ago`. */
+  status: string
+  /** Raw port-mapping string, e.g. `0.0.0.0:80->80/tcp`. */
+  ports: string
+  /** Raw creation timestamp from the runtime. */
+  createdAt: string
+}
+
+export type ContainerState =
+  | 'running'
+  | 'exited'
+  | 'paused'
+  | 'created'
+  | 'restarting'
+  | 'dead'
+  | 'unknown'
+
+/** Containers for one server, plus reachability + runtime detection. */
+export interface ServerContainers {
+  serverId: string
+  /** False when the host is unreachable / auth failed. */
+  reachable: boolean
+  /** Detected runtime (`docker`) or empty string when none was found. */
+  runtime: string
+  /** Human-readable error when reachable is false or no runtime was found. Never a secret. */
+  error: string
+  containers: ContainerInfo[]
+  /** Count of containers in the `running` state. */
+  running: number
+  /** Total containers (all states). */
+  total: number
+  collectedAt: string
+}
+
+/** Fetch the container inventory for every registered server (parallel, fault-isolated). */
+export async function getAllContainers(): Promise<ServerContainers[]> {
+  const res = await http.get<{ items: ServerContainers[] }>('/api/servers/containers')
+  return res.items ?? []
+}
+
+/** Fetch the container inventory for a single server. */
+export async function getServerContainers(id: string): Promise<ServerContainers> {
+  return http.get<ServerContainers>(`/api/servers/${id}/containers`)
+}

--- a/web/src/api/containers.ts
+++ b/web/src/api/containers.ts
@@ -229,6 +229,65 @@ export async function diagnoseContainer(serverId: string, name: string): Promise
   )
 }
 
+// ─── 数据卷 ───────────────────────────────────────────────────────────────────
+
+export interface VolumeInfo {
+  name: string
+  driver: string
+}
+export interface ServerVolumes {
+  serverId: string
+  reachable: boolean
+  runtime: string
+  error: string
+  volumes: VolumeInfo[]
+  collectedAt: string
+}
+export interface VolNetActionResult {
+  serverId: string
+  action: string
+  name: string
+  ok: boolean
+  error: string
+}
+
+export async function getServerVolumes(id: string): Promise<ServerVolumes> {
+  return http.get<ServerVolumes>(`/api/servers/${id}/volumes`)
+}
+export async function createVolume(id: string, name: string): Promise<VolNetActionResult> {
+  return http.post<VolNetActionResult>(`/api/servers/${id}/volumes/create`, { name })
+}
+export async function removeVolume(id: string, name: string): Promise<VolNetActionResult> {
+  return http.post<VolNetActionResult>(`/api/servers/${id}/volumes/remove`, { name })
+}
+
+// ─── 网络 ─────────────────────────────────────────────────────────────────────
+
+export interface NetworkInfo {
+  id: string
+  name: string
+  driver: string
+  scope: string
+}
+export interface ServerNetworks {
+  serverId: string
+  reachable: boolean
+  runtime: string
+  error: string
+  networks: NetworkInfo[]
+  collectedAt: string
+}
+
+export async function getServerNetworks(id: string): Promise<ServerNetworks> {
+  return http.get<ServerNetworks>(`/api/servers/${id}/networks`)
+}
+export async function createNetwork(id: string, name: string): Promise<VolNetActionResult> {
+  return http.post<VolNetActionResult>(`/api/servers/${id}/networks/create`, { name })
+}
+export async function removeNetwork(id: string, name: string): Promise<VolNetActionResult> {
+  return http.post<VolNetActionResult>(`/api/servers/${id}/networks/remove`, { name })
+}
+
 /** Deploy a stack from compose yaml (docker compose up -d). */
 export async function deployStack(id: string, name: string, compose: string): Promise<StackActionResult> {
   return http.post<StackActionResult>(`/api/servers/${id}/stacks/deploy`, { name, compose })

--- a/web/src/api/containers.ts
+++ b/web/src/api/containers.ts
@@ -333,3 +333,100 @@ export async function stackAction(
 ): Promise<StackActionResult> {
   return http.post<StackActionResult>(`/api/servers/${id}/stacks/action`, { name, action, configFile })
 }
+
+// ─── 容器实时资源 stats(A1)──────────────────────────────────────────────────
+
+/** 单容器实时资源样本(docker stats --no-stream;字符串为运行时已格式化的人读值)。 */
+export interface ContainerStat {
+  name: string
+  cpuPerc: string
+  memUsage: string
+  memPerc: string
+  netIO: string
+  blockIO: string
+}
+export interface ServerContainerStats {
+  serverId: string
+  reachable: boolean
+  runtime: string
+  error: string
+  stats: ContainerStat[]
+  collectedAt: string
+}
+/** 一次性拉取某服务器所有运行中容器的资源样本(只读;不可达/无运行时不 500)。 */
+export async function getServerContainerStats(id: string): Promise<ServerContainerStats> {
+  return http.get<ServerContainerStats>(`/api/servers/${id}/containers/stats`)
+}
+
+// ─── 容器详情 inspect(A2)─────────────────────────────────────────────────────
+
+export interface ContainerMount {
+  source: string
+  destination: string
+  mode: string
+  rw: boolean
+}
+export interface ContainerNetwork {
+  name: string
+  ipAddress: string
+}
+export interface ContainerPort {
+  containerPort: string
+  hostIp?: string
+  hostPort?: string
+}
+export interface ContainerInspect {
+  serverId: string
+  containerId: string
+  reachable: boolean
+  error?: string
+  image?: string
+  command?: string
+  createdAt?: string
+  state?: string
+  restartPolicy?: string
+  env: string[]
+  mounts: ContainerMount[]
+  networks: ContainerNetwork[]
+  ports: ContainerPort[]
+  labels: Record<string, string>
+}
+/** 拉取指定容器的 inspect 详情(containerId 后端白名单校验)。 */
+export function getContainerInspect(serverId: string, containerId: string): Promise<ContainerInspect> {
+  return http.get<ContainerInspect>(
+    `/api/servers/${encodeURIComponent(serverId)}/containers/${encodeURIComponent(containerId)}/inspect`,
+  )
+}
+
+// ─── 一键清理 system df / prune(A3)──────────────────────────────────────────
+
+export interface DfEntry {
+  type: string
+  totalCount: number
+  active: number
+  size: string
+  reclaimable: string
+}
+export interface SystemDf {
+  serverId: string
+  reachable: boolean
+  dockerAvailable: boolean
+  entries: DfEntry[]
+  error: string
+}
+export type PruneScope = 'containers' | 'images' | 'volumes' | 'builder' | 'all'
+export interface SystemPruneResult {
+  serverId: string
+  scope: PruneScope
+  ok: boolean
+  output: string
+  error: string
+}
+/** 某主机 Docker 磁盘占用(只读)。 */
+export async function getSystemDf(id: string): Promise<SystemDf> {
+  return http.get<SystemDf>(`/api/servers/${id}/system/df`)
+}
+/** 对某主机执行指定 scope 的 docker prune(写;过 CSRF)。 */
+export async function systemPrune(id: string, scope: PruneScope): Promise<SystemPruneResult> {
+  return http.post<SystemPruneResult>(`/api/servers/${id}/system/prune`, { scope })
+}

--- a/web/src/api/containers.ts
+++ b/web/src/api/containers.ts
@@ -112,3 +112,50 @@ export async function createContainer(
 ): Promise<CreateContainerResult> {
   return http.post<CreateContainerResult>(`/api/servers/${serverId}/containers`, input)
 }
+
+// ─── Images ──────────────────────────────────────────────────────────────────
+
+/** One image as reported by `docker images`. */
+export interface ImageInfo {
+  id: string
+  /** `<none>` for dangling images. */
+  repository: string
+  tag: string
+  /** Human-readable size, e.g. `142MB`. */
+  size: string
+  /** Human-readable age, e.g. `3 weeks ago`. */
+  createdSince: string
+}
+
+export interface ServerImages {
+  serverId: string
+  reachable: boolean
+  runtime: string
+  error: string
+  images: ImageInfo[]
+  collectedAt: string
+}
+
+export interface ImageActionResult {
+  serverId: string
+  action: string
+  image: string
+  ok: boolean
+  output: string
+  error: string
+}
+
+/** List images on a server (docker images). */
+export async function getServerImages(id: string): Promise<ServerImages> {
+  return http.get<ServerImages>(`/api/servers/${id}/images`)
+}
+
+/** Pull an image onto a server (docker pull). */
+export async function pullImage(id: string, image: string): Promise<ImageActionResult> {
+  return http.post<ImageActionResult>(`/api/servers/${id}/images/pull`, { image })
+}
+
+/** Remove an image from a server (docker rmi). */
+export async function removeImage(id: string, image: string, force = false): Promise<ImageActionResult> {
+  return http.post<ImageActionResult>(`/api/servers/${id}/images/remove`, { image, force })
+}

--- a/web/src/api/servers.ts
+++ b/web/src/api/servers.ts
@@ -291,8 +291,21 @@ export async function getAllServerMetrics(): Promise<ServerMetrics[]> {
 /** Service kind the operation targets. */
 export type ServiceType = 'systemd' | 'docker'
 
-/** Lifecycle operation. Destructive (restart/stop) — UI should confirm. */
-export type ServiceAction = 'restart' | 'stop' | 'start'
+/**
+ * Lifecycle operation. Destructive (restart/stop/kill/rm) — UI should confirm.
+ *
+ * systemd accepts only restart/stop/start; docker additionally accepts
+ * pause/unpause/kill/rm (container management). The server enforces the
+ * per-type whitelist — this widened union is shared by both kinds.
+ */
+export type ServiceAction =
+  | 'restart'
+  | 'stop'
+  | 'start'
+  | 'pause'
+  | 'unpause'
+  | 'kill'
+  | 'rm'
 
 export interface ServiceActionInput {
   type: ServiceType

--- a/web/src/components/ops/AiDiagnosisModal.vue
+++ b/web/src/components/ops/AiDiagnosisModal.vue
@@ -130,7 +130,7 @@ void run()
 .modal-scrim {
   position: fixed;
   inset: 0;
-  z-index: 60;
+  z-index: 500;
   background: oklch(0% 0 0 / 0.45);
   display: flex;
   align-items: center;

--- a/web/src/components/ops/AiDiagnosisModal.vue
+++ b/web/src/components/ops/AiDiagnosisModal.vue
@@ -1,0 +1,352 @@
+<script setup lang="ts">
+/*
+  AiDiagnosisModal.vue — 容器 AI 诊断 / 看日志。取容器最近日志 → ai.Diagnose,
+  展示根因假说 + 置信度 + 修复建议 + 可粘贴修复脚本 + 证据行。AI 未配/失败优雅降级。
+*/
+import { ref } from 'vue'
+import { diagnoseContainer, type ContainerDiagnosis } from '../../api/containers'
+import { HttpError } from '../../api/http'
+import { useToast } from '../../composables/useToast'
+
+const props = defineProps<{ serverId: string; containerName: string }>()
+const emit = defineEmits<{ (e: 'close'): void }>()
+
+const toast = useToast()
+const state = ref<'loading' | 'done' | 'error'>('loading')
+const errorMsg = ref('')
+const diag = ref<ContainerDiagnosis | null>(null)
+
+const CONFIDENCE_LABEL: Record<string, string> = { high: '高', medium: '中', low: '低', '': '' }
+
+async function run(): Promise<void> {
+  state.value = 'loading'
+  errorMsg.value = ''
+  try {
+    diag.value = await diagnoseContainer(props.serverId, props.containerName)
+    state.value = 'done'
+  } catch (err) {
+    state.value = 'error'
+    errorMsg.value =
+      err instanceof HttpError ? (err.apiError?.message ?? `诊断失败(${err.status})`) : '诊断请求失败'
+  }
+}
+
+async function copyScript(): Promise<void> {
+  if (!diag.value?.fixScript) return
+  try {
+    await navigator.clipboard.writeText(diag.value.fixScript)
+    toast.success('修复脚本已复制')
+  } catch {
+    toast.error('复制失败', { detail: '需 https/localhost' })
+  }
+}
+
+void run()
+</script>
+
+<template>
+  <div class="modal-scrim" @click.self="emit('close')">
+    <div class="modal" role="dialog" aria-label="AI 容器诊断">
+      <header class="modal__head">
+        <h3 class="modal__title">
+          <span class="ai-spark">✦</span> AI 诊断 · <span class="mono">{{ containerName }}</span>
+        </h3>
+        <button class="modal__close" aria-label="关闭" @click="emit('close')">✕</button>
+      </header>
+
+      <div class="modal__body">
+        <!-- 加载中 -->
+        <div v-if="state === 'loading'" class="center">
+          <span class="spinner" /> 正在取日志并让 AI 分析…
+        </div>
+
+        <!-- 请求错误 -->
+        <div v-else-if="state === 'error'" class="center err">⚠ {{ errorMsg }}</div>
+
+        <!-- AI 未配 / 不可用 -->
+        <div v-else-if="diag && diag.status !== 'ready'" class="unavail">
+          <p class="unavail__t">诊断暂不可用</p>
+          <p class="unavail__r">{{ diag.reason }}</p>
+        </div>
+
+        <!-- 诊断结果 -->
+        <template v-else-if="diag">
+          <section class="block">
+            <div class="block__h">
+              根因假说
+              <span v-if="diag.confidence" class="conf" :class="`conf--${diag.confidence}`">
+                置信度 {{ CONFIDENCE_LABEL[diag.confidence] }}
+              </span>
+            </div>
+            <p class="hyp">{{ diag.hypothesis }}</p>
+          </section>
+
+          <section v-if="diag.fixSuggestions.length" class="block">
+            <div class="block__h">修复建议</div>
+            <ul class="fixlist">
+              <li v-for="(f, i) in diag.fixSuggestions" :key="i">{{ f }}</li>
+            </ul>
+          </section>
+
+          <section v-if="diag.fixScript" class="block">
+            <div class="block__h">
+              修复脚本
+              <button class="copy" @click="copyScript">复制</button>
+            </div>
+            <pre class="script mono">{{ diag.fixScript }}</pre>
+          </section>
+
+          <section v-if="diag.alternateCauses.length" class="block">
+            <div class="block__h">其它可能原因</div>
+            <ul class="fixlist fixlist--dim">
+              <li v-for="(c, i) in diag.alternateCauses" :key="i">{{ c }}</li>
+            </ul>
+          </section>
+
+          <section v-if="diag.evidence.length" class="block">
+            <div class="block__h">日志证据</div>
+            <pre class="evidence mono"><span
+              v-for="(e, i) in diag.evidence"
+              :key="i"
+              class="evline"
+              :class="{ 'evline--hl': e.highlight }"
+            >{{ e.text }}
+</span></pre>
+          </section>
+        </template>
+      </div>
+
+      <footer class="modal__foot">
+        <span class="foot-hint">日志出网前已脱敏 · AI 仅供参考</span>
+        <span class="grow" />
+        <button class="btn btn--ghost" @click="run">重新诊断</button>
+        <button class="btn btn--primary" @click="emit('close')">关闭</button>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.modal-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: oklch(0% 0 0 / 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+.modal {
+  width: min(640px, 96vw);
+  max-height: 88vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-card);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded-lg, 12px);
+  box-shadow: var(--shadow-modal);
+}
+.modal__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--color-border);
+}
+.modal__title {
+  margin: 0;
+  font-size: var(--text-section);
+  font-weight: 700;
+  color: var(--color-text);
+}
+.ai-spark {
+  color: var(--color-primary);
+}
+.modal__close {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-dim);
+  cursor: pointer;
+}
+.modal__close:hover {
+  color: var(--color-text);
+  border-color: var(--color-text);
+}
+.modal__body {
+  padding: 18px 20px;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.center {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  justify-content: center;
+  padding: 36px 0;
+  color: var(--color-dim);
+  font-size: var(--text-label);
+}
+.center.err {
+  color: var(--color-red);
+}
+.spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--color-border-strong);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+.unavail {
+  padding: 24px 4px;
+}
+.unavail__t {
+  margin: 0 0 6px;
+  font-weight: 700;
+  color: var(--color-amber);
+}
+.unavail__r {
+  margin: 0;
+  color: var(--color-dim);
+  font-size: var(--text-label);
+}
+
+.block {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.block__h {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: var(--text-caps);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-faint);
+  font-weight: 700;
+}
+.conf {
+  font-size: var(--text-micro);
+  font-weight: 600;
+  padding: 1px 8px;
+  border-radius: 999px;
+  text-transform: none;
+  letter-spacing: 0;
+}
+.conf--high { color: var(--color-green); background: var(--color-green-soft); }
+.conf--medium { color: var(--color-amber); background: var(--color-amber-soft); }
+.conf--low { color: var(--color-faint); background: var(--color-inset); }
+.hyp {
+  margin: 0;
+  font-size: var(--text-body);
+  line-height: 1.6;
+  color: var(--color-text);
+}
+.fixlist {
+  margin: 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: var(--text-label);
+  color: var(--color-text);
+  line-height: 1.55;
+}
+.fixlist--dim {
+  color: var(--color-dim);
+}
+.copy {
+  font-size: var(--text-micro);
+  padding: 2px 9px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-border-strong);
+  background: transparent;
+  color: var(--color-dim);
+  cursor: pointer;
+  text-transform: none;
+  letter-spacing: 0;
+}
+.copy:hover {
+  color: var(--color-text);
+  border-color: var(--color-text);
+}
+.script {
+  margin: 0;
+  padding: 12px 14px;
+  background: var(--color-term);
+  color: oklch(88% 0.06 150);
+  border-radius: var(--rounded-sm);
+  font-size: var(--text-mono);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.evidence {
+  margin: 0;
+  padding: 10px 12px;
+  background: var(--color-term);
+  border-radius: var(--rounded-sm);
+  font-size: var(--text-mono);
+  line-height: 1.5;
+  color: oklch(72% 0.01 250);
+  max-height: 220px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.evline {
+  display: block;
+}
+.evline--hl {
+  color: var(--color-amber);
+  background: var(--color-amber-soft);
+}
+.modal__foot {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 20px;
+  border-top: 1px solid var(--color-border);
+}
+.foot-hint {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+}
+.grow {
+  flex: 1;
+}
+.btn {
+  font-size: var(--text-label);
+  font-weight: 600;
+  padding: 8px 16px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+.btn--ghost {
+  background: transparent;
+  border-color: var(--color-border-strong);
+  color: var(--color-dim);
+}
+.btn--ghost:hover {
+  color: var(--color-text);
+  border-color: var(--color-text);
+}
+.btn--primary {
+  background: var(--color-primary);
+  color: #fff;
+}
+.btn--primary:hover {
+  background: var(--color-primary-press);
+}
+</style>

--- a/web/src/components/ops/AiOpsPanel.vue
+++ b/web/src/components/ops/AiOpsPanel.vue
@@ -9,7 +9,7 @@
   设计照 demos/ai-terminal-demo.html:cyan=智能、命令卡左色条按风险、对话气泡、入场动画。
 -->
 <script setup lang="ts">
-import { ref, nextTick, useTemplateRef } from 'vue'
+import { ref, computed, nextTick, useTemplateRef } from 'vue'
 import { useRouter } from 'vue-router'
 import {
   suggestCommand,
@@ -21,6 +21,8 @@ import {
 const props = defineProps<{
   /** 终端会话上下文(container/shell/os),随命令一起发给 AI。 */
   context: CommandContext
+  /** 快捷提示词(默认通用运维;调用方可传领域专属,如容器管理)。 */
+  chips?: string[]
 }>()
 
 const emit = defineEmits<{
@@ -63,13 +65,14 @@ async function scrollToEnd(): Promise<void> {
   if (el) el.scrollTop = el.scrollHeight
 }
 
-const CHIPS = [
+const DEFAULT_CHIPS = [
   '磁盘占用 top 10',
   '8080 端口被谁占',
   '实时跟踪应用日志',
   '看 CPU 飙升原因',
   '清理 7 天前的日志',
 ]
+const CHIPS = computed(() => (props.chips && props.chips.length ? props.chips : DEFAULT_CHIPS))
 
 const riskLabel: Record<CommandRisk, string> = {
   safe: '● 只读 · 安全',

--- a/web/src/components/ops/ContainerAiPanel.vue
+++ b/web/src/components/ops/ContainerAiPanel.vue
@@ -13,6 +13,16 @@ const emit = defineEmits<{ (e: 'close'): void }>()
 
 const toast = useToast()
 
+// 容器/镜像/compose 导向的快捷提示(区别于终端那套通用运维提示)。
+const CONTAINER_CHIPS = [
+  '看所有容器的内存和 CPU 占用',
+  '清理无用镜像、停止的容器和悬空卷',
+  '把某容器的日志导出到文件',
+  '限制某容器内存为 512M',
+  '查看某容器的端口映射和挂载',
+  '列出占空间最大的镜像',
+]
+
 async function copyCommand(command: string): Promise<void> {
   try {
     await navigator.clipboard.writeText(command)
@@ -30,10 +40,11 @@ async function copyCommand(command: string): Promise<void> {
         <span class="ai-title"><span class="spark">✦</span> AI 助手</span>
         <button class="ai-close" aria-label="关闭" @click="emit('close')">✕</button>
       </header>
-      <p class="ai-sub">用中文描述运维意图,AI 给出命令(带风险分级)。命令复制后到服务器终端执行。</p>
+      <p class="ai-sub">围绕容器 / 镜像 / compose 描述意图,AI 给出 docker 命令(带风险分级)。命令复制后到服务器终端执行。</p>
       <div class="ai-body">
         <AiOpsPanel
           :context="context"
+          :chips="CONTAINER_CHIPS"
           @insert="copyCommand"
           @execute="copyCommand"
           @collapse="emit('close')"
@@ -47,7 +58,7 @@ async function copyCommand(command: string): Promise<void> {
 .ai-scrim {
   position: fixed;
   inset: 0;
-  z-index: 60;
+  z-index: 500;
   background: oklch(0% 0 0 / 0.42);
   display: flex;
   justify-content: flex-end;

--- a/web/src/components/ops/ContainerAiPanel.vue
+++ b/web/src/components/ops/ContainerAiPanel.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+/*
+  ContainerAiPanel.vue — 容器页 AI 助手抽屉。复用运维终端那套 AiOpsPanel(中文描述 →
+  命令卡 + 确定性风险分级 + 解释)。本页无 PTY,故 insert/execute 映射为「复制命令」,
+  用户可去任一服务器终端粘贴执行。
+*/
+import AiOpsPanel from './AiOpsPanel.vue'
+import type { CommandContext } from '../../api/aiOps'
+import { useToast } from '../../composables/useToast'
+
+defineProps<{ context: CommandContext }>()
+const emit = defineEmits<{ (e: 'close'): void }>()
+
+const toast = useToast()
+
+async function copyCommand(command: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(command)
+    toast.success('命令已复制', { detail: '到任一服务器终端粘贴执行' })
+  } catch {
+    toast.error('复制失败', { detail: '需 https/localhost' })
+  }
+}
+</script>
+
+<template>
+  <div class="ai-scrim" @click.self="emit('close')">
+    <aside class="ai-drawer" role="dialog" aria-label="容器 AI 助手">
+      <header class="ai-head">
+        <span class="ai-title"><span class="spark">✦</span> AI 助手</span>
+        <button class="ai-close" aria-label="关闭" @click="emit('close')">✕</button>
+      </header>
+      <p class="ai-sub">用中文描述运维意图,AI 给出命令(带风险分级)。命令复制后到服务器终端执行。</p>
+      <div class="ai-body">
+        <AiOpsPanel
+          :context="context"
+          @insert="copyCommand"
+          @execute="copyCommand"
+          @collapse="emit('close')"
+        />
+      </div>
+    </aside>
+  </div>
+</template>
+
+<style scoped>
+.ai-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: oklch(0% 0 0 / 0.42);
+  display: flex;
+  justify-content: flex-end;
+  animation: scrimIn var(--duration-fast) var(--ease-out-expo);
+}
+@keyframes scrimIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.ai-drawer {
+  width: min(460px, 94vw);
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-card);
+  border-left: 1px solid var(--color-border-strong);
+  box-shadow: var(--shadow-modal);
+  animation: drawerIn var(--duration-normal) var(--ease-out-expo);
+}
+@keyframes drawerIn {
+  from { transform: translateX(24px); opacity: 0.4; }
+  to { transform: translateX(0); opacity: 1; }
+}
+.ai-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px 10px;
+}
+.ai-title {
+  font-size: var(--text-section);
+  font-weight: 700;
+  color: var(--color-text);
+}
+.spark {
+  color: var(--color-primary);
+}
+.ai-close {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-dim);
+  cursor: pointer;
+}
+.ai-close:hover {
+  color: var(--color-text);
+  border-color: var(--color-text);
+}
+.ai-sub {
+  margin: 0;
+  padding: 0 18px 12px;
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  border-bottom: 1px solid var(--color-border);
+}
+.ai-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+</style>

--- a/web/src/components/ops/ContainerInspectModal.vue
+++ b/web/src/components/ops/ContainerInspectModal.vue
@@ -1,0 +1,464 @@
+<!--
+  ContainerInspectModal.vue — 容器详情(inspect)弹窗
+
+  挂载即拉 GET /api/servers/{id}/containers/{name}/inspect,分区展示容器精选元信息:
+    · 基本信息(镜像 / 命令 / 状态 / 重启策略 / 创建时间)
+    · 环境变量(等宽字体列表 —— 值可能含密钥,仅展示给已登录管理员,不复制到剪贴板按钮)
+    · 挂载 / 网络 / 端口 / 标签
+
+  优雅降级:加载中骨架;请求层失败(404/503 等)→ 错误条;后端 reachable:false(容器不存在/
+  连接失败)→ 人读 error 条而非崩溃。scrim z-index 500(盖住主题切换按钮,与现有弹窗一致)。
+-->
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { getContainerInspect, type ContainerInspect } from '../../api/containers'
+import { HttpError } from '../../api/http'
+
+const props = defineProps<{
+  serverId: string
+  containerName: string
+}>()
+
+const emit = defineEmits<{ (e: 'close'): void }>()
+
+const loading = ref(true)
+/** 请求层错误(网络/404/503 等);与后端 reachable:false 区分。 */
+const requestError = ref('')
+const data = ref<ContainerInspect | null>(null)
+
+async function load(): Promise<void> {
+  loading.value = true
+  requestError.value = ''
+  data.value = null
+  try {
+    data.value = await getContainerInspect(props.serverId, props.containerName)
+  } catch (e) {
+    requestError.value =
+      e instanceof HttpError ? e.message || '加载容器详情失败' : '加载容器详情失败'
+  } finally {
+    loading.value = false
+  }
+}
+
+function onKeydown(e: KeyboardEvent): void {
+  if (e.key === 'Escape') emit('close')
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', onKeydown)
+  void load()
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeydown)
+})
+
+/** 端口的可读表示:发布 → host:port → container;未发布 → 仅容器端口。 */
+function portLabel(p: ContainerInspect['ports'][number]): string {
+  if (p.hostPort) {
+    const host = p.hostIp ? `${p.hostIp}:${p.hostPort}` : p.hostPort
+    return `${host} → ${p.containerPort}`
+  }
+  return `${p.containerPort}(未发布)`
+}
+</script>
+
+<template>
+  <div class="ci-backdrop" @click.self="emit('close')">
+    <div class="ci-modal" role="dialog" aria-modal="true" aria-labelledby="ci-title">
+      <header class="ci-head">
+        <div class="ci-head-text">
+          <h3 id="ci-title" class="ci-title">容器详情</h3>
+          <span class="ci-sub mono">{{ containerName }}</span>
+        </div>
+        <button type="button" class="ci-close" aria-label="关闭" @click="emit('close')">×</button>
+      </header>
+
+      <div class="ci-body">
+        <!-- 加载中 -->
+        <div v-if="loading" class="ci-loading">
+          <span class="ci-spinner" aria-hidden="true"></span>
+          正在读取容器信息…
+        </div>
+
+        <!-- 请求层错误 -->
+        <div v-else-if="requestError" class="ci-banner ci-banner--error" role="alert">
+          {{ requestError }}
+        </div>
+
+        <!-- 后端可达但 inspect 失败 / 容器不存在 -->
+        <div
+          v-else-if="data && !data.reachable"
+          class="ci-banner ci-banner--warn"
+          role="alert"
+        >
+          {{ data.error || '无法获取容器详情' }}
+        </div>
+
+        <!-- 正常详情 -->
+        <template v-else-if="data">
+          <!-- 基本信息 -->
+          <section class="ci-section">
+            <h4 class="ci-section-title">基本信息</h4>
+            <dl class="ci-kv">
+              <dt>镜像</dt>
+              <dd class="mono">{{ data.image || '—' }}</dd>
+              <dt>命令</dt>
+              <dd class="mono">{{ data.command || '—' }}</dd>
+              <dt>状态</dt>
+              <dd>
+                <span class="ci-state" :class="`ci-state--${data.state || 'unknown'}`">{{
+                  data.state || '未知'
+                }}</span>
+              </dd>
+              <dt>重启策略</dt>
+              <dd class="mono">{{ data.restartPolicy || '—' }}</dd>
+              <dt>创建时间</dt>
+              <dd class="mono">{{ data.createdAt || '—' }}</dd>
+            </dl>
+          </section>
+
+          <!-- 环境变量 -->
+          <section class="ci-section">
+            <h4 class="ci-section-title">
+              环境变量
+              <span class="ci-count">{{ data.env.length }}</span>
+            </h4>
+            <ul v-if="data.env.length" class="ci-list mono">
+              <li v-for="(e, i) in data.env" :key="i" class="ci-list-item">{{ e }}</li>
+            </ul>
+            <p v-else class="ci-empty">无环境变量</p>
+          </section>
+
+          <!-- 挂载 -->
+          <section class="ci-section">
+            <h4 class="ci-section-title">
+              挂载
+              <span class="ci-count">{{ data.mounts.length }}</span>
+            </h4>
+            <ul v-if="data.mounts.length" class="ci-list mono">
+              <li v-for="(m, i) in data.mounts" :key="i" class="ci-list-item ci-mount">
+                <span class="ci-mount-path">{{ m.source }} → {{ m.destination }}</span>
+                <span class="ci-tag">{{ m.rw ? 'rw' : 'ro' }}{{ m.mode ? `,${m.mode}` : '' }}</span>
+              </li>
+            </ul>
+            <p v-else class="ci-empty">无挂载</p>
+          </section>
+
+          <!-- 网络 -->
+          <section class="ci-section">
+            <h4 class="ci-section-title">
+              网络
+              <span class="ci-count">{{ data.networks.length }}</span>
+            </h4>
+            <ul v-if="data.networks.length" class="ci-list mono">
+              <li v-for="(n, i) in data.networks" :key="i" class="ci-list-item ci-mount">
+                <span class="ci-mount-path">{{ n.name }}</span>
+                <span class="ci-tag">{{ n.ipAddress || '无 IP' }}</span>
+              </li>
+            </ul>
+            <p v-else class="ci-empty">无网络</p>
+          </section>
+
+          <!-- 端口 -->
+          <section class="ci-section">
+            <h4 class="ci-section-title">
+              端口
+              <span class="ci-count">{{ data.ports.length }}</span>
+            </h4>
+            <ul v-if="data.ports.length" class="ci-list mono">
+              <li v-for="(p, i) in data.ports" :key="i" class="ci-list-item">{{ portLabel(p) }}</li>
+            </ul>
+            <p v-else class="ci-empty">无端口映射</p>
+          </section>
+
+          <!-- 标签 -->
+          <section class="ci-section">
+            <h4 class="ci-section-title">
+              标签
+              <span class="ci-count">{{ Object.keys(data.labels).length }}</span>
+            </h4>
+            <ul v-if="Object.keys(data.labels).length" class="ci-list mono">
+              <li
+                v-for="(val, key) in data.labels"
+                :key="key"
+                class="ci-list-item ci-mount"
+              >
+                <span class="ci-mount-path">{{ key }}</span>
+                <span class="ci-tag ci-tag--label">{{ val }}</span>
+              </li>
+            </ul>
+            <p v-else class="ci-empty">无标签</p>
+          </section>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.ci-backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.55);
+  z-index: 500;
+  padding: 24px;
+}
+
+.ci-modal {
+  width: min(680px, 100%);
+  max-height: min(82vh, 880px);
+  display: flex;
+  flex-direction: column;
+  background: var(--color-surface, #fff);
+  color: var(--color-text, #111827);
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 14px;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
+  overflow: hidden;
+}
+
+.ci-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 18px 20px;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+
+.ci-head-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.ci-title {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 650;
+}
+
+.ci-sub {
+  font-size: 13px;
+  color: var(--color-text-muted, #6b7280);
+  word-break: break-all;
+}
+
+.ci-close {
+  flex: none;
+  width: 30px;
+  height: 30px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--color-text-muted, #6b7280);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.ci-close:hover {
+  background: var(--color-inset, #f3f4f6);
+  color: var(--color-text, #111827);
+}
+
+.ci-close:focus-visible {
+  outline: 2px solid var(--color-accent, #4f46e5);
+  outline-offset: 1px;
+}
+
+.ci-body {
+  padding: 16px 20px 20px;
+  overflow-y: auto;
+}
+
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+/* ─── 加载 / 错误 ──────────────────────────────────────────────────────────── */
+.ci-loading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 24px 4px;
+  font-size: 14px;
+  color: var(--color-text-muted, #6b7280);
+}
+
+.ci-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--color-border, #d1d5db);
+  border-top-color: var(--color-accent, #4f46e5);
+  border-radius: 50%;
+  animation: ci-spin 700ms linear infinite;
+}
+
+@keyframes ci-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.ci-banner {
+  padding: 12px 14px;
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.ci-banner--error {
+  background: var(--color-danger-soft, #fef2f2);
+  color: var(--color-danger, #991b1b);
+  border: 1px solid var(--color-red-line, #fecaca);
+}
+
+.ci-banner--warn {
+  background: var(--color-amber-soft, #fffbeb);
+  color: var(--color-warn, #92400e);
+  border: 1px solid var(--color-amber-line, #fde68a);
+}
+
+/* ─── 分区 ────────────────────────────────────────────────────────────────── */
+.ci-section + .ci-section {
+  margin-top: 18px;
+}
+
+.ci-section-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 8px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-muted, #6b7280);
+}
+
+.ci-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: var(--color-inset, #f3f4f6);
+  color: var(--color-text-muted, #6b7280);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.ci-kv {
+  display: grid;
+  grid-template-columns: 88px 1fr;
+  gap: 6px 14px;
+  margin: 0;
+  font-size: 13px;
+}
+
+.ci-kv dt {
+  color: var(--color-text-muted, #6b7280);
+}
+
+.ci-kv dd {
+  margin: 0;
+  word-break: break-word;
+}
+
+.ci-state {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  background: var(--color-inset, #f3f4f6);
+  color: var(--color-text, #374151);
+}
+
+.ci-state--running {
+  background: var(--color-green-soft, #dcfce7);
+  color: var(--color-green, #15803d);
+}
+
+.ci-state--exited,
+.ci-state--dead {
+  background: var(--color-red-soft, #fee2e2);
+  color: var(--color-red, #b91c1c);
+}
+
+.ci-state--paused,
+.ci-state--restarting {
+  background: var(--color-amber-soft, #fef3c7);
+  color: var(--color-warn, #b45309);
+}
+
+.ci-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 8px 10px;
+  list-style: none;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 8px;
+  background: var(--color-code-bg, #f8fafc);
+}
+
+.ci-list-item {
+  font-size: 12.5px;
+  line-height: 1.5;
+  word-break: break-all;
+}
+
+.ci-mount {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.ci-mount-path {
+  min-width: 0;
+  word-break: break-all;
+}
+
+.ci-tag {
+  flex: none;
+  padding: 1px 6px;
+  border-radius: 5px;
+  font-size: 11px;
+  background: var(--color-inset, #eef2f7);
+  color: var(--color-text-muted, #6b7280);
+}
+
+.ci-tag--label {
+  max-width: 55%;
+  word-break: break-all;
+}
+
+.ci-empty {
+  margin: 0;
+  padding: 8px 2px;
+  font-size: 13px;
+  color: var(--color-text-muted, #9ca3af);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ci-spinner {
+    animation-duration: 1600ms;
+  }
+  .ci-close {
+    transition: none;
+  }
+}
+</style>

--- a/web/src/components/ops/ContainerLogsDrawer.vue
+++ b/web/src/components/ops/ContainerLogsDrawer.vue
@@ -1,0 +1,353 @@
+<script setup lang="ts">
+/*
+  ContainerLogsDrawer.vue — 容器日志抽屉(Portainer 式)。
+  复用既有 /api/servers/:id/logs(source=docker)历史拉取 + SSE 实时 tail。
+  右侧滑入,顶栏显示容器名/短 ID,可切 tail 行数、开/停实时跟随、复制、清屏。
+*/
+import { ref, watch, nextTick, onBeforeUnmount } from 'vue'
+import { getServerLogs, subscribeServerLogs } from '../../api/servers'
+import { HttpError } from '../../api/http'
+import { useToast } from '../../composables/useToast'
+
+const props = defineProps<{
+  serverId: string
+  containerName: string
+  containerId?: string
+}>()
+const emit = defineEmits<{ (e: 'close'): void }>()
+
+const toast = useToast()
+
+type ViewState = 'idle' | 'loading' | 'loaded' | 'streaming' | 'error'
+const viewState = ref<ViewState>('idle')
+const errorMsg = ref('')
+const lines = ref<string[]>([])
+const tailN = ref(200)
+const TAIL_OPTIONS = [100, 200, 500, 1000]
+const following = ref(false)
+const bodyEl = ref<HTMLElement | null>(null)
+
+let unsub: (() => void) | null = null
+
+function stopStream(): void {
+  if (unsub) {
+    unsub()
+    unsub = null
+  }
+  following.value = false
+}
+
+async function scrollToBottom(): Promise<void> {
+  await nextTick()
+  const el = bodyEl.value
+  if (el) el.scrollTop = el.scrollHeight
+}
+
+async function loadHistory(): Promise<void> {
+  stopStream()
+  viewState.value = 'loading'
+  errorMsg.value = ''
+  try {
+    const res = await getServerLogs(props.serverId, {
+      source: 'docker',
+      target: props.containerName,
+      lines: tailN.value,
+    })
+    if (res.error) {
+      viewState.value = 'error'
+      errorMsg.value = res.error
+      return
+    }
+    lines.value = res.lines.map((l) => l.text)
+    viewState.value = 'loaded'
+    void scrollToBottom()
+  } catch (err) {
+    viewState.value = 'error'
+    errorMsg.value =
+      err instanceof HttpError ? (err.apiError?.message ?? `加载日志失败(${err.status})`) : '加载日志失败'
+  }
+}
+
+function toggleFollow(): void {
+  if (following.value) {
+    stopStream()
+    viewState.value = 'loaded'
+    return
+  }
+  // 开实时:先保留已有历史,再订阅增量。
+  following.value = true
+  viewState.value = 'streaming'
+  unsub = subscribeServerLogs(
+    props.serverId,
+    { source: 'docker', target: props.containerName, lines: tailN.value },
+    {
+      onLine(line) {
+        lines.value.push(line)
+        // 防爆:实时跟随时只保留最近 5000 行。
+        if (lines.value.length > 5000) lines.value.splice(0, lines.value.length - 5000)
+        void scrollToBottom()
+      },
+      onError(message) {
+        errorMsg.value = message
+        stopStream()
+        viewState.value = 'error'
+      },
+      onTransportError() {
+        stopStream()
+        // 传输断开不当致命错误:停跟随,保留已拉到的内容。
+        viewState.value = 'loaded'
+      },
+    },
+  )
+}
+
+async function copyAll(): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(lines.value.join('\n'))
+    toast.success('日志已复制', { detail: `${lines.value.length} 行` })
+  } catch {
+    toast.error('复制失败', { detail: '浏览器不支持或无剪贴板权限(需 https/localhost)' })
+  }
+}
+
+function clearView(): void {
+  lines.value = []
+}
+
+watch(tailN, () => void loadHistory())
+
+// 打开即拉历史(组件随抽屉 v-if 挂载)。
+void loadHistory()
+
+onBeforeUnmount(stopStream)
+</script>
+
+<template>
+  <div class="drawer-scrim" @click.self="emit('close')">
+    <aside class="drawer" role="dialog" aria-label="容器日志">
+      <header class="drawer__head">
+        <div class="drawer__title">
+          <span class="drawer__name">{{ containerName }}</span>
+          <span v-if="containerId" class="drawer__cid mono">{{ containerId }}</span>
+          <span class="drawer__src">docker logs</span>
+        </div>
+        <button class="drawer__close" aria-label="关闭日志" @click="emit('close')">✕</button>
+      </header>
+
+      <div class="drawer__toolbar">
+        <label class="tool">
+          <span class="tool__k">行数</span>
+          <select v-model.number="tailN" class="tool__sel" aria-label="日志行数">
+            <option v-for="n in TAIL_OPTIONS" :key="n" :value="n">{{ n }}</option>
+          </select>
+        </label>
+        <button class="tool-btn" :disabled="viewState === 'loading'" @click="loadHistory">↻ 刷新</button>
+        <button class="tool-btn" :class="{ 'tool-btn--on': following }" @click="toggleFollow">
+          {{ following ? '⏸ 停止实时' : '▶ 实时跟随' }}
+        </button>
+        <span class="grow" />
+        <button class="tool-btn" :disabled="lines.length === 0" @click="copyAll">复制</button>
+        <button class="tool-btn" :disabled="lines.length === 0" @click="clearView">清屏</button>
+      </div>
+
+      <div ref="bodyEl" class="drawer__body" :class="{ 'is-live': following }">
+        <div v-if="viewState === 'loading'" class="drawer__hint">正在拉取日志…</div>
+        <div v-else-if="viewState === 'error'" class="drawer__hint drawer__hint--err">⚠ {{ errorMsg }}</div>
+        <div v-else-if="lines.length === 0" class="drawer__hint">暂无日志输出。</div>
+        <pre v-else class="drawer__pre mono"><span v-for="(l, i) in lines" :key="i" class="logline">{{ l }}
+</span></pre>
+      </div>
+
+      <footer class="drawer__foot">
+        <span class="foot__s">{{ lines.length }} 行</span>
+        <span v-if="following" class="foot__live"><span class="foot__dot" /> 实时</span>
+        <span class="grow" />
+        <span class="foot__hint">经 SSH 跑 docker logs · 历史 + 实时 tail</span>
+      </footer>
+    </aside>
+  </div>
+</template>
+
+<style scoped>
+.drawer-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: oklch(0% 0 0 / 0.42);
+  display: flex;
+  justify-content: flex-end;
+  animation: scrimIn var(--duration-fast) var(--ease-out-expo);
+}
+@keyframes scrimIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.drawer {
+  width: min(760px, 92vw);
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-card);
+  border-left: 1px solid var(--color-border-strong);
+  box-shadow: var(--shadow-modal);
+  animation: drawerIn var(--duration-normal) var(--ease-out-expo);
+}
+@keyframes drawerIn {
+  from { transform: translateX(24px); opacity: 0.4; }
+  to { transform: translateX(0); opacity: 1; }
+}
+
+.drawer__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--color-border);
+}
+.drawer__title {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
+.drawer__name {
+  font-size: var(--text-section);
+  font-weight: 700;
+  color: var(--color-text);
+}
+.drawer__cid {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+}
+.drawer__src {
+  font-size: var(--text-micro);
+  color: var(--color-cyan);
+  background: var(--color-cyan-soft);
+  border: 1px solid var(--color-cyan-line);
+  padding: 1px 7px;
+  border-radius: 999px;
+}
+.drawer__close {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-dim);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out-expo);
+}
+.drawer__close:hover {
+  color: var(--color-text);
+  border-color: var(--color-text);
+}
+
+.drawer__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-card-2);
+}
+.tool {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.tool__k {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+}
+.tool__sel {
+  font-size: var(--text-label);
+  padding: 3px 6px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-card);
+  color: var(--color-text);
+}
+.tool-btn {
+  font-size: var(--text-micro);
+  font-weight: 600;
+  padding: 5px 11px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-border-strong);
+  background: transparent;
+  color: var(--color-dim);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out-expo);
+}
+.tool-btn:hover:not(:disabled) {
+  color: var(--color-text);
+  border-color: var(--color-text);
+}
+.tool-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.tool-btn--on {
+  color: var(--color-green);
+  border-color: var(--color-green-line);
+  background: var(--color-green-soft);
+}
+.grow {
+  flex: 1;
+}
+
+.drawer__body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  background: var(--color-term);
+  padding: 12px 16px;
+}
+.drawer__pre {
+  margin: 0;
+  font-size: var(--text-mono);
+  line-height: 1.5;
+  color: oklch(88% 0.01 250);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.logline {
+  display: block;
+}
+.drawer__hint {
+  color: var(--color-faint);
+  font-size: var(--text-label);
+  padding: 8px 2px;
+}
+.drawer__hint--err {
+  color: var(--color-red);
+}
+
+.drawer__foot {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 18px;
+  border-top: 1px solid var(--color-border);
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+}
+.foot__live {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--color-green);
+}
+.foot__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--color-green);
+  animation: dotPulse 1.6s var(--ease-out-expo) infinite;
+}
+@keyframes dotPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+</style>

--- a/web/src/components/ops/ContainerLogsDrawer.vue
+++ b/web/src/components/ops/ContainerLogsDrawer.vue
@@ -172,7 +172,7 @@ onBeforeUnmount(stopStream)
 .drawer-scrim {
   position: fixed;
   inset: 0;
-  z-index: 60;
+  z-index: 500;
   background: oklch(0% 0 0 / 0.42);
   display: flex;
   justify-content: flex-end;

--- a/web/src/components/ops/CreateContainerModal.vue
+++ b/web/src/components/ops/CreateContainerModal.vue
@@ -152,7 +152,7 @@ async function submit(): Promise<void> {
 .modal-scrim {
   position: fixed;
   inset: 0;
-  z-index: 60;
+  z-index: 500;
   background: oklch(0% 0 0 / 0.45);
   display: flex;
   align-items: center;

--- a/web/src/components/ops/CreateContainerModal.vue
+++ b/web/src/components/ops/CreateContainerModal.vue
@@ -6,6 +6,8 @@
 */
 import { ref, computed } from 'vue'
 import { createContainer, type CreateContainerInput, type RestartPolicy } from '../../api/containers'
+import { suggestCommand } from '../../api/aiOps'
+import { parseDockerRun } from '../../lib/dockerRun'
 import { HttpError } from '../../api/http'
 import { useToast } from '../../composables/useToast'
 
@@ -29,6 +31,44 @@ const command = ref('')
 
 const submitting = ref(false)
 const banner = ref('')
+
+// ─── AI 生成配置:中文描述 → docker run → 解析填表 ──────────────────────────────
+const aiNl = ref('')
+const aiBusy = ref(false)
+const aiNote = ref('')
+async function aiGenerate(): Promise<void> {
+  const nl = aiNl.value.trim()
+  if (!nl || aiBusy.value) return
+  aiBusy.value = true
+  aiNote.value = ''
+  banner.value = ''
+  try {
+    const res = await suggestCommand(nl, { os: 'linux', shell: '/bin/sh', container: '(docker 主机)' })
+    if (!res.available) {
+      aiNote.value = 'AI 未配置:请到「设置 › AI」配置模型后再用生成。'
+      return
+    }
+    const parsed = parseDockerRun(res.command)
+    if (!parsed) {
+      aiNote.value = `AI 给的不是可解析的 docker run,已显示原文供参考:${res.command}`
+      return
+    }
+    // 填表(只覆盖 AI 给出的部分;空的保持)。
+    if (parsed.image) image.value = parsed.image
+    if (parsed.name) name.value = parsed.name
+    if (parsed.ports.length) portsText.value = parsed.ports.join('\n')
+    if (parsed.env.length) envText.value = parsed.env.join('\n')
+    if (parsed.volumes.length) volumesText.value = parsed.volumes.join('\n')
+    if (parsed.restart) restart.value = parsed.restart
+    if (parsed.command) command.value = parsed.command
+    aiNote.value = `已按 AI 建议填表 · 原命令:${res.command}`
+    toast.success('AI 已生成配置', { detail: '请核对后再创建' })
+  } catch (err) {
+    aiNote.value = err instanceof HttpError ? (err.apiError?.message ?? `生成失败(${err.status})`) : '生成请求失败'
+  } finally {
+    aiBusy.value = false
+  }
+}
 
 const RESTART_OPTIONS: { value: RestartPolicy; label: string }[] = [
   { value: 'no', label: '不自动重启 (no)' },
@@ -88,6 +128,21 @@ async function submit(): Promise<void> {
 
       <div class="modal__body">
         <p v-if="banner" class="form-banner">⚠ {{ banner }}</p>
+
+        <!-- AI 生成:中文描述 → 自动填表 -->
+        <div class="ai-gen">
+          <span class="ai-gen__spark">✦</span>
+          <input
+            v-model="aiNl"
+            class="ai-gen__in"
+            placeholder="用中文描述,如:起个 nginx 映射 8080,挂载 /data/web,自动重启"
+            @keyup.enter="aiGenerate"
+          />
+          <button class="ai-gen__btn" :disabled="aiBusy || !aiNl.trim()" @click="aiGenerate">
+            {{ aiBusy ? '生成中…' : 'AI 生成' }}
+          </button>
+        </div>
+        <p v-if="aiNote" class="ai-gen__note">{{ aiNote }}</p>
 
         <div class="grid2">
           <label class="field">
@@ -251,6 +306,53 @@ async function submit(): Promise<void> {
 .field__in:focus {
   outline: none;
   border-color: var(--color-primary);
+}
+.ai-gen {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-primary-soft);
+  background: var(--color-primary-soft);
+  border-radius: var(--rounded-sm);
+}
+.ai-gen__spark {
+  color: var(--color-primary);
+  font-weight: 700;
+}
+.ai-gen__in {
+  flex: 1;
+  font-size: var(--text-label);
+  padding: 6px 10px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-card);
+  color: var(--color-text);
+}
+.ai-gen__in:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+.ai-gen__btn {
+  font-size: var(--text-label);
+  font-weight: 600;
+  padding: 6px 14px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-primary);
+  background: var(--color-primary);
+  color: #fff;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.ai-gen__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.ai-gen__note {
+  margin: 0;
+  font-size: var(--text-micro);
+  color: var(--color-dim);
+  word-break: break-all;
 }
 .form-banner {
   margin: 0;

--- a/web/src/components/ops/CreateContainerModal.vue
+++ b/web/src/components/ops/CreateContainerModal.vue
@@ -1,0 +1,307 @@
+<script setup lang="ts">
+/*
+  CreateContainerModal.vue — 新增容器(docker run -d)。
+  表单收集镜像/名/端口/env/卷/重启/命令 → POST /api/servers/:id/containers。
+  端口/env/卷用多行文本框(一行一条),空行忽略。后端严格白名单校验,绝不拼 shell。
+*/
+import { ref, computed } from 'vue'
+import { createContainer, type CreateContainerInput, type RestartPolicy } from '../../api/containers'
+import { HttpError } from '../../api/http'
+import { useToast } from '../../composables/useToast'
+
+interface ServerOption {
+  id: string
+  name: string
+}
+const props = defineProps<{ servers: ServerOption[] }>()
+const emit = defineEmits<{ (e: 'close'): void; (e: 'created', serverId: string): void }>()
+
+const toast = useToast()
+
+const serverId = ref(props.servers[0]?.id ?? '')
+const image = ref('')
+const name = ref('')
+const portsText = ref('')
+const envText = ref('')
+const volumesText = ref('')
+const restart = ref<RestartPolicy>('unless-stopped')
+const command = ref('')
+
+const submitting = ref(false)
+const banner = ref('')
+
+const RESTART_OPTIONS: { value: RestartPolicy; label: string }[] = [
+  { value: 'no', label: '不自动重启 (no)' },
+  { value: 'unless-stopped', label: '除非手动停止 (unless-stopped)' },
+  { value: 'always', label: '总是重启 (always)' },
+  { value: 'on-failure', label: '失败时重启 (on-failure)' },
+]
+
+const canSubmit = computed(() => serverId.value !== '' && image.value.trim() !== '' && !submitting.value)
+
+/** 多行文本 → 去空行、去首尾空白的数组。 */
+function linesToArray(text: string): string[] {
+  return text
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l !== '')
+}
+
+async function submit(): Promise<void> {
+  if (!canSubmit.value) return
+  banner.value = ''
+  submitting.value = true
+  const input: CreateContainerInput = {
+    image: image.value.trim(),
+    name: name.value.trim() || undefined,
+    ports: linesToArray(portsText.value),
+    env: linesToArray(envText.value),
+    volumes: linesToArray(volumesText.value),
+    restart: restart.value,
+    command: command.value.trim() || undefined,
+  }
+  try {
+    const res = await createContainer(serverId.value, input)
+    if (res.ok) {
+      toast.success('容器已创建', { detail: `${name.value || image.value} · ${res.containerId.slice(0, 12)}` })
+      emit('created', serverId.value)
+      emit('close')
+    } else {
+      banner.value = res.error || 'docker run 失败'
+    }
+  } catch (err) {
+    banner.value =
+      err instanceof HttpError ? (err.apiError?.message ?? `创建失败(${err.status})`) : '创建请求失败'
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="modal-scrim" @click.self="emit('close')">
+    <div class="modal" role="dialog" aria-label="新增容器">
+      <header class="modal__head">
+        <h3 class="modal__title">新增容器</h3>
+        <button class="modal__close" aria-label="关闭" @click="emit('close')">✕</button>
+      </header>
+
+      <div class="modal__body">
+        <p v-if="banner" class="form-banner">⚠ {{ banner }}</p>
+
+        <div class="grid2">
+          <label class="field">
+            <span class="field__k">目标服务器</span>
+            <select v-model="serverId" class="field__in">
+              <option v-for="s in props.servers" :key="s.id" :value="s.id">{{ s.name }}</option>
+            </select>
+          </label>
+          <label class="field">
+            <span class="field__k">重启策略</span>
+            <select v-model="restart" class="field__in">
+              <option v-for="o in RESTART_OPTIONS" :key="o.value" :value="o.value">{{ o.label }}</option>
+            </select>
+          </label>
+        </div>
+
+        <div class="grid2">
+          <label class="field">
+            <span class="field__k">镜像 <em>*</em></span>
+            <input v-model="image" class="field__in mono" placeholder="例:nginx:latest" />
+          </label>
+          <label class="field">
+            <span class="field__k">容器名(可选)</span>
+            <input v-model="name" class="field__in mono" placeholder="例:my-web" />
+          </label>
+        </div>
+
+        <label class="field">
+          <span class="field__k">端口映射 <span class="field__hint">一行一条,host:container</span></span>
+          <textarea v-model="portsText" class="field__in mono" rows="2" placeholder="8080:80&#10;127.0.0.1:9090:90/tcp" />
+        </label>
+
+        <label class="field">
+          <span class="field__k">环境变量 <span class="field__hint">一行一条,KEY=VALUE</span></span>
+          <textarea v-model="envText" class="field__in mono" rows="2" placeholder="TZ=Asia/Shanghai&#10;FOO=bar" />
+        </label>
+
+        <label class="field">
+          <span class="field__k">数据卷 <span class="field__hint">一行一条,host:container[:ro]</span></span>
+          <textarea v-model="volumesText" class="field__in mono" rows="2" placeholder="/data/web:/usr/share/nginx/html:ro&#10;myvol:/cache" />
+        </label>
+
+        <label class="field">
+          <span class="field__k">启动命令(可选)</span>
+          <input v-model="command" class="field__in mono" placeholder="覆盖镜像默认 CMD,按空格拆参数" />
+        </label>
+      </div>
+
+      <footer class="modal__foot">
+        <span class="foot-hint">将在所选服务器执行 docker run -d</span>
+        <span class="grow" />
+        <button class="btn btn--ghost" :disabled="submitting" @click="emit('close')">取消</button>
+        <button class="btn btn--primary" :disabled="!canSubmit" @click="submit">
+          {{ submitting ? '创建中…' : '创建并运行' }}
+        </button>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.modal-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: oklch(0% 0 0 / 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  animation: scrimIn var(--duration-fast) var(--ease-out-expo);
+}
+@keyframes scrimIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.modal {
+  width: min(640px, 96vw);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-card);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded-lg, 12px);
+  box-shadow: var(--shadow-modal);
+  animation: modalIn var(--duration-normal) var(--ease-out-expo);
+}
+@keyframes modalIn {
+  from { transform: translateY(12px) scale(0.99); opacity: 0.5; }
+  to { transform: translateY(0) scale(1); opacity: 1; }
+}
+.modal__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--color-border);
+}
+.modal__title {
+  margin: 0;
+  font-size: var(--text-h1);
+  font-weight: 700;
+  color: var(--color-text);
+}
+.modal__close {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-dim);
+  cursor: pointer;
+}
+.modal__close:hover {
+  color: var(--color-text);
+  border-color: var(--color-text);
+}
+.modal__body {
+  padding: 18px 20px;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.grid2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+@media (max-width: 560px) {
+  .grid2 { grid-template-columns: 1fr; }
+}
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.field__k {
+  font-size: var(--text-label);
+  font-weight: 600;
+  color: var(--color-dim);
+}
+.field__k em {
+  color: var(--color-red);
+  font-style: normal;
+}
+.field__hint {
+  font-weight: 400;
+  color: var(--color-faint);
+  font-size: var(--text-micro);
+}
+.field__in {
+  font-size: var(--text-body);
+  padding: 8px 10px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-inset);
+  color: var(--color-text);
+  resize: vertical;
+}
+.field__in:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+.form-banner {
+  margin: 0;
+  padding: 9px 12px;
+  border-radius: var(--rounded-sm);
+  background: var(--color-red-soft);
+  border: 1px solid var(--color-red-line);
+  color: var(--color-red);
+  font-size: var(--text-label);
+}
+.modal__foot {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 20px;
+  border-top: 1px solid var(--color-border);
+}
+.foot-hint {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+}
+.grow {
+  flex: 1;
+}
+.btn {
+  font-size: var(--text-label);
+  font-weight: 600;
+  padding: 8px 16px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out-expo);
+}
+.btn--ghost {
+  background: transparent;
+  border-color: var(--color-border-strong);
+  color: var(--color-dim);
+}
+.btn--ghost:hover:not(:disabled) {
+  color: var(--color-text);
+  border-color: var(--color-text);
+}
+.btn--primary {
+  background: var(--color-primary);
+  color: #fff;
+}
+.btn--primary:hover:not(:disabled) {
+  background: var(--color-primary-press);
+}
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/web/src/components/ops/ServerCard.vue
+++ b/web/src/components/ops/ServerCard.vue
@@ -12,11 +12,19 @@ import {
   getServerStacks,
   deployStack,
   stackAction,
+  getServerVolumes,
+  createVolume,
+  removeVolume,
+  getServerNetworks,
+  createNetwork,
+  removeNetwork,
   type ServerContainers,
   type ContainerInfo,
   type ImageInfo,
   type StackInfo,
   type StackAction,
+  type VolumeInfo,
+  type NetworkInfo,
 } from '../../api/containers'
 import { serviceAction } from '../../api/servers'
 import { HttpError } from '../../api/http'
@@ -52,7 +60,7 @@ const emit = defineEmits<{
 const toast = useToast()
 const confirm = useConfirm()
 
-type TabKey = 'containers' | 'images' | 'stacks'
+type TabKey = 'containers' | 'images' | 'stacks' | 'volumes' | 'networks'
 const tab = ref<TabKey>('containers')
 
 // 运行时显示名:首字母大写(docker → Docker)。
@@ -139,7 +147,130 @@ function switchTab(t: TabKey): void {
   tab.value = t
   if (t === 'images' && imgState.value === 'idle') void loadImages()
   if (t === 'stacks' && stackState.value === 'idle') void loadStacks()
+  if (t === 'volumes' && volState.value === 'idle') void loadVolumes()
+  if (t === 'networks' && netState.value === 'idle') void loadNetworks()
 }
+
+// ─── 数据卷(懒加载) ──────────────────────────────────────────────────────────
+const volumes = ref<VolumeInfo[]>([])
+const volState = ref<'idle' | 'loading' | 'loaded' | 'error'>('idle')
+const volError = ref('')
+const newVol = ref('')
+const busyVol = ref('')
+
+async function loadVolumes(): Promise<void> {
+  volState.value = 'loading'
+  volError.value = ''
+  try {
+    const res = await getServerVolumes(props.group.serverId)
+    if (!res.reachable || !res.runtime) {
+      volState.value = 'error'
+      volError.value = res.error || '该服务器不可达或无容器运行时'
+      return
+    }
+    volumes.value = res.volumes
+    volState.value = 'loaded'
+  } catch (err) {
+    volState.value = 'error'
+    volError.value = err instanceof HttpError ? (err.apiError?.message ?? `加载卷失败(${err.status})`) : '加载卷失败'
+  }
+}
+async function doCreateVol(): Promise<void> {
+  const name = newVol.value.trim()
+  if (!name) return
+  busyVol.value = '@create'
+  try {
+    const res = await createVolume(props.group.serverId, name)
+    if (res.ok) {
+      toast.success('数据卷已创建', { detail: name })
+      newVol.value = ''
+      void loadVolumes()
+    } else toast.error('创建失败', { detail: res.error })
+  } finally {
+    busyVol.value = ''
+  }
+}
+async function doRemoveVol(v: VolumeInfo): Promise<void> {
+  const ok = await confirm.open({
+    title: `删除数据卷 ${v.name}?`,
+    body: '将执行 docker volume rm。若有容器在用会删除失败。卷内数据随之删除,不可恢复。',
+    confirmLabel: '删除卷',
+    variant: 'danger',
+  })
+  if (!ok) return
+  busyVol.value = v.name
+  try {
+    const res = await removeVolume(props.group.serverId, v.name)
+    if (res.ok) {
+      toast.success('数据卷已删除', { detail: v.name })
+      void loadVolumes()
+    } else toast.error('删除失败', { detail: res.error || '卷可能正被容器使用' })
+  } finally {
+    busyVol.value = ''
+  }
+}
+
+// ─── 网络(懒加载) ────────────────────────────────────────────────────────────
+const networks = ref<NetworkInfo[]>([])
+const netState = ref<'idle' | 'loading' | 'loaded' | 'error'>('idle')
+const netError = ref('')
+const newNet = ref('')
+const busyNet = ref('')
+
+async function loadNetworks(): Promise<void> {
+  netState.value = 'loading'
+  netError.value = ''
+  try {
+    const res = await getServerNetworks(props.group.serverId)
+    if (!res.reachable || !res.runtime) {
+      netState.value = 'error'
+      netError.value = res.error || '该服务器不可达或无容器运行时'
+      return
+    }
+    networks.value = res.networks
+    netState.value = 'loaded'
+  } catch (err) {
+    netState.value = 'error'
+    netError.value = err instanceof HttpError ? (err.apiError?.message ?? `加载网络失败(${err.status})`) : '加载网络失败'
+  }
+}
+async function doCreateNet(): Promise<void> {
+  const name = newNet.value.trim()
+  if (!name) return
+  busyNet.value = '@create'
+  try {
+    const res = await createNetwork(props.group.serverId, name)
+    if (res.ok) {
+      toast.success('网络已创建', { detail: name })
+      newNet.value = ''
+      void loadNetworks()
+    } else toast.error('创建失败', { detail: res.error })
+  } finally {
+    busyNet.value = ''
+  }
+}
+async function doRemoveNet(n: NetworkInfo): Promise<void> {
+  const ok = await confirm.open({
+    title: `删除网络 ${n.name}?`,
+    body: '将执行 docker network rm。若有容器连接在该网络上会删除失败。',
+    confirmLabel: '删除网络',
+    variant: 'danger',
+  })
+  if (!ok) return
+  busyNet.value = n.id
+  try {
+    const res = await removeNetwork(props.group.serverId, n.name)
+    if (res.ok) {
+      toast.success('网络已删除', { detail: n.name })
+      void loadNetworks()
+    } else toast.error('删除失败', { detail: res.error || '网络可能有容器连接' })
+  } finally {
+    busyNet.value = ''
+  }
+}
+
+// 内置网络(bridge/host/none)不可删,删除按钮置灰。
+const BUILTIN_NETWORKS = new Set(['bridge', 'host', 'none'])
 
 // ─── Stacks / Compose(懒加载) ────────────────────────────────────────────────
 const stacks = ref<StackInfo[]>([])
@@ -336,6 +467,12 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
         <button class="ctab" :class="{ 'ctab--active': tab === 'stacks' }" role="tab" @click="switchTab('stacks')">
           Stacks <span v-if="stackState === 'loaded'" class="ctab__n">{{ stacks.length }}</span>
         </button>
+        <button class="ctab" :class="{ 'ctab--active': tab === 'volumes' }" role="tab" @click="switchTab('volumes')">
+          卷 <span v-if="volState === 'loaded'" class="ctab__n">{{ volumes.length }}</span>
+        </button>
+        <button class="ctab" :class="{ 'ctab--active': tab === 'networks' }" role="tab" @click="switchTab('networks')">
+          网络 <span v-if="netState === 'loaded'" class="ctab__n">{{ networks.length }}</span>
+        </button>
       </div>
 
       <!-- 容器 tab -->
@@ -407,7 +544,7 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
       </template>
 
       <!-- Stacks tab -->
-      <template v-else>
+      <template v-else-if="tab === 'stacks'">
         <div class="img-toolbar">
           <button class="pull__btn" @click="showDeploy = !showDeploy">{{ showDeploy ? '收起部署' : '+ 部署 Stack' }}</button>
           <span class="grow" />
@@ -452,6 +589,66 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
                 @click="doStackAction(s, a.action, a.label, a.danger)"
               >
                 {{ a.label }}
+              </button>
+            </div>
+          </li>
+        </ul>
+      </template>
+
+      <!-- 卷 tab -->
+      <template v-else-if="tab === 'volumes'">
+        <div class="img-toolbar">
+          <div class="pull">
+            <input v-model="newVol" class="pull__in mono" placeholder="新建数据卷名" @keyup.enter="doCreateVol" />
+            <button class="pull__btn" :disabled="busyVol === '@create' || !newVol.trim()" @click="doCreateVol">创建</button>
+          </div>
+          <span class="grow" />
+          <button class="refresh" :disabled="volState === 'loading'" @click="loadVolumes">↻ 刷新</button>
+        </div>
+        <p v-if="volState === 'error'" class="panel__hint panel__hint--down">⚠ {{ volError }}</p>
+        <p v-else-if="volState === 'loading' && volumes.length === 0" class="panel__hint">正在加载数据卷…</p>
+        <p v-else-if="volumes.length === 0" class="panel__hint">该服务器暂无数据卷。</p>
+        <ul v-else class="ilist" role="list">
+          <li v-for="v in volumes" :key="v.name" class="srow" :class="{ 'irow--busy': busyVol === v.name }">
+            <div class="srow__main">
+              <div class="srow__name">{{ v.name }}</div>
+            </div>
+            <div class="srow__status mono">{{ v.driver }}</div>
+            <div class="srow__act">
+              <button class="op op--ghost" :disabled="busyVol === v.name" @click="doRemoveVol(v)">删除</button>
+            </div>
+          </li>
+        </ul>
+      </template>
+
+      <!-- 网络 tab -->
+      <template v-else>
+        <div class="img-toolbar">
+          <div class="pull">
+            <input v-model="newNet" class="pull__in mono" placeholder="新建网络名(默认 bridge 驱动)" @keyup.enter="doCreateNet" />
+            <button class="pull__btn" :disabled="busyNet === '@create' || !newNet.trim()" @click="doCreateNet">创建</button>
+          </div>
+          <span class="grow" />
+          <button class="refresh" :disabled="netState === 'loading'" @click="loadNetworks">↻ 刷新</button>
+        </div>
+        <p v-if="netState === 'error'" class="panel__hint panel__hint--down">⚠ {{ netError }}</p>
+        <p v-else-if="netState === 'loading' && networks.length === 0" class="panel__hint">正在加载网络…</p>
+        <p v-else-if="networks.length === 0" class="panel__hint">该服务器暂无网络。</p>
+        <ul v-else class="ilist" role="list">
+          <li v-for="n in networks" :key="n.id" class="srow" :class="{ 'irow--busy': busyNet === n.id }">
+            <div class="srow__main">
+              <div class="srow__name">{{ n.name }}</div>
+              <div class="srow__cfg mono">{{ n.id }} · {{ n.scope }}</div>
+            </div>
+            <div class="srow__status mono">{{ n.driver }}</div>
+            <div class="srow__act">
+              <button
+                class="op op--ghost"
+                :disabled="busyNet === n.id || BUILTIN_NETWORKS.has(n.name)"
+                :title="BUILTIN_NETWORKS.has(n.name) ? '内置网络不可删除' : '删除网络(docker network rm)'"
+                @click="doRemoveNet(n)"
+              >
+                删除
               </button>
             </div>
           </li>

--- a/web/src/components/ops/ServerCard.vue
+++ b/web/src/components/ops/ServerCard.vue
@@ -19,6 +19,7 @@ import {
   createNetwork,
   removeNetwork,
   getNetworkContainers,
+  connectNetwork,
   disconnectNetwork,
   type ServerContainers,
   type ContainerInfo,
@@ -304,6 +305,36 @@ async function toggleNetDetail(n: NetworkInfo): Promise<void> {
     netConnState.value = 'error'
     netConnError.value = err instanceof HttpError ? (err.apiError?.message ?? '读取失败') : '读取失败'
   }
+}
+
+// 连接容器到网络:从该机容器里选一个,docker network connect。
+const connectName = ref('')
+async function doConnect(network: string): Promise<void> {
+  const name = connectName.value.trim()
+  if (!name) return
+  busyConn.value = '@connect'
+  try {
+    const res = await connectNetwork(props.group.serverId, network, name)
+    if (res.ok) {
+      toast.success('已连接', { detail: `${name} ⇢ ${network}` })
+      connectName.value = ''
+      // 刷新该网络的连接列表。
+      const r = await getNetworkContainers(props.group.serverId, network)
+      if (r.reachable) netConns.value = r.containers
+    } else toast.error('连接失败', { detail: res.error })
+  } catch (err) {
+    toast.error('连接失败', {
+      detail: err instanceof HttpError ? (err.apiError?.message ?? '请求失败') : '网络错误',
+    })
+  } finally {
+    busyConn.value = ''
+  }
+}
+
+/** 尚未连接到该网络的本机容器(供「连接」下拉)。 */
+function attachableContainers(): string[] {
+  const connected = new Set(netConns.value.map((c) => c.name))
+  return props.group.containers.map((c) => c.names).filter((n) => !connected.has(n))
 }
 
 async function doDisconnect(network: string, c: NetworkContainer): Promise<void> {
@@ -722,6 +753,16 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
                   <button class="op op--ghost" :disabled="busyConn === c.id" @click="doDisconnect(n.name, c)">断开</button>
                 </li>
               </ul>
+              <!-- 连接容器到该网络 -->
+              <div v-if="netConnState === 'loaded'" class="connadd">
+                <select v-model="connectName" class="connadd__sel" :disabled="attachableContainers().length === 0">
+                  <option value="">{{ attachableContainers().length ? '选择要连接的容器…' : '无可连接的容器' }}</option>
+                  <option v-for="name in attachableContainers()" :key="name" :value="name">{{ name }}</option>
+                </select>
+                <button class="op op--default" :disabled="!connectName || busyConn === '@connect'" @click="doConnect(n.name)">
+                  连接
+                </button>
+              </div>
             </div>
           </li>
         </ul>
@@ -1159,6 +1200,23 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
   flex: 1;
   font-size: var(--text-micro);
   color: var(--color-faint);
+}
+.connadd {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-top: 8px;
+  margin-top: 4px;
+  border-top: 1px dashed var(--color-border);
+}
+.connadd__sel {
+  font-size: var(--text-micro);
+  padding: 5px 8px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-card);
+  color: var(--color-text);
+  max-width: 240px;
 }
 
 /* 行内迷你操作按钮 */

--- a/web/src/components/ops/ServerCard.vue
+++ b/web/src/components/ops/ServerCard.vue
@@ -4,8 +4,9 @@
   tab 内容只针对这一台(Portainer 式按主机管理)。容器 tab:生命周期操作 + 日志 + 终端;
   镜像 tab:列表 + 拉取 + 删除。生命周期/镜像写操作完成后 emit('changed') 让父刷新聚合。
 */
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import {
+  getServerContainerStats,
   getServerImages,
   pullImage,
   removeImage,
@@ -23,6 +24,7 @@ import {
   disconnectNetwork,
   type ServerContainers,
   type ContainerInfo,
+  type ContainerStat,
   type ImageInfo,
   type StackInfo,
   type StackAction,
@@ -54,12 +56,20 @@ const props = defineProps<{
   host: string
   /** 容器状态筛选(来自页面级筛选段);'all' = 不筛。 */
   stateFilter: 'all' | StateBucket
+  /** 文本搜索(来自页面级搜索框);按 names / image 忽略大小写包含。 */
+  search: string
+  /** 批量模式:容器行左侧显示复选框。 */
+  bulkMode: boolean
+  /** 父持有的选择集;key = `${serverId}::${containerName}`。 */
+  selectedSet: Set<string>
 }>()
 const emit = defineEmits<{
   (e: 'changed'): void
   (e: 'logs', c: ContainerInfo): void
   (e: 'terminal', c: ContainerInfo): void
   (e: 'diagnose', c: ContainerInfo): void
+  (e: 'inspect', c: ContainerInfo): void
+  (e: 'toggle-select', name: string): void
 }>()
 
 const toast = useToast()
@@ -84,9 +94,32 @@ function isBusy(cid: string, action: string): boolean {
 }
 
 const visibleContainers = computed(() => {
-  if (props.stateFilter === 'all') return props.group.containers
-  return props.group.containers.filter((c) => stateBucket(c.state) === props.stateFilter)
+  let list = props.group.containers
+  if (props.stateFilter !== 'all') {
+    list = list.filter((c) => stateBucket(c.state) === props.stateFilter)
+  }
+  const q = props.search.trim().toLowerCase()
+  if (q) {
+    list = list.filter(
+      (c) => c.names.toLowerCase().includes(q) || c.image.toLowerCase().includes(q),
+    )
+  }
+  return list
 })
+
+// 容器 tab 过滤后为空时的提示文案(区分搜索 / 状态筛选)。
+const emptyContainersHint = computed(() => {
+  const hasSearch = props.search.trim().length > 0
+  const hasFilter = props.stateFilter !== 'all'
+  if (hasSearch && hasFilter) return `无匹配「${props.search.trim()}」且符合当前状态筛选的容器(共 ${props.group.total} 个)。`
+  if (hasSearch) return `无匹配「${props.search.trim()}」的容器(共 ${props.group.total} 个)。`
+  return `无匹配当前筛选的容器(共 ${props.group.total} 个)。`
+})
+
+// 批量:该容器是否已被选中(key 带本机 serverId)。
+function isSelected(name: string): boolean {
+  return props.selectedSet.has(`${props.group.serverId}::${name}`)
+}
 
 async function runAction(c: ContainerInfo, spec: ActionSpec): Promise<void> {
   if (spec.danger) {
@@ -114,6 +147,38 @@ async function runAction(c: ContainerInfo, spec: ActionSpec): Promise<void> {
     next.delete(key)
     busy.value = next
     setTimeout(() => emit('changed'), 600)
+  }
+}
+
+// ─── 实时资源 stats(进容器 tab 拉一次 + 手动刷新) ──────────────────────────────
+// docker stats --no-stream:仅 running 容器有样本,按容器名 merge 到行上。失败静默(只读
+// 锦上添花,不打断容器管理);不可达/无运行时 → 空 Map,行上不显示。
+const containerStats = ref<Map<string, ContainerStat>>(new Map())
+const statsLoading = ref(false)
+
+function statFor(name: string): ContainerStat | undefined {
+  return containerStats.value.get(name)
+}
+
+// 容器是默认 tab → 挂载即拉一次,让资源数据随卡片一起出现(仅当默认就是容器 tab)。
+onMounted(() => {
+  if (tab.value === 'containers') void loadStats()
+})
+
+async function loadStats(): Promise<void> {
+  if (statsLoading.value) return
+  statsLoading.value = true
+  try {
+    const res = await getServerContainerStats(props.group.serverId)
+    const next = new Map<string, ContainerStat>()
+    if (res.reachable && res.runtime) {
+      for (const s of res.stats) next.set(s.name, s)
+    }
+    containerStats.value = next
+  } catch {
+    // 静默:stats 仅为容器行的附加信息,拉失败不影响主流程。
+  } finally {
+    statsLoading.value = false
   }
 }
 
@@ -150,6 +215,7 @@ async function loadImages(): Promise<void> {
 
 function switchTab(t: TabKey): void {
   tab.value = t
+  if (t === 'containers') void loadStats()
   if (t === 'images' && imgState.value === 'idle') void loadImages()
   if (t === 'stacks' && stackState.value === 'idle') void loadStacks()
   if (t === 'volumes' && volState.value === 'idle') void loadVolumes()
@@ -592,10 +658,24 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
 
       <!-- 容器 tab -->
       <template v-if="tab === 'containers'">
+        <div v-if="group.total > 0" class="cstats-bar">
+          <span class="cstats-bar__label">实时资源(docker stats)</span>
+          <button class="op op--ghost" :disabled="statsLoading" :title="'刷新实时资源采样'" @click="loadStats">
+            {{ statsLoading ? '采样中…' : '刷新' }}
+          </button>
+        </div>
         <p v-if="group.total === 0" class="panel__hint">该服务器暂无容器。</p>
-        <p v-else-if="visibleContainers.length === 0" class="panel__hint">无匹配当前筛选的容器(共 {{ group.total }} 个)。</p>
+        <p v-else-if="visibleContainers.length === 0" class="panel__hint">{{ emptyContainersHint }}</p>
         <ul v-else class="clist" role="list">
-          <li v-for="c in visibleContainers" :key="c.id" class="crow" :class="{ 'crow--busy': rowBusy(c.id) }">
+          <li v-for="c in visibleContainers" :key="c.id" class="crow" :class="{ 'crow--busy': rowBusy(c.id), 'crow--bulk': bulkMode }">
+            <label v-if="bulkMode" class="crow__check">
+              <input
+                type="checkbox"
+                :checked="isSelected(c.names)"
+                :aria-label="`选择容器 ${c.names}`"
+                @change="emit('toggle-select', c.names)"
+              />
+            </label>
             <div class="crow__state">
               <span class="dot" :class="[`dot--${stateMeta(c.state).tone}`, { 'dot--pulse': stateMeta(c.state).pulse }]" aria-hidden="true" />
               <span class="crow__statelabel" :class="`txt--${stateMeta(c.state).tone}`">{{ stateMeta(c.state).label }}</span>
@@ -607,6 +687,13 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
             <div class="crow__status">
               <div class="crow__statustxt" :title="c.status">{{ c.status }}</div>
               <div v-if="c.ports" class="crow__ports mono" :title="c.ports">{{ c.ports }}</div>
+              <div
+                v-if="c.state === 'running' && statFor(c.names)"
+                class="crow__stats mono"
+                :title="`网络 ${statFor(c.names)!.netIO} · 块 ${statFor(c.names)!.blockIO}`"
+              >
+                CPU {{ statFor(c.names)!.cpuPerc }} · 内存 {{ statFor(c.names)!.memUsage }} ({{ statFor(c.names)!.memPerc }})
+              </div>
             </div>
             <div class="crow__actions">
               <button
@@ -620,6 +707,7 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
               >
                 {{ a.label }}
               </button>
+              <button class="op op--ghost" title="容器详情(docker inspect)" @click="emit('inspect', c)">详情</button>
               <button class="op op--ai" title="AI 诊断:取日志 → 根因 + 修复建议" @click="emit('diagnose', c)">✦ AI</button>
               <button class="op op--ghost" title="查看容器日志(docker logs)" @click="emit('logs', c)">日志</button>
               <button class="op op--ghost" :disabled="rowBusy(c.id)" title="进入容器终端(docker exec -it)" @click="emit('terminal', c)">终端</button>
@@ -956,6 +1044,20 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
 .crow--busy {
   opacity: 0.55;
 }
+.crow--bulk {
+  grid-template-columns: 26px 92px minmax(0, 1.4fr) minmax(0, 1.3fr) auto;
+}
+.crow__check {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+.crow__check input {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  accent-color: var(--color-primary);
+}
 .crow__state {
   display: flex;
   align-items: center;
@@ -1017,6 +1119,26 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+.crow__stats {
+  margin-top: 2px;
+  font-size: var(--text-micro);
+  color: var(--color-accent);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cstats-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 18px;
+  border-bottom: 1px solid var(--color-border);
+}
+.cstats-bar__label {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
 }
 .crow__actions {
   display: flex;
@@ -1308,7 +1430,7 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
 .op--busy { opacity: 0.6; pointer-events: none; }
 
 @media (max-width: 720px) {
-  .crow, .irow { grid-template-columns: 1fr; gap: 8px; }
+  .crow, .crow--bulk, .irow { grid-template-columns: 1fr; gap: 8px; }
   .crow__actions { justify-content: flex-start; }
 }
 </style>

--- a/web/src/components/ops/ServerCard.vue
+++ b/web/src/components/ops/ServerCard.vue
@@ -18,6 +18,8 @@ import {
   getServerNetworks,
   createNetwork,
   removeNetwork,
+  getNetworkContainers,
+  disconnectNetwork,
   type ServerContainers,
   type ContainerInfo,
   type ImageInfo,
@@ -25,6 +27,7 @@ import {
   type StackAction,
   type VolumeInfo,
   type NetworkInfo,
+  type NetworkContainer,
 } from '../../api/containers'
 import { serviceAction } from '../../api/servers'
 import { HttpError } from '../../api/http'
@@ -271,6 +274,57 @@ async function doRemoveNet(n: NetworkInfo): Promise<void> {
 
 // 内置网络(bridge/host/none)不可删,删除按钮置灰。
 const BUILTIN_NETWORKS = new Set(['bridge', 'host', 'none'])
+
+// 网络详情展开:点网络行 → 显示连着的容器(可断开)。
+const expandedNet = ref<string>('')
+const netConns = ref<NetworkContainer[]>([])
+const netConnState = ref<'idle' | 'loading' | 'loaded' | 'error'>('idle')
+const netConnError = ref('')
+const busyConn = ref('')
+
+async function toggleNetDetail(n: NetworkInfo): Promise<void> {
+  if (expandedNet.value === n.name) {
+    expandedNet.value = ''
+    return
+  }
+  expandedNet.value = n.name
+  netConnState.value = 'loading'
+  netConnError.value = ''
+  netConns.value = []
+  try {
+    const res = await getNetworkContainers(props.group.serverId, n.name)
+    if (!res.reachable) {
+      netConnState.value = 'error'
+      netConnError.value = res.error || '读取失败'
+      return
+    }
+    netConns.value = res.containers
+    netConnState.value = 'loaded'
+  } catch (err) {
+    netConnState.value = 'error'
+    netConnError.value = err instanceof HttpError ? (err.apiError?.message ?? '读取失败') : '读取失败'
+  }
+}
+
+async function doDisconnect(network: string, c: NetworkContainer): Promise<void> {
+  const ok = await confirm.open({
+    title: `把容器 ${c.name} 从网络 ${network} 断开?`,
+    body: '将执行 docker network disconnect。容器会失去该网络的连接(可能影响服务互通)。',
+    confirmLabel: '断开',
+    variant: 'danger',
+  })
+  if (!ok) return
+  busyConn.value = c.id
+  try {
+    const res = await disconnectNetwork(props.group.serverId, network, c.name)
+    if (res.ok) {
+      toast.success('已断开', { detail: `${c.name} ⇠ ${network}` })
+      netConns.value = netConns.value.filter((x) => x.id !== c.id)
+    } else toast.error('断开失败', { detail: res.error })
+  } finally {
+    busyConn.value = ''
+  }
+}
 
 // ─── Stacks / Compose(懒加载) ────────────────────────────────────────────────
 const stacks = ref<StackInfo[]>([])
@@ -635,21 +689,39 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
         <p v-else-if="netState === 'loading' && networks.length === 0" class="panel__hint">正在加载网络…</p>
         <p v-else-if="networks.length === 0" class="panel__hint">该服务器暂无网络。</p>
         <ul v-else class="ilist" role="list">
-          <li v-for="n in networks" :key="n.id" class="srow" :class="{ 'irow--busy': busyNet === n.id }">
-            <div class="srow__main">
-              <div class="srow__name">{{ n.name }}</div>
-              <div class="srow__cfg mono">{{ n.id }} · {{ n.scope }}</div>
-            </div>
-            <div class="srow__status mono">{{ n.driver }}</div>
-            <div class="srow__act">
-              <button
-                class="op op--ghost"
-                :disabled="busyNet === n.id || BUILTIN_NETWORKS.has(n.name)"
-                :title="BUILTIN_NETWORKS.has(n.name) ? '内置网络不可删除' : '删除网络(docker network rm)'"
-                @click="doRemoveNet(n)"
-              >
-                删除
+          <li v-for="n in networks" :key="n.id">
+            <div class="srow" :class="{ 'irow--busy': busyNet === n.id }">
+              <button class="srow__main netexp" @click="toggleNetDetail(n)">
+                <span class="netexp__caret" :class="{ 'netexp__caret--open': expandedNet === n.name }">▸</span>
+                <span>
+                  <span class="srow__name">{{ n.name }}</span>
+                  <span class="srow__cfg mono">{{ n.id }} · {{ n.scope }}</span>
+                </span>
               </button>
+              <div class="srow__status mono">{{ n.driver }}</div>
+              <div class="srow__act">
+                <button
+                  class="op op--ghost"
+                  :disabled="busyNet === n.id || BUILTIN_NETWORKS.has(n.name)"
+                  :title="BUILTIN_NETWORKS.has(n.name) ? '内置网络不可删除' : '删除网络(docker network rm)'"
+                  @click="doRemoveNet(n)"
+                >
+                  删除
+                </button>
+              </div>
+            </div>
+            <!-- 展开:该网络上连着的容器 -->
+            <div v-if="expandedNet === n.name" class="netdetail">
+              <p v-if="netConnState === 'loading'" class="netdetail__hint">正在读取连接的容器…</p>
+              <p v-else-if="netConnState === 'error'" class="netdetail__hint netdetail__hint--err">⚠ {{ netConnError }}</p>
+              <p v-else-if="netConns.length === 0" class="netdetail__hint">该网络上暂无容器连接。</p>
+              <ul v-else class="connlist" role="list">
+                <li v-for="c in netConns" :key="c.id" class="connrow" :class="{ 'irow--busy': busyConn === c.id }">
+                  <span class="connrow__name">{{ c.name }}</span>
+                  <span class="connrow__ip mono">{{ c.ipv4 || '—' }}</span>
+                  <button class="op op--ghost" :disabled="busyConn === c.id" @click="doDisconnect(n.name, c)">断开</button>
+                </li>
+              </ul>
             </div>
           </li>
         </ul>
@@ -1030,6 +1102,63 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
   gap: 6px;
   justify-content: flex-end;
   flex-wrap: wrap;
+}
+
+/* 网络展开:连接的容器 */
+.netexp {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+  min-width: 0;
+}
+.netexp__caret {
+  color: var(--color-faint);
+  font-size: var(--text-micro);
+  transition: transform var(--duration-fast) var(--ease-out-expo);
+}
+.netexp__caret--open {
+  transform: rotate(90deg);
+}
+.netdetail {
+  padding: 4px 18px 12px 40px;
+  background: var(--color-card-2);
+  border-bottom: 1px solid var(--color-border);
+}
+.netdetail__hint {
+  margin: 0;
+  padding: 8px 0;
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+}
+.netdetail__hint--err {
+  color: var(--color-red);
+}
+.connlist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.connrow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 0;
+}
+.connrow__name {
+  font-size: var(--text-label);
+  font-weight: 600;
+  color: var(--color-text);
+  min-width: 0;
+}
+.connrow__ip {
+  flex: 1;
+  font-size: var(--text-micro);
+  color: var(--color-faint);
 }
 
 /* 行内迷你操作按钮 */

--- a/web/src/components/ops/ServerCard.vue
+++ b/web/src/components/ops/ServerCard.vue
@@ -46,6 +46,7 @@ const emit = defineEmits<{
   (e: 'changed'): void
   (e: 'logs', c: ContainerInfo): void
   (e: 'terminal', c: ContainerInfo): void
+  (e: 'diagnose', c: ContainerInfo): void
 }>()
 
 const toast = useToast()
@@ -367,6 +368,7 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
               >
                 {{ a.label }}
               </button>
+              <button class="op op--ai" title="AI 诊断:取日志 → 根因 + 修复建议" @click="emit('diagnose', c)">✦ AI</button>
               <button class="op op--ghost" title="查看容器日志(docker logs)" @click="emit('logs', c)">日志</button>
               <button class="op op--ghost" :disabled="rowBusy(c.id)" title="进入容器终端(docker exec -it)" @click="emit('terminal', c)">终端</button>
             </div>
@@ -848,6 +850,8 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
 .op:hover:not(:disabled) { color: var(--color-text); border-color: var(--color-text); }
 .op--default { color: var(--color-primary); border-color: var(--color-primary-soft); }
 .op--default:hover:not(:disabled) { color: #fff; background: var(--color-primary); border-color: var(--color-primary); }
+.op--ai { color: var(--color-primary); border-color: var(--color-primary-soft); }
+.op--ai:hover:not(:disabled) { color: #fff; background: var(--color-primary); border-color: var(--color-primary); }
 .op:disabled { opacity: 0.45; cursor: not-allowed; }
 .op--busy { opacity: 0.6; pointer-events: none; }
 

--- a/web/src/components/ops/ServerCard.vue
+++ b/web/src/components/ops/ServerCard.vue
@@ -1,0 +1,618 @@
+<script setup lang="ts">
+/*
+  ServerCard.vue — 单台服务器的容器管理卡片。卡片内部按「容器 / 镜像」分 tab,
+  tab 内容只针对这一台(Portainer 式按主机管理)。容器 tab:生命周期操作 + 日志 + 终端;
+  镜像 tab:列表 + 拉取 + 删除。生命周期/镜像写操作完成后 emit('changed') 让父刷新聚合。
+*/
+import { ref, computed } from 'vue'
+import {
+  getServerImages,
+  pullImage,
+  removeImage,
+  type ServerContainers,
+  type ContainerInfo,
+  type ImageInfo,
+} from '../../api/containers'
+import { serviceAction } from '../../api/servers'
+import { HttpError } from '../../api/http'
+import { useToast } from '../../composables/useToast'
+import { useConfirm } from '../../composables/useConfirm'
+import { NIcon } from 'naive-ui'
+import { BrandDocker, AlertTriangle } from '@vicons/tabler'
+import {
+  stateBucket,
+  stateMeta,
+  shortId,
+  actionsFor,
+  ACTION_HINTS,
+  DANGER_COPY,
+  type ActionSpec,
+  type StateBucket,
+} from '../../lib/containerState'
+
+const props = defineProps<{
+  group: ServerContainers
+  name: string
+  host: string
+  /** 容器状态筛选(来自页面级筛选段);'all' = 不筛。 */
+  stateFilter: 'all' | StateBucket
+}>()
+const emit = defineEmits<{
+  (e: 'changed'): void
+  (e: 'logs', c: ContainerInfo): void
+  (e: 'terminal', c: ContainerInfo): void
+}>()
+
+const toast = useToast()
+const confirm = useConfirm()
+
+type TabKey = 'containers' | 'images'
+const tab = ref<TabKey>('containers')
+
+// 运行时显示名:首字母大写(docker → Docker)。
+const runtimeLabel = computed(() =>
+  props.group.runtime ? props.group.runtime.charAt(0).toUpperCase() + props.group.runtime.slice(1) : '',
+)
+
+// ─── 容器 ─────────────────────────────────────────────────────────────────────
+const busy = ref<Set<string>>(new Set())
+function rowBusy(cid: string): boolean {
+  for (const k of busy.value) if (k.startsWith(cid + ':')) return true
+  return false
+}
+function isBusy(cid: string, action: string): boolean {
+  return busy.value.has(`${cid}:${action}`)
+}
+
+const visibleContainers = computed(() => {
+  if (props.stateFilter === 'all') return props.group.containers
+  return props.group.containers.filter((c) => stateBucket(c.state) === props.stateFilter)
+})
+
+async function runAction(c: ContainerInfo, spec: ActionSpec): Promise<void> {
+  if (spec.danger) {
+    const copy = DANGER_COPY[spec.action]
+    const ok = await confirm.open({
+      title: copy?.title(c.names) ?? `对 ${c.names} 执行 ${spec.label}?`,
+      body: copy?.body ?? '该操作会影响容器运行状态。',
+      confirmLabel: copy?.confirmLabel ?? spec.label,
+      variant: 'danger',
+    })
+    if (!ok) return
+  }
+  const key = `${c.id}:${spec.action}`
+  busy.value = new Set(busy.value).add(key)
+  try {
+    const res = await serviceAction(props.group.serverId, { type: 'docker', target: c.names, action: spec.action })
+    if (res.ok) toast.success(`${spec.label}成功`, { detail: `${c.names} · ${props.name}` })
+    else toast.error(`${spec.label}失败`, { detail: res.error || '远端命令以非零状态退出' })
+  } catch (err) {
+    toast.error(`${spec.label}失败`, {
+      detail: err instanceof HttpError ? (err.apiError?.message ?? `请求失败(${err.status})`) : '网络错误',
+    })
+  } finally {
+    const next = new Set(busy.value)
+    next.delete(key)
+    busy.value = next
+    setTimeout(() => emit('changed'), 600)
+  }
+}
+
+// ─── 镜像(懒加载:首次切到镜像 tab 才拉) ───────────────────────────────────────
+const images = ref<ImageInfo[]>([])
+const imgState = ref<'idle' | 'loading' | 'loaded' | 'error'>('idle')
+const imgError = ref('')
+const pullRef = ref('')
+const pulling = ref(false)
+const busyImage = ref('')
+
+function repoTag(img: ImageInfo): string {
+  return img.repository === '<none>' ? `<none>:${img.tag}` : `${img.repository}:${img.tag}`
+}
+
+async function loadImages(): Promise<void> {
+  imgState.value = 'loading'
+  imgError.value = ''
+  try {
+    const res = await getServerImages(props.group.serverId)
+    if (!res.reachable || !res.runtime) {
+      imgState.value = 'error'
+      imgError.value = res.error || '该服务器不可达或无容器运行时'
+      return
+    }
+    images.value = res.images
+    imgState.value = 'loaded'
+  } catch (err) {
+    imgState.value = 'error'
+    imgError.value =
+      err instanceof HttpError ? (err.apiError?.message ?? `加载镜像失败(${err.status})`) : '加载镜像失败'
+  }
+}
+
+function switchTab(t: TabKey): void {
+  tab.value = t
+  if (t === 'images' && imgState.value === 'idle') void loadImages()
+}
+
+async function doPull(): Promise<void> {
+  const ref = pullRef.value.trim()
+  if (!ref || pulling.value) return
+  pulling.value = true
+  try {
+    const res = await pullImage(props.group.serverId, ref)
+    if (res.ok) {
+      toast.success('镜像已拉取', { detail: ref })
+      pullRef.value = ''
+      void loadImages()
+    } else {
+      toast.error('拉取失败', { detail: res.error || '请检查镜像名与网络' })
+    }
+  } catch (err) {
+    toast.error('拉取失败', {
+      detail: err instanceof HttpError ? (err.apiError?.message ?? `请求失败(${err.status})`) : '网络错误',
+    })
+  } finally {
+    pulling.value = false
+  }
+}
+
+async function doRemoveImage(img: ImageInfo): Promise<void> {
+  const tagStr = repoTag(img)
+  const ok = await confirm.open({
+    title: `删除镜像 ${tagStr}?`,
+    body: '将执行 docker rmi 删除该镜像。若有容器正在使用会删除失败。',
+    confirmLabel: '删除镜像',
+    variant: 'danger',
+  })
+  if (!ok) return
+  busyImage.value = img.id
+  try {
+    const res = await removeImage(props.group.serverId, img.id, false)
+    if (res.ok) {
+      toast.success('镜像已删除', { detail: tagStr })
+      void loadImages()
+    } else {
+      toast.error('删除失败', { detail: res.error || '镜像可能正被容器使用' })
+    }
+  } catch (err) {
+    toast.error('删除失败', {
+      detail: err instanceof HttpError ? (err.apiError?.message ?? `请求失败(${err.status})`) : '网络错误',
+    })
+  } finally {
+    busyImage.value = ''
+  }
+}
+</script>
+
+<template>
+  <article class="panel">
+    <header class="panel__head">
+      <div class="panel__id">
+        <h2 class="panel__name">{{ name }}</h2>
+        <span class="panel__host mono">{{ host }}</span>
+      </div>
+      <div class="panel__meta">
+        <span
+          class="rt-badge"
+          :class="{
+            'rt-badge--ok': group.reachable && group.runtime,
+            'rt-badge--warn': group.reachable && !group.runtime,
+            'rt-badge--down': !group.reachable,
+          }"
+        >
+          <NIcon :size="15" class="rt-badge__icon">
+            <BrandDocker v-if="group.reachable && group.runtime" />
+            <AlertTriangle v-else />
+          </NIcon>
+          {{ !group.reachable ? '不可达' : group.runtime ? runtimeLabel : '无容器运行时' }}
+        </span>
+        <span v-if="group.reachable && group.runtime" class="panel__count mono">
+          {{ group.running }}/{{ group.total }} 运行
+        </span>
+      </div>
+    </header>
+
+    <!-- 不可达 / 无运行时:行内提示 -->
+    <p v-if="!group.reachable" class="panel__hint panel__hint--down">⚠ {{ group.error }}</p>
+    <p v-else-if="!group.runtime" class="panel__hint">{{ group.error }}</p>
+
+    <template v-else>
+      <!-- 卡片内 tab:容器 / 镜像 -->
+      <div class="card-tabs" role="tablist">
+        <button class="ctab" :class="{ 'ctab--active': tab === 'containers' }" role="tab" @click="switchTab('containers')">
+          容器 <span class="ctab__n">{{ group.total }}</span>
+        </button>
+        <button class="ctab" :class="{ 'ctab--active': tab === 'images' }" role="tab" @click="switchTab('images')">
+          镜像 <span v-if="imgState === 'loaded'" class="ctab__n">{{ images.length }}</span>
+        </button>
+      </div>
+
+      <!-- 容器 tab -->
+      <template v-if="tab === 'containers'">
+        <p v-if="group.total === 0" class="panel__hint">该服务器暂无容器。</p>
+        <p v-else-if="visibleContainers.length === 0" class="panel__hint">无匹配当前筛选的容器(共 {{ group.total }} 个)。</p>
+        <ul v-else class="clist" role="list">
+          <li v-for="c in visibleContainers" :key="c.id" class="crow" :class="{ 'crow--busy': rowBusy(c.id) }">
+            <div class="crow__state">
+              <span class="dot" :class="[`dot--${stateMeta(c.state).tone}`, { 'dot--pulse': stateMeta(c.state).pulse }]" aria-hidden="true" />
+              <span class="crow__statelabel" :class="`txt--${stateMeta(c.state).tone}`">{{ stateMeta(c.state).label }}</span>
+            </div>
+            <div class="crow__main">
+              <div class="crow__name" :title="c.names">{{ c.names }}</div>
+              <div class="crow__sub mono" :title="`${c.image} · ${c.id}`">{{ c.image }} · {{ shortId(c.id) }}</div>
+            </div>
+            <div class="crow__status">
+              <div class="crow__statustxt" :title="c.status">{{ c.status }}</div>
+              <div v-if="c.ports" class="crow__ports mono" :title="c.ports">{{ c.ports }}</div>
+            </div>
+            <div class="crow__actions">
+              <button
+                v-for="a in actionsFor(c.state)"
+                :key="a.action"
+                class="op"
+                :class="[`op--${a.variant}`, { 'op--busy': isBusy(c.id, a.action) }]"
+                :disabled="rowBusy(c.id)"
+                :title="ACTION_HINTS[a.action]"
+                @click="runAction(c, a)"
+              >
+                {{ a.label }}
+              </button>
+              <button class="op op--ghost" title="查看容器日志(docker logs)" @click="emit('logs', c)">日志</button>
+              <button class="op op--ghost" :disabled="rowBusy(c.id)" title="进入容器终端(docker exec -it)" @click="emit('terminal', c)">终端</button>
+            </div>
+          </li>
+        </ul>
+      </template>
+
+      <!-- 镜像 tab -->
+      <template v-else>
+        <div class="img-toolbar">
+          <div class="pull">
+            <input v-model="pullRef" class="pull__in mono" placeholder="拉取镜像,例:nginx:latest" @keyup.enter="doPull" />
+            <button class="pull__btn" :disabled="pulling || !pullRef.trim()" @click="doPull">
+              {{ pulling ? '拉取中…' : '拉取' }}
+            </button>
+          </div>
+          <span class="grow" />
+          <button class="refresh" :disabled="imgState === 'loading'" @click="loadImages">↻ 刷新</button>
+        </div>
+        <p v-if="imgState === 'error'" class="panel__hint panel__hint--down">⚠ {{ imgError }}</p>
+        <p v-else-if="imgState === 'loading' && images.length === 0" class="panel__hint">正在加载镜像…</p>
+        <p v-else-if="images.length === 0" class="panel__hint">该服务器暂无镜像。</p>
+        <ul v-else class="ilist" role="list">
+          <li v-for="img in images" :key="img.id + repoTag(img)" class="irow" :class="{ 'irow--busy': busyImage === img.id }">
+            <div class="irow__main">
+              <div class="irow__tag" :title="repoTag(img)">{{ repoTag(img) }}</div>
+              <div class="irow__id mono">{{ img.id }}</div>
+            </div>
+            <div class="irow__size mono">{{ img.size }}</div>
+            <div class="irow__age">{{ img.createdSince }}</div>
+            <div class="irow__act">
+              <button class="op op--ghost" :disabled="busyImage === img.id" title="删除镜像(docker rmi)" @click="doRemoveImage(img)">删除</button>
+            </div>
+          </li>
+        </ul>
+      </template>
+    </template>
+  </article>
+</template>
+
+<style scoped>
+.panel {
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-lg, 12px);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+.panel__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-card-2);
+}
+.panel__id {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
+.panel__name {
+  margin: 0;
+  font-size: var(--text-section);
+  font-weight: 700;
+  color: var(--color-text);
+}
+.panel__host {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.panel__meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+.panel__count {
+  font-size: var(--text-micro);
+  color: var(--color-dim);
+  font-variant-numeric: tabular-nums;
+}
+.rt-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: var(--text-label);
+  font-weight: 700;
+  padding: 4px 11px 4px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border-strong);
+  color: var(--color-dim);
+  white-space: nowrap;
+}
+.rt-badge__icon {
+  display: inline-flex;
+}
+.rt-badge--ok {
+  color: var(--color-green);
+  background: var(--color-green-soft);
+  border-color: var(--color-green-line);
+}
+.rt-badge--warn {
+  color: var(--color-amber);
+  background: var(--color-amber-soft);
+  border-color: var(--color-amber-line);
+}
+.rt-badge--down {
+  color: var(--color-red);
+  background: var(--color-red-soft);
+  border-color: var(--color-red-line);
+}
+.panel__hint {
+  margin: 0;
+  padding: 16px 18px;
+  font-size: var(--text-label);
+  color: var(--color-faint);
+}
+.panel__hint--down {
+  color: var(--color-red);
+}
+
+/* 卡片内 tab */
+.card-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--color-border);
+}
+.ctab {
+  padding: 9px 14px;
+  font-size: var(--text-label);
+  font-weight: 600;
+  color: var(--color-faint);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--ease-out-expo);
+}
+.ctab:hover {
+  color: var(--color-dim);
+}
+.ctab--active {
+  color: var(--color-text);
+  border-bottom-color: var(--color-primary);
+}
+.ctab__n {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+/* 容器行 */
+.clist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.crow {
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1.4fr) minmax(0, 1.3fr) auto;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--color-border);
+  transition: background var(--duration-fast) var(--ease-out-expo);
+}
+.crow:last-child {
+  border-bottom: none;
+}
+.crow:hover {
+  background: var(--color-card-2);
+}
+.crow--busy {
+  opacity: 0.55;
+}
+.crow__state {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.crow__statelabel {
+  font-size: var(--text-micro);
+  font-weight: 600;
+}
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--color-faint);
+}
+.dot--green { background: var(--color-green); }
+.dot--amber { background: var(--color-amber); }
+.dot--cyan { background: var(--color-cyan); }
+.dot--red { background: var(--color-red); }
+.dot--faint { background: var(--color-faint); }
+.dot--pulse { animation: dotPulse 1.8s var(--ease-out-expo) infinite; }
+@keyframes dotPulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.45; transform: scale(0.8); }
+}
+.txt--green { color: var(--color-green); }
+.txt--amber { color: var(--color-amber); }
+.txt--cyan { color: var(--color-cyan); }
+.txt--red { color: var(--color-red); }
+.txt--faint { color: var(--color-faint); }
+.crow__main { min-width: 0; }
+.crow__name {
+  font-size: var(--text-body);
+  font-weight: 600;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.crow__sub {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.crow__status { min-width: 0; }
+.crow__statustxt {
+  font-size: var(--text-label);
+  color: var(--color-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.crow__ports {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.crow__actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+/* 镜像 tab */
+.img-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--color-border);
+  flex-wrap: wrap;
+}
+.pull {
+  display: inline-flex;
+  gap: 6px;
+}
+.pull__in {
+  width: 260px;
+  max-width: 50vw;
+  font-size: var(--text-label);
+  padding: 6px 10px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-inset);
+  color: var(--color-text);
+}
+.pull__in:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+.pull__btn {
+  font-size: var(--text-label);
+  font-weight: 600;
+  padding: 6px 14px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-primary);
+  background: var(--color-primary);
+  color: #fff;
+  cursor: pointer;
+}
+.pull__btn:hover:not(:disabled) { background: var(--color-primary-press); }
+.refresh {
+  font-size: var(--text-label);
+  font-weight: 600;
+  padding: 6px 14px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-border-strong);
+  background: transparent;
+  color: var(--color-dim);
+  cursor: pointer;
+}
+.refresh:hover:not(:disabled) { color: var(--color-text); border-color: var(--color-text); }
+.pull__btn:disabled, .refresh:disabled { opacity: 0.5; cursor: not-allowed; }
+.grow { flex: 1; }
+
+.ilist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.irow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 100px 130px auto;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--color-border);
+  transition: background var(--duration-fast) var(--ease-out-expo);
+}
+.irow:last-child { border-bottom: none; }
+.irow:hover { background: var(--color-card-2); }
+.irow--busy { opacity: 0.55; }
+.irow__main { min-width: 0; }
+.irow__tag {
+  font-size: var(--text-body);
+  font-weight: 600;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.irow__id { font-size: var(--text-micro); color: var(--color-faint); }
+.irow__size { font-size: var(--text-label); color: var(--color-dim); font-variant-numeric: tabular-nums; }
+.irow__age { font-size: var(--text-label); color: var(--color-faint); }
+.irow__act { display: flex; justify-content: flex-end; }
+
+/* 行内迷你操作按钮 */
+.op {
+  font-size: var(--text-micro);
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-border-strong);
+  background: transparent;
+  color: var(--color-dim);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out-expo);
+}
+.op:hover:not(:disabled) { color: var(--color-text); border-color: var(--color-text); }
+.op--default { color: var(--color-primary); border-color: var(--color-primary-soft); }
+.op--default:hover:not(:disabled) { color: #fff; background: var(--color-primary); border-color: var(--color-primary); }
+.op:disabled { opacity: 0.45; cursor: not-allowed; }
+.op--busy { opacity: 0.6; pointer-events: none; }
+
+@media (max-width: 720px) {
+  .crow, .irow { grid-template-columns: 1fr; gap: 8px; }
+  .crow__actions { justify-content: flex-start; }
+}
+</style>

--- a/web/src/components/ops/ServerCard.vue
+++ b/web/src/components/ops/ServerCard.vue
@@ -31,6 +31,7 @@ import {
   type NetworkContainer,
 } from '../../api/containers'
 import { serviceAction } from '../../api/servers'
+import { generateCompose } from '../../api/aiOps'
 import { HttpError } from '../../api/http'
 import { useToast } from '../../composables/useToast'
 import { useConfirm } from '../../composables/useConfirm'
@@ -432,6 +433,35 @@ async function doStackAction(s: StackInfo, action: StackAction, label: string, d
   }
 }
 
+// AI 生成 compose:中文需求 → docker-compose.yml,填进部署表单。
+const aiComposeNl = ref('')
+const aiComposeBusy = ref(false)
+async function aiGenCompose(): Promise<void> {
+  const nl = aiComposeNl.value.trim()
+  if (!nl || aiComposeBusy.value) return
+  aiComposeBusy.value = true
+  try {
+    const res = await generateCompose(nl)
+    if (!res.available) {
+      toast.error('AI 未配置', { detail: '请到「设置 › AI」配置模型' })
+      return
+    }
+    if (res.yaml) {
+      deployCompose.value = res.yaml
+      if (!deployName.value.trim()) deployName.value = 'ai-stack'
+      toast.success('AI 已生成 compose', { detail: '请核对后再部署' })
+    } else {
+      toast.error('生成失败', { detail: res.reason || '模型未产出 compose' })
+    }
+  } catch (err) {
+    toast.error('生成失败', {
+      detail: err instanceof HttpError ? (err.apiError?.message ?? '请求失败') : '网络错误',
+    })
+  } finally {
+    aiComposeBusy.value = false
+  }
+}
+
 async function doDeploy(): Promise<void> {
   const name = deployName.value.trim()
   const compose = deployCompose.value.trim()
@@ -638,6 +668,18 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
 
         <!-- 部署表单(贴 compose yaml) -->
         <div v-if="showDeploy" class="deploy">
+          <div class="deploy__ai">
+            <span class="deploy__spark">✦</span>
+            <input
+              v-model="aiComposeNl"
+              class="deploy__ainl mono"
+              placeholder="用中文描述,如:nginx + redis,nginx 映射 8080,redis 持久化"
+              @keyup.enter="aiGenCompose"
+            />
+            <button class="pull__btn" :disabled="aiComposeBusy || !aiComposeNl.trim()" @click="aiGenCompose">
+              {{ aiComposeBusy ? '生成中…' : 'AI 生成' }}
+            </button>
+          </div>
           <input v-model="deployName" class="deploy__name mono" placeholder="项目名,例:my-stack" />
           <textarea
             v-model="deployCompose"
@@ -1075,6 +1117,32 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
   padding: 14px 18px;
   border-bottom: 1px solid var(--color-border);
   background: var(--color-inset);
+}
+.deploy__ai {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--color-primary-soft);
+  background: var(--color-primary-soft);
+  border-radius: var(--rounded-sm);
+}
+.deploy__spark {
+  color: var(--color-primary);
+  font-weight: 700;
+}
+.deploy__ainl {
+  flex: 1;
+  font-size: var(--text-label);
+  padding: 6px 10px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-card);
+  color: var(--color-text);
+}
+.deploy__ainl:focus {
+  outline: none;
+  border-color: var(--color-primary);
 }
 .deploy__name {
   font-size: var(--text-label);

--- a/web/src/components/ops/ServerCard.vue
+++ b/web/src/components/ops/ServerCard.vue
@@ -9,9 +9,14 @@ import {
   getServerImages,
   pullImage,
   removeImage,
+  getServerStacks,
+  deployStack,
+  stackAction,
   type ServerContainers,
   type ContainerInfo,
   type ImageInfo,
+  type StackInfo,
+  type StackAction,
 } from '../../api/containers'
 import { serviceAction } from '../../api/servers'
 import { HttpError } from '../../api/http'
@@ -46,7 +51,7 @@ const emit = defineEmits<{
 const toast = useToast()
 const confirm = useConfirm()
 
-type TabKey = 'containers' | 'images'
+type TabKey = 'containers' | 'images' | 'stacks'
 const tab = ref<TabKey>('containers')
 
 // 运行时显示名:首字母大写(docker → Docker)。
@@ -132,6 +137,108 @@ async function loadImages(): Promise<void> {
 function switchTab(t: TabKey): void {
   tab.value = t
   if (t === 'images' && imgState.value === 'idle') void loadImages()
+  if (t === 'stacks' && stackState.value === 'idle') void loadStacks()
+}
+
+// ─── Stacks / Compose(懒加载) ────────────────────────────────────────────────
+const stacks = ref<StackInfo[]>([])
+const stackState = ref<'idle' | 'loading' | 'loaded' | 'error'>('idle')
+const stackError = ref('')
+const busyStack = ref('')
+const showDeploy = ref(false)
+const deployName = ref('')
+const deployCompose = ref('')
+const deploying = ref(false)
+
+async function loadStacks(): Promise<void> {
+  stackState.value = 'loading'
+  stackError.value = ''
+  try {
+    const res = await getServerStacks(props.group.serverId)
+    if (!res.reachable || !res.runtime) {
+      stackState.value = 'error'
+      stackError.value = res.error || '该服务器不可达或无 docker compose'
+      return
+    }
+    stacks.value = res.stacks
+    stackState.value = 'loaded'
+  } catch (err) {
+    stackState.value = 'error'
+    stackError.value =
+      err instanceof HttpError ? (err.apiError?.message ?? `加载 Stacks 失败(${err.status})`) : '加载 Stacks 失败'
+  }
+}
+
+const STACK_ACTIONS: { action: StackAction; label: string; danger?: boolean; title?: string }[] = [
+  { action: 'update', label: '更新', danger: true, title: 'docker compose up -d --pull always:拉取新镜像 + 重建有变化的服务(升级到最新)' },
+  { action: 'start', label: '启动' },
+  { action: 'restart', label: '重启', danger: true },
+  { action: 'stop', label: '停止', danger: true },
+  { action: 'down', label: '销毁', danger: true },
+]
+
+async function doStackAction(s: StackInfo, action: StackAction, label: string, danger?: boolean): Promise<void> {
+  if (action === 'update' && !s.configFiles) {
+    toast.error('无法更新', { detail: '该 Stack 无可用 compose 配置文件' })
+    return
+  }
+  if (danger) {
+    const ok = await confirm.open({
+      title: `对 Stack ${s.name} 执行${label}?`,
+      body:
+        action === 'down'
+          ? '将销毁该 compose 项目的所有容器与网络(数据卷默认保留)。'
+          : action === 'update'
+            ? '将按现有 compose 文件拉取新镜像并重建有变化的服务(docker compose up -d --pull always),实现升级。'
+            : `将对该 compose 项目的所有服务执行${label}。`,
+      confirmLabel: label,
+      variant: 'danger',
+    })
+    if (!ok) return
+  }
+  busyStack.value = s.name
+  try {
+    const res = await stackAction(props.group.serverId, s.name, action, s.configFiles)
+    if (res.ok) {
+      toast.success(`Stack ${label}成功`, { detail: s.name })
+      void loadStacks()
+      emit('changed')
+    } else {
+      toast.error(`Stack ${label}失败`, { detail: res.error || '远端命令以非零状态退出' })
+    }
+  } catch (err) {
+    toast.error(`Stack ${label}失败`, {
+      detail: err instanceof HttpError ? (err.apiError?.message ?? `请求失败(${err.status})`) : '网络错误',
+    })
+  } finally {
+    busyStack.value = ''
+  }
+}
+
+async function doDeploy(): Promise<void> {
+  const name = deployName.value.trim()
+  const compose = deployCompose.value.trim()
+  if (!name || !compose || deploying.value) return
+  deploying.value = true
+  try {
+    const res = await deployStack(props.group.serverId, name, compose)
+    if (res.ok) {
+      toast.success('Stack 已部署', { detail: name })
+      showDeploy.value = false
+      deployName.value = ''
+      deployCompose.value = ''
+      void loadStacks()
+      emit('changed')
+    } else {
+      toast.error('部署失败', { detail: res.error || 'docker compose up 失败' })
+    }
+  } catch (err) {
+    toast.error('部署失败', {
+      detail: err instanceof HttpError ? (err.apiError?.message ?? `请求失败(${err.status})`) : '网络错误',
+    })
+  } finally {
+    deploying.value = false
+  }
 }
 
 async function doPull(): Promise<void> {
@@ -225,6 +332,9 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
         <button class="ctab" :class="{ 'ctab--active': tab === 'images' }" role="tab" @click="switchTab('images')">
           镜像 <span v-if="imgState === 'loaded'" class="ctab__n">{{ images.length }}</span>
         </button>
+        <button class="ctab" :class="{ 'ctab--active': tab === 'stacks' }" role="tab" @click="switchTab('stacks')">
+          Stacks <span v-if="stackState === 'loaded'" class="ctab__n">{{ stacks.length }}</span>
+        </button>
       </div>
 
       <!-- 容器 tab -->
@@ -265,7 +375,7 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
       </template>
 
       <!-- 镜像 tab -->
-      <template v-else>
+      <template v-else-if="tab === 'images'">
         <div class="img-toolbar">
           <div class="pull">
             <input v-model="pullRef" class="pull__in mono" placeholder="拉取镜像,例:nginx:latest" @keyup.enter="doPull" />
@@ -289,6 +399,58 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
             <div class="irow__age">{{ img.createdSince }}</div>
             <div class="irow__act">
               <button class="op op--ghost" :disabled="busyImage === img.id" title="删除镜像(docker rmi)" @click="doRemoveImage(img)">删除</button>
+            </div>
+          </li>
+        </ul>
+      </template>
+
+      <!-- Stacks tab -->
+      <template v-else>
+        <div class="img-toolbar">
+          <button class="pull__btn" @click="showDeploy = !showDeploy">{{ showDeploy ? '收起部署' : '+ 部署 Stack' }}</button>
+          <span class="grow" />
+          <button class="refresh" :disabled="stackState === 'loading'" @click="loadStacks">↻ 刷新</button>
+        </div>
+
+        <!-- 部署表单(贴 compose yaml) -->
+        <div v-if="showDeploy" class="deploy">
+          <input v-model="deployName" class="deploy__name mono" placeholder="项目名,例:my-stack" />
+          <textarea
+            v-model="deployCompose"
+            class="deploy__yaml mono"
+            rows="8"
+            placeholder="粘贴 docker-compose.yml 内容…&#10;services:&#10;  web:&#10;    image: nginx:latest&#10;    ports: [&quot;8088:80&quot;]"
+          />
+          <div class="deploy__act">
+            <span class="deploy__hint">将写入主机受管目录并 docker compose up -d</span>
+            <button class="pull__btn" :disabled="deploying || !deployName.trim() || !deployCompose.trim()" @click="doDeploy">
+              {{ deploying ? '部署中…' : '部署' }}
+            </button>
+          </div>
+        </div>
+
+        <p v-if="stackState === 'error'" class="panel__hint panel__hint--down">⚠ {{ stackError }}</p>
+        <p v-else-if="stackState === 'loading' && stacks.length === 0" class="panel__hint">正在加载 Stacks…</p>
+        <p v-else-if="stacks.length === 0" class="panel__hint">该服务器暂无 compose 项目。点「+ 部署 Stack」贴 yaml 部署一个。</p>
+        <ul v-else class="ilist" role="list">
+          <li v-for="s in stacks" :key="s.name" class="srow" :class="{ 'irow--busy': busyStack === s.name }">
+            <div class="srow__main">
+              <div class="srow__name">{{ s.name }}</div>
+              <div class="srow__cfg mono" :title="s.configFiles">{{ s.configFiles || '—' }}</div>
+            </div>
+            <div class="srow__status mono">{{ s.status }}</div>
+            <div class="srow__act">
+              <button
+                v-for="a in STACK_ACTIONS"
+                :key="a.action"
+                class="op"
+                :class="{ 'op--default': a.action === 'update' }"
+                :disabled="busyStack === s.name"
+                :title="a.title"
+                @click="doStackAction(s, a.action, a.label, a.danger)"
+              >
+                {{ a.label }}
+              </button>
             </div>
           </li>
         </ul>
@@ -592,6 +754,84 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
 .irow__size { font-size: var(--text-label); color: var(--color-dim); font-variant-numeric: tabular-nums; }
 .irow__age { font-size: var(--text-label); color: var(--color-faint); }
 .irow__act { display: flex; justify-content: flex-end; }
+
+/* 部署表单 + stack 行 */
+.deploy {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-inset);
+}
+.deploy__name {
+  font-size: var(--text-label);
+  padding: 7px 10px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-card);
+  color: var(--color-text);
+}
+.deploy__yaml {
+  font-size: var(--text-mono);
+  line-height: 1.5;
+  padding: 10px 12px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-term);
+  color: oklch(88% 0.01 250);
+  resize: vertical;
+}
+.deploy__name:focus,
+.deploy__yaml:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+.deploy__act {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.deploy__hint {
+  flex: 1;
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+}
+
+.srow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 120px auto;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--color-border);
+  transition: background var(--duration-fast) var(--ease-out-expo);
+}
+.srow:last-child { border-bottom: none; }
+.srow:hover { background: var(--color-card-2); }
+.srow__main { min-width: 0; }
+.srow__name {
+  font-size: var(--text-body);
+  font-weight: 600;
+  color: var(--color-text);
+}
+.srow__cfg {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.srow__status {
+  font-size: var(--text-label);
+  color: var(--color-dim);
+}
+.srow__act {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
 
 /* 行内迷你操作按钮 */
 .op {

--- a/web/src/components/ops/ServiceOpsPanel.vue
+++ b/web/src/components/ops/ServiceOpsPanel.vue
@@ -45,7 +45,9 @@ const targetValid = computed(() => targetInput.value.trim().length > 0)
 const pendingAction = ref<ServiceAction | null>(null)
 const submitting = ref(false)
 
-const actionLabel: Record<ServiceAction, string> = {
+// 本面板仅提供 restart/stop/start 三个动作(systemd/docker 通用);ServiceAction 联合类型
+// 另含容器专用的 pause/unpause/kill/rm(由「容器」页驱动),此处用 Partial 只列用到的键。
+const actionLabel: Partial<Record<ServiceAction, string>> = {
   restart: '重启',
   stop: '停止',
   start: '启动',

--- a/web/src/components/ops/SystemPruneModal.vue
+++ b/web/src/components/ops/SystemPruneModal.vue
@@ -1,0 +1,417 @@
+<script setup lang="ts">
+/**
+ * SystemPruneModal — 容器管理一键清理(docker system df / prune)。
+ *
+ * 选一台主机,看它的 Docker 磁盘占用(镜像 / 容器 / 卷 / 构建缓存的大小 + 可回收量),
+ * 一键清理停止的容器 / 悬空镜像 / 无用卷 / 构建缓存 / 全部。每个清理走二次确认(说明会删什么、
+ * 全部不含数据卷),结果走 toast,清理后刷新占用。
+ *
+ * 安全:scope 走后端枚举白名单;命令服务端 array 化、不拼 shell;all 不加 --volumes(不误删卷)。
+ */
+import { ref, computed, watch, onMounted } from 'vue'
+import {
+  getSystemDf,
+  systemPrune,
+  type SystemDf,
+  type PruneScope,
+} from '../../api/containers'
+import { HttpError } from '../../api/http'
+import { useToast } from '../../composables/useToast'
+import { useConfirm } from '../../composables/useConfirm'
+import AppButton from '../ui/AppButton.vue'
+
+const props = defineProps<{
+  /** 可作用于的服务器(通常是 reachable + 装了 docker 的)。 */
+  servers: { id: string; name: string }[]
+}>()
+
+const emit = defineEmits<{ (e: 'close'): void }>()
+
+const toast = useToast()
+const confirm = useConfirm()
+
+const selectedId = ref(props.servers[0]?.id ?? '')
+const df = ref<SystemDf | null>(null)
+const loading = ref(false)
+const loadError = ref('')
+/** 正在清理的 scope(禁用所有按钮 + 给该按钮 loading)。 */
+const busyScope = ref<PruneScope | ''>('')
+
+const selectedName = computed(
+  () => props.servers.find((s) => s.id === selectedId.value)?.name ?? selectedId.value,
+)
+
+/** 清理动作定义(顺序即展示顺序)。 */
+interface PruneAction {
+  scope: PruneScope
+  label: string
+  /** 二次确认正文:明确说明会删什么。 */
+  confirmBody: string
+  danger?: boolean
+}
+
+const actions: PruneAction[] = [
+  {
+    scope: 'containers',
+    label: '停止的容器',
+    confirmBody: '将删除该主机上所有「已停止」的容器(运行中的不受影响)。此操作不可撤销。',
+  },
+  {
+    scope: 'images',
+    label: '悬空镜像',
+    confirmBody: '将删除「悬空(dangling)」镜像 —— 没有标签且未被任何容器引用的镜像层。被使用的镜像不受影响。',
+  },
+  {
+    scope: 'volumes',
+    label: '无用卷',
+    confirmBody: '将删除「未被任何容器引用」的数据卷。卷里的数据会一并永久删除,请确认这些卷确实不再需要。',
+    danger: true,
+  },
+  {
+    scope: 'builder',
+    label: '构建缓存',
+    confirmBody: '将清理 Docker 构建缓存(build cache)。下次构建会重新拉取/编译相关层,首次会更慢。',
+  },
+  {
+    scope: 'all',
+    label: '全部',
+    confirmBody:
+      '将一次性清理:已停止的容器、悬空镜像、未使用的网络、构建缓存。\n\n注意:此操作「不含」数据卷(named volumes),你的卷数据是安全的。',
+    danger: true,
+  },
+]
+
+async function loadDf(): Promise<void> {
+  if (!selectedId.value) return
+  loading.value = true
+  loadError.value = ''
+  try {
+    df.value = await getSystemDf(selectedId.value)
+  } catch (err: unknown) {
+    df.value = null
+    loadError.value =
+      err instanceof HttpError
+        ? err.status === 0
+          ? '无法连接到服务器,请稍后重试'
+          : err.apiError?.message ?? `读取磁盘占用失败(${err.status})`
+        : '读取磁盘占用失败,请稍后重试'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function runPrune(action: PruneAction): Promise<void> {
+  if (!selectedId.value || busyScope.value) return
+  const ok = await confirm.open({
+    title: `清理「${action.label}」 · ${selectedName.value}`,
+    body: action.confirmBody,
+    confirmLabel: `清理${action.label}`,
+    variant: action.danger ? 'danger' : 'primary',
+  })
+  if (!ok) return
+
+  busyScope.value = action.scope
+  try {
+    const res = await systemPrune(selectedId.value, action.scope)
+    if (res.ok) {
+      const summary = res.output.trim()
+      toast.success(`已清理「${action.label}」`, {
+        detail: summary || '没有可清理的内容',
+      })
+    } else {
+      toast.error(`清理「${action.label}」失败`, { detail: res.error || '远端命令执行失败' })
+    }
+  } catch (err: unknown) {
+    const msg =
+      err instanceof HttpError
+        ? err.apiError?.message ?? `请求失败(${err.status})`
+        : '请求失败,请稍后重试'
+    toast.error(`清理「${action.label}」失败`, { detail: msg })
+  } finally {
+    busyScope.value = ''
+    // 清理后刷新占用(无论成功失败,占用都可能变了)。
+    void loadDf()
+  }
+}
+
+watch(selectedId, () => void loadDf())
+onMounted(() => void loadDf())
+</script>
+
+<template>
+  <div class="scrim" @click.self="emit('close')">
+    <div class="modal" role="dialog" aria-modal="true" aria-label="一键清理 Docker 磁盘">
+      <header class="head">
+        <div>
+          <h2 class="title">一键清理 · Docker 磁盘</h2>
+          <p class="sub">查看并清理目标主机上的 Docker 占用,免逐台 SSH。</p>
+        </div>
+        <button class="close" aria-label="关闭" @click="emit('close')">✕</button>
+      </header>
+
+      <!-- Server picker -->
+      <div v-if="servers.length === 0" class="empty">
+        没有可清理的主机。请先在「设置 › 服务器」登记并确保服务器可达且已安装 Docker。
+      </div>
+      <template v-else>
+        <div class="field">
+          <label class="label" for="prune-server">目标主机</label>
+          <select id="prune-server" v-model="selectedId" class="select">
+            <option v-for="s in servers" :key="s.id" :value="s.id">{{ s.name }}</option>
+          </select>
+        </div>
+
+        <!-- Disk usage table -->
+        <section class="usage" aria-label="Docker 磁盘占用">
+          <div class="usage-head">
+            <span>磁盘占用</span>
+            <button class="link" :disabled="loading" @click="loadDf">
+              {{ loading ? '刷新中…' : '刷新' }}
+            </button>
+          </div>
+
+          <p v-if="loadError" class="err">{{ loadError }}</p>
+          <p v-else-if="loading && !df" class="hint">读取中…</p>
+          <p v-else-if="df && !df.reachable" class="err">主机不可达:{{ df.error }}</p>
+          <p v-else-if="df && !df.dockerAvailable" class="err">{{ df.error }}</p>
+          <table v-else-if="df && df.entries.length > 0" class="df">
+            <thead>
+              <tr>
+                <th>类型</th>
+                <th class="num">数量</th>
+                <th class="num">活跃</th>
+                <th class="num">大小</th>
+                <th class="num">可回收</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="e in df.entries" :key="e.type">
+                <td>{{ e.type }}</td>
+                <td class="num">{{ e.totalCount }}</td>
+                <td class="num">{{ e.active }}</td>
+                <td class="num">{{ e.size }}</td>
+                <td class="num reclaim">{{ e.reclaimable }}</td>
+              </tr>
+            </tbody>
+          </table>
+          <p v-else class="hint">无占用数据。</p>
+        </section>
+
+        <!-- Cleanup actions -->
+        <section class="actions" aria-label="清理操作">
+          <p class="actions-title">清理</p>
+          <div class="action-grid">
+            <AppButton
+              v-for="a in actions"
+              :key="a.scope"
+              :variant="a.danger ? 'danger' : 'default'"
+              :disabled="busyScope !== '' || !df?.dockerAvailable"
+              :loading="busyScope === a.scope"
+              @click="runPrune(a)"
+            >
+              {{ a.label }}
+            </AppButton>
+          </div>
+          <p class="note">「全部」清理已停止容器 / 悬空镜像 / 未用网络 / 构建缓存,<strong>不含数据卷</strong>。</p>
+        </section>
+      </template>
+
+      <footer class="foot">
+        <button class="btn-secondary" @click="emit('close')">关闭</button>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.scrim {
+  position: fixed;
+  inset: 0;
+  background: oklch(0% 0 0 / 0.55);
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  z-index: 500;
+}
+.modal {
+  width: min(600px, 100%);
+  max-height: 88vh;
+  overflow-y: auto;
+  background: var(--color-card);
+  border: 1px solid var(--color-border-strong);
+  border-radius: 18px;
+  box-shadow: var(--shadow-modal);
+  padding: 1.4rem;
+}
+.head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.1rem;
+}
+.title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 640;
+  color: var(--color-text);
+}
+.sub {
+  margin: 0.3rem 0 0;
+  font-size: 0.85rem;
+  color: var(--color-dim);
+}
+.close {
+  border: none;
+  background: none;
+  color: var(--color-dim);
+  font-size: 1rem;
+  cursor: pointer;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+.close:hover {
+  background: var(--color-inset);
+  color: var(--color-text);
+}
+
+.empty {
+  padding: 1rem;
+  border: 1px dashed var(--color-border);
+  border-radius: 11px;
+  color: var(--color-dim);
+  font-size: 0.88rem;
+  line-height: 1.6;
+}
+
+.field {
+  margin-bottom: 1.1rem;
+}
+.label {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-size: 0.83rem;
+  font-weight: 560;
+  color: var(--color-dim);
+}
+.select {
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  background: var(--color-inset);
+  border: 1px solid var(--color-border);
+  border-radius: 9px;
+  color: var(--color-text);
+  font-size: 0.9rem;
+}
+.select:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.usage {
+  margin-bottom: 1.2rem;
+}
+.usage-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 0.55rem;
+  font-size: 0.83rem;
+  font-weight: 560;
+  color: var(--color-dim);
+}
+.link {
+  border: none;
+  background: none;
+  color: var(--color-primary);
+  font-size: 0.83rem;
+  cursor: pointer;
+  padding: 0;
+}
+.link:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.df {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+.df th,
+.df td {
+  padding: 0.45rem 0.6rem;
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+  color: var(--color-text);
+}
+.df th {
+  color: var(--color-dim);
+  font-weight: 560;
+}
+.df .num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.df .reclaim {
+  color: var(--color-green, #2e7d32);
+}
+
+.actions-title {
+  margin: 0 0 0.55rem;
+  font-size: 0.83rem;
+  font-weight: 560;
+  color: var(--color-dim);
+}
+.action-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.note {
+  margin: 0.7rem 0 0;
+  font-size: 0.8rem;
+  color: var(--color-dim);
+  line-height: 1.5;
+}
+.note strong {
+  color: var(--color-text);
+}
+
+.err {
+  margin: 0;
+  padding: 0.6rem 0.85rem;
+  border-radius: 9px;
+  font-size: 0.85rem;
+  color: var(--color-red);
+  background: var(--color-red-soft);
+  border: 1px solid var(--color-red-line);
+}
+.hint {
+  margin: 0;
+  color: var(--color-dim);
+  font-size: 0.85rem;
+}
+
+.foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+  margin-top: 1.4rem;
+}
+.btn-secondary {
+  padding: 0.55rem 1.1rem;
+  background: var(--color-card-2);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+  border-radius: 10px;
+  font-weight: 560;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+.btn-secondary:hover {
+  border-color: var(--color-primary);
+}
+</style>

--- a/web/src/layouts/AppShell.vue
+++ b/web/src/layouts/AppShell.vue
@@ -8,6 +8,7 @@ import {
   GitFork,
   ChartBar,
   Server,
+  Box,
   AlertTriangle,
   Bell,
   Settings,
@@ -74,6 +75,8 @@ const navItems: NavItem[] = [
   { name: 'dora',          to: '/metrics/dora',  icon: ChartBar,   label: 'DORA 指标', ariaLabel: 'DORA 指标' },
   // Story 6-1: 多机状态总览(服务器层指标 FR-15);登记在 设置 → 服务器。
   { name: 'server-status', to: '/server-status', icon: Server,     label: '服务器', ariaLabel: '服务器' },
+  // 容器管理:跨服务器聚合容器总览 + 行内生命周期操作(docker over SSH)。
+  { name: 'containers',    to: '/containers',    icon: Box,        label: '容器',  ariaLabel: '容器' },
   // Story 6-5: configurable anomaly detection & alerts (FR-23)
   { name: 'anomaly',       to: '/anomaly',       icon: AlertTriangle, label: '异常检测', ariaLabel: '异常检测' },
   { name: 'notifications', to: '/settings/notifications', icon: Bell, label: '通知',  ariaLabel: '通知' },

--- a/web/src/lib/containerState.ts
+++ b/web/src/lib/containerState.ts
@@ -1,0 +1,93 @@
+/**
+ * 容器状态展示与生命周期操作的共享元数据。
+ * 总览页(计数/筛选)与单机卡片(渲染/操作)共用,避免重复。
+ */
+import type { ContainerState } from '../api/containers'
+import type { ServiceAction } from '../api/servers'
+
+/** 六态归并三桶,供筛选与计数。 */
+export type StateBucket = 'running' | 'paused' | 'stopped'
+
+export function stateBucket(s: ContainerState): StateBucket {
+  if (s === 'running' || s === 'restarting') return 'running'
+  if (s === 'paused') return 'paused'
+  return 'stopped'
+}
+
+export interface StateMeta {
+  label: string
+  tone: 'green' | 'amber' | 'cyan' | 'red' | 'faint'
+  pulse: boolean
+}
+
+const STATE_META: Record<ContainerState, StateMeta> = {
+  running: { label: '运行中', tone: 'green', pulse: true },
+  paused: { label: '已暂停', tone: 'amber', pulse: false },
+  restarting: { label: '重启中', tone: 'amber', pulse: true },
+  created: { label: '已创建', tone: 'cyan', pulse: false },
+  exited: { label: '已停止', tone: 'faint', pulse: false },
+  dead: { label: '异常', tone: 'red', pulse: false },
+  unknown: { label: '未知', tone: 'faint', pulse: false },
+}
+
+export function stateMeta(s: ContainerState): StateMeta {
+  return STATE_META[s] ?? STATE_META.unknown
+}
+
+export function shortId(id: string): string {
+  return id.length > 12 ? id.slice(0, 12) : id
+}
+
+export interface ActionSpec {
+  action: ServiceAction
+  label: string
+  variant: 'default' | 'ghost' | 'danger'
+  /** 需二次确认。 */
+  danger?: boolean
+}
+
+/** 据容器状态给出可用生命周期操作集(顺序即展示顺序)。 */
+export function actionsFor(state: ContainerState): ActionSpec[] {
+  switch (state) {
+    case 'running':
+      return [
+        { action: 'restart', label: '重启', variant: 'default', danger: true },
+        { action: 'stop', label: '停止', variant: 'ghost', danger: true },
+        { action: 'pause', label: '暂停', variant: 'ghost' },
+        { action: 'kill', label: 'Kill', variant: 'ghost', danger: true },
+      ]
+    case 'paused':
+      return [
+        { action: 'unpause', label: '恢复', variant: 'default' },
+        { action: 'stop', label: '停止', variant: 'ghost', danger: true },
+      ]
+    case 'restarting':
+      return [{ action: 'stop', label: '停止', variant: 'ghost', danger: true }]
+    default: // exited / created / dead / unknown
+      return [
+        { action: 'start', label: '启动', variant: 'default' },
+        { action: 'rm', label: '删除', variant: 'ghost', danger: true },
+      ]
+  }
+}
+
+/** 操作按钮的 hover 提示(原生 title):点明各动作机制与区别。 */
+export const ACTION_HINTS: Record<ServiceAction, string> = {
+  start: '启动已停止的容器(docker start),从头跑新进程。',
+  restart: '重启:先优雅停止(SIGTERM,10 秒宽限)再启动(docker restart)。',
+  stop: '优雅停止:发 SIGTERM,10 秒内未退再补 SIGKILL(docker stop)。日常停服务用这个,能让程序收尾、落盘。',
+  pause: '暂停:cgroup 冻结容器内所有进程(docker pause),内存原样保留、CPU 不再分给它;点「恢复」从断点续跑。不释放内存。',
+  unpause: '恢复:解冻已暂停的容器(docker unpause),同一进程从断点继续。',
+  kill: '强制 Kill:直接发 SIGKILL 立即终止,不给清理机会(docker kill),可能丢未落盘数据。仅在「停止」卡住时用。',
+  rm: '删除容器(docker rm),运行中的需先停止。容器配置移除,挂载的数据卷不受影响。',
+}
+
+/** 破坏性操作的二次确认文案。 */
+export const DANGER_COPY: Partial<
+  Record<ServiceAction, { title: (n: string) => string; body: string; confirmLabel: string }>
+> = {
+  restart: { title: (n) => `重启容器 ${n}?`, body: '容器将停止后重新启动,期间该服务短暂不可用。', confirmLabel: '确认重启' },
+  stop: { title: (n) => `停止容器 ${n}?`, body: '容器将被停止,其提供的服务会中断,直到再次启动。', confirmLabel: '确认停止' },
+  kill: { title: (n) => `强制 Kill 容器 ${n}?`, body: '将发送 SIGKILL 立即终止容器进程,可能丢失未落盘数据。', confirmLabel: '强制 Kill' },
+  rm: { title: (n) => `删除容器 ${n}?`, body: '将删除该容器(运行中的需先停止)。容器配置随之移除,数据卷不受影响。', confirmLabel: '确认删除' },
+}

--- a/web/src/lib/dockerRun.test.ts
+++ b/web/src/lib/dockerRun.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { parseDockerRun } from './dockerRun'
+
+describe('parseDockerRun', () => {
+  it('parses a full docker run', () => {
+    const p = parseDockerRun(
+      'docker run -d --name web -p 8080:80 -p 443:443 -e TZ=Asia/Shanghai -v /data:/usr/share/nginx/html:ro --restart unless-stopped nginx:latest nginx -g "daemon off;"',
+    )
+    expect(p).not.toBeNull()
+    expect(p!.name).toBe('web')
+    expect(p!.image).toBe('nginx:latest')
+    expect(p!.ports).toEqual(['8080:80', '443:443'])
+    expect(p!.env).toEqual(['TZ=Asia/Shanghai'])
+    expect(p!.volumes).toEqual(['/data:/usr/share/nginx/html:ro'])
+    expect(p!.restart).toBe('unless-stopped')
+    expect(p!.command).toContain('nginx -g')
+  })
+
+  it('supports --flag=value form and sudo prefix', () => {
+    const p = parseDockerRun('sudo docker run --name=cache --restart=always redis:latest')
+    expect(p!.name).toBe('cache')
+    expect(p!.restart).toBe('always')
+    expect(p!.image).toBe('redis:latest')
+  })
+
+  it('handles minimal run', () => {
+    const p = parseDockerRun('docker run nginx')
+    expect(p!.image).toBe('nginx')
+    expect(p!.ports).toEqual([])
+  })
+
+  it('ignores boolean flags (-it, --rm)', () => {
+    const p = parseDockerRun('docker run -it --rm alpine sh')
+    expect(p!.image).toBe('alpine')
+    expect(p!.command).toBe('sh')
+  })
+
+  it('returns null for non docker-run', () => {
+    expect(parseDockerRun('ls -la')).toBeNull()
+    expect(parseDockerRun('docker ps')).toBeNull()
+  })
+})

--- a/web/src/lib/dockerRun.ts
+++ b/web/src/lib/dockerRun.ts
@@ -1,0 +1,109 @@
+/**
+ * 把一条 `docker run ...` 命令解析为新增容器表单的结构化字段。
+ * 用于「AI 生成配置」:AI 给出 docker run 命令 → 自动填表。尽力解析,无法识别的 flag 跳过。
+ */
+import type { RestartPolicy } from '../api/containers'
+
+export interface ParsedRun {
+  image: string
+  name: string
+  ports: string[]
+  env: string[]
+  volumes: string[]
+  restart?: RestartPolicy
+  command: string
+}
+
+/** 不带值的布尔 flag(出现即开,不吞下一个 token)。 */
+const BOOL_FLAGS = new Set([
+  '-d', '--detach', '--rm', '-i', '-t', '-it', '-ti', '--privileged', '--init',
+  '--read-only', '-q', '--quiet', '--no-healthcheck', '--interactive', '--tty',
+])
+
+const RESTART_VALUES = new Set<RestartPolicy>(['no', 'always', 'unless-stopped', 'on-failure'])
+
+/** 按空白分词,尊重单/双引号。 */
+function tokenize(s: string): string[] {
+  const out: string[] = []
+  let cur = ''
+  let quote = ''
+  for (const ch of s) {
+    if (quote) {
+      if (ch === quote) quote = ''
+      else cur += ch
+    } else if (ch === '"' || ch === "'") {
+      quote = ch
+    } else if (/\s/.test(ch)) {
+      if (cur) {
+        out.push(cur)
+        cur = ''
+      }
+    } else {
+      cur += ch
+    }
+  }
+  if (cur) out.push(cur)
+  return out
+}
+
+/** 取一个 flag 的值:支持 `--name x` 与 `--name=x` 两种写法。 */
+function flagValue(tok: string, next: string | undefined): { value: string; consumedNext: boolean } {
+  const eq = tok.indexOf('=')
+  if (eq >= 0) return { value: tok.slice(eq + 1), consumedNext: false }
+  return { value: next ?? '', consumedNext: true }
+}
+
+/**
+ * 解析 docker run 命令。返回 null 表示不是可识别的 docker run。
+ */
+export function parseDockerRun(cmd: string): ParsedRun | null {
+  const toks = tokenize(cmd.trim())
+  // 跳到 "docker run" 之后(容忍前面有 sudo)。
+  let i = 0
+  while (i < toks.length && toks[i] !== 'docker') i++
+  if (i + 1 >= toks.length || toks[i] !== 'docker' || toks[i + 1] !== 'run') return null
+  i += 2
+
+  const res: ParsedRun = { image: '', name: '', ports: [], env: [], volumes: [], command: '' }
+
+  // 解析 flags 直到遇到第一个非 flag(= 镜像)。
+  while (i < toks.length) {
+    const t = toks[i]
+    if (!t.startsWith('-')) break // 镜像
+    const key = t.includes('=') ? t.slice(0, t.indexOf('=')) : t
+    if (BOOL_FLAGS.has(key)) {
+      i++
+      continue
+    }
+    const { value, consumedNext } = flagValue(t, toks[i + 1])
+    switch (key) {
+      case '--name':
+        res.name = value
+        break
+      case '-p':
+      case '--publish':
+        if (value) res.ports.push(value)
+        break
+      case '-e':
+      case '--env':
+        if (value) res.env.push(value)
+        break
+      case '-v':
+      case '--volume':
+        if (value) res.volumes.push(value)
+        break
+      case '--restart':
+        if (RESTART_VALUES.has(value as RestartPolicy)) res.restart = value as RestartPolicy
+        break
+      default:
+        break // 其它 flag(--network/-w 等)暂不映射,但仍吞掉其值避免误判为镜像
+    }
+    i += consumedNext ? 2 : 1
+  }
+
+  if (i >= toks.length) return null // 没有镜像
+  res.image = toks[i]
+  i++
+  res.command = toks.slice(i).join(' ')
+  return res
+}

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -17,6 +17,8 @@ const DoraDashboard = () => import('../views/DoraDashboard.vue')
 const Environments = () => import('../views/Environments.vue')
 // Story 6-1: multi-host status overview (server-layer CPU/memory/disk metrics, FR-15)
 const ServerStatus = () => import('../views/ServerStatus.vue')
+// 容器管理:跨所有已登记服务器聚合容器(docker ps over SSH)+ 行内生命周期操作
+const Containers = () => import('../views/Containers.vue')
 // Story 6-5: configurable anomaly detection & alerts (FR-23)
 const AnomalyDetection = () => import('../views/AnomalyDetection.vue')
 const Settings    = () => import('../views/Settings.vue')
@@ -115,6 +117,8 @@ const router = createRouter({
         { path: 'servers', name: 'servers', redirect: { name: 'server-status' } },
         // Story 6-1: multi-host status overview (server-layer metrics, FR-15)
         { path: 'server-status', name: 'server-status', component: ServerStatus, meta: { title: '服务器状态' } },
+
+        { path: 'containers', name: 'containers', component: Containers, meta: { title: '容器' } },
         // Story 6-5: configurable anomaly detection & alerts (FR-23)
         { path: 'anomaly', name: 'anomaly', component: AnomalyDetection, meta: { title: '异常检测' } },
         // 顶层「通知」占位页 → 重定向到真实的通知配置页。

--- a/web/src/views/Containers.vue
+++ b/web/src/views/Containers.vue
@@ -217,10 +217,13 @@ async function runAction(serverId: string, c: ContainerInfo, spec: ActionSpec): 
 }
 
 function openTerminal(serverId: string, c: ContainerInfo): void {
-  // 跳主机终端全屏页(新标签),用户在 shell 内 `docker exec -it <name> sh` 进容器。
-  const url = router.resolve({ name: 'server-terminal', params: { id: serverId } }).href
+  // 跳终端全屏页(新标签),带 ?container= → 直接 `docker exec -it <容器> sh` 进该容器。
+  const url = router.resolve({
+    name: 'server-terminal',
+    params: { id: serverId },
+    query: { container: c.names },
+  }).href
   window.open(url, '_blank', 'noopener')
-  void c
 }
 
 // ─── 加载 ─────────────────────────────────────────────────────────────────────

--- a/web/src/views/Containers.vue
+++ b/web/src/views/Containers.vue
@@ -18,6 +18,7 @@ import ServerCard from '../components/ops/ServerCard.vue'
 import ContainerLogsDrawer from '../components/ops/ContainerLogsDrawer.vue'
 import CreateContainerModal from '../components/ops/CreateContainerModal.vue'
 import AiDiagnosisModal from '../components/ops/AiDiagnosisModal.vue'
+import ContainerAiPanel from '../components/ops/ContainerAiPanel.vue'
 
 type LoadState = 'idle' | 'loading' | 'error'
 type StateFilter = 'all' | StateBucket
@@ -104,6 +105,10 @@ function openTerminal(serverId: string, c: ContainerInfo): void {
   window.open(url, '_blank', 'noopener')
 }
 
+// AI 助手抽屉。
+const showAi = ref(false)
+const aiContext = { os: 'linux', shell: '/bin/sh', container: '(docker 主机)' }
+
 // AI 诊断弹窗。
 const diagnoseTarget = ref<{ serverId: string; name: string } | null>(null)
 function openDiagnose(serverId: string, c: ContainerInfo): void {
@@ -161,6 +166,7 @@ onUnmounted(() => {
         </p>
       </div>
       <div class="header-actions">
+        <AppButton variant="ai" @click="showAi = true">✦ AI 助手</AppButton>
         <AppButton variant="primary" :disabled="creatableServers.length === 0" @click="showCreate = true">
           + 新增容器
         </AppButton>
@@ -269,6 +275,9 @@ onUnmounted(() => {
       :container-name="diagnoseTarget.name"
       @close="diagnoseTarget = null"
     />
+
+    <!-- AI 助手抽屉 -->
+    <ContainerAiPanel v-if="showAi" :context="aiContext" @close="showAi = false" />
   </div>
 </template>
 

--- a/web/src/views/Containers.vue
+++ b/web/src/views/Containers.vue
@@ -1,41 +1,33 @@
 <script setup lang="ts">
 /*
-  Containers.vue — 容器总览(Portainer 式):聚合所有已登记服务器上的容器,逐台分组展示,
-  行内可执行生命周期操作(起停重启 / 暂停恢复 / kill / 删除)+ 跳主机终端 docker exec。
-
-  · 数据:GET /api/servers/containers(批量,逐台并行、单台失败不连累全局)+ listServers(取名/主机)。
-  · 操作:复用 serviceAction(type=docker);破坏性操作(停止/重启/kill/删除)走 useConfirm。
-  · 每 12s 自动刷新(stale-while-revalidate:刷新保留旧数据,仅首屏显骨架)。
+  Containers.vue — 容器/镜像管理总览。顶部聚合 KPI + 状态筛选,下面每台服务器一张
+  ServerCard(卡片内部按 容器/镜像 分 tab,只针对这一台)。日志走抽屉、终端跳全屏页、
+  新增容器走弹窗。每 12s 自动刷新聚合(stale-while-revalidate)。
 */
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
-import { getAllContainers, type ServerContainers, type ContainerInfo, type ContainerState } from '../api/containers'
-import { listServers, serviceAction, type Server, type ServiceAction } from '../api/servers'
+import { getAllContainers, type ServerContainers, type ContainerInfo } from '../api/containers'
+import { listServers, type Server } from '../api/servers'
 import { HttpError } from '../api/http'
-import { useToast } from '../composables/useToast'
-import { useConfirm } from '../composables/useConfirm'
-import { NIcon } from 'naive-ui'
-import { BrandDocker, AlertTriangle } from '@vicons/tabler'
+import { stateBucket, type StateBucket } from '../lib/containerState'
 import AppButton from '../components/ui/AppButton.vue'
 import EmptyState from '../components/ui/EmptyState.vue'
 import ErrorState from '../components/ui/ErrorState.vue'
 import SkeletonBlock from '../components/ui/SkeletonBlock.vue'
+import ServerCard from '../components/ops/ServerCard.vue'
 import ContainerLogsDrawer from '../components/ops/ContainerLogsDrawer.vue'
 import CreateContainerModal from '../components/ops/CreateContainerModal.vue'
 
 type LoadState = 'idle' | 'loading' | 'error'
+type StateFilter = 'all' | StateBucket
 
 const router = useRouter()
-const toast = useToast()
-const confirm = useConfirm()
 
 const loadState = ref<LoadState>('idle')
 const loadError = ref('')
 const groups = ref<ServerContainers[]>([])
 const serverById = ref<Map<string, Server>>(new Map())
 const refreshing = ref(false)
-/** 正在执行操作的 `${serverId}:${containerId}:${action}`,用于禁用对应按钮并显示 loading。 */
-const busy = ref<Set<string>>(new Set())
 
 const POLL_MS = 12_000
 let timer: ReturnType<typeof setInterval> | null = null
@@ -46,23 +38,17 @@ const runningContainers = computed(() => groups.value.reduce((n, g) => n + g.run
 const stoppedContainers = computed(() => totalContainers.value - runningContainers.value)
 const coveredServers = computed(() => groups.value.filter((g) => g.reachable && g.runtime).length)
 
-// ─── 状态筛选 ─────────────────────────────────────────────────────────────────
-// 把六种容器状态归并为三档「桶」,供筛选段与计数使用:
-//   running   = running / restarting   （在跑)
-//   paused    = paused                 （已暂停)
-//   stopped   = exited / created / dead / unknown  （未在跑)
-type StateBucket = 'running' | 'paused' | 'stopped'
-type StateFilter = 'all' | StateBucket
-
-function stateBucket(s: ContainerState): StateBucket {
-  if (s === 'running' || s === 'restarting') return 'running'
-  if (s === 'paused') return 'paused'
-  return 'stopped'
+function serverName(id: string): string {
+  return serverById.value.get(id)?.name ?? id
+}
+function serverHost(id: string): string {
+  const s = serverById.value.get(id)
+  return s ? `${s.user}@${s.host}:${s.port}` : ''
 }
 
+// ─── 状态筛选 ─────────────────────────────────────────────────────────────────
 const stateFilter = ref<StateFilter>('all')
 
-/** 各档全局计数(跨所有服务器)。 */
 const bucketCounts = computed(() => {
   let running = 0
   let paused = 0
@@ -91,169 +77,28 @@ const FILTER_OPTIONS: FilterOption[] = [
 function filterCount(key: StateFilter): number {
   return bucketCounts.value[key]
 }
-const activeFilterLabel = computed(() => FILTER_OPTIONS.find((f) => f.key === stateFilter.value)?.label ?? '')
 
-/** 应用当前筛选后该服务器可见的容器(all 时原样返回)。 */
-function visibleContainers(g: ServerContainers): ContainerInfo[] {
-  if (stateFilter.value === 'all') return g.containers
-  return g.containers.filter((c) => stateBucket(c.state) === stateFilter.value)
-}
-
-function serverName(id: string): string {
-  return serverById.value.get(id)?.name ?? id
-}
-function serverHost(id: string): string {
-  const s = serverById.value.get(id)
-  return s ? `${s.user}@${s.host}:${s.port}` : ''
-}
-
-/** 运行时显示名:首字母大写(docker → Docker),未知则原样。 */
-function runtimeLabel(runtime: string): string {
-  if (!runtime) return ''
-  return runtime.charAt(0).toUpperCase() + runtime.slice(1)
-}
-
-// ─── 状态徽标 ─────────────────────────────────────────────────────────────────
-interface StateMeta {
-  label: string
-  tone: 'green' | 'amber' | 'cyan' | 'red' | 'faint'
-  pulse: boolean
-}
-const STATE_META: Record<ContainerState, StateMeta> = {
-  running:    { label: '运行中', tone: 'green', pulse: true },
-  paused:     { label: '已暂停', tone: 'amber', pulse: false },
-  restarting: { label: '重启中', tone: 'amber', pulse: true },
-  created:    { label: '已创建', tone: 'cyan', pulse: false },
-  exited:     { label: '已停止', tone: 'faint', pulse: false },
-  dead:       { label: '异常', tone: 'red', pulse: false },
-  unknown:    { label: '未知', tone: 'faint', pulse: false },
-}
-function stateMeta(s: ContainerState): StateMeta {
-  return STATE_META[s] ?? STATE_META.unknown
-}
-function shortId(id: string): string {
-  return id.length > 12 ? id.slice(0, 12) : id
-}
-
-// ─── 行内操作 ─────────────────────────────────────────────────────────────────
-interface ActionSpec {
-  action: ServiceAction
-  label: string
-  variant: 'default' | 'ghost' | 'danger'
-  danger?: boolean // 需二次确认
-}
-
-/** 据容器状态给出可用操作集(顺序即展示顺序)。 */
-function actionsFor(state: ContainerState): ActionSpec[] {
-  switch (state) {
-    case 'running':
-      return [
-        { action: 'restart', label: '重启', variant: 'default', danger: true },
-        { action: 'stop', label: '停止', variant: 'ghost', danger: true },
-        { action: 'pause', label: '暂停', variant: 'ghost' },
-        { action: 'kill', label: 'Kill', variant: 'ghost', danger: true },
-      ]
-    case 'paused':
-      return [
-        { action: 'unpause', label: '恢复', variant: 'default' },
-        { action: 'stop', label: '停止', variant: 'ghost', danger: true },
-      ]
-    case 'restarting':
-      return [{ action: 'stop', label: '停止', variant: 'ghost', danger: true }]
-    default: // exited / created / dead / unknown
-      return [
-        { action: 'start', label: '启动', variant: 'default' },
-        { action: 'rm', label: '删除', variant: 'ghost', danger: true },
-      ]
-  }
-}
-
-// 行内操作的 hover 提示(原生 title):点明各动作机制与区别,鼠标悬停即见。
-const ACTION_HINTS: Record<ServiceAction, string> = {
-  start: '启动已停止的容器(docker start),从头跑新进程。',
-  restart: '重启:先优雅停止(SIGTERM,10 秒宽限)再启动(docker restart)。',
-  stop: '优雅停止:发 SIGTERM,10 秒内未退再补 SIGKILL(docker stop)。日常停服务用这个,能让程序收尾、落盘。',
-  pause: '暂停:cgroup 冻结容器内所有进程(docker pause),内存原样保留、CPU 不再分给它;点「恢复」从断点续跑。不释放内存。',
-  unpause: '恢复:解冻已暂停的容器(docker unpause),同一进程从断点继续。',
-  kill: '强制 Kill:直接发 SIGKILL 立即终止,不给清理机会(docker kill),可能丢未落盘数据。仅在「停止」卡住时用。',
-  rm: '删除容器(docker rm),运行中的需先停止。容器配置移除,挂载的数据卷不受影响。',
-}
-
-const DANGER_COPY: Partial<Record<ServiceAction, { title: (n: string) => string; body: string; confirmLabel: string }>> = {
-  restart: { title: (n) => `重启容器 ${n}?`, body: '容器将停止后重新启动,期间该服务短暂不可用。', confirmLabel: '确认重启' },
-  stop:    { title: (n) => `停止容器 ${n}?`, body: '容器将被停止,其提供的服务会中断,直到再次启动。', confirmLabel: '确认停止' },
-  kill:    { title: (n) => `强制 Kill 容器 ${n}?`, body: '将发送 SIGKILL 立即终止容器进程,可能丢失未落盘数据。', confirmLabel: '强制 Kill' },
-  rm:      { title: (n) => `删除容器 ${n}?`, body: '将删除该容器(运行中的需先停止)。容器配置随之移除,数据卷不受影响。', confirmLabel: '确认删除' },
-}
-
-function busyKey(serverId: string, containerId: string, action: ServiceAction): string {
-  return `${serverId}:${containerId}:${action}`
-}
-function isBusy(serverId: string, containerId: string, action: ServiceAction): boolean {
-  return busy.value.has(busyKey(serverId, containerId, action))
-}
-function rowBusy(serverId: string, containerId: string): boolean {
-  for (const k of busy.value) if (k.startsWith(`${serverId}:${containerId}:`)) return true
-  return false
-}
-
-async function runAction(serverId: string, c: ContainerInfo, spec: ActionSpec): Promise<void> {
-  if (spec.danger) {
-    const copy = DANGER_COPY[spec.action]
-    const ok = await confirm.open({
-      title: copy?.title(c.names) ?? `对 ${c.names} 执行 ${spec.label}?`,
-      body: copy?.body ?? '该操作会影响容器运行状态。',
-      confirmLabel: copy?.confirmLabel ?? spec.label,
-      variant: 'danger',
-    })
-    if (!ok) return
-  }
-
-  const key = busyKey(serverId, c.id, spec.action)
-  busy.value = new Set(busy.value).add(key)
-  try {
-    const res = await serviceAction(serverId, { type: 'docker', target: c.names, action: spec.action })
-    if (res.ok) {
-      toast.success(`${spec.label}成功`, { detail: `${c.names} · ${serverName(serverId)}` })
-    } else {
-      toast.error(`${spec.label}失败`, { detail: res.error || '远端命令以非零状态退出' })
-    }
-  } catch (err) {
-    toast.error(`${spec.label}失败`, { detail: err instanceof HttpError ? (err.apiError?.message ?? `请求失败(${err.status})`) : '网络错误' })
-  } finally {
-    const next = new Set(busy.value)
-    next.delete(key)
-    busy.value = next
-    // 操作后刷新该台的容器状态(稍候让 docker 状态稳定)。
-    setTimeout(() => void load(), 600)
-  }
-}
-
-// 新增容器弹窗。
+// ─── 新增容器 ─────────────────────────────────────────────────────────────────
 const showCreate = ref(false)
-// 可作为创建目标的服务器(连得上且有 docker 运行时)。
 const creatableServers = computed(() =>
   groups.value
     .filter((g) => g.reachable && g.runtime)
     .map((g) => ({ id: g.serverId, name: serverName(g.serverId) })),
 )
-function onContainerCreated(serverId: string): void {
-  void serverId
+function onContainerCreated(): void {
   void load()
 }
 
-// 日志抽屉:当前查看的容器(null = 关闭)。
+// ─── 日志抽屉 / 终端 ──────────────────────────────────────────────────────────
 const logsTarget = ref<{ serverId: string; name: string; id: string } | null>(null)
 function openLogs(serverId: string, c: ContainerInfo): void {
-  logsTarget.value = { serverId, name: c.names, id: shortId(c.id) }
+  logsTarget.value = { serverId, name: c.names, id: c.id.length > 12 ? c.id.slice(0, 12) : c.id }
 }
-
 function openTerminal(serverId: string, c: ContainerInfo): void {
-  // 跳终端全屏页(新标签),带 ?container= → 直接 `docker exec -it <容器> sh` 进该容器。
   const url = router.resolve({
     name: 'server-terminal',
     params: { id: serverId },
-    query: { container: c.names, cid: shortId(c.id) },
+    query: { container: c.names, cid: c.id.length > 12 ? c.id.slice(0, 12) : c.id },
   }).href
   window.open(url, '_blank', 'noopener')
 }
@@ -301,19 +146,15 @@ onUnmounted(() => {
       <div class="view-header__text">
         <h1 class="view-title">容器</h1>
         <p class="view-sub">
-          跨所有已登记服务器的容器总览
+          跨所有已登记服务器,按主机管理容器与镜像
           <span v-if="totalContainers > 0" class="view-sub__count">
-            · 共 {{ totalContainers }} 个 · {{ runningContainers }} 运行中
+            · 共 {{ totalContainers }} 个容器 · {{ runningContainers }} 运行中
           </span>
           <span class="view-sub__count">· 每 12 秒自动刷新</span>
         </p>
       </div>
       <div class="header-actions">
-        <AppButton
-          variant="primary"
-          :disabled="creatableServers.length === 0"
-          @click="showCreate = true"
-        >
+        <AppButton variant="primary" :disabled="creatableServers.length === 0" @click="showCreate = true">
           + 新增容器
         </AppButton>
         <AppButton variant="default" :loading="loadState === 'loading' && groups.length === 0" @click="load">
@@ -331,7 +172,6 @@ onUnmounted(() => {
       </div>
     </div>
 
-    <!-- 整页加载失败 -->
     <ErrorState
       v-else-if="loadState === 'error' && groups.length === 0"
       title="加载容器列表失败"
@@ -339,29 +179,13 @@ onUnmounted(() => {
       @retry="load"
     />
 
-    <!-- 无已登记服务器 -->
     <EmptyState
       v-else-if="groups.length === 0"
       title="尚无已登记服务器"
-      description="先在「设置 › 服务器」登记目标服务器,这里就会汇总它们上面的容器。"
+      description="先在「设置 › 服务器」登记目标服务器,这里就会汇总它们上面的容器与镜像。"
     />
 
     <template v-else>
-      <!-- 状态筛选段 -->
-      <div class="filter-bar" role="group" aria-label="按状态筛选容器">
-        <button
-          v-for="f in FILTER_OPTIONS"
-          :key="f.key"
-          class="filter-chip"
-          :class="{ 'filter-chip--active': stateFilter === f.key }"
-          :aria-pressed="stateFilter === f.key"
-          @click="stateFilter = f.key"
-        >
-          {{ f.label }}
-          <span class="filter-chip__count">{{ filterCount(f.key) }}</span>
-        </button>
-      </div>
-
       <!-- 聚合 KPI 条 -->
       <section class="kpi-strip" aria-label="容器聚合统计">
         <div class="kpi kpi--total">
@@ -382,84 +206,34 @@ onUnmounted(() => {
         </div>
       </section>
 
-      <!-- 逐台分组 -->
-      <section class="groups" :aria-busy="refreshing || undefined">
-        <article v-for="g in groups" :key="g.serverId" class="panel">
-          <header class="panel__head">
-            <div class="panel__id">
-              <h2 class="panel__name">{{ serverName(g.serverId) }}</h2>
-              <span class="panel__host mono">{{ serverHost(g.serverId) }}</span>
-            </div>
-            <div class="panel__meta">
-              <span
-                class="rt-badge"
-                :class="{
-                  'rt-badge--ok': g.reachable && g.runtime,
-                  'rt-badge--warn': g.reachable && !g.runtime,
-                  'rt-badge--down': !g.reachable,
-                }"
-              >
-                <NIcon :size="15" class="rt-badge__icon">
-                  <BrandDocker v-if="g.reachable && g.runtime" />
-                  <AlertTriangle v-else />
-                </NIcon>
-                {{ !g.reachable ? '不可达' : g.runtime ? runtimeLabel(g.runtime) : '无容器运行时' }}
-              </span>
-              <span v-if="g.reachable && g.runtime" class="panel__count mono">
-                {{ g.running }}/{{ g.total }} 运行
-              </span>
-            </div>
-          </header>
+      <!-- 状态筛选段(作用于各卡片的容器 tab) -->
+      <div class="filter-bar" role="group" aria-label="按状态筛选容器">
+        <button
+          v-for="f in FILTER_OPTIONS"
+          :key="f.key"
+          class="filter-chip"
+          :class="{ 'filter-chip--active': stateFilter === f.key }"
+          :aria-pressed="stateFilter === f.key"
+          @click="stateFilter = f.key"
+        >
+          {{ f.label }}
+          <span class="filter-chip__count">{{ filterCount(f.key) }}</span>
+        </button>
+      </div>
 
-          <!-- 不可达 / 无运行时:行内提示,不连累全局 -->
-          <p v-if="!g.reachable" class="panel__hint panel__hint--down">⚠ {{ g.error }}</p>
-          <p v-else-if="!g.runtime" class="panel__hint">{{ g.error }}</p>
-          <p v-else-if="g.total === 0" class="panel__hint">该服务器暂无容器。</p>
-          <p v-else-if="visibleContainers(g).length === 0" class="panel__hint">
-            无「{{ activeFilterLabel }}」状态的容器(该服务器共 {{ g.total }} 个)。
-          </p>
-
-          <!-- 容器表 -->
-          <ul v-else class="clist" role="list">
-            <li v-for="c in visibleContainers(g)" :key="c.id" class="crow" :class="{ 'crow--busy': rowBusy(g.serverId, c.id) }">
-              <div class="crow__state">
-                <span
-                  class="dot"
-                  :class="[`dot--${stateMeta(c.state).tone}`, { 'dot--pulse': stateMeta(c.state).pulse }]"
-                  aria-hidden="true"
-                />
-                <span class="crow__statelabel" :class="`txt--${stateMeta(c.state).tone}`">{{ stateMeta(c.state).label }}</span>
-              </div>
-              <div class="crow__main">
-                <div class="crow__name" :title="c.names">{{ c.names }}</div>
-                <div class="crow__sub mono" :title="`${c.image} · ${c.id}`">{{ c.image }} · {{ shortId(c.id) }}</div>
-              </div>
-              <div class="crow__status">
-                <div class="crow__statustxt" :title="c.status">{{ c.status }}</div>
-                <div v-if="c.ports" class="crow__ports mono" :title="c.ports">{{ c.ports }}</div>
-              </div>
-              <div class="crow__actions">
-                <button
-                  v-for="a in actionsFor(c.state)"
-                  :key="a.action"
-                  class="op"
-                  :class="[`op--${a.variant}`, { 'op--busy': isBusy(g.serverId, c.id, a.action) }]"
-                  :disabled="rowBusy(g.serverId, c.id)"
-                  :title="ACTION_HINTS[a.action]"
-                  @click="runAction(g.serverId, c, a)"
-                >
-                  {{ a.label }}
-                </button>
-                <button class="op op--ghost" title="查看容器日志(docker logs,历史 + 实时 tail)" @click="openLogs(g.serverId, c)">
-                  日志
-                </button>
-                <button class="op op--ghost" :disabled="rowBusy(g.serverId, c.id)" title="进入容器交互终端(docker exec -it)" @click="openTerminal(g.serverId, c)">
-                  终端
-                </button>
-              </div>
-            </li>
-          </ul>
-        </article>
+      <!-- 逐台卡片(卡片内自带 容器/镜像 tab) -->
+      <section class="cards" :aria-busy="refreshing || undefined">
+        <ServerCard
+          v-for="g in groups"
+          :key="g.serverId"
+          :group="g"
+          :name="serverName(g.serverId)"
+          :host="serverHost(g.serverId)"
+          :state-filter="stateFilter"
+          @changed="load"
+          @logs="(c) => openLogs(g.serverId, c)"
+          @terminal="(c) => openTerminal(g.serverId, c)"
+        />
       </section>
     </template>
 
@@ -489,7 +263,6 @@ onUnmounted(() => {
   gap: 22px;
 }
 
-/* header — 与 server-status 一致 */
 .view-header {
   display: flex;
   align-items: flex-start;
@@ -523,7 +296,7 @@ onUnmounted(() => {
   font-variant-numeric: tabular-nums;
 }
 
-/* ── 状态筛选段 ── */
+/* 状态筛选段 */
 .filter-bar {
   display: flex;
   flex-wrap: wrap;
@@ -541,10 +314,7 @@ onUnmounted(() => {
   border: 1px solid var(--color-border);
   border-radius: 999px;
   cursor: pointer;
-  transition:
-    color var(--duration-fast) var(--ease-out-expo),
-    border-color var(--duration-fast) var(--ease-out-expo),
-    background var(--duration-fast) var(--ease-out-expo);
+  transition: color var(--duration-fast) var(--ease-out-expo), border-color var(--duration-fast) var(--ease-out-expo), background var(--duration-fast) var(--ease-out-expo);
 }
 .filter-chip:hover {
   color: var(--color-text);
@@ -568,7 +338,7 @@ onUnmounted(() => {
   color: #fff;
 }
 
-/* ── 聚合 KPI 条:bento 式,语义左描边 ── */
+/* KPI 条 */
 .kpi-strip {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
@@ -615,244 +385,17 @@ onUnmounted(() => {
   color: var(--color-faint);
 }
 
-/* ── 逐台分组面板 ── */
-.groups {
+/* 卡片列表 */
+.cards {
   display: flex;
   flex-direction: column;
   gap: 16px;
   transition: opacity var(--duration-fast) var(--ease-out-expo);
 }
-.groups[aria-busy='true'] {
+.cards[aria-busy='true'] {
   opacity: 0.7;
 }
-.panel {
-  background: var(--color-card);
-  border: 1px solid var(--color-border);
-  border-radius: var(--rounded-lg, 12px);
-  box-shadow: var(--shadow);
-  overflow: hidden;
-}
-.panel__head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 14px 18px;
-  border-bottom: 1px solid var(--color-border);
-  background: var(--color-card-2);
-}
-.panel__id {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-  min-width: 0;
-}
-.panel__name {
-  margin: 0;
-  font-size: var(--text-section);
-  font-weight: 700;
-  color: var(--color-text);
-}
-.panel__host {
-  font-size: var(--text-micro);
-  color: var(--color-faint);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.panel__meta {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-shrink: 0;
-}
-.panel__count {
-  font-size: var(--text-micro);
-  color: var(--color-dim);
-  font-variant-numeric: tabular-nums;
-}
 
-.rt-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  font-size: var(--text-label);
-  font-weight: 700;
-  letter-spacing: 0.01em;
-  padding: 4px 11px 4px 9px;
-  border-radius: 999px;
-  border: 1px solid var(--color-border-strong);
-  color: var(--color-dim);
-  white-space: nowrap;
-}
-.rt-badge__icon {
-  display: inline-flex;
-}
-.rt-badge--ok {
-  color: var(--color-green);
-  background: var(--color-green-soft);
-  border-color: var(--color-green-line);
-}
-.rt-badge--warn {
-  color: var(--color-amber);
-  background: var(--color-amber-soft);
-  border-color: var(--color-amber-line);
-}
-.rt-badge--down {
-  color: var(--color-red);
-  background: var(--color-red-soft);
-  border-color: var(--color-red-line);
-}
-
-.panel__hint {
-  margin: 0;
-  padding: 16px 18px;
-  font-size: var(--text-label);
-  color: var(--color-faint);
-}
-.panel__hint--down {
-  color: var(--color-red);
-}
-
-/* ── 容器行 ── */
-.clist {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-.crow {
-  display: grid;
-  grid-template-columns: 92px minmax(0, 1.4fr) minmax(0, 1.3fr) auto;
-  align-items: center;
-  gap: 14px;
-  padding: 12px 18px;
-  border-bottom: 1px solid var(--color-border);
-  transition: background var(--duration-fast) var(--ease-out-expo);
-}
-.crow:last-child {
-  border-bottom: none;
-}
-.crow:hover {
-  background: var(--color-card-2);
-}
-.crow--busy {
-  opacity: 0.55;
-}
-.crow__state {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-}
-.crow__statelabel {
-  font-size: var(--text-micro);
-  font-weight: 600;
-}
-.dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  flex-shrink: 0;
-  background: var(--color-faint);
-}
-.dot--green { background: var(--color-green); }
-.dot--amber { background: var(--color-amber); }
-.dot--cyan { background: var(--color-cyan); }
-.dot--red { background: var(--color-red); }
-.dot--faint { background: var(--color-faint); }
-.dot--pulse {
-  animation: dotPulse 1.8s var(--ease-out-expo) infinite;
-}
-@keyframes dotPulse {
-  0%, 100% { opacity: 1; transform: scale(1); }
-  50% { opacity: 0.45; transform: scale(0.8); }
-}
-.txt--green { color: var(--color-green); }
-.txt--amber { color: var(--color-amber); }
-.txt--cyan { color: var(--color-cyan); }
-.txt--red { color: var(--color-red); }
-.txt--faint { color: var(--color-faint); }
-
-.crow__main {
-  min-width: 0;
-}
-.crow__name {
-  font-size: var(--text-body);
-  font-weight: 600;
-  color: var(--color-text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.crow__sub {
-  font-size: var(--text-micro);
-  color: var(--color-faint);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.crow__status {
-  min-width: 0;
-}
-.crow__statustxt {
-  font-size: var(--text-label);
-  color: var(--color-dim);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.crow__ports {
-  font-size: var(--text-micro);
-  color: var(--color-faint);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.crow__actions {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  justify-content: flex-end;
-  flex-wrap: wrap;
-}
-
-/* 行内迷你操作按钮(比 AppButton 更紧凑,适配密集表格) */
-.op {
-  font-size: var(--text-micro);
-  font-weight: 600;
-  padding: 4px 10px;
-  border-radius: var(--rounded-sm);
-  border: 1px solid var(--color-border-strong);
-  background: transparent;
-  color: var(--color-dim);
-  cursor: pointer;
-  transition:
-    background var(--duration-fast) var(--ease-out-expo),
-    color var(--duration-fast) var(--ease-out-expo),
-    border-color var(--duration-fast) var(--ease-out-expo);
-}
-.op:hover:not(:disabled) {
-  color: var(--color-text);
-  border-color: var(--color-text);
-}
-.op--default {
-  color: var(--color-primary);
-  border-color: var(--color-primary-soft);
-}
-.op--default:hover:not(:disabled) {
-  color: #fff;
-  background: var(--color-primary);
-  border-color: var(--color-primary);
-}
-.op:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-.op--busy {
-  opacity: 0.6;
-  pointer-events: none;
-}
-
-/* 骨架 */
 .skeletons {
   display: flex;
   flex-direction: column;
@@ -866,15 +409,5 @@ onUnmounted(() => {
   border: 1px solid var(--color-border);
   border-radius: var(--rounded-lg, 12px);
   background: var(--color-card);
-}
-
-@media (max-width: 720px) {
-  .crow {
-    grid-template-columns: 1fr;
-    gap: 8px;
-  }
-  .crow__actions {
-    justify-content: flex-start;
-  }
 }
 </style>

--- a/web/src/views/Containers.vue
+++ b/web/src/views/Containers.vue
@@ -21,6 +21,7 @@ import EmptyState from '../components/ui/EmptyState.vue'
 import ErrorState from '../components/ui/ErrorState.vue'
 import SkeletonBlock from '../components/ui/SkeletonBlock.vue'
 import ContainerLogsDrawer from '../components/ops/ContainerLogsDrawer.vue'
+import CreateContainerModal from '../components/ops/CreateContainerModal.vue'
 
 type LoadState = 'idle' | 'loading' | 'error'
 
@@ -228,6 +229,19 @@ async function runAction(serverId: string, c: ContainerInfo, spec: ActionSpec): 
   }
 }
 
+// 新增容器弹窗。
+const showCreate = ref(false)
+// 可作为创建目标的服务器(连得上且有 docker 运行时)。
+const creatableServers = computed(() =>
+  groups.value
+    .filter((g) => g.reachable && g.runtime)
+    .map((g) => ({ id: g.serverId, name: serverName(g.serverId) })),
+)
+function onContainerCreated(serverId: string): void {
+  void serverId
+  void load()
+}
+
 // 日志抽屉:当前查看的容器(null = 关闭)。
 const logsTarget = ref<{ serverId: string; name: string; id: string } | null>(null)
 function openLogs(serverId: string, c: ContainerInfo): void {
@@ -294,9 +308,18 @@ onUnmounted(() => {
           <span class="view-sub__count">· 每 12 秒自动刷新</span>
         </p>
       </div>
-      <AppButton variant="default" :loading="loadState === 'loading' && groups.length === 0" @click="load">
-        刷新
-      </AppButton>
+      <div class="header-actions">
+        <AppButton
+          variant="primary"
+          :disabled="creatableServers.length === 0"
+          @click="showCreate = true"
+        >
+          + 新增容器
+        </AppButton>
+        <AppButton variant="default" :loading="loadState === 'loading' && groups.length === 0" @click="load">
+          刷新
+        </AppButton>
+      </div>
     </header>
 
     <!-- 首屏骨架 -->
@@ -440,6 +463,14 @@ onUnmounted(() => {
       </section>
     </template>
 
+    <!-- 新增容器弹窗 -->
+    <CreateContainerModal
+      v-if="showCreate"
+      :servers="creatableServers"
+      @close="showCreate = false"
+      @created="onContainerCreated"
+    />
+
     <!-- 容器日志抽屉 -->
     <ContainerLogsDrawer
       v-if="logsTarget"
@@ -469,6 +500,12 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   gap: 4px;
+}
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
 }
 .view-title {
   margin: 0;

--- a/web/src/views/Containers.vue
+++ b/web/src/views/Containers.vue
@@ -166,6 +166,17 @@ function actionsFor(state: ContainerState): ActionSpec[] {
   }
 }
 
+// 行内操作的 hover 提示(原生 title):点明各动作机制与区别,鼠标悬停即见。
+const ACTION_HINTS: Record<ServiceAction, string> = {
+  start: '启动已停止的容器(docker start),从头跑新进程。',
+  restart: '重启:先优雅停止(SIGTERM,10 秒宽限)再启动(docker restart)。',
+  stop: '优雅停止:发 SIGTERM,10 秒内未退再补 SIGKILL(docker stop)。日常停服务用这个,能让程序收尾、落盘。',
+  pause: '暂停:cgroup 冻结容器内所有进程(docker pause),内存原样保留、CPU 不再分给它;点「恢复」从断点续跑。不释放内存。',
+  unpause: '恢复:解冻已暂停的容器(docker unpause),同一进程从断点继续。',
+  kill: '强制 Kill:直接发 SIGKILL 立即终止,不给清理机会(docker kill),可能丢未落盘数据。仅在「停止」卡住时用。',
+  rm: '删除容器(docker rm),运行中的需先停止。容器配置移除,挂载的数据卷不受影响。',
+}
+
 const DANGER_COPY: Partial<Record<ServiceAction, { title: (n: string) => string; body: string; confirmLabel: string }>> = {
   restart: { title: (n) => `重启容器 ${n}?`, body: '容器将停止后重新启动,期间该服务短暂不可用。', confirmLabel: '确认重启' },
   stop:    { title: (n) => `停止容器 ${n}?`, body: '容器将被停止,其提供的服务会中断,直到再次启动。', confirmLabel: '确认停止' },
@@ -390,11 +401,11 @@ onUnmounted(() => {
                 <span class="crow__statelabel" :class="`txt--${stateMeta(c.state).tone}`">{{ stateMeta(c.state).label }}</span>
               </div>
               <div class="crow__main">
-                <div class="crow__name">{{ c.names }}</div>
-                <div class="crow__sub mono">{{ c.image }} · {{ shortId(c.id) }}</div>
+                <div class="crow__name" :title="c.names">{{ c.names }}</div>
+                <div class="crow__sub mono" :title="`${c.image} · ${c.id}`">{{ c.image }} · {{ shortId(c.id) }}</div>
               </div>
               <div class="crow__status">
-                <div class="crow__statustxt">{{ c.status }}</div>
+                <div class="crow__statustxt" :title="c.status">{{ c.status }}</div>
                 <div v-if="c.ports" class="crow__ports mono" :title="c.ports">{{ c.ports }}</div>
               </div>
               <div class="crow__actions">
@@ -404,11 +415,12 @@ onUnmounted(() => {
                   class="op"
                   :class="[`op--${a.variant}`, { 'op--busy': isBusy(g.serverId, c.id, a.action) }]"
                   :disabled="rowBusy(g.serverId, c.id)"
+                  :title="ACTION_HINTS[a.action]"
                   @click="runAction(g.serverId, c, a)"
                 >
                   {{ a.label }}
                 </button>
-                <button class="op op--ghost" :disabled="rowBusy(g.serverId, c.id)" @click="openTerminal(g.serverId, c)">
+                <button class="op op--ghost" :disabled="rowBusy(g.serverId, c.id)" title="进入容器交互终端(docker exec -it)" @click="openTerminal(g.serverId, c)">
                   终端
                 </button>
               </div>

--- a/web/src/views/Containers.vue
+++ b/web/src/views/Containers.vue
@@ -7,9 +7,11 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { getAllContainers, type ServerContainers, type ContainerInfo } from '../api/containers'
-import { listServers, type Server } from '../api/servers'
+import { listServers, serviceAction, type Server, type ServiceAction } from '../api/servers'
 import { HttpError } from '../api/http'
 import { stateBucket, type StateBucket } from '../lib/containerState'
+import { useToast } from '../composables/useToast'
+import { useConfirm } from '../composables/useConfirm'
 import AppButton from '../components/ui/AppButton.vue'
 import EmptyState from '../components/ui/EmptyState.vue'
 import ErrorState from '../components/ui/ErrorState.vue'
@@ -19,11 +21,15 @@ import ContainerLogsDrawer from '../components/ops/ContainerLogsDrawer.vue'
 import CreateContainerModal from '../components/ops/CreateContainerModal.vue'
 import AiDiagnosisModal from '../components/ops/AiDiagnosisModal.vue'
 import ContainerAiPanel from '../components/ops/ContainerAiPanel.vue'
+import ContainerInspectModal from '../components/ops/ContainerInspectModal.vue'
+import SystemPruneModal from '../components/ops/SystemPruneModal.vue'
 
 type LoadState = 'idle' | 'loading' | 'error'
 type StateFilter = 'all' | StateBucket
 
 const router = useRouter()
+const toast = useToast()
+const confirm = useConfirm()
 
 const loadState = ref<LoadState>('idle')
 const loadError = ref('')
@@ -80,6 +86,86 @@ function filterCount(key: StateFilter): number {
   return bucketCounts.value[key]
 }
 
+// ─── 文本搜索 ─────────────────────────────────────────────────────────────────
+// 透传给各 ServerCard,与状态筛选叠加(按名字 / 镜像,忽略大小写)。
+const searchText = ref('')
+
+// ─── 批量操作 ─────────────────────────────────────────────────────────────────
+// 父统一持有选择集;key = `${serverId}::${containerName}`。ServerCard 上报勾选,父加 serverId。
+const bulkMode = ref(false)
+const selected = ref<Set<string>>(new Set())
+const bulkBusy = ref(false)
+const selectedCount = computed(() => selected.value.size)
+
+function selectKey(serverId: string, name: string): string {
+  return `${serverId}::${name}`
+}
+function toggleSelect(serverId: string, name: string): void {
+  const key = selectKey(serverId, name)
+  const next = new Set(selected.value)
+  if (next.has(key)) next.delete(key)
+  else next.add(key)
+  selected.value = next
+}
+function clearSelection(): void {
+  selected.value = new Set()
+}
+function toggleBulkMode(): void {
+  bulkMode.value = !bulkMode.value
+  if (!bulkMode.value) clearSelection()
+}
+
+interface BulkAction {
+  action: ServiceAction
+  label: string
+  danger: boolean
+}
+const BULK_ACTIONS: BulkAction[] = [
+  { action: 'start', label: '启动', danger: false },
+  { action: 'stop', label: '停止', danger: true },
+  { action: 'restart', label: '重启', danger: true },
+  { action: 'rm', label: '删除', danger: true },
+]
+
+async function runBulk({ action, label, danger }: BulkAction): Promise<void> {
+  if (selected.value.size === 0 || bulkBusy.value) return
+  const targets = [...selected.value].map((key) => {
+    const i = key.indexOf('::')
+    return { serverId: key.slice(0, i), name: key.slice(i + 2) }
+  })
+  if (danger) {
+    const ok = await confirm.open({
+      title: `批量${label} ${targets.length} 个容器?`,
+      body:
+        action === 'rm'
+          ? '将对所选容器执行删除(docker rm)。运行中的容器需先停止,否则会删除失败(计入失败数)。'
+          : `将对所选 ${targets.length} 个容器执行${label}操作,期间相关服务可能短暂中断。`,
+      confirmLabel: `${label} ${targets.length} 个`,
+      variant: 'danger',
+    })
+    if (!ok) return
+  }
+  bulkBusy.value = true
+  try {
+    const results = await Promise.allSettled(
+      targets.map((t) => serviceAction(t.serverId, { type: 'docker', target: t.name, action })),
+    )
+    let okCount = 0
+    let failCount = 0
+    for (const r of results) {
+      if (r.status === 'fulfilled' && r.value.ok) okCount++
+      else failCount++
+    }
+    if (failCount === 0) toast.success(`批量${label}完成`, { detail: `成功 ${okCount} 个` })
+    else if (okCount === 0) toast.error(`批量${label}失败`, { detail: `失败 ${failCount} 个` })
+    else toast.warn(`批量${label}部分完成`, { detail: `成功 ${okCount} · 失败 ${failCount}` })
+    clearSelection()
+    await load()
+  } finally {
+    bulkBusy.value = false
+  }
+}
+
 // ─── 新增容器 ─────────────────────────────────────────────────────────────────
 const showCreate = ref(false)
 const creatableServers = computed(() =>
@@ -114,6 +200,15 @@ const diagnoseTarget = ref<{ serverId: string; name: string } | null>(null)
 function openDiagnose(serverId: string, c: ContainerInfo): void {
   diagnoseTarget.value = { serverId, name: c.names }
 }
+
+// 容器详情 inspect 弹窗。
+const inspectTarget = ref<{ serverId: string; name: string } | null>(null)
+function openInspect(serverId: string, c: ContainerInfo): void {
+  inspectTarget.value = { serverId, name: c.names }
+}
+
+// 一键清理弹窗(作用于有 docker 的服务器,复用 creatableServers)。
+const showPrune = ref(false)
 
 // ─── 加载 ─────────────────────────────────────────────────────────────────────
 async function load(): Promise<void> {
@@ -167,6 +262,12 @@ onUnmounted(() => {
       </div>
       <div class="header-actions">
         <AppButton variant="ai" @click="showAi = true">✦ AI 助手</AppButton>
+        <AppButton variant="default" :disabled="creatableServers.length === 0" @click="showPrune = true">
+          🧹 清理
+        </AppButton>
+        <AppButton :variant="bulkMode ? 'primary' : 'default'" @click="toggleBulkMode">
+          {{ bulkMode ? '退出批量' : '批量' }}
+        </AppButton>
         <AppButton variant="primary" :disabled="creatableServers.length === 0" @click="showCreate = true">
           + 新增容器
         </AppButton>
@@ -219,19 +320,51 @@ onUnmounted(() => {
         </div>
       </section>
 
-      <!-- 状态筛选段(作用于各卡片的容器 tab) -->
-      <div class="filter-bar" role="group" aria-label="按状态筛选容器">
-        <button
-          v-for="f in FILTER_OPTIONS"
-          :key="f.key"
-          class="filter-chip"
-          :class="{ 'filter-chip--active': stateFilter === f.key }"
-          :aria-pressed="stateFilter === f.key"
-          @click="stateFilter = f.key"
-        >
-          {{ f.label }}
-          <span class="filter-chip__count">{{ filterCount(f.key) }}</span>
-        </button>
+      <!-- 状态筛选段 + 文本搜索(均作用于各卡片的容器 tab) -->
+      <div class="controls-row">
+        <div class="filter-bar" role="group" aria-label="按状态筛选容器">
+          <button
+            v-for="f in FILTER_OPTIONS"
+            :key="f.key"
+            class="filter-chip"
+            :class="{ 'filter-chip--active': stateFilter === f.key }"
+            :aria-pressed="stateFilter === f.key"
+            @click="stateFilter = f.key"
+          >
+            {{ f.label }}
+            <span class="filter-chip__count">{{ filterCount(f.key) }}</span>
+          </button>
+        </div>
+        <div class="search-box">
+          <input
+            v-model="searchText"
+            type="search"
+            class="search-box__input"
+            placeholder="按名字 / 镜像搜索容器"
+            aria-label="按名字或镜像搜索容器"
+          />
+          <button v-if="searchText" class="search-box__clear" title="清除搜索" @click="searchText = ''">✕</button>
+        </div>
+      </div>
+
+      <!-- 批量操作条 -->
+      <div v-if="bulkMode" class="bulk-bar" role="group" aria-label="批量操作">
+        <span class="bulk-bar__count">已选 <strong>{{ selectedCount }}</strong> 个</span>
+        <div class="bulk-bar__actions">
+          <button
+            v-for="a in BULK_ACTIONS"
+            :key="a.action"
+            class="bulk-btn"
+            :class="{ 'bulk-btn--danger': a.danger }"
+            :disabled="selectedCount === 0 || bulkBusy"
+            @click="runBulk(a)"
+          >
+            {{ a.label }}
+          </button>
+          <button class="bulk-btn bulk-btn--ghost" :disabled="selectedCount === 0 || bulkBusy" @click="clearSelection">
+            清空所选
+          </button>
+        </div>
       </div>
 
       <!-- 逐台卡片(卡片内自带 容器/镜像 tab) -->
@@ -243,10 +376,15 @@ onUnmounted(() => {
           :name="serverName(g.serverId)"
           :host="serverHost(g.serverId)"
           :state-filter="stateFilter"
+          :search="searchText"
+          :bulk-mode="bulkMode"
+          :selected-set="selected"
+          @toggle-select="(name) => toggleSelect(g.serverId, name)"
           @changed="load"
           @logs="(c) => openLogs(g.serverId, c)"
           @terminal="(c) => openTerminal(g.serverId, c)"
           @diagnose="(c) => openDiagnose(g.serverId, c)"
+          @inspect="(c) => openInspect(g.serverId, c)"
         />
       </section>
     </template>
@@ -278,6 +416,17 @@ onUnmounted(() => {
 
     <!-- AI 助手抽屉 -->
     <ContainerAiPanel v-if="showAi" :context="aiContext" @close="showAi = false" />
+
+    <!-- 容器详情 inspect 弹窗 -->
+    <ContainerInspectModal
+      v-if="inspectTarget"
+      :server-id="inspectTarget.serverId"
+      :container-name="inspectTarget.name"
+      @close="inspectTarget = null"
+    />
+
+    <!-- 一键清理弹窗 -->
+    <SystemPruneModal v-if="showPrune" :servers="creatableServers" @close="showPrune = false" />
   </div>
 </template>
 
@@ -321,11 +470,122 @@ onUnmounted(() => {
   font-variant-numeric: tabular-nums;
 }
 
+/* 筛选段 + 搜索同一行 */
+.controls-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
 /* 状态筛选段 */
 .filter-bar {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+}
+
+/* 文本搜索 */
+.search-box {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  flex: 0 1 320px;
+  min-width: 200px;
+}
+.search-box__input {
+  width: 100%;
+  padding: 7px 30px 7px 13px;
+  font-size: var(--text-label);
+  color: var(--color-text);
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  transition: border-color var(--duration-fast) var(--ease-out-expo);
+}
+.search-box__input::placeholder {
+  color: var(--color-faint);
+}
+.search-box__input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+.search-box__clear {
+  position: absolute;
+  right: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  font-size: 11px;
+  line-height: 1;
+  color: var(--color-faint);
+  background: transparent;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+}
+.search-box__clear:hover {
+  color: var(--color-text);
+}
+
+/* 批量操作条 */
+.bulk-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 10px 16px;
+  background: var(--color-card-2);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded);
+}
+.bulk-bar__count {
+  font-size: var(--text-label);
+  color: var(--color-dim);
+}
+.bulk-bar__count strong {
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+.bulk-bar__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.bulk-btn {
+  font-size: var(--text-label);
+  font-weight: 600;
+  padding: 6px 14px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-card);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out-expo);
+}
+.bulk-btn:hover:not(:disabled) {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+.bulk-btn--danger:hover:not(:disabled) {
+  border-color: var(--color-red);
+  color: var(--color-red);
+}
+.bulk-btn--ghost {
+  color: var(--color-dim);
+}
+.bulk-btn--ghost:hover:not(:disabled) {
+  color: var(--color-text);
+  border-color: var(--color-text);
+}
+.bulk-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 .filter-chip {
   display: inline-flex;

--- a/web/src/views/Containers.vue
+++ b/web/src/views/Containers.vue
@@ -221,7 +221,7 @@ function openTerminal(serverId: string, c: ContainerInfo): void {
   const url = router.resolve({
     name: 'server-terminal',
     params: { id: serverId },
-    query: { container: c.names },
+    query: { container: c.names, cid: shortId(c.id) },
   }).href
   window.open(url, '_blank', 'noopener')
 }

--- a/web/src/views/Containers.vue
+++ b/web/src/views/Containers.vue
@@ -14,6 +14,8 @@ import { listServers, serviceAction, type Server, type ServiceAction } from '../
 import { HttpError } from '../api/http'
 import { useToast } from '../composables/useToast'
 import { useConfirm } from '../composables/useConfirm'
+import { NIcon } from 'naive-ui'
+import { BrandDocker, AlertTriangle } from '@vicons/tabler'
 import AppButton from '../components/ui/AppButton.vue'
 import EmptyState from '../components/ui/EmptyState.vue'
 import ErrorState from '../components/ui/ErrorState.vue'
@@ -42,12 +44,71 @@ const runningContainers = computed(() => groups.value.reduce((n, g) => n + g.run
 const stoppedContainers = computed(() => totalContainers.value - runningContainers.value)
 const coveredServers = computed(() => groups.value.filter((g) => g.reachable && g.runtime).length)
 
+// ─── 状态筛选 ─────────────────────────────────────────────────────────────────
+// 把六种容器状态归并为三档「桶」,供筛选段与计数使用:
+//   running   = running / restarting   （在跑)
+//   paused    = paused                 （已暂停)
+//   stopped   = exited / created / dead / unknown  （未在跑)
+type StateBucket = 'running' | 'paused' | 'stopped'
+type StateFilter = 'all' | StateBucket
+
+function stateBucket(s: ContainerState): StateBucket {
+  if (s === 'running' || s === 'restarting') return 'running'
+  if (s === 'paused') return 'paused'
+  return 'stopped'
+}
+
+const stateFilter = ref<StateFilter>('all')
+
+/** 各档全局计数(跨所有服务器)。 */
+const bucketCounts = computed(() => {
+  let running = 0
+  let paused = 0
+  let stopped = 0
+  for (const g of groups.value) {
+    for (const c of g.containers) {
+      const b = stateBucket(c.state)
+      if (b === 'running') running++
+      else if (b === 'paused') paused++
+      else stopped++
+    }
+  }
+  return { all: running + paused + stopped, running, paused, stopped }
+})
+
+interface FilterOption {
+  key: StateFilter
+  label: string
+}
+const FILTER_OPTIONS: FilterOption[] = [
+  { key: 'all', label: '全部' },
+  { key: 'running', label: '运行中' },
+  { key: 'stopped', label: '已停止' },
+  { key: 'paused', label: '已暂停' },
+]
+function filterCount(key: StateFilter): number {
+  return bucketCounts.value[key]
+}
+const activeFilterLabel = computed(() => FILTER_OPTIONS.find((f) => f.key === stateFilter.value)?.label ?? '')
+
+/** 应用当前筛选后该服务器可见的容器(all 时原样返回)。 */
+function visibleContainers(g: ServerContainers): ContainerInfo[] {
+  if (stateFilter.value === 'all') return g.containers
+  return g.containers.filter((c) => stateBucket(c.state) === stateFilter.value)
+}
+
 function serverName(id: string): string {
   return serverById.value.get(id)?.name ?? id
 }
 function serverHost(id: string): string {
   const s = serverById.value.get(id)
   return s ? `${s.user}@${s.host}:${s.port}` : ''
+}
+
+/** 运行时显示名:首字母大写(docker → Docker),未知则原样。 */
+function runtimeLabel(runtime: string): string {
+  if (!runtime) return ''
+  return runtime.charAt(0).toUpperCase() + runtime.slice(1)
 }
 
 // ─── 状态徽标 ─────────────────────────────────────────────────────────────────
@@ -242,6 +303,21 @@ onUnmounted(() => {
     />
 
     <template v-else>
+      <!-- 状态筛选段 -->
+      <div class="filter-bar" role="group" aria-label="按状态筛选容器">
+        <button
+          v-for="f in FILTER_OPTIONS"
+          :key="f.key"
+          class="filter-chip"
+          :class="{ 'filter-chip--active': stateFilter === f.key }"
+          :aria-pressed="stateFilter === f.key"
+          @click="stateFilter = f.key"
+        >
+          {{ f.label }}
+          <span class="filter-chip__count">{{ filterCount(f.key) }}</span>
+        </button>
+      </div>
+
       <!-- 聚合 KPI 条 -->
       <section class="kpi-strip" aria-label="容器聚合统计">
         <div class="kpi kpi--total">
@@ -279,7 +355,11 @@ onUnmounted(() => {
                   'rt-badge--down': !g.reachable,
                 }"
               >
-                {{ !g.reachable ? '不可达' : g.runtime ? g.runtime : '无容器运行时' }}
+                <NIcon :size="15" class="rt-badge__icon">
+                  <BrandDocker v-if="g.reachable && g.runtime" />
+                  <AlertTriangle v-else />
+                </NIcon>
+                {{ !g.reachable ? '不可达' : g.runtime ? runtimeLabel(g.runtime) : '无容器运行时' }}
               </span>
               <span v-if="g.reachable && g.runtime" class="panel__count mono">
                 {{ g.running }}/{{ g.total }} 运行
@@ -291,10 +371,13 @@ onUnmounted(() => {
           <p v-if="!g.reachable" class="panel__hint panel__hint--down">⚠ {{ g.error }}</p>
           <p v-else-if="!g.runtime" class="panel__hint">{{ g.error }}</p>
           <p v-else-if="g.total === 0" class="panel__hint">该服务器暂无容器。</p>
+          <p v-else-if="visibleContainers(g).length === 0" class="panel__hint">
+            无「{{ activeFilterLabel }}」状态的容器(该服务器共 {{ g.total }} 个)。
+          </p>
 
           <!-- 容器表 -->
           <ul v-else class="clist" role="list">
-            <li v-for="c in g.containers" :key="c.id" class="crow" :class="{ 'crow--busy': rowBusy(g.serverId, c.id) }">
+            <li v-for="c in visibleContainers(g)" :key="c.id" class="crow" :class="{ 'crow--busy': rowBusy(g.serverId, c.id) }">
               <div class="crow__state">
                 <span
                   class="dot"
@@ -367,6 +450,51 @@ onUnmounted(() => {
 .view-sub__count {
   color: var(--color-faint);
   font-variant-numeric: tabular-nums;
+}
+
+/* ── 状态筛选段 ── */
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 13px;
+  font-size: var(--text-label);
+  font-weight: 600;
+  color: var(--color-dim);
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  cursor: pointer;
+  transition:
+    color var(--duration-fast) var(--ease-out-expo),
+    border-color var(--duration-fast) var(--ease-out-expo),
+    background var(--duration-fast) var(--ease-out-expo);
+}
+.filter-chip:hover {
+  color: var(--color-text);
+  border-color: var(--color-border-strong);
+}
+.filter-chip--active {
+  color: #fff;
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+}
+.filter-chip__count {
+  font-size: var(--text-micro);
+  font-variant-numeric: tabular-nums;
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: var(--color-inset);
+  color: var(--color-faint);
+}
+.filter-chip--active .filter-chip__count {
+  background: oklch(100% 0 0 / 0.22);
+  color: #fff;
 }
 
 /* ── 聚合 KPI 条:bento 式,语义左描边 ── */
@@ -474,13 +602,20 @@ onUnmounted(() => {
 }
 
 .rt-badge {
-  font-size: var(--text-micro);
-  font-weight: 600;
-  padding: 2px 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: var(--text-label);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  padding: 4px 11px 4px 9px;
   border-radius: 999px;
   border: 1px solid var(--color-border-strong);
   color: var(--color-dim);
   white-space: nowrap;
+}
+.rt-badge__icon {
+  display: inline-flex;
 }
 .rt-badge--ok {
   color: var(--color-green);

--- a/web/src/views/Containers.vue
+++ b/web/src/views/Containers.vue
@@ -17,6 +17,7 @@ import SkeletonBlock from '../components/ui/SkeletonBlock.vue'
 import ServerCard from '../components/ops/ServerCard.vue'
 import ContainerLogsDrawer from '../components/ops/ContainerLogsDrawer.vue'
 import CreateContainerModal from '../components/ops/CreateContainerModal.vue'
+import AiDiagnosisModal from '../components/ops/AiDiagnosisModal.vue'
 
 type LoadState = 'idle' | 'loading' | 'error'
 type StateFilter = 'all' | StateBucket
@@ -101,6 +102,12 @@ function openTerminal(serverId: string, c: ContainerInfo): void {
     query: { container: c.names, cid: c.id.length > 12 ? c.id.slice(0, 12) : c.id },
   }).href
   window.open(url, '_blank', 'noopener')
+}
+
+// AI 诊断弹窗。
+const diagnoseTarget = ref<{ serverId: string; name: string } | null>(null)
+function openDiagnose(serverId: string, c: ContainerInfo): void {
+  diagnoseTarget.value = { serverId, name: c.names }
 }
 
 // ─── 加载 ─────────────────────────────────────────────────────────────────────
@@ -233,6 +240,7 @@ onUnmounted(() => {
           @changed="load"
           @logs="(c) => openLogs(g.serverId, c)"
           @terminal="(c) => openTerminal(g.serverId, c)"
+          @diagnose="(c) => openDiagnose(g.serverId, c)"
         />
       </section>
     </template>
@@ -252,6 +260,14 @@ onUnmounted(() => {
       :container-name="logsTarget.name"
       :container-id="logsTarget.id"
       @close="logsTarget = null"
+    />
+
+    <!-- AI 诊断弹窗 -->
+    <AiDiagnosisModal
+      v-if="diagnoseTarget"
+      :server-id="diagnoseTarget.serverId"
+      :container-name="diagnoseTarget.name"
+      @close="diagnoseTarget = null"
     />
   </div>
 </template>

--- a/web/src/views/Containers.vue
+++ b/web/src/views/Containers.vue
@@ -1,0 +1,674 @@
+<script setup lang="ts">
+/*
+  Containers.vue — 容器总览(Portainer 式):聚合所有已登记服务器上的容器,逐台分组展示,
+  行内可执行生命周期操作(起停重启 / 暂停恢复 / kill / 删除)+ 跳主机终端 docker exec。
+
+  · 数据:GET /api/servers/containers(批量,逐台并行、单台失败不连累全局)+ listServers(取名/主机)。
+  · 操作:复用 serviceAction(type=docker);破坏性操作(停止/重启/kill/删除)走 useConfirm。
+  · 每 12s 自动刷新(stale-while-revalidate:刷新保留旧数据,仅首屏显骨架)。
+*/
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { getAllContainers, type ServerContainers, type ContainerInfo, type ContainerState } from '../api/containers'
+import { listServers, serviceAction, type Server, type ServiceAction } from '../api/servers'
+import { HttpError } from '../api/http'
+import { useToast } from '../composables/useToast'
+import { useConfirm } from '../composables/useConfirm'
+import AppButton from '../components/ui/AppButton.vue'
+import EmptyState from '../components/ui/EmptyState.vue'
+import ErrorState from '../components/ui/ErrorState.vue'
+import SkeletonBlock from '../components/ui/SkeletonBlock.vue'
+
+type LoadState = 'idle' | 'loading' | 'error'
+
+const router = useRouter()
+const toast = useToast()
+const confirm = useConfirm()
+
+const loadState = ref<LoadState>('idle')
+const loadError = ref('')
+const groups = ref<ServerContainers[]>([])
+const serverById = ref<Map<string, Server>>(new Map())
+const refreshing = ref(false)
+/** 正在执行操作的 `${serverId}:${containerId}:${action}`,用于禁用对应按钮并显示 loading。 */
+const busy = ref<Set<string>>(new Set())
+
+const POLL_MS = 12_000
+let timer: ReturnType<typeof setInterval> | null = null
+
+// ─── 聚合统计 ─────────────────────────────────────────────────────────────────
+const totalContainers = computed(() => groups.value.reduce((n, g) => n + g.total, 0))
+const runningContainers = computed(() => groups.value.reduce((n, g) => n + g.running, 0))
+const stoppedContainers = computed(() => totalContainers.value - runningContainers.value)
+const coveredServers = computed(() => groups.value.filter((g) => g.reachable && g.runtime).length)
+
+function serverName(id: string): string {
+  return serverById.value.get(id)?.name ?? id
+}
+function serverHost(id: string): string {
+  const s = serverById.value.get(id)
+  return s ? `${s.user}@${s.host}:${s.port}` : ''
+}
+
+// ─── 状态徽标 ─────────────────────────────────────────────────────────────────
+interface StateMeta {
+  label: string
+  tone: 'green' | 'amber' | 'cyan' | 'red' | 'faint'
+  pulse: boolean
+}
+const STATE_META: Record<ContainerState, StateMeta> = {
+  running:    { label: '运行中', tone: 'green', pulse: true },
+  paused:     { label: '已暂停', tone: 'amber', pulse: false },
+  restarting: { label: '重启中', tone: 'amber', pulse: true },
+  created:    { label: '已创建', tone: 'cyan', pulse: false },
+  exited:     { label: '已停止', tone: 'faint', pulse: false },
+  dead:       { label: '异常', tone: 'red', pulse: false },
+  unknown:    { label: '未知', tone: 'faint', pulse: false },
+}
+function stateMeta(s: ContainerState): StateMeta {
+  return STATE_META[s] ?? STATE_META.unknown
+}
+function shortId(id: string): string {
+  return id.length > 12 ? id.slice(0, 12) : id
+}
+
+// ─── 行内操作 ─────────────────────────────────────────────────────────────────
+interface ActionSpec {
+  action: ServiceAction
+  label: string
+  variant: 'default' | 'ghost' | 'danger'
+  danger?: boolean // 需二次确认
+}
+
+/** 据容器状态给出可用操作集(顺序即展示顺序)。 */
+function actionsFor(state: ContainerState): ActionSpec[] {
+  switch (state) {
+    case 'running':
+      return [
+        { action: 'restart', label: '重启', variant: 'default', danger: true },
+        { action: 'stop', label: '停止', variant: 'ghost', danger: true },
+        { action: 'pause', label: '暂停', variant: 'ghost' },
+        { action: 'kill', label: 'Kill', variant: 'ghost', danger: true },
+      ]
+    case 'paused':
+      return [
+        { action: 'unpause', label: '恢复', variant: 'default' },
+        { action: 'stop', label: '停止', variant: 'ghost', danger: true },
+      ]
+    case 'restarting':
+      return [{ action: 'stop', label: '停止', variant: 'ghost', danger: true }]
+    default: // exited / created / dead / unknown
+      return [
+        { action: 'start', label: '启动', variant: 'default' },
+        { action: 'rm', label: '删除', variant: 'ghost', danger: true },
+      ]
+  }
+}
+
+const DANGER_COPY: Partial<Record<ServiceAction, { title: (n: string) => string; body: string; confirmLabel: string }>> = {
+  restart: { title: (n) => `重启容器 ${n}?`, body: '容器将停止后重新启动,期间该服务短暂不可用。', confirmLabel: '确认重启' },
+  stop:    { title: (n) => `停止容器 ${n}?`, body: '容器将被停止,其提供的服务会中断,直到再次启动。', confirmLabel: '确认停止' },
+  kill:    { title: (n) => `强制 Kill 容器 ${n}?`, body: '将发送 SIGKILL 立即终止容器进程,可能丢失未落盘数据。', confirmLabel: '强制 Kill' },
+  rm:      { title: (n) => `删除容器 ${n}?`, body: '将删除该容器(运行中的需先停止)。容器配置随之移除,数据卷不受影响。', confirmLabel: '确认删除' },
+}
+
+function busyKey(serverId: string, containerId: string, action: ServiceAction): string {
+  return `${serverId}:${containerId}:${action}`
+}
+function isBusy(serverId: string, containerId: string, action: ServiceAction): boolean {
+  return busy.value.has(busyKey(serverId, containerId, action))
+}
+function rowBusy(serverId: string, containerId: string): boolean {
+  for (const k of busy.value) if (k.startsWith(`${serverId}:${containerId}:`)) return true
+  return false
+}
+
+async function runAction(serverId: string, c: ContainerInfo, spec: ActionSpec): Promise<void> {
+  if (spec.danger) {
+    const copy = DANGER_COPY[spec.action]
+    const ok = await confirm.open({
+      title: copy?.title(c.names) ?? `对 ${c.names} 执行 ${spec.label}?`,
+      body: copy?.body ?? '该操作会影响容器运行状态。',
+      confirmLabel: copy?.confirmLabel ?? spec.label,
+      variant: 'danger',
+    })
+    if (!ok) return
+  }
+
+  const key = busyKey(serverId, c.id, spec.action)
+  busy.value = new Set(busy.value).add(key)
+  try {
+    const res = await serviceAction(serverId, { type: 'docker', target: c.names, action: spec.action })
+    if (res.ok) {
+      toast.success(`${spec.label}成功`, { detail: `${c.names} · ${serverName(serverId)}` })
+    } else {
+      toast.error(`${spec.label}失败`, { detail: res.error || '远端命令以非零状态退出' })
+    }
+  } catch (err) {
+    toast.error(`${spec.label}失败`, { detail: err instanceof HttpError ? (err.apiError?.message ?? `请求失败(${err.status})`) : '网络错误' })
+  } finally {
+    const next = new Set(busy.value)
+    next.delete(key)
+    busy.value = next
+    // 操作后刷新该台的容器状态(稍候让 docker 状态稳定)。
+    setTimeout(() => void load(), 600)
+  }
+}
+
+function openTerminal(serverId: string, c: ContainerInfo): void {
+  // 跳主机终端全屏页(新标签),用户在 shell 内 `docker exec -it <name> sh` 进容器。
+  const url = router.resolve({ name: 'server-terminal', params: { id: serverId } }).href
+  window.open(url, '_blank', 'noopener')
+  void c
+}
+
+// ─── 加载 ─────────────────────────────────────────────────────────────────────
+async function load(): Promise<void> {
+  const firstLoad = groups.value.length === 0
+  loadState.value = 'loading'
+  loadError.value = ''
+  if (!firstLoad) refreshing.value = true
+  try {
+    const [servers, items] = await Promise.all([listServers(), getAllContainers()])
+    const m = new Map<string, Server>()
+    for (const s of servers) m.set(s.id, s)
+    serverById.value = m
+    groups.value = items
+    loadState.value = 'idle'
+  } catch (err) {
+    if (err instanceof HttpError) {
+      loadError.value =
+        err.status === 0
+          ? '无法连接到服务器,请检查后端是否运行后重试'
+          : (err.apiError?.message ?? `加载容器列表失败(${err.status})`)
+    } else {
+      loadError.value = '加载容器列表失败,请稍后重试'
+    }
+    loadState.value = 'error'
+  } finally {
+    refreshing.value = false
+  }
+}
+
+onMounted(() => {
+  void load()
+  timer = setInterval(() => void load(), POLL_MS)
+})
+onUnmounted(() => {
+  if (timer) clearInterval(timer)
+})
+</script>
+
+<template>
+  <div class="containers-view">
+    <header class="view-header">
+      <div class="view-header__text">
+        <h1 class="view-title">容器</h1>
+        <p class="view-sub">
+          跨所有已登记服务器的容器总览
+          <span v-if="totalContainers > 0" class="view-sub__count">
+            · 共 {{ totalContainers }} 个 · {{ runningContainers }} 运行中
+          </span>
+          <span class="view-sub__count">· 每 12 秒自动刷新</span>
+        </p>
+      </div>
+      <AppButton variant="default" :loading="loadState === 'loading' && groups.length === 0" @click="load">
+        刷新
+      </AppButton>
+    </header>
+
+    <!-- 首屏骨架 -->
+    <div v-if="loadState === 'loading' && groups.length === 0" class="skeletons" aria-busy="true" aria-label="正在加载容器列表">
+      <div v-for="n in 2" :key="n" class="skeleton-panel">
+        <SkeletonBlock :height="20" width="40%" />
+        <SkeletonBlock :height="48" width="100%" />
+        <SkeletonBlock :height="48" width="100%" />
+      </div>
+    </div>
+
+    <!-- 整页加载失败 -->
+    <ErrorState
+      v-else-if="loadState === 'error' && groups.length === 0"
+      title="加载容器列表失败"
+      :description="loadError"
+      @retry="load"
+    />
+
+    <!-- 无已登记服务器 -->
+    <EmptyState
+      v-else-if="groups.length === 0"
+      title="尚无已登记服务器"
+      description="先在「设置 › 服务器」登记目标服务器,这里就会汇总它们上面的容器。"
+    />
+
+    <template v-else>
+      <!-- 聚合 KPI 条 -->
+      <section class="kpi-strip" aria-label="容器聚合统计">
+        <div class="kpi kpi--total">
+          <span class="kpi__num">{{ totalContainers }}</span>
+          <span class="kpi__label">容器总数</span>
+        </div>
+        <div class="kpi kpi--running">
+          <span class="kpi__num">{{ runningContainers }}</span>
+          <span class="kpi__label">运行中</span>
+        </div>
+        <div class="kpi kpi--stopped">
+          <span class="kpi__num">{{ stoppedContainers }}</span>
+          <span class="kpi__label">已停止</span>
+        </div>
+        <div class="kpi kpi--hosts">
+          <span class="kpi__num">{{ coveredServers }}<span class="kpi__den">/{{ groups.length }}</span></span>
+          <span class="kpi__label">有容器的服务器</span>
+        </div>
+      </section>
+
+      <!-- 逐台分组 -->
+      <section class="groups" :aria-busy="refreshing || undefined">
+        <article v-for="g in groups" :key="g.serverId" class="panel">
+          <header class="panel__head">
+            <div class="panel__id">
+              <h2 class="panel__name">{{ serverName(g.serverId) }}</h2>
+              <span class="panel__host mono">{{ serverHost(g.serverId) }}</span>
+            </div>
+            <div class="panel__meta">
+              <span
+                class="rt-badge"
+                :class="{
+                  'rt-badge--ok': g.reachable && g.runtime,
+                  'rt-badge--warn': g.reachable && !g.runtime,
+                  'rt-badge--down': !g.reachable,
+                }"
+              >
+                {{ !g.reachable ? '不可达' : g.runtime ? g.runtime : '无容器运行时' }}
+              </span>
+              <span v-if="g.reachable && g.runtime" class="panel__count mono">
+                {{ g.running }}/{{ g.total }} 运行
+              </span>
+            </div>
+          </header>
+
+          <!-- 不可达 / 无运行时:行内提示,不连累全局 -->
+          <p v-if="!g.reachable" class="panel__hint panel__hint--down">⚠ {{ g.error }}</p>
+          <p v-else-if="!g.runtime" class="panel__hint">{{ g.error }}</p>
+          <p v-else-if="g.total === 0" class="panel__hint">该服务器暂无容器。</p>
+
+          <!-- 容器表 -->
+          <ul v-else class="clist" role="list">
+            <li v-for="c in g.containers" :key="c.id" class="crow" :class="{ 'crow--busy': rowBusy(g.serverId, c.id) }">
+              <div class="crow__state">
+                <span
+                  class="dot"
+                  :class="[`dot--${stateMeta(c.state).tone}`, { 'dot--pulse': stateMeta(c.state).pulse }]"
+                  aria-hidden="true"
+                />
+                <span class="crow__statelabel" :class="`txt--${stateMeta(c.state).tone}`">{{ stateMeta(c.state).label }}</span>
+              </div>
+              <div class="crow__main">
+                <div class="crow__name">{{ c.names }}</div>
+                <div class="crow__sub mono">{{ c.image }} · {{ shortId(c.id) }}</div>
+              </div>
+              <div class="crow__status">
+                <div class="crow__statustxt">{{ c.status }}</div>
+                <div v-if="c.ports" class="crow__ports mono" :title="c.ports">{{ c.ports }}</div>
+              </div>
+              <div class="crow__actions">
+                <button
+                  v-for="a in actionsFor(c.state)"
+                  :key="a.action"
+                  class="op"
+                  :class="[`op--${a.variant}`, { 'op--busy': isBusy(g.serverId, c.id, a.action) }]"
+                  :disabled="rowBusy(g.serverId, c.id)"
+                  @click="runAction(g.serverId, c, a)"
+                >
+                  {{ a.label }}
+                </button>
+                <button class="op op--ghost" :disabled="rowBusy(g.serverId, c.id)" @click="openTerminal(g.serverId, c)">
+                  终端
+                </button>
+              </div>
+            </li>
+          </ul>
+        </article>
+      </section>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.containers-view {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+/* header — 与 server-status 一致 */
+.view-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+.view-header__text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.view-title {
+  margin: 0;
+  font-size: var(--text-h1);
+  font-weight: 700;
+  color: var(--color-text);
+}
+.view-sub {
+  margin: 0;
+  font-size: var(--text-label);
+  color: var(--color-dim);
+}
+.view-sub__count {
+  color: var(--color-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── 聚合 KPI 条:bento 式,语义左描边 ── */
+.kpi-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+.kpi {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 16px 18px;
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded);
+  overflow: hidden;
+}
+.kpi::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--color-faint);
+}
+.kpi--running::before { background: var(--color-green); }
+.kpi--stopped::before { background: var(--color-faint); }
+.kpi--total::before { background: var(--color-primary); }
+.kpi--hosts::before { background: var(--color-cyan); }
+.kpi__num {
+  font-size: var(--text-kpi);
+  font-weight: 700;
+  line-height: 1;
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+.kpi__den {
+  font-size: var(--text-body);
+  font-weight: 600;
+  color: var(--color-faint);
+}
+.kpi__label {
+  font-size: var(--text-caps);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-faint);
+}
+
+/* ── 逐台分组面板 ── */
+.groups {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  transition: opacity var(--duration-fast) var(--ease-out-expo);
+}
+.groups[aria-busy='true'] {
+  opacity: 0.7;
+}
+.panel {
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-lg, 12px);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+.panel__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-card-2);
+}
+.panel__id {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
+.panel__name {
+  margin: 0;
+  font-size: var(--text-section);
+  font-weight: 700;
+  color: var(--color-text);
+}
+.panel__host {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.panel__meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+.panel__count {
+  font-size: var(--text-micro);
+  color: var(--color-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+.rt-badge {
+  font-size: var(--text-micro);
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border-strong);
+  color: var(--color-dim);
+  white-space: nowrap;
+}
+.rt-badge--ok {
+  color: var(--color-green);
+  background: var(--color-green-soft);
+  border-color: var(--color-green-line);
+}
+.rt-badge--warn {
+  color: var(--color-amber);
+  background: var(--color-amber-soft);
+  border-color: var(--color-amber-line);
+}
+.rt-badge--down {
+  color: var(--color-red);
+  background: var(--color-red-soft);
+  border-color: var(--color-red-line);
+}
+
+.panel__hint {
+  margin: 0;
+  padding: 16px 18px;
+  font-size: var(--text-label);
+  color: var(--color-faint);
+}
+.panel__hint--down {
+  color: var(--color-red);
+}
+
+/* ── 容器行 ── */
+.clist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.crow {
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1.4fr) minmax(0, 1.3fr) auto;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--color-border);
+  transition: background var(--duration-fast) var(--ease-out-expo);
+}
+.crow:last-child {
+  border-bottom: none;
+}
+.crow:hover {
+  background: var(--color-card-2);
+}
+.crow--busy {
+  opacity: 0.55;
+}
+.crow__state {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.crow__statelabel {
+  font-size: var(--text-micro);
+  font-weight: 600;
+}
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--color-faint);
+}
+.dot--green { background: var(--color-green); }
+.dot--amber { background: var(--color-amber); }
+.dot--cyan { background: var(--color-cyan); }
+.dot--red { background: var(--color-red); }
+.dot--faint { background: var(--color-faint); }
+.dot--pulse {
+  animation: dotPulse 1.8s var(--ease-out-expo) infinite;
+}
+@keyframes dotPulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.45; transform: scale(0.8); }
+}
+.txt--green { color: var(--color-green); }
+.txt--amber { color: var(--color-amber); }
+.txt--cyan { color: var(--color-cyan); }
+.txt--red { color: var(--color-red); }
+.txt--faint { color: var(--color-faint); }
+
+.crow__main {
+  min-width: 0;
+}
+.crow__name {
+  font-size: var(--text-body);
+  font-weight: 600;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.crow__sub {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.crow__status {
+  min-width: 0;
+}
+.crow__statustxt {
+  font-size: var(--text-label);
+  color: var(--color-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.crow__ports {
+  font-size: var(--text-micro);
+  color: var(--color-faint);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.crow__actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+/* 行内迷你操作按钮(比 AppButton 更紧凑,适配密集表格) */
+.op {
+  font-size: var(--text-micro);
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: var(--rounded-sm);
+  border: 1px solid var(--color-border-strong);
+  background: transparent;
+  color: var(--color-dim);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) var(--ease-out-expo),
+    color var(--duration-fast) var(--ease-out-expo),
+    border-color var(--duration-fast) var(--ease-out-expo);
+}
+.op:hover:not(:disabled) {
+  color: var(--color-text);
+  border-color: var(--color-text);
+}
+.op--default {
+  color: var(--color-primary);
+  border-color: var(--color-primary-soft);
+}
+.op--default:hover:not(:disabled) {
+  color: #fff;
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+}
+.op:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.op--busy {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+/* 骨架 */
+.skeletons {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.skeleton-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-lg, 12px);
+  background: var(--color-card);
+}
+
+@media (max-width: 720px) {
+  .crow {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+  .crow__actions {
+    justify-content: flex-start;
+  }
+}
+</style>

--- a/web/src/views/Containers.vue
+++ b/web/src/views/Containers.vue
@@ -20,6 +20,7 @@ import AppButton from '../components/ui/AppButton.vue'
 import EmptyState from '../components/ui/EmptyState.vue'
 import ErrorState from '../components/ui/ErrorState.vue'
 import SkeletonBlock from '../components/ui/SkeletonBlock.vue'
+import ContainerLogsDrawer from '../components/ops/ContainerLogsDrawer.vue'
 
 type LoadState = 'idle' | 'loading' | 'error'
 
@@ -227,6 +228,12 @@ async function runAction(serverId: string, c: ContainerInfo, spec: ActionSpec): 
   }
 }
 
+// 日志抽屉:当前查看的容器(null = 关闭)。
+const logsTarget = ref<{ serverId: string; name: string; id: string } | null>(null)
+function openLogs(serverId: string, c: ContainerInfo): void {
+  logsTarget.value = { serverId, name: c.names, id: shortId(c.id) }
+}
+
 function openTerminal(serverId: string, c: ContainerInfo): void {
   // 跳终端全屏页(新标签),带 ?container= → 直接 `docker exec -it <容器> sh` 进该容器。
   const url = router.resolve({
@@ -420,6 +427,9 @@ onUnmounted(() => {
                 >
                   {{ a.label }}
                 </button>
+                <button class="op op--ghost" title="查看容器日志(docker logs,历史 + 实时 tail)" @click="openLogs(g.serverId, c)">
+                  日志
+                </button>
                 <button class="op op--ghost" :disabled="rowBusy(g.serverId, c.id)" title="进入容器交互终端(docker exec -it)" @click="openTerminal(g.serverId, c)">
                   终端
                 </button>
@@ -429,6 +439,15 @@ onUnmounted(() => {
         </article>
       </section>
     </template>
+
+    <!-- 容器日志抽屉 -->
+    <ContainerLogsDrawer
+      v-if="logsTarget"
+      :server-id="logsTarget.serverId"
+      :container-name="logsTarget.name"
+      :container-id="logsTarget.id"
+      @close="logsTarget = null"
+    />
   </div>
 </template>
 

--- a/web/src/views/ServerTerminal.vue
+++ b/web/src/views/ServerTerminal.vue
@@ -38,7 +38,13 @@ const allowedShells: TerminalShell[] = ['/bin/sh', '/bin/bash', '/bin/ash', '/bi
 // 容器目标:带 ?container=<名/ID> 时,终端直接 `docker exec -it` 进该容器;否则连主机 shell。
 // 从「容器」页点行内「终端」即带此参数过来。空串 = 主机 shell 模式。
 const containerName = computed(() => String(route.query.container ?? '').trim())
+// 容器短 ID(展示用,由「容器」页一并带过来);docker exec 用名字即可,ID 仅用于显示区分。
+const containerId = computed(() => String(route.query.cid ?? '').trim())
 const isContainer = computed(() => containerName.value !== '')
+// 容器人读标签:有 ID 则「redis · b2d5b2c20e9a」,否则仅名字。
+const containerLabel = computed(() =>
+  containerId.value ? `${containerName.value} · ${containerId.value}` : containerName.value,
+)
 
 // ─── session controls(顶栏会话段) ───────────────────────────────────────────────
 // 终端目标 = 服务器**主机 shell**(SSH 直起登录 shell),或 ?container= 指定的**容器内 shell**。
@@ -633,7 +639,7 @@ onBeforeUnmount(() => {
       <div class="seg">
         <div class="cell">
           <span class="k">{{ isContainer ? '容器' : '主机' }}</span>
-          <span class="v">{{ isContainer ? `${containerName} @ ${hostLabel}` : hostLabel }}</span>
+          <span class="v">{{ isContainer ? `${containerLabel} @ ${hostLabel}` : hostLabel }}</span>
         </div>
         <div class="cell">
           <span class="k">Shell</span>
@@ -659,7 +665,7 @@ onBeforeUnmount(() => {
       <section class="term-wrap">
         <div class="term-bar">
           <span class="tdot r" /><span class="tdot y" /><span class="tdot g" />
-          <span class="name">{{ serverName }} · <b>{{ isContainer ? `容器 ${containerName}` : '主机 shell' }}</b></span>
+          <span class="name">{{ serverName }} · <b>{{ isContainer ? `容器 ${containerLabel}` : '主机 shell' }}</b></span>
         </div>
 
         <div
@@ -678,7 +684,7 @@ onBeforeUnmount(() => {
 
         <!-- 终端状态行 -->
         <div class="term-status">
-          <span class="s">⟢ <b>{{ serverName }}</b></span>
+          <span class="s">⟢ <b>{{ isContainer ? `容器 ${containerLabel}` : serverName }}</b></span>
           <span v-if="latencyMs !== null && connState === 'connected'" class="s">延迟 <b>{{ latencyMs }}ms</b></span>
           <span class="s"><kbd>⌘C</kbd> 复制</span>
           <span class="s"><kbd>⌘V</kbd> 粘贴</span>

--- a/web/src/views/ServerTerminal.vue
+++ b/web/src/views/ServerTerminal.vue
@@ -17,6 +17,7 @@ import { setDocumentTitle } from '../router'
 import {
   listServers,
   openServerTerminal,
+  openContainerTerminal,
   type Server,
   type TerminalConnection,
   type TerminalHandlers,
@@ -34,9 +35,13 @@ const router = useRouter()
 const serverId = computed(() => String(route.params.id ?? ''))
 const allowedShells: TerminalShell[] = ['/bin/sh', '/bin/bash', '/bin/ash', '/bin/zsh', 'sh', 'bash']
 
+// 容器目标:带 ?container=<名/ID> 时,终端直接 `docker exec -it` 进该容器;否则连主机 shell。
+// 从「容器」页点行内「终端」即带此参数过来。空串 = 主机 shell 模式。
+const containerName = computed(() => String(route.query.container ?? '').trim())
+const isContainer = computed(() => containerName.value !== '')
+
 // ─── session controls(顶栏会话段) ───────────────────────────────────────────────
-// 终端目标 = 服务器**主机 shell**(SSH 直起登录 shell)。进容器留给用户在 shell 里自己
-// `docker exec` 自由探索 —— 不把终端绑死到容器(很多服务器根本没 docker)。
+// 终端目标 = 服务器**主机 shell**(SSH 直起登录 shell),或 ?container= 指定的**容器内 shell**。
 const server = ref<Server | null>(null)
 const shell = ref<TerminalShell>(
   allowedShells.includes(route.query.shell as TerminalShell) ? (route.query.shell as TerminalShell) : '/bin/sh',
@@ -59,7 +64,8 @@ watch(
   [serverName, connState],
   ([name, st]) => {
     const prefix = st === 'connected' ? '' : st === 'connecting' ? '连接中 · ' : '⚠ 已断开 · '
-    setDocumentTitle(`${prefix}${name} · 运维终端`)
+    const scope = isContainer.value ? `${containerName.value} · ` : ''
+    setDocumentTitle(`${prefix}${scope}${name} · 运维终端`)
   },
   { immediate: true },
 )
@@ -67,7 +73,7 @@ watch(
 const aiContext = computed(() => ({
   os: 'linux',
   shell: shell.value,
-  container: '(宿主机)',
+  container: isContainer.value ? containerName.value : '(宿主机)',
 }))
 
 // ─── AI 助手折叠态 ────────────────────────────────────────────────────────────────
@@ -427,7 +433,9 @@ async function connect(): Promise<void> {
   t.reset()
   t.focus()
   connState.value = 'connecting'
-  statusMsg.value = `正在连接主机 ${hostLabel.value} …`
+  statusMsg.value = isContainer.value
+    ? `正在进入容器 ${containerName.value}(${hostLabel.value})…`
+    : `正在连接主机 ${hostLabel.value} …`
   const startedAt = performance.now()
 
   const handlers: TerminalHandlers = {
@@ -455,7 +463,10 @@ async function connect(): Promise<void> {
       },
   }
 
-  conn.value = openServerTerminal(serverId.value, handlers, shell.value)
+  // 容器模式 → docker exec -it <容器> <shell>;否则主机登录 shell。
+  conn.value = isContainer.value
+    ? openContainerTerminal(serverId.value, containerName.value, handlers, shell.value)
+    : openServerTerminal(serverId.value, handlers, shell.value)
 
   if (!resizeObserver && termHost.value) {
     resizeObserver = new ResizeObserver(() => refit())
@@ -620,7 +631,10 @@ onBeforeUnmount(() => {
       <span class="grow" />
 
       <div class="seg">
-        <div class="cell"><span class="k">主机</span><span class="v">{{ hostLabel }}</span></div>
+        <div class="cell">
+          <span class="k">{{ isContainer ? '容器' : '主机' }}</span>
+          <span class="v">{{ isContainer ? `${containerName} @ ${hostLabel}` : hostLabel }}</span>
+        </div>
         <div class="cell">
           <span class="k">Shell</span>
           <select v-model="shell" class="seg-select" aria-label="Shell">
@@ -645,7 +659,7 @@ onBeforeUnmount(() => {
       <section class="term-wrap">
         <div class="term-bar">
           <span class="tdot r" /><span class="tdot y" /><span class="tdot g" />
-          <span class="name">{{ serverName }} · <b>主机 shell</b></span>
+          <span class="name">{{ serverName }} · <b>{{ isContainer ? `容器 ${containerName}` : '主机 shell' }}</b></span>
         </div>
 
         <div
@@ -657,7 +671,9 @@ onBeforeUnmount(() => {
           @contextmenu="onTermContextMenu"
         />
 
-        <div v-if="connState === 'idle'" class="term-hint">点「连接」进入主机 shell。</div>
+        <div v-if="connState === 'idle'" class="term-hint">
+          点「连接」{{ isContainer ? `进入容器 ${containerName}（docker exec）。` : '进入主机 shell。' }}
+        </div>
         <div v-else-if="statusMsg && connState !== 'connected'" class="term-hint err">{{ statusMsg }}</div>
 
         <!-- 终端状态行 -->


### PR DESCRIPTION
## 这是什么

新增「容器」侧栏页(Portainer 式):跨所有已登记服务器**聚合容器**,逐台分组展示,行内执行**生命周期操作**。这是容器管理特性的第一刀(后续 PR:镜像 / 卷 / 网络)。

沿用 6-1 指标采集的架构 —— 经 SSH 跑固定白名单只读命令(`docker ps -a --format '{{json .}}'`),**目标机零侵入**(不装 agent、不开 Docker API socket),逐台并行有界并发、单台失败不连累全局、永不 500。

## 后端

- `GET /api/servers/containers`(批量聚合)+ `GET /api/servers/{id}/containers`(单机)。chi 字面段 `/servers/containers` 优先于 `{id}`。
- 运行时探测**预留抽象**(`containerRuntimePref`,当前仅 docker;后续 append podman/nerdctl 即可)。
- 旧 Docker(无 `State` 字段)→ 据 `Status` 前缀回退推断状态。
- 扩展既有 `/service/action` 的 docker action 白名单:`restart/stop/start` 之外增 `pause/unpause/kill/rm`(systemd **不**放宽)。命令仍全 array 化、容器名走正则防 flag/shell 注入,写操作过 CSRF + 审计 —— **AC-SEC-02 不变**。

## 前端

- `Containers.vue`:聚合 KPI 条(总数 / 运行中 / 已停止 / 覆盖服务器)+ 逐台面板(运行时徽标、不可达 / 无运行时**行内降级提示**)+ 容器行(语义状态点 + 镜像 / ID / 端口 + 上下文相关操作按钮)。
- 破坏性操作(停止 / 重启 / kill / 删除)走 `useConfirm`,结果走 `toast`。每 12s 自动刷新(stale-while-revalidate)。
- `containers.ts` API 客户端;`ServiceAction` 联合类型加宽(容器专用动作)。

## 测试 / 自检

- `server_containers_test.go`:解析(含 / 不含 `State` 字段、脏行跳过)、单机 / 批量端点(docker 在场 / 无运行时)、action 白名单扩展 + 防注入。
- 后端 `go vet ./... && go build ./...` + 全量 `go test ./internal/httpapi/` 绿;`gofmt -l` 空。
- 前端 `npm run lint`(0 error)`&& typecheck && test`(311 passed)`&& build` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)