### PR TITLE
feat(containers): Stack 详情(查看服务+在线编辑 compose) + 修复老 docker/compose v1 三处不兼容

### DIFF
--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -642,8 +642,10 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		// Compose/Stacks —— 列表(只读)+ 部署(贴 yaml → up)+ start/stop/restart/down。
 		// 项目名严格白名单 + array 化;compose 内容经 Upload 落文件(非 shell 注入面)。写过 CSRF + 审计。
 		ar.Get("/servers/{id}/stacks", makeServerStacksHandler(sv))
+		ar.Get("/servers/{id}/stacks/{name}", makeServerStackDetailHandler(sv))
 		ar.Post("/servers/{id}/stacks/deploy", makeStackDeployHandler(sv, aud))
 		ar.Post("/servers/{id}/stacks/action", makeStackActionHandler(sv, aud))
+		ar.Post("/servers/{id}/stacks/save", makeStackSaveHandler(sv, aud))
 		// 容器 AI 诊断 / 看日志(AI moat):取容器日志 → ai.Diagnose 出根因+修复。复用 sv +
 		// o.aiSettings。出网前脱敏;AI 未配/失败 → 200 unavailable,绝不 500。比 {id} 多两段不被吞。
 		ar.Post("/servers/{id}/containers/{containerId}/diagnose", makeContainerDiagnoseHandler(sv, o.aiSettings))

