### PR TITLE
fix(runner): 同阶段无 needs 的并行节点真并行执行

### DIFF
--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -137,10 +137,14 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 
 		sink := &reporterSink{rep: rep}
 		hasPost := len(stage.Post) > 0
-		// 阶段内 job 级 DAG:任一 job 声明 needs → 按 job DAG 并发调度(无依赖 job 并行,各 job
-		// 独立克隆工作区以保并发安全);整阶段无 job needs → 沿用既有「按类型分组串行 + 单一阶段工作区」
-		// (零行为变化,守护存量流水线)。
-		hasJobDAG := stageHasJobNeeds(stage.Jobs)
+		// 阶段内 job 级 DAG:多 job(且都带 ID)或任一 job 声明 needs → 按 job 级 DAG 并发调度
+		// (无依赖 job 并行,对齐画布「并行节点(无 needs)」语义;有 needs 的 job 等其全部上游成功后
+		// 再跑;各 job 独立克隆工作区以保并发安全)。单 job 阶段沿用既有路径(零额外克隆)。
+		// 要求都带 ID:DAG 需唯一节点 ID 建图(生产侧保存流水线时 job 必有 ID);无 ID(测试/异常数据)
+		// 退回既有类型分组路径以防建图失败。
+		// 注:无 needs 的同阶段 job 现按「并行」跑(各自独立工作区);若需「串行 + 共享 env/产物」,应给
+		// 下游 job 显式声明 needs(画布「串行节点」),与 UI 的串/并语义一致。
+		hasJobDAG := stageHasJobNeeds(stage.Jobs) || (len(stage.Jobs) > 1 && allJobsHaveIDs(stage.Jobs))
 
 		// 工作区:
 		//  - 非 DAG 路径:有 script/build_image **或** 有 post 步骤时克隆一份阶段工作区(沿用既有语义)。
@@ -320,6 +324,17 @@ func stageHasJobNeeds(jobs []pipeline.Job) bool {
 		}
 	}
 	return false
+}
+
+// allJobsHaveIDs 报告阶段内每个 job 都有非空 ID。job 级 DAG 调度需唯一节点 ID 建图;生产侧保存
+// 流水线时 job 必有 ID,无 ID(仅测试/异常数据)时调用方退回既有类型分组路径以防 dag 建图失败。
+func allJobsHaveIDs(jobs []pipeline.Job) bool {
+	for _, jb := range jobs {
+		if strings.TrimSpace(jb.ID) == "" {
+			return false
+		}
+	}
+	return true
 }
 
 // runStageJobsDAG 按「阶段内 job 级 DAG」并发执行该阶段的所有 job:无依赖的 job 并行跑、有 needs

--- a/internal/build/dag_stage_exec_test.go
+++ b/internal/build/dag_stage_exec_test.go
@@ -676,3 +676,54 @@ func TestStageExecutorJobDAGFailureSkipsDependents(t *testing.T) {
 		t.Errorf("B 与 A 无依赖,应仍执行;order=%v", drv.order)
 	}
 }
+
+// countingCloner 记录 Clone 调用次数:旧版类型分组路径全阶段共享一次克隆;job 级 DAG 路径每个需
+// 工作区的 job 各克隆一次。用克隆次数确定性判定走了哪条路(不依赖并发时序)。
+type countingCloner struct {
+	mu sync.Mutex
+	n  int
+}
+
+func (c *countingCloner) Clone(_ context.Context, _, _, _, _, destDir string) (*CloneResolved, error) {
+	c.mu.Lock()
+	c.n++
+	c.mu.Unlock()
+	return &CloneResolved{CommitShort: "abc1234"}, nil
+}
+
+// TestSameStageNoNeedsJobsRunParallel:同阶段两个【无 needs】但都带 ID 的 job(=画布「并行节点」),
+// 应走 job 级 DAG 并行路径(各自独立克隆工作区),而非旧版串行单工作区。回归 fix(parallel-jobs-same-stage)。
+func TestSameStageNoNeedsJobsRunParallel(t *testing.T) {
+	drv := &orderDriver{codes: map[string]int{}}
+	cl := &countingCloner{}
+	b := newDAGTestBuilder(drv, cl)
+	exec := NewStageExecutor(b, nil)
+	stage := pipeline.Stage{ID: "s1", Name: "构建", Kind: pipeline.KindBuild, Jobs: []pipeline.Job{
+		scriptJobID("fe", "imgFE"),
+		scriptJobID("be", "imgBE"),
+	}}
+	if err := exec(context.Background(), &run.Run{ProjectID: "p1"}, stage, &fakeReporter{}); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if len(drv.order) != 2 {
+		t.Fatalf("两个 job 都应执行, got order=%v", drv.order)
+	}
+	if cl.n != 2 {
+		t.Fatalf("无 needs 的两 job 应各自独立克隆工作区(DAG 并行路径);clone 次数=%d, want 2(=1 则退回了旧版串行单工作区)", cl.n)
+	}
+}
+
+// TestSameStageSingleJobUsesLegacyPath:单 job 阶段仍走既有路径(共享单工作区,仅 1 次克隆),
+// 不因多 job 并行改动引入额外克隆。
+func TestSameStageSingleJobUsesLegacyPath(t *testing.T) {
+	drv := &orderDriver{codes: map[string]int{}}
+	cl := &countingCloner{}
+	b := newDAGTestBuilder(drv, cl)
+	exec := NewStageExecutor(b, nil)
+	if err := exec(context.Background(), &run.Run{ProjectID: "p1"}, scriptStage(scriptJobID("only", "img1")), &fakeReporter{}); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if cl.n != 1 {
+		t.Fatalf("单 job 阶段应共享单一克隆;clone 次数=%d, want 1", cl.n)
+	}
+}


### PR DESCRIPTION
同阶段【无 needs】节点画布标为「并行」,但引擎 dag_stage_exec 的 hasJobDAG=stageHasJobNeeds 只在「任一 job 有 needs」时才走 job 级 DAG 并发路;两个都无 needs 反而退回旧版「类型分组串行+单一共享工作区」逐个跑,与 UI 语义矛盾。修法:多 job(都带 ID)或有 needs → 走 job 级 DAG(无依赖并行/有 needs 串行),单 job 阶段不变;无 ID 退回旧路防御。行为变更:无 needs 同阶段 job 现并行(各自独立工作区),需串行共享 env 应显式声明 needs(串行节点)。自检:gofmt/vet/build/go test ./... 全过 + 新增 TestSameStageNoNeedsJobsRunParallel / TestSameStageSingleJobUsesLegacyPath 回归。