### PR TITLE
fix(runs): 运行详情进行中实时刷新 commit/步骤

### DIFF
--- a/web/src/views/RunDetail.vue
+++ b/web/src/views/RunDetail.vue
@@ -393,11 +393,30 @@ async function loadRun(): Promise<void> {
   }
 }
 
+// Silent full-snapshot refresh — re-fetch RunDetail WITHOUT toggling loadState
+// (no spinner flicker). The SSE `step` event only carries flat status metadata
+// and never the resolved commit, so while a run is in-progress the commit field
+// and per-stage step grouping would otherwise stay stale until the terminal
+// reload. A periodic silent refresh keeps commit + steps (with stage) + status
+// current during execution; SSE still drives live log tailing.
+async function silentRefresh(): Promise<void> {
+  try {
+    const fresh = await getRun(runId.value)
+    run.value = fresh
+    if (fresh.status === 'waiting_approval') void loadApprovals()
+  } catch {
+    // Transient fetch failure — next tick retries; never surfaced to the UI.
+  }
+}
+
 // ─── SSE subscription ─────────────────────────────────────────────────────────
 // Subscribes when run is in-progress (running/queued).
 // Cleans up on terminal states or component unmount.
 
 let cleanupSse: (() => void) | null = null
+// Periodic in-progress snapshot refresh; lives exactly as long as the SSE
+// subscription (started/stopped alongside it).
+let refreshTimer: ReturnType<typeof setInterval> | null = null
 
 function startSse(): void {
   if (cleanupSse) return
@@ -422,12 +441,19 @@ function startSse(): void {
     },
     // onError is intentionally omitted — subscribeRunEvents falls back to polling
   })
+  if (refreshTimer === null) {
+    refreshTimer = setInterval(() => { void silentRefresh() }, 4000)
+  }
 }
 
 function stopSse(): void {
   if (cleanupSse) {
     cleanupSse()
     cleanupSse = null
+  }
+  if (refreshTimer !== null) {
+    clearInterval(refreshTimer)
+    refreshTimer = null
   }
 }
 


### PR DESCRIPTION
## 问题
运行详情页**进行中**态：顶部 COMMIT 空、阶段卡片恒显「0 步骤 / 尚无步骤」,只有 run 结束重拉才正常(用户截图反馈)。

## 根因
进行中态全靠 SSE,但 SSE 的 step 更新**根本没生效**:后端 `stepPayload`(`internal/httpapi/runs.go`)发的是**扁平** JSON `{runId,id,name,status,ordinal}`,而前端 `RunDetail.vue` 的 `onStep({step})` 期望**嵌套** `{runId, step:{...}}`(`SseStepEvent` 类型 + polling 兜底都是嵌套)。扁平 → `step` 为 `undefined` → `step.id` 抛错 → 被 `addEventListener` 的 `catch{}` 静默吞掉 → 步骤从不 live 更新;commit 则 SSE 压根不推(只有 status/step/log 事件)。

## 修法(前端单点,低风险)
进行中每 4s 静默 `getRun` 拉整份 `RunDetail` 快照(commit + 步骤含 stage + 状态),不动 `loadState`(不闪 spinner),跟 SSE 生命周期同起停;SSE 继续只负责 live 日志。**未改动冻结的 SSE 契约**(底层扁平/嵌套不匹配留待后续单独治)。

## 自检
- `vue-tsc --noEmit` 0 错
- `eslint` 0 错(仅既有 warning)
- `vitest` 316 测试全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)