--- a/internal/httpapi/server_images.go
+++ b/internal/httpapi/server_images.go
@@ -28,7 +28,12 @@ const (
 // reImageRef 已在 container_create.go 定义(镜像引用白名单)。删除可用镜像 ID(sha256 短/长)
 // 或 repo:tag —— 同一套 reImageRef 即可覆盖(十六进制 ID 也匹配 [A-Za-z0-9._/:@-])。
 
-var cmdImagesList = []string{"docker", "images", "--format", "{{json .}}"}
+// 列表 **不用** `--format "{{json .}}"`:老 docker(如 CentOS7 自带的 1.13.1)的 `docker images`
+// 对 json 模板函数恒输出 `{}`(同版本 `docker ps` 却支持,版本怪癖),会解析出一堆空字段。
+// 改用逐字段模板 + Tab 分隔(repo/tag 不含 Tab,Size/CreatedSince 仅含空格),新旧 docker 通吃。
+const imagesFieldSep = "\t"
+
+var cmdImagesList = []string{"docker", "images", "--format", `{{.ID}}\t{{.Repository}}\t{{.Tag}}\t{{.Size}}\t{{.CreatedSince}}`}
 
 // imageDTO 是单个镜像的展示 DTO(冻结契约)。
 type imageDTO struct {
@@ -49,34 +54,36 @@ type serverImagesDTO struct {
 	CollectedAt string     `json:"collectedAt"`
 }
 
-type dockerImageLine struct {
-	ID           string `json:"ID"`
-	Repository   string `json:"Repository"`
-	Tag          string `json:"Tag"`
-	Size         string `json:"Size"`
-	CreatedSince string `json:"CreatedSince"`
-}
-
+// parseImages 解析逐字段 Tab 分隔的 `docker images` 输出。每行
+// `ID\tRepository\tTag\tSize\tCreatedSince`;按 Tab 切分(不按空格,Size 形如 "842 MB"
+// 含内部空格)。首列 ID 为空的行跳过(空输出 / 模板异常的兜底)。
 func parseImages(out string) []imageDTO {
 	list := []imageDTO{}
 	if len(out) > imagesOutMax {
 		out = out[:imagesOutMax]
 	}
 	for _, line := range strings.Split(out, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" {
 			continue
 		}
-		var p dockerImageLine
-		if err := json.Unmarshal([]byte(line), &p); err != nil {
+		f := strings.Split(line, imagesFieldSep)
+		field := func(i int) string {
+			if i < len(f) {
+				return strings.TrimSpace(f[i])
+			}
+			return ""
+		}
+		id := field(0)
+		if id == "" {
 			continue
 		}
 		list = append(list, imageDTO{
-			ID:           p.ID,
-			Repository:   p.Repository,
-			Tag:          p.Tag,
-			Size:         p.Size,
-			CreatedSince: p.CreatedSince,
+			ID:           id,
+			Repository:   field(1),
+			Tag:          field(2),
+			Size:         field(3),
+			CreatedSince: field(4),
 		})
 	}
 	return list

--- a/internal/httpapi/server_images_test.go
+++ b/internal/httpapi/server_images_test.go
@@ -3,15 +3,15 @@ package httpapi
 import "testing"
 
 func TestParseImages(t *testing.T) {
-	out := `{"ID":"ad5fe409de38","Repository":"calciumion/new-api","Tag":"latest","Size":"232MB","CreatedSince":"7 weeks ago"}
-{"ID":"1f073813b641","Repository":"redis","Tag":"latest","Size":"202MB","CreatedSince":"2 months ago"}
-{"ID":"deadbeef0001","Repository":"<none>","Tag":"<none>","Size":"100MB","CreatedSince":"1 day ago"}
-`
+	// 逐字段 Tab 分隔(真实 docker images --format "{{.ID}}\t...");Size 含内部空格不应被拆。
+	out := "ad5fe409de38\tcalciumion/new-api\tlatest\t232 MB\t7 weeks ago\n" +
+		"1f073813b641\tredis\tlatest\t202MB\t2 months ago\n" +
+		"deadbeef0001\t<none>\t<none>\t100MB\t1 day ago\n"
 	got := parseImages(out)
 	if len(got) != 3 {
 		t.Fatalf("len = %d, want 3", len(got))
 	}
-	if got[0].Repository != "calciumion/new-api" || got[0].Tag != "latest" || got[0].Size != "232MB" {
+	if got[0].Repository != "calciumion/new-api" || got[0].Tag != "latest" || got[0].Size != "232 MB" {
 		t.Fatalf("img0 wrong: %+v", got[0])
 	}
 	if got[2].Repository != "<none>" {
@@ -19,10 +19,15 @@ func TestParseImages(t *testing.T) {
 	}
 }
 
-func TestParseImages_SkipsGarbage(t *testing.T) {
-	got := parseImages("garbage\n{\"ID\":\"x\",\"Repository\":\"a\",\"Tag\":\"b\"}\n\n")
-	if len(got) != 1 || got[0].ID != "x" {
+func TestParseImages_SkipsBlankAndShortLines(t *testing.T) {
+	// 空行 / 首列 ID 为空(老 docker json 模板异常会输出空)应被跳过;字段不足补空不崩。
+	out := "\n\t\t\t\t\nx\ta\tb\n"
+	got := parseImages(out)
+	if len(got) != 1 || got[0].ID != "x" || got[0].Repository != "a" || got[0].Tag != "b" {
 		t.Fatalf("want 1 valid image, got %+v", got)
+	}
+	if got[0].Size != "" || got[0].CreatedSince != "" {
+		t.Fatalf("missing trailing fields should be empty: %+v", got[0])
 	}
 }
 

--- a/internal/httpapi/server_stacks.go
+++ b/internal/httpapi/server_stacks.go
@@ -153,6 +153,375 @@ func makeServerStacksHandler(svc target.Service) http.HandlerFunc {
 	}
 }
 
+// ─── Stack 详情(查看某项目里的服务/容器 + compose 文件) ──────────────────────
+// 列表只给项目名 + 计数;详情让用户「点进去」看这个 compose 项目里到底有哪些服务/容器,
+// 以及(能定位到时)compose 文件原文。服务/容器靠项目标签聚合(v1/v2、新旧 docker 通吃,
+// 不依赖 compose CLI);compose 原文从 `config_files` 标签指向的路径 cat 出来(老 v1 常无此
+// 标签 → 只读展示服务、提示无法在线编辑)。
+
+const stackComposeReadMax = 256 << 10 // compose 文件读取上限 256 KiB
+
+// stackServiceDTO 是 stack 内单个服务/容器的展示 DTO(冻结契约)。
+type stackServiceDTO struct {
+	Service string `json:"service"` // compose 服务名(com.docker.compose.service 标签;可能为空)
+	Name    string `json:"name"`    // 容器名
+	Image   string `json:"image"`   // 镜像
+	State   string `json:"state"`   // running/exited/... (deriveState)
+	Status  string `json:"status"`  // 人读状态
+	Ports   string `json:"ports"`   // 端口映射原文
+}
+
+// stackDetailDTO 是单个 compose 项目的详情响应体(冻结契约)。
+type stackDetailDTO struct {
+	ServerID      string            `json:"serverId"`
+	Name          string            `json:"name"`
+	Reachable     bool              `json:"reachable"`
+	Runtime       string            `json:"runtime"`
+	Error         string            `json:"error"`
+	Services      []stackServiceDTO `json:"services"`
+	Running       int               `json:"running"`
+	Total         int               `json:"total"`
+	ConfigFiles   string            `json:"configFiles"`   // config_files 标签原文(逗号分隔;v1 旧版常空)
+	Compose       string            `json:"compose"`       // compose 文件内容(可定位且可读才填)
+	ComposeSource string            `json:"composeSource"` // "file"(读到原文) | "none"(无法定位)
+	Editable      bool              `json:"editable"`      // 单一绝对路径 → 可在线编辑保存重部署
+	CollectedAt   string            `json:"collectedAt"`
+}
+
+// cmdStackServices 按项目标签列该 stack 的所有容器(逐字段 Tab 模板,新旧 docker 通吃)。
+func cmdStackServices(project string) []string {
+	return []string{
+		"docker", "ps", "-a", "--no-trunc",
+		"--filter", "label=com.docker.compose.project=" + project,
+		"--format", `{{.Label "com.docker.compose.service"}}\t{{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}`,
+	}
+}
+
+// cmdStackConfigFiles 取该项目容器的 config_files 标签(逐行,取首个非空)。
+func cmdStackConfigFiles(project string) []string {
+	return []string{
+		"docker", "ps", "-a",
+		"--filter", "label=com.docker.compose.project=" + project,
+		"--format", `{{.Label "com.docker.compose.project.config_files"}}`,
+	}
+}
+
+func parseStackServices(out string) []stackServiceDTO {
+	list := []stackServiceDTO{}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		f := strings.Split(line, "\t")
+		field := func(i int) string {
+			if i < len(f) {
+				return strings.TrimSpace(f[i])
+			}
+			return ""
+		}
+		name := field(1)
+		if name == "" {
+			continue
+		}
+		status := field(3)
+		list = append(list, stackServiceDTO{
+			Service: field(0),
+			Name:    strings.TrimPrefix(name, "/"),
+			Image:   field(2),
+			State:   deriveState(status),
+			Status:  status,
+			Ports:   field(4),
+		})
+	}
+	return list
+}
+
+// primaryComposePath 从 config_files 标签取「单一绝对路径」用于读取/写回。多文件或相对路径
+// 返回 ok=false(无法安全地在线编辑)。路径经绝对 + 无控制字符校验,经 array 传参不拼 shell。
+func primaryComposePath(configFiles string) (string, bool) {
+	var paths []string
+	for _, p := range strings.Split(configFiles, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			paths = append(paths, p)
+		}
+	}
+	if len(paths) != 1 {
+		return "", false
+	}
+	p := paths[0]
+	if len(p) > 512 || !strings.HasPrefix(p, "/") || strings.ContainsAny(p, "\n\r\x00") {
+		return "", false
+	}
+	return p, true
+}
+
+func collectStackDetail(ctx context.Context, svc target.Service, id, project string) (stackDetailDTO, error) {
+	out := stackDetailDTO{ServerID: id, Name: project, Services: []stackServiceDTO{}, ComposeSource: "none", CollectedAt: time.Now().UTC().Format(time.RFC3339)}
+	cctx, cancel := context.WithTimeout(ctx, stacksCmdTimeout)
+	defer cancel()
+
+	res, err := svc.Exec(cctx, id, cmdStackServices(project))
+	if err != nil {
+		out.Reachable = false
+		out.Error = humanContainersError(err)
+		if isLocateError(err) {
+			return out, err
+		}
+		return out, nil
+	}
+	out.Reachable = true
+	if res.ExitCode != 0 {
+		out.Error = "未检测到容器运行时(docker 未安装或当前用户无权限)"
+		return out, nil
+	}
+	out.Runtime = "docker"
+	out.Services = parseStackServices(res.Stdout)
+	out.Total = len(out.Services)
+	for _, s := range out.Services {
+		if s.State == "running" {
+			out.Running++
+		}
+	}
+
+	// config_files 标签 → 取首个非空。
+	if cfgRes, cfgErr := svc.Exec(cctx, id, cmdStackConfigFiles(project)); cfgErr == nil && cfgRes.ExitCode == 0 {
+		for _, ln := range strings.Split(cfgRes.Stdout, "\n") {
+			if ln = strings.TrimSpace(ln); ln != "" {
+				out.ConfigFiles = ln
+				break
+			}
+		}
+	}
+	// 三级解析 compose 文件(标签 → 受管目录 → 探测);读到 = 可编辑。
+	if cpath, body, ok := resolveComposeFile(cctx, svc, id, project, out.ConfigFiles); ok {
+		out.Compose = body
+		out.ConfigFiles = cpath
+		out.ComposeSource = "file"
+		out.Editable = true
+	}
+	return out, nil
+}
+
+// resolveComposeFile 三级解析某 stack 的 compose 文件并读出原文,返回(路径, 内容, 命中):
+//
+//	① config_files 标签的单一绝对路径(新版 compose 有;老 v1 恒空)
+//	② Pipewright 受管目录 /opt/pipewright/stacks/<project>/docker-compose.yml(自部署的)
+//	③ 有界扫描常见根,按「父目录名规范化 == 项目名」匹配(存量外部、文件还在的)
+//
+// 每级都要求文件**可读**才算命中(标签可能指向已删文件)。详情展示与「更新」共用此函数,
+// 确保「详情能编辑」⇔「更新能跑」一致。project 经调用方 reDockerTgt 校验,无路径穿越。
+func resolveComposeFile(ctx context.Context, svc target.Service, id, project, labelCfg string) (string, string, bool) {
+	if p, ok := primaryComposePath(labelCfg); ok {
+		if body, readOK := catComposeFile(ctx, svc, id, p); readOK {
+			return p, body, true
+		}
+	}
+	managed := stacksBaseDir + "/" + project + "/" + composeFileName
+	if body, readOK := catComposeFile(ctx, svc, id, managed); readOK {
+		return managed, body, true
+	}
+	if dpath, ok := discoverComposeFile(ctx, svc, id, project); ok {
+		if body, readOK := catComposeFile(ctx, svc, id, dpath); readOK {
+			return dpath, body, true
+		}
+	}
+	return "", "", false
+}
+
+// stackDiscoverRoots 是有界扫描的常见 compose 部署根(只扫这些 + maxdepth,绝不全盘 find)。
+var stackDiscoverRoots = []string{"/root", "/home", "/opt", "/srv", "/data", "/app", "/usr/local"}
+
+// cmdDiscoverComposeFiles 是定值 find 命令(array 化,无 shell、无用户输入):列常见根下的
+// compose 文件路径。某些根不存在会让 find 非零退出 + stderr 噪声,但 stdout 仍含已找到的文件
+// → 调用方忽略 ExitCode,只解析 stdout。
+var cmdDiscoverComposeFiles = append(append([]string{"find"}, stackDiscoverRoots...),
+	"-maxdepth", "5", "(",
+	"-name", "docker-compose.yml", "-o", "-name", "docker-compose.yaml",
+	"-o", "-name", "compose.yml", "-o", "-name", "compose.yaml", ")")
+
+// composeProjectFromPath 按 docker-compose v1 规则从 compose 文件路径反推项目名:取父目录
+// basename,小写,仅保留 [a-z0-9](compose 把其余字符剔除,如 "docker-compose" → "dockercompose")。
+func composeProjectFromPath(p string) string {
+	p = strings.TrimRight(p, "/")
+	if i := strings.LastIndex(p, "/"); i >= 0 { // 去文件名 → 父目录
+		p = p[:i]
+	}
+	if i := strings.LastIndex(p, "/"); i >= 0 { // 父目录 basename
+		p = p[i+1:]
+	}
+	var sb strings.Builder
+	for _, r := range strings.ToLower(p) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			sb.WriteRune(r)
+		}
+	}
+	return sb.String()
+}
+
+// discoverComposeFile 有界扫描常见根,返回「父目录名规范化 == project」的首个 compose 文件路径。
+func discoverComposeFile(ctx context.Context, svc target.Service, id, project string) (string, bool) {
+	if project == "" {
+		return "", false
+	}
+	res, err := svc.Exec(ctx, id, cmdDiscoverComposeFiles)
+	if err != nil { // 传输层失败才放弃;find 非零退出(根不存在)仍可能有 stdout
+		return "", false
+	}
+	for _, line := range strings.Split(res.Stdout, "\n") {
+		p := strings.TrimSpace(line)
+		if p == "" || !strings.HasPrefix(p, "/") || strings.ContainsAny(p, "\n\r\x00") {
+			continue
+		}
+		if composeProjectFromPath(p) == project {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+// catComposeFile 读取远端 compose 文件(array 化 cat,非 shell)。文件不存在/为空 → readOK=false。
+func catComposeFile(ctx context.Context, svc target.Service, id, path string) (string, bool) {
+	res, err := svc.Exec(ctx, id, []string{"cat", path})
+	if err != nil || res.ExitCode != 0 {
+		return "", false
+	}
+	if strings.TrimSpace(res.Stdout) == "" {
+		return "", false
+	}
+	body := res.Stdout
+	if len(body) > stackComposeReadMax {
+		body = body[:stackComposeReadMax]
+	}
+	return body, true
+}
+
+// makeServerStackDetailHandler 返回 GET /api/servers/{id}/stacks/{name}(认证,只读)。
+func makeServerStackDetailHandler(svc target.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		name := chi.URLParam(r, "name")
+		if !reDockerTgt.MatchString(name) || len(name) > 128 {
+			writeError(w, http.StatusBadRequest, "invalid_stack", "项目名非法")
+			return
+		}
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeServerError(w, err)
+			return
+		}
+		out, locErr := collectStackDetail(r.Context(), svc, id, name)
+		if locErr != nil {
+			writeServerError(w, locErr)
+			return
+		}
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+// stackSaveRequest 是「在线编辑 compose 并保存重部署」请求体。
+type stackSaveRequest struct {
+	Name       string `json:"name"`
+	Compose    string `json:"compose"`
+	ConfigFile string `json:"configFile"` // 详情给的单一绝对路径(写回原位)
+}
+
+// makeStackSaveHandler 返回 POST /api/servers/{id}/stacks/save(认证 + CSRF;写)。
+// 把编辑后的 compose 写回原始路径 → `docker compose -p <name> -f <path> up -d`(就地升级)。
+// 仅对详情判定 editable(单一绝对路径)的 stack 可用;detail 内容不入审计(仅项目名 + 动作)。
+func makeStackSaveHandler(svc target.Service, aud audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "服务器服务未初始化")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+		var req stackSaveRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		if !reDockerTgt.MatchString(req.Name) || len(req.Name) > 128 {
+			writeError(w, http.StatusBadRequest, "invalid_stack", "项目名非法")
+			return
+		}
+		path, ok := primaryComposePath(req.ConfigFile)
+		if !ok {
+			writeError(w, http.StatusBadRequest, "invalid_stack", "该 Stack 无单一可写 compose 路径,无法在线保存")
+			return
+		}
+		compose := strings.TrimSpace(req.Compose)
+		if compose == "" {
+			writeError(w, http.StatusBadRequest, "invalid_stack", "compose 内容不能为空")
+			return
+		}
+		if len(compose) > composeMaxBytes {
+			writeError(w, http.StatusBadRequest, "invalid_stack", "compose 内容过大")
+			return
+		}
+		if _, err := svc.Get(r.Context(), id); err != nil {
+			writeServerError(w, err)
+			return
+		}
+
+		out := stackDTOResult{ServerID: id, Name: req.Name, Action: "save"}
+		auditOp := func(ok bool) {
+			recordAudit(r.Context(), aud, audit.Entry{
+				Actor: auditActor, Action: audit.ActionStackOp, TargetType: audit.TargetServer, TargetID: id,
+				Detail: map[string]any{"name": req.Name, "action": "save", "ok": ok}, IP: clientIP(r),
+			})
+		}
+
+		cctx, cancel := context.WithTimeout(r.Context(), stacksUpTimeout)
+		defer cancel()
+
+		bin := detectComposeBin(cctx, svc, id)
+		if bin == nil {
+			out.Error = "该主机未检测到 docker compose / docker-compose,无法保存重部署"
+			auditOp(false)
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		// 写回原始路径(字节流,非 shell)。
+		if err := svc.Upload(cctx, id, strings.NewReader(compose), path); err != nil {
+			out.Error = "写入 compose 文件失败:" + humanServiceError(err)
+			auditOp(false)
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		upCmd := append(append([]string{}, bin...), "-p", req.Name, "-f", path, "up", "-d")
+		res, err := svc.Exec(cctx, id, upCmd)
+		if err != nil {
+			if errors.Is(err, target.ErrNotFound) || errors.Is(err, target.ErrCredentialNotFound) || errors.Is(err, target.ErrVaultUnconfigured) {
+				auditOp(false)
+				writeServerError(w, err)
+				return
+			}
+			out.Error = humanServiceError(err)
+			auditOp(false)
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		if res.ExitCode != 0 {
+			msg := strings.TrimSpace(res.Stderr)
+			if msg == "" {
+				msg = "docker compose up 以非零状态退出"
+			}
+			out.OK = false
+			out.Error = truncateLog(msg, 1024)
+		} else {
+			out.OK = true
+			out.Output = truncateLog(strings.TrimSpace(res.Stdout)+"\n"+strings.TrimSpace(res.Stderr), 2048)
+		}
+		auditOp(out.OK)
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
 // stackActionRequest 是 update/down/start/stop/restart 请求体。
 type stackActionRequest struct {
 	Name       string `json:"name"`
@@ -274,14 +643,32 @@ func makeStackActionHandler(svc target.Service, aud audit.Recorder) http.Handler
 				writeJSON(w, http.StatusOK, out)
 				return
 			}
+			// compose 文件路径:优先用前端从列表带来的 config_files;为空/非法(老 compose v1
+			// 标签恒空)时,走与详情一致的三级解析(受管目录 → 探测)兜底,使「详情能编辑」⇔
+			// 「更新能跑」一致。都解析不到才报清晰错误。
 			fileArgs, ferr := composeFileArgs(req.ConfigFile)
 			if ferr != nil {
-				writeError(w, http.StatusBadRequest, "invalid_stack", ferr.Error())
-				return
+				if cpath, _, ok := resolveComposeFile(cctx, svc, id, req.Name, req.ConfigFile); ok {
+					fileArgs = []string{"-f", cpath}
+				} else {
+					out.OK = false
+					out.Error = "未找到该 Stack 的 compose 文件(外部部署且文件已移除/无法定位),无法更新(可改用重启)"
+					auditOp(false)
+					writeJSON(w, http.StatusOK, out)
+					return
+				}
 			}
-			cmd = append(append([]string{}, bin...), "-p", req.Name)
-			cmd = append(cmd, fileArgs...)
-			cmd = append(cmd, "up", "-d", "--pull", "always")
+			// 「更新」= 拉新镜像 + 重建有变化的服务。**不用** `up -d --pull always`:`--pull` 标志
+			// 是 compose v2 才有的,docker-compose v1(如 1.18)的 up 不认会报 usage 退出。改成版本
+			// 通吃的两步:先独立 `pull`(v1/v2 都有),再 `up -d`。pull best-effort(可能离线/部分
+			// 镜像本地构建无法拉),失败不阻断后续 up(仍按本地镜像重建有变化的服务)。
+			base := append(append([]string{}, bin...), "-p", req.Name)
+			base = append(base, fileArgs...)
+			pullCmd := append(append([]string{}, base...), "pull")
+			if pullRes, pullErr := svc.Exec(cctx, id, pullCmd); pullErr == nil && pullRes.ExitCode != 0 {
+				out.Output = "⚠ 拉取镜像未全部成功(可能离线或镜像为本地构建),已按现有镜像继续重建。\n"
+			}
+			cmd = append(append([]string{}, base...), "up", "-d")
 		} else {
 			// start/stop/restart/down:按标签取容器 ID,用纯 docker 操作(版本无关)。
 			ids, ierr := projectContainerIDs(cctx, svc, id, req.Name)
@@ -336,7 +723,8 @@ func makeStackActionHandler(svc target.Service, aud audit.Recorder) http.Handler
 			out.Error = truncateLog(msg, 1024)
 		} else {
 			out.OK = true
-			out.Output = truncateLog(strings.TrimSpace(res.Stdout), 2048)
+			// out.Output 可能已含 update 的 pull 警告前缀,追加 up 的输出而非覆盖。
+			out.Output = truncateLog(strings.TrimSpace(out.Output+"\n"+strings.TrimSpace(res.Stdout)), 2048)
 		}
 		auditOp(out.OK)
 		writeJSON(w, http.StatusOK, out)

--- a/internal/httpapi/server_stacks_test.go
+++ b/internal/httpapi/server_stacks_test.go
@@ -76,3 +76,66 @@ func TestComposeFileArgs(t *testing.T) {
 		}
 	}
 }
+
+func TestParseStackServices(t *testing.T) {
+	// service\tname\timage\tstatus\tports;status 含内部空格、Ports 含逗号都不应被拆错。
+	out := "web\tdc_web_1\tnginx:latest\tUp 2 hours\t0.0.0.0:8080->80/tcp\n" +
+		"db\tdc_db_1\tmysql:8\tExited (0) 3 days ago\t\n" +
+		"\tbare_named\tredis:7\tUp 5 minutes (Paused)\t6379/tcp\n"
+	got := parseStackServices(out)
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	if got[0].Service != "web" || got[0].Image != "nginx:latest" || got[0].State != "running" || got[0].Ports != "0.0.0.0:8080->80/tcp" {
+		t.Fatalf("svc0 wrong: %+v", got[0])
+	}
+	if got[1].State != "exited" {
+		t.Fatalf("svc1 state wrong: %+v", got[1])
+	}
+	if got[2].Service != "" || got[2].Name != "bare_named" || got[2].State != "paused" {
+		t.Fatalf("svc2 wrong: %+v", got[2])
+	}
+}
+
+func TestParseStackServices_SkipsBlankAndNameless(t *testing.T) {
+	// 空行、name 为空的行跳过。
+	got := parseStackServices("\n\t\t\t\t\nweb\tn1\timg\tUp\t\n")
+	if len(got) != 1 || got[0].Name != "n1" {
+		t.Fatalf("want 1, got %+v", got)
+	}
+}
+
+func TestPrimaryComposePath(t *testing.T) {
+	// 单一绝对路径 → ok。
+	if p, ok := primaryComposePath("/opt/app/docker-compose.yml"); !ok || p != "/opt/app/docker-compose.yml" {
+		t.Fatalf("single abs: p=%q ok=%v", p, ok)
+	}
+	// 空(老 v1 无标签)→ 不可编辑。
+	if _, ok := primaryComposePath(""); ok {
+		t.Fatalf("empty should not be editable")
+	}
+	// 多文件 → 不可在线编辑(写回有歧义)。
+	if _, ok := primaryComposePath("/a/x.yml,/a/y.yml"); ok {
+		t.Fatalf("multi should not be editable")
+	}
+	// 相对路径 / 含控制字符 → 拒绝。
+	for _, bad := range []string{"relative.yml", "/a\nb.yml", "/a\x00b.yml"} {
+		if _, ok := primaryComposePath(bad); ok {
+			t.Fatalf("%q should be rejected", bad)
+		}
+	}
+}
+
+func TestComposeProjectFromPath(t *testing.T) {
+	cases := map[string]string{
+		"/home/fn0S/docker-compose/nacos/docker-compose.yml": "nacos",
+		"/home/fn0S/docker-compose/docker-compose.yml":       "dockercompose", // 父目录 docker-compose → 剔连字符
+		"/opt/My_App/compose.yaml":                           "myapp",         // 大写+下划线被剔/小写
+		"/srv/web-1/docker-compose.yml":                      "web1",
+	}
+	for path, want := range cases {
+		if got := composeProjectFromPath(path); got != want {
+			t.Fatalf("composeProjectFromPath(%q) = %q, want %q", path, got, want)
+		}
+	}
+}

--- a/web/src/api/containers.ts
+++ b/web/src/api/containers.ts
@@ -196,6 +196,50 @@ export async function getServerStacks(id: string): Promise<ServerStacks> {
   return http.get<ServerStacks>(`/api/servers/${id}/stacks`)
 }
 
+/** One service/container inside a compose project. */
+export interface StackService {
+  service: string
+  name: string
+  image: string
+  state: string
+  status: string
+  ports: string
+}
+
+/** Drill-in detail for one compose project: its services + (when locatable) the compose file. */
+export interface StackDetail {
+  serverId: string
+  name: string
+  reachable: boolean
+  runtime: string
+  error: string
+  services: StackService[]
+  running: number
+  total: number
+  configFiles: string
+  compose: string
+  /** `file` = compose 原文已读出;`none` = 无法定位(外部部署、老 v1 无标签)。 */
+  composeSource: 'file' | 'none'
+  /** 单一绝对路径 → 可在线编辑保存重部署。 */
+  editable: boolean
+  collectedAt: string
+}
+
+/** Drill into one compose project (services + compose file when available). */
+export async function getStackDetail(id: string, name: string): Promise<StackDetail> {
+  return http.get<StackDetail>(`/api/servers/${id}/stacks/${encodeURIComponent(name)}`)
+}
+
+/** Save edited compose back to its original path and redeploy (docker compose up -d). */
+export async function saveStackCompose(
+  id: string,
+  name: string,
+  compose: string,
+  configFile: string,
+): Promise<StackActionResult> {
+  return http.post<StackActionResult>(`/api/servers/${id}/stacks/save`, { name, compose, configFile })
+}
+
 // ─── AI 诊断 / 看日志 ─────────────────────────────────────────────────────────
 
 export interface DiagnosisEvidence {

--- a/web/src/components/ops/ServerCard.vue
+++ b/web/src/components/ops/ServerCard.vue
@@ -11,6 +11,8 @@ import {
   pullImage,
   removeImage,
   getServerStacks,
+  getStackDetail,
+  saveStackCompose,
   deployStack,
   stackAction,
   getServerVolumes,
@@ -28,6 +30,7 @@ import {
   type ImageInfo,
   type StackInfo,
   type StackAction,
+  type StackDetail,
   type VolumeInfo,
   type NetworkInfo,
   type NetworkContainer,
@@ -470,10 +473,8 @@ const STACK_ACTIONS: { action: StackAction; label: string; danger?: boolean; tit
 ]
 
 async function doStackAction(s: StackInfo, action: StackAction, label: string, danger?: boolean): Promise<void> {
-  if (action === 'update' && !s.configFiles) {
-    toast.error('无法更新', { detail: '该 Stack 无可用 compose 配置文件' })
-    return
-  }
+  // 「更新」不再据列表 configFiles 预拦:老 compose v1 标签恒空,后端会三级解析(受管目录/探测)
+  // 兜底找 compose 文件,真定位不到才返回清晰错误。预拦会误伤可探测到文件的存量 stack。
   if (danger) {
     const ok = await confirm.open({
       title: `对 Stack ${s.name} 执行${label}?`,
@@ -504,6 +505,74 @@ async function doStackAction(s: StackInfo, action: StackAction, label: string, d
     })
   } finally {
     busyStack.value = ''
+  }
+}
+
+// ─── Stack 详情(点「详情」展开:看服务/容器 + compose 文件,可编辑就地保存) ─────────
+const detailName = ref('') // 当前展开的 stack(空 = 都收起)
+const detailState = ref<'idle' | 'loading' | 'loaded' | 'error'>('idle')
+const detailError = ref('')
+const stackDetail = ref<StackDetail | null>(null)
+const editCompose = ref('') // compose 编辑缓冲
+const savingStack = ref(false)
+
+async function toggleDetail(s: StackInfo): Promise<void> {
+  if (detailName.value === s.name) {
+    detailName.value = '' // 再点一次收起
+    return
+  }
+  detailName.value = s.name
+  stackDetail.value = null
+  detailState.value = 'loading'
+  detailError.value = ''
+  try {
+    const res = await getStackDetail(props.group.serverId, s.name)
+    if (!res.reachable || !res.runtime) {
+      detailState.value = 'error'
+      detailError.value = res.error || '该服务器不可达'
+      return
+    }
+    stackDetail.value = res
+    editCompose.value = res.compose
+    detailState.value = 'loaded'
+  } catch (err) {
+    detailState.value = 'error'
+    detailError.value =
+      err instanceof HttpError ? (err.apiError?.message ?? `加载详情失败(${err.status})`) : '加载详情失败'
+  }
+}
+
+async function doSaveStack(): Promise<void> {
+  const d = stackDetail.value
+  if (!d || !d.editable || savingStack.value) return
+  const compose = editCompose.value.trim()
+  if (!compose) {
+    toast.error('无法保存', { detail: 'compose 内容不能为空' })
+    return
+  }
+  const ok = await confirm.open({
+    title: `保存并重部署 Stack ${d.name}?`,
+    body: `将把编辑后的 compose 写回 ${d.configFiles} 并执行 docker compose up -d(就地升级,有变化的服务会被重建)。`,
+    confirmLabel: '保存并重部署',
+    variant: 'danger',
+  })
+  if (!ok) return
+  savingStack.value = true
+  try {
+    const res = await saveStackCompose(props.group.serverId, d.name, compose, d.configFiles)
+    if (res.ok) {
+      toast.success('已保存并重部署', { detail: d.name })
+      void loadStacks()
+      emit('changed')
+    } else {
+      toast.error('保存失败', { detail: res.error || '远端命令以非零状态退出' })
+    }
+  } catch (err) {
+    toast.error('保存失败', {
+      detail: err instanceof HttpError ? (err.apiError?.message ?? `请求失败(${err.status})`) : '网络错误',
+    })
+  } finally {
+    savingStack.value = false
   }
 }
 
@@ -795,24 +864,79 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
         <p v-else-if="stackState === 'loading' && stacks.length === 0" class="panel__hint">正在加载 Stacks…</p>
         <p v-else-if="stacks.length === 0" class="panel__hint">该服务器暂无 compose 项目。点「+ 部署 Stack」贴 yaml 部署一个。</p>
         <ul v-else class="ilist" role="list">
-          <li v-for="s in stacks" :key="s.name" class="srow" :class="{ 'irow--busy': busyStack === s.name }">
-            <div class="srow__main">
-              <div class="srow__name">{{ s.name }}</div>
-              <div class="srow__cfg mono" :title="s.configFiles">{{ s.configFiles || '—' }}</div>
-            </div>
-            <div class="srow__status mono">{{ s.status }}</div>
-            <div class="srow__act">
+          <li
+            v-for="s in stacks"
+            :key="s.name"
+            class="srow srow--stack"
+            :class="{ 'irow--busy': busyStack === s.name, 'srow--open': detailName === s.name }"
+          >
+            <div class="srow__head">
               <button
-                v-for="a in STACK_ACTIONS"
-                :key="a.action"
-                class="op"
-                :class="{ 'op--default': a.action === 'update' }"
-                :disabled="busyStack === s.name"
-                :title="a.title"
-                @click="doStackAction(s, a.action, a.label, a.danger)"
+                class="srow__toggle"
+                :title="detailName === s.name ? '收起详情' : '查看里面的服务 / compose'"
+                @click="toggleDetail(s)"
               >
-                {{ a.label }}
+                <span class="srow__caret" :class="{ 'srow__caret--open': detailName === s.name }">▸</span>
+                <span class="srow__name">{{ s.name }}</span>
               </button>
+              <div class="srow__status mono">{{ s.status }}</div>
+              <div class="srow__act">
+                <button
+                  v-for="a in STACK_ACTIONS"
+                  :key="a.action"
+                  class="op"
+                  :class="{ 'op--default': a.action === 'update' }"
+                  :disabled="busyStack === s.name"
+                  :title="a.title"
+                  @click="doStackAction(s, a.action, a.label, a.danger)"
+                >
+                  {{ a.label }}
+                </button>
+              </div>
+            </div>
+
+            <!-- 展开:服务/容器 + compose -->
+            <div v-if="detailName === s.name" class="sdetail">
+              <p v-if="detailState === 'loading'" class="panel__hint">正在加载详情…</p>
+              <p v-else-if="detailState === 'error'" class="panel__hint panel__hint--down">⚠ {{ detailError }}</p>
+              <template v-else-if="detailState === 'loaded' && stackDetail">
+                <div class="sdetail__sub">服务 / 容器 · {{ stackDetail.running }}/{{ stackDetail.total }} 运行</div>
+                <ul class="svc" role="list">
+                  <li v-for="svc in stackDetail.services" :key="svc.name" class="svc__row">
+                    <span class="svc__dot" :class="`svc__dot--${svc.state}`" :title="svc.state" />
+                    <span class="svc__name mono">{{ svc.service || svc.name }}</span>
+                    <span class="svc__img mono" :title="svc.image">{{ svc.image }}</span>
+                    <span class="svc__ports mono" :title="svc.ports">{{ svc.ports || '—' }}</span>
+                    <span class="svc__status mono">{{ svc.status }}</span>
+                  </li>
+                </ul>
+
+                <div class="sdetail__sub sdetail__sub--gap">
+                  compose 文件
+                  <span v-if="stackDetail.composeSource === 'file'" class="sdetail__path mono" :title="stackDetail.configFiles">
+                    · {{ stackDetail.configFiles }}
+                  </span>
+                </div>
+                <template v-if="stackDetail.composeSource === 'file'">
+                  <textarea v-model="editCompose" class="deploy__yaml mono" rows="12" spellcheck="false" />
+                  <div class="deploy__act">
+                    <span class="deploy__hint">
+                      {{ stackDetail.editable ? '保存将写回原文件并 docker compose up -d(就地升级)' : '多文件 compose,只读不可在线保存' }}
+                    </span>
+                    <button
+                      v-if="stackDetail.editable"
+                      class="pull__btn"
+                      :disabled="savingStack || !editCompose.trim()"
+                      @click="doSaveStack"
+                    >
+                      {{ savingStack ? '保存中…' : '保存并重部署' }}
+                    </button>
+                  </div>
+                </template>
+                <p v-else class="panel__hint">
+                  该 Stack 为外部部署、未记录 compose 路径,无法在线读取/编辑。可用上方「+ 部署 Stack」以同项目名「{{ stackDetail.name }}」粘贴 compose 接管。
+                </p>
+              </template>
             </div>
           </li>
         </ul>
@@ -1283,6 +1407,8 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
   color: var(--color-text);
 }
 .deploy__yaml {
+  width: 100%;
+  box-sizing: border-box;
   font-size: var(--text-mono);
   line-height: 1.5;
   padding: 10px 12px;
@@ -1341,6 +1467,88 @@ async function doRemoveImage(img: ImageInfo): Promise<void> {
   gap: 6px;
   justify-content: flex-end;
   flex-wrap: wrap;
+}
+
+/* Stack 行:可展开,head 是原来的三列网格,展开内容垂直堆在下方 */
+.srow--stack {
+  display: block;
+  padding: 0;
+}
+.srow--stack:hover { background: transparent; }
+.srow--open { background: var(--color-card-2); }
+.srow__head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 120px auto;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 18px;
+}
+.srow__toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+}
+.srow__caret {
+  color: var(--color-faint);
+  font-size: 11px;
+  transition: transform var(--duration-fast) var(--ease-out-expo);
+}
+.srow__caret--open { transform: rotate(90deg); color: var(--color-accent); }
+.srow__toggle:hover .srow__name { color: var(--color-accent); }
+
+.sdetail {
+  padding: 4px 18px 16px 38px;
+  border-top: 1px dashed var(--color-border);
+}
+.sdetail__sub {
+  font-size: var(--text-micro);
+  font-weight: 600;
+  color: var(--color-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 10px 0 8px;
+}
+.sdetail__sub--gap { margin-top: 18px; }
+.sdetail__path {
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--color-faint);
+}
+.svc { display: flex; flex-direction: column; gap: 2px; }
+.svc__row {
+  display: grid;
+  grid-template-columns: 14px minmax(80px, 1.1fr) minmax(0, 1.4fr) minmax(0, 1.2fr) minmax(0, 1.3fr);
+  align-items: center;
+  gap: 10px;
+  padding: 5px 8px;
+  border-radius: 6px;
+  font-size: var(--text-micro);
+}
+.svc__row:hover { background: var(--color-card); }
+.svc__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-faint);
+}
+.svc__dot--running { background: #16a34a; }
+.svc__dot--exited, .svc__dot--dead { background: #9ca3af; }
+.svc__dot--paused { background: #d97706; }
+.svc__dot--restarting { background: #2563eb; }
+.svc__dot--created { background: #6366f1; }
+.svc__name { font-weight: 600; color: var(--color-text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.svc__img, .svc__ports, .svc__status {
+  color: var(--color-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* 网络展开:连接的容器 */


### PR DESCRIPTION
## 背景
本地起开发实例真机连 **103(docker 1.13.1 / docker-compose 1.18)** 调试容器管理,逼出并修掉 **3 个 compose v1 兼容性问题**,并补齐 Stacks 的「点进去看 + 在线编辑」能力。

## 修复(真机逼出)
| 真相 | 修法 |
|---|---|
| docker **1.13.1** `images --format "{{json .}}"` 恒输出 `{}`(同版本 ps 却支持) | 逐字段 Tab 模板 + 按 Tab 解析,新旧通吃 |
| docker-compose **1.18** 不写 `config_files`/`working_dir` 标签 | compose 文件三级解析兜底(见下) |
| docker-compose **1.18** 的 `up` 不认 `--pull always`(v2 专属标志) | 「更新」改成版本通吃的「先 `pull` 再 `up -d`」 |

## 新增:Stack 详情
- `GET /api/servers/{id}/stacks/{name}` — 列项目内服务/容器(按标签聚合) + 读出 compose 原文
- `POST /api/servers/{id}/stacks/save` — 编辑后写回原路径并 `up -d`(就地升级)
- **compose 文件三级解析**(详情与「更新」共用,确保一致):
  1. `config_files` 标签的单一绝对路径(新版 compose 有)
  2. Pipewright 受管目录 `/opt/pipewright/stacks/<project>/docker-compose.yml`(自部署的)
  3. 有界扫描常见根,按 compose v1 规则「父目录名规范化 == 项目名」匹配(存量外部、文件还在的)

## 前端
- 每个 Stack 加「详情」展开:服务/容器列表 + compose 编辑区(可定位 → 可编辑保存;否则只读 + 接管提示)
- compose 编辑区改满宽,修掉「左边一小条、右边大片空白」
- 「更新」不再据列表 `configFiles` 预拦,交后端三级解析兜底

## 真机验证
- 镜像 14 个全部正常显示
- `nacos`(外部手工部署)经探测变可编辑并读出真实 compose
- 自部署 stack:编辑 compose → 保存 → 容器重建
- 「更新」在 compose v1 上 `ok=true`
- 已知物理边界:`dockercompose` 的 compose 文件在 103 上已被物理删除/挪走,全盘扫不到 → 保持只读

## 自检
后端 `gofmt -l`(空)/`go vet`/`go build`/`go test` 全绿;前端 `typecheck`/`lint`(0 error)/`test`(316 passed) 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)