### PR TITLE
feat(i18n): Part C — 通知语言设置 + 默认通知文案多语言

### DIFF
--- a/internal/httpapi/notify_config.go
+++ b/internal/httpapi/notify_config.go
@@ -1,0 +1,49 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/huangchengsir/pipewright/internal/notify"
+)
+
+// notifyConfigDTO 是通知全局配置(本期仅 language:外发通知默认文案语言)。
+type notifyConfigDTO struct {
+	Language string `json:"language"`
+}
+
+// GET /api/notifications/config — 读取通知语言。
+func makeGetNotifyConfigHandler(svc notify.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "通知服务未初始化")
+			return
+		}
+		writeJSON(w, http.StatusOK, notifyConfigDTO{Language: svc.NotifyLanguage(r.Context())})
+	}
+}
+
+// PUT /api/notifications/config — 设置通知语言(受支持 locale 码)。
+func makeSetNotifyConfigHandler(svc notify.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "通知服务未初始化")
+			return
+		}
+		var in notifyConfigDTO
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
+			return
+		}
+		if err := svc.SetNotifyLanguage(r.Context(), in.Language); err != nil {
+			if errors.Is(err, notify.ErrInvalidLanguage) {
+				writeError(w, http.StatusUnprocessableEntity, "invalid_language", "通知语言非法:须为受支持的语言代码")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+			return
+		}
+		writeJSON(w, http.StatusOK, notifyConfigDTO{Language: in.Language})
+	}
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -686,6 +686,10 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		// GET(列表/详情)过 auth;POST/PUT/DELETE/test 为写方法,过 auth + CSRF。
 		// 敏感字段(SMTP 密码)加密入库、响应仅 hasPassword。test 须在 {id} 路由内单独注册。
 		nf := o.notifications
+		// 通知全局配置(外发通知默认文案语言)。
+		ar.Get("/notifications/config", makeGetNotifyConfigHandler(nf))
+		ar.Put("/notifications/config", makeSetNotifyConfigHandler(nf))
+
 		ar.Get("/notifications/channels", makeListChannelsHandler(nf))
 		ar.Post("/notifications/channels", makeCreateChannelHandler(nf))
 		ar.Get("/notifications/channels/{id}", makeGetChannelHandler(nf))

--- a/internal/i18n/messages_notify.go
+++ b/internal/i18n/messages_notify.go
@@ -1,0 +1,32 @@
+package i18n
+
+// Notify default-content strings: event labels, field labels, and titles used
+// when rendering the platform-default notification (飞书/email/webhook). Localized
+// by the notify_config language at send time (background worker, no request locale).
+func init() {
+	register(map[string]map[string]string{
+		// Event labels.
+		"构建成功":   {"zh-TW": "建置成功", "en": "Build succeeded", "ja": "ビルド成功", "ko": "빌드 성공", "es": "Compilación exitosa", "fr": "Build réussi", "de": "Build erfolgreich"},
+		"构建失败":   {"zh-TW": "建置失敗", "en": "Build failed", "ja": "ビルド失敗", "ko": "빌드 실패", "es": "Compilación fallida", "fr": "Build échoué", "de": "Build fehlgeschlagen"},
+		"部署成功":   {"zh-TW": "部署成功", "en": "Deployment succeeded", "ja": "デプロイ成功", "ko": "배포 성공", "es": "Despliegue exitoso", "fr": "Déploiement réussi", "de": "Bereitstellung erfolgreich"},
+		"部署失败":   {"zh-TW": "部署失敗", "en": "Deployment failed", "ja": "デプロイ失敗", "ko": "배포 실패", "es": "Despliegue fallido", "fr": "Déploiement échoué", "de": "Bereitstellung fehlgeschlagen"},
+		"已回滚":    {"zh-TW": "已回滾", "en": "Rolled back", "ja": "ロールバック済み", "ko": "롤백됨", "es": "Revertido", "fr": "Annulé", "de": "Zurückgerollt"},
+		"健康检查失败": {"zh-TW": "健康檢查失敗", "en": "Health check failed", "ja": "ヘルスチェック失敗", "ko": "상태 점검 실패", "es": "Comprobación de estado fallida", "fr": "Échec de la vérification de santé", "de": "Health-Check fehlgeschlagen"},
+
+		// Field labels (notification body + feishu card field list).
+		"项目": {"zh-TW": "專案", "en": "Project", "ja": "プロジェクト", "ko": "프로젝트", "es": "Proyecto", "fr": "Projet", "de": "Projekt"},
+		"分支": {"zh-TW": "分支", "en": "Branch", "ja": "ブランチ", "ko": "브랜치", "es": "Rama", "fr": "Branche", "de": "Branch"},
+		"提交": {"zh-TW": "提交", "en": "Commit", "ja": "コミット", "ko": "커밋", "es": "Commit", "fr": "Commit", "de": "Commit"},
+		"状态": {"zh-TW": "狀態", "en": "Status", "ja": "ステータス", "ko": "상태", "es": "Estado", "fr": "Statut", "de": "Status"},
+		"耗时": {"zh-TW": "耗時", "en": "Duration", "ja": "所要時間", "ko": "소요 시간", "es": "Duración", "fr": "Durée", "de": "Dauer"},
+		"事件": {"zh-TW": "事件", "en": "Event", "ja": "イベント", "ko": "이벤트", "es": "Evento", "fr": "Événement", "de": "Ereignis"},
+		"来源": {"zh-TW": "來源", "en": "Source", "ja": "ソース", "ko": "소스", "es": "Origen", "fr": "Source", "de": "Quelle"},
+		"类型": {"zh-TW": "類型", "en": "Type", "ja": "種類", "ko": "유형", "es": "Tipo", "fr": "Type", "de": "Typ"},
+
+		// Titles / misc.
+		"Pipewright 通知": {"zh-TW": "Pipewright 通知", "en": "Pipewright notification", "ja": "Pipewright 通知", "ko": "Pipewright 알림", "es": "Notificación de Pipewright", "fr": "Notification Pipewright", "de": "Pipewright-Benachrichtigung"},
+		"(空通知)":         {"zh-TW": "(空通知)", "en": "(empty notification)", "ja": "(空の通知)", "ko": "(빈 알림)", "es": "(notificación vacía)", "fr": "(notification vide)", "de": "(leere Benachrichtigung)"},
+		"测试通知已发送":       {"zh-TW": "測試通知已發送", "en": "Test notification sent", "ja": "テスト通知を送信しました", "ko": "테스트 알림을 보냈습니다", "es": "Notificación de prueba enviada", "fr": "Notification de test envoyée", "de": "Testbenachrichtigung gesendet"},
+		"通知语言非法:须为受支持的语言代码": {"zh-TW": "通知語言非法:須為受支持的語言代碼", "en": "Invalid notification language: must be a supported language code", "ja": "通知言語が不正です:サポートされている言語コードである必要があります", "ko": "알림 언어가 잘못되었습니다: 지원되는 언어 코드여야 합니다", "es": "Idioma de notificación no válido: debe ser un código de idioma admitido", "fr": "Langue de notification non valide : doit être un code de langue pris en charge", "de": "Ungültige Benachrichtigungssprache: muss ein unterstützter Sprachcode sein"},
+	})
+}

--- a/internal/notify/email.go
+++ b/internal/notify/email.go
@@ -7,6 +7,8 @@ import (
 	"net/smtp"
 	"sort"
 	"strings"
+
+	"github.com/huangchengsir/pipewright/internal/i18n"
 )
 
 // emailSender 抽象 SMTP 发信(默认 net/smtp;单测注入 stub,无需真起 SMTP server)。
@@ -83,7 +85,7 @@ func sanitizeHeader(s string) string {
 func buildMessage(from string, to []string, payload Payload) []byte {
 	subject := payload.Title
 	if subject == "" {
-		subject = "Pipewright 通知"
+		subject = i18n.T(payload.Lang, "Pipewright 通知")
 	}
 	subject = sanitizeHeader(subject)
 	safeFrom := sanitizeHeader(from)

--- a/internal/notify/feishu.go
+++ b/internal/notify/feishu.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/huangchengsir/pipewright/internal/i18n"
 )
 
 // 飞书自定义机器人投递。
@@ -172,24 +174,24 @@ func (s *service) sendFeishu(ctx context.Context, ch *Channel, sealed []byte, pa
 var feishuFieldOrder = []string{"project", "branch", "commit", "status", "duration", "event"}
 
 // feishuFieldLabel 字段 key → 中文标签(卡片里展示更友好)。未知 key 原样用 key。
-func feishuFieldLabel(key string) string {
+func feishuFieldLabel(key, lang string) string {
 	switch key {
 	case "project":
-		return "项目"
+		return i18n.T(lang, "项目")
 	case "branch":
-		return "分支"
+		return i18n.T(lang, "分支")
 	case "commit":
-		return "提交"
+		return i18n.T(lang, "提交")
 	case "status":
-		return "状态"
+		return i18n.T(lang, "状态")
 	case "duration":
-		return "耗时"
+		return i18n.T(lang, "耗时")
 	case "event":
-		return "事件"
+		return i18n.T(lang, "事件")
 	case "source":
-		return "来源"
+		return i18n.T(lang, "来源")
 	case "kind":
-		return "类型"
+		return i18n.T(lang, "类型")
 	default:
 		return key
 	}
@@ -199,7 +201,7 @@ func feishuFieldLabel(key string) string {
 func feishuCardFor(p Payload) feishuCard {
 	title := strings.TrimSpace(p.Title)
 	if title == "" {
-		title = "Pipewright 通知"
+		title = i18n.T(p.Lang, "Pipewright 通知")
 	}
 
 	card := feishuCard{
@@ -219,7 +221,7 @@ func feishuCardFor(p Payload) feishuCard {
 	}
 
 	// 字段双列(lark_md,每格 **标签**\n值)。按业务顺序排,稳定不抖动。
-	if fields := feishuOrderedFields(p.Fields); len(fields) > 0 {
+	if fields := feishuOrderedFields(p.Fields, p.Lang); len(fields) > 0 {
 		card.Elements = append(card.Elements, feishuCardElem{
 			Tag:    "div",
 			Fields: fields,
@@ -230,14 +232,14 @@ func feishuCardFor(p Payload) feishuCard {
 	if len(card.Elements) == 0 {
 		card.Elements = append(card.Elements, feishuCardElem{
 			Tag:  "div",
-			Text: &feishuCardText{Tag: "lark_md", Content: "(空通知)"},
+			Text: &feishuCardText{Tag: "lark_md", Content: i18n.T(p.Lang, "(空通知)")},
 		})
 	}
 	return card
 }
 
 // feishuOrderedFields 把 Payload.Fields 渲染成双列卡片字段格(业务顺序优先,稳定)。
-func feishuOrderedFields(fields map[string]string) []feishuCardField {
+func feishuOrderedFields(fields map[string]string, lang string) []feishuCardField {
 	if len(fields) == 0 {
 		return nil
 	}
@@ -266,7 +268,7 @@ func feishuOrderedFields(fields map[string]string) []feishuCardField {
 			IsShort: true, // 半宽 → 两两并排成双列
 			Text: feishuCardText{
 				Tag:     "lark_md",
-				Content: "**" + feishuFieldLabel(k) + "**\n" + fields[k],
+				Content: "**" + feishuFieldLabel(k, lang) + "**\n" + fields[k],
 			},
 		})
 	}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/huangchengsir/pipewright/internal/i18n"
 	"github.com/huangchengsir/pipewright/internal/vault"
 )
 
@@ -80,6 +81,38 @@ type Payload struct {
 	Title  string
 	Body   string
 	Fields map[string]string
+	// Lang 是渲染该通知默认文案/字段标签用的语言(notify_config.language)。
+	// 空 = deliver 时按配置解析;渲染器(feishu/email)据此本地化标签与标题。
+	Lang string
+}
+
+// ErrInvalidLanguage 表示设置的通知语言不是受支持的 locale 码。
+var ErrInvalidLanguage = errors.New("notify: invalid language")
+
+// notifyLanguage 读取通知语言配置(notify_config 单行);缺失/出错回退默认。
+func (s *service) notifyLanguage(ctx context.Context) string {
+	var lang string
+	err := s.db.QueryRowContext(ctx, `SELECT language FROM notify_config WHERE id = 1`).Scan(&lang)
+	if err != nil || i18n.Normalize(lang) == "" {
+		return i18n.Default
+	}
+	return lang
+}
+
+// NotifyLanguage 暴露当前通知语言(供 HTTP 层 GET)。
+func (s *service) NotifyLanguage(ctx context.Context) string {
+	return s.notifyLanguage(ctx)
+}
+
+// SetNotifyLanguage 持久化通知语言;要求精确的受支持 locale 码(如 zh-CN/en/ja)。
+func (s *service) SetNotifyLanguage(ctx context.Context, lang string) error {
+	if i18n.Normalize(lang) != lang {
+		return ErrInvalidLanguage
+	}
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE notify_config SET language = ?, updated_at = ? WHERE id = 1`,
+		lang, time.Now().UTC().Format(time.RFC3339))
+	return err
 }
 
 // Channel 是对外可见的渠道视图:含非敏感 per-type 配置 + HasSecret 布尔,绝无敏感字段明文/密文。
@@ -159,6 +192,11 @@ type Service interface {
 	// 渠道不存在 → ErrNotFound;**未启用 → 优雅跳过(返回 nil,不发不报错)**;
 	// 投递失败 → 人读错误。
 	SendVia(ctx context.Context, channelID string, payload Payload) error
+
+	// NotifyLanguage 返回外发通知默认文案语言(notify_config;缺失回退默认)。
+	NotifyLanguage(ctx context.Context) string
+	// SetNotifyLanguage 设置外发通知默认文案语言;非受支持 locale → ErrInvalidLanguage。
+	SetNotifyLanguage(ctx context.Context, lang string) error
 
 	// RouteService 嵌入事件路由 CRUD + 引擎(Story 5.2;FR-20)。
 	RouteService
@@ -387,7 +425,7 @@ func (s *service) Test(ctx context.Context, id string) (*TestResult, error) {
 	return &TestResult{
 		OK:        true,
 		LatencyMs: time.Since(start).Milliseconds(),
-		Detail:    "测试通知已发送",
+		Detail:    i18n.T(s.notifyLanguage(ctx), "测试通知已发送"),
 	}, nil
 }
 
@@ -406,6 +444,10 @@ func (s *service) SendVia(ctx context.Context, channelID string, payload Payload
 // deliver 按 type 分派投递(webhook/email 实现;其余 not_implemented 人读)。
 // 返回人读错误(绝无敏感字段明文)。需 sealed(敏感字段密文)时在各 notifier 内解密、用完即弃。
 func (s *service) deliver(ctx context.Context, ch *Channel, sealed []byte, payload Payload) error {
+	// 确保渲染语言已定(直接投递的预构造 payload 可能未设)——飞书/邮件据此本地化标签。
+	if payload.Lang == "" {
+		payload.Lang = s.notifyLanguage(ctx)
+	}
 	switch ch.Type {
 	case TypeWebhook:
 		return s.sendWebhook(ctx, ch, payload)

--- a/internal/notify/router.go
+++ b/internal/notify/router.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/huangchengsir/pipewright/internal/i18n"
 )
 
 // 通知事件枚举(冻结契约;DB 存小写串;JSON 同名)。run 终态 → 事件由 main 装配的 NotifyHook
@@ -388,8 +389,11 @@ func scanRoute(sc scanner) (*Route, error) {
 //
 // 入参为运行的展示元数据(项目名 / 分支 / commit / 状态 / 耗时);任一为空则在文案中省略。
 // 形状对齐冻结 Payload(Title/Body/Fields),5-3 仅替换文案生成方式、不改形状。
-func EventPayload(event, projectName, branch, commit, status string, durationMs int64) Payload {
-	title := eventTitle(event, projectName)
+func EventPayload(lang, event, projectName, branch, commit, status string, durationMs int64) Payload {
+	if lang == "" {
+		lang = i18n.Default
+	}
+	title := eventTitle(event, projectName, lang)
 
 	fields := map[string]string{
 		"event": event,
@@ -410,56 +414,77 @@ func EventPayload(event, projectName, branch, commit, status string, durationMs 
 		fields["duration"] = humanDuration(durationMs)
 	}
 
-	var b strings.Builder
-	b.WriteString(eventLabel(event))
+	// 正文:事件标签 + 「字段标签 值」列表(本地化标签),分隔/收尾随语言。
+	parts := make([]string, 0, 5)
 	if projectName != "" {
-		b.WriteString(":项目 ")
-		b.WriteString(projectName)
+		parts = append(parts, i18n.T(lang, "项目")+" "+projectName)
 	}
 	if branch != "" {
-		b.WriteString(",分支 ")
-		b.WriteString(branch)
+		parts = append(parts, i18n.T(lang, "分支")+" "+branch)
 	}
 	if commit != "" {
-		b.WriteString(",commit ")
-		b.WriteString(shortCommit(commit))
+		parts = append(parts, i18n.T(lang, "提交")+" "+shortCommit(commit))
 	}
 	if status != "" {
-		b.WriteString(",状态 ")
-		b.WriteString(status)
+		parts = append(parts, i18n.T(lang, "状态")+" "+status)
 	}
 	if durationMs > 0 {
-		b.WriteString(",耗时 ")
-		b.WriteString(humanDuration(durationMs))
+		parts = append(parts, i18n.T(lang, "耗时")+" "+humanDuration(durationMs))
 	}
-	b.WriteString("。")
+	var b strings.Builder
+	b.WriteString(eventLabel(event, lang))
+	if len(parts) > 0 {
+		b.WriteString(bodySeparator(lang))
+		b.WriteString(strings.Join(parts, bodyComma(lang)))
+	}
+	b.WriteString(bodyPeriod(lang))
 
-	return Payload{Title: title, Body: b.String(), Fields: fields}
+	return Payload{Title: title, Body: b.String(), Fields: fields, Lang: lang}
 }
 
-// eventLabel 返回事件的中文标签(默认文案)。
-func eventLabel(event string) string {
+// 正文标点随语言:中文/日文用全角,其余用半角。
+func bodySeparator(lang string) string {
+	if lang == "zh-CN" || lang == "zh-TW" || lang == "ja" {
+		return ":"
+	}
+	return ": "
+}
+func bodyComma(lang string) string {
+	if lang == "zh-CN" || lang == "zh-TW" || lang == "ja" {
+		return ","
+	}
+	return ", "
+}
+func bodyPeriod(lang string) string {
+	if lang == "zh-CN" || lang == "zh-TW" || lang == "ja" {
+		return "。"
+	}
+	return "."
+}
+
+// eventLabel 返回事件标签(默认文案,按 lang 本地化)。
+func eventLabel(event, lang string) string {
 	switch event {
 	case EventBuildSucceeded:
-		return "构建成功"
+		return i18n.T(lang, "构建成功")
 	case EventBuildFailed:
-		return "构建失败"
+		return i18n.T(lang, "构建失败")
 	case EventDeploySucceeded:
-		return "部署成功"
+		return i18n.T(lang, "部署成功")
 	case EventDeployFailed:
-		return "部署失败"
+		return i18n.T(lang, "部署失败")
 	case EventRollback:
-		return "已回滚"
+		return i18n.T(lang, "已回滚")
 	case EventHealthCheckFailed:
-		return "健康检查失败"
+		return i18n.T(lang, "健康检查失败")
 	default:
 		return event
 	}
 }
 
 // eventTitle 组合通知标题。
-func eventTitle(event, projectName string) string {
-	label := eventLabel(event)
+func eventTitle(event, projectName, lang string) string {
+	label := eventLabel(event, lang)
 	if projectName != "" {
 		return fmt.Sprintf("[%s] %s", projectName, label)
 	}

--- a/internal/notify/router_test.go
+++ b/internal/notify/router_test.go
@@ -53,7 +53,7 @@ func TestRouteEventDeliversToConfiguredChannel(t *testing.T) {
 		t.Fatalf("create route: %v", err)
 	}
 
-	payload := EventPayload(EventBuildFailed, "demo", "main", "abcdef1234", "failed", 1500)
+	payload := EventPayload("zh-CN", EventBuildFailed, "demo", "main", "abcdef1234", "failed", 1500)
 	if err := s.RouteEvent(ctx(), EventBuildFailed, payload); err != nil {
 		t.Fatalf("route event: %v", err)
 	}
@@ -215,7 +215,7 @@ func TestDeleteChannelCascadesRoutes(t *testing.T) {
 }
 
 func TestEventPayloadShape(t *testing.T) {
-	p := EventPayload(EventBuildSucceeded, "proj", "main", "deadbeefcafe", "success", 2500)
+	p := EventPayload("zh-CN", EventBuildSucceeded, "proj", "main", "deadbeefcafe", "success", 2500)
 	if p.Title == "" || p.Body == "" {
 		t.Fatalf("empty payload: %+v", p)
 	}

--- a/internal/notify/template.go
+++ b/internal/notify/template.go
@@ -257,7 +257,7 @@ func (s *service) RenderPayload(ctx context.Context, event, channelID string, va
 	tpl := s.matchTemplate(ctx, event, channelID)
 	if tpl == nil {
 		// 无匹配模板:回平台默认(行为向后兼容 5-2)。
-		return s.defaultPayload(event, vars)
+		return s.defaultPayload(ctx, event, vars)
 	}
 
 	m := vars.asMap()
@@ -266,20 +266,21 @@ func (s *service) RenderPayload(ctx context.Context, event, channelID string, va
 
 	// 标题为空时回退到默认标题(避免空主题);保持 Fields 一致供 webhook/email 透出。
 	if strings.TrimSpace(title) == "" {
-		title = s.defaultPayload(event, vars).Title
+		title = s.defaultPayload(ctx, event, vars).Title
 	}
-	return Payload{Title: title, Body: body, Fields: varsFields(vars)}
+	// 自定义模板正文是用户文本(不翻译),但 Lang 仍要带上,供飞书/邮件本地化字段标签与标题。
+	return Payload{Title: title, Body: body, Fields: varsFields(vars), Lang: s.notifyLanguage(ctx)}
 }
 
-// defaultPayload 用 TemplateVars 还原 EventPayload 入参,产出平台默认 Payload。
-func (s *service) defaultPayload(event string, vars TemplateVars) Payload {
+// defaultPayload 用 TemplateVars 还原 EventPayload 入参,产出平台默认 Payload(按通知语言本地化)。
+func (s *service) defaultPayload(ctx context.Context, event string, vars TemplateVars) Payload {
 	var durationMs int64
 	if vars.DurationMs != "" {
 		if d, err := strconv.ParseInt(vars.DurationMs, 10, 64); err == nil {
 			durationMs = d
 		}
 	}
-	return EventPayload(event, vars.Project, vars.Branch, vars.Commit, vars.Status, durationMs)
+	return EventPayload(s.notifyLanguage(ctx), event, vars.Project, vars.Branch, vars.Commit, vars.Status, durationMs)
 }
 
 // varsFields 把 TemplateVars 展开为 Payload.Fields(仅非空项),供 webhook/email 透出结构化键值。

--- a/internal/notify/template_test.go
+++ b/internal/notify/template_test.go
@@ -103,7 +103,7 @@ func TestRenderPayloadFallsBackToDefault(t *testing.T) {
 	vars := TemplateVars{Project: "demo", Branch: "main", Status: "failed", Event: EventBuildFailed, DurationMs: "1500"}
 
 	got := s.RenderPayload(ctx(), EventBuildFailed, "", vars)
-	want := EventPayload(EventBuildFailed, "demo", "main", "", "failed", 1500)
+	want := EventPayload("zh-CN", EventBuildFailed, "demo", "main", "", "failed", 1500)
 	if got.Title != want.Title || got.Body != want.Body {
 		t.Fatalf("default fallback mismatch:\n got=%+v\nwant=%+v", got, want)
 	}

--- a/internal/store/migrations/mysql/0038_notify_config.sql
+++ b/internal/store/migrations/mysql/0038_notify_config.sql
@@ -1,0 +1,7 @@
+-- 0038 notify_config(MySQL):通知语言单例配置(id=1);外发通知默认文案语言。
+CREATE TABLE IF NOT EXISTS notify_config (
+    id          INT PRIMARY KEY CHECK (id = 1),
+    language    VARCHAR(16) NOT NULL DEFAULT 'zh-CN',
+    updated_at  VARCHAR(32) NOT NULL DEFAULT ''
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+INSERT IGNORE INTO notify_config (id, language, updated_at) VALUES (1, 'zh-CN', '');

--- a/internal/store/migrations/sqlite/0038_notify_config.sql
+++ b/internal/store/migrations/sqlite/0038_notify_config.sql
@@ -1,0 +1,9 @@
+-- 0038 notify_config:通知语言单例配置(id=1)。
+-- 外发通知(飞书/邮件等)的默认文案语言,与界面语言解耦——后台通知 worker 无请求
+-- 上下文,发送时从本表读取语言。language 为受支持的 locale 码(zh-CN 默认)。
+CREATE TABLE IF NOT EXISTS notify_config (
+    id          INTEGER PRIMARY KEY CHECK (id = 1),
+    language    TEXT NOT NULL DEFAULT 'zh-CN',
+    updated_at  TEXT NOT NULL DEFAULT ''
+);
+INSERT OR IGNORE INTO notify_config (id, language, updated_at) VALUES (1, 'zh-CN', '');

--- a/internal/storetest/dialect_integration_test.go
+++ b/internal/storetest/dialect_integration_test.go
@@ -19,8 +19,8 @@ func TestMigrationsApplied(t *testing.T) {
 		if err := st.DB.QueryRowContext(ctx, `SELECT COUNT(1) FROM schema_migrations`).Scan(&n); err != nil {
 			t.Fatalf("count migrations: %v", err)
 		}
-		if n != 36 {
-			t.Fatalf("应用迁移数 = %d, 期望 36", n)
+		if n != 37 {
+			t.Fatalf("应用迁移数 = %d, 期望 37", n)
 		}
 		// 核心领域表存在(随手验一张)。
 		if _, err := st.DB.ExecContext(ctx, `SELECT 1 FROM audit_log WHERE 1=0`); err != nil {

--- a/web/src/api/notifications.ts
+++ b/web/src/api/notifications.ts
@@ -248,3 +248,16 @@ export async function updateTemplate(
 export async function deleteTemplate(id: string): Promise<void> {
   await http.delete<void>(`/api/notifications/templates/${id}`)
 }
+
+/** Global notification config — currently just the outbound-content language. */
+export interface NotifyConfig {
+  language: string
+}
+
+export async function getNotifyConfig(): Promise<NotifyConfig> {
+  return http.get<NotifyConfig>('/api/notifications/config')
+}
+
+export async function setNotifyConfig(language: string): Promise<NotifyConfig> {
+  return http.put<NotifyConfig>('/api/notifications/config', { language })
+}

--- a/web/src/i18n/locales/de/settingsNotifications.ts
+++ b/web/src/i18n/locales/de/settingsNotifications.ts
@@ -1,4 +1,8 @@
 export default {
+  langTitle: 'Benachrichtigungssprache',
+  langDesc: 'Sprache der Standardinhalte für ausgehende Benachrichtigungen (Lark/E-Mail), unabhängig von der UI-Sprache.',
+  langSaved: 'Benachrichtigungssprache gespeichert',
+  langSaveFailed: 'Speichern der Benachrichtigungssprache fehlgeschlagen',
   typeWebhookDesc: 'Benutzerdefiniertes HTTP POST',
   typeEmailLabel: 'E-Mail',
   typeEmailDesc: 'SMTP-Versand',

--- a/web/src/i18n/locales/en/settingsNotifications.ts
+++ b/web/src/i18n/locales/en/settingsNotifications.ts
@@ -1,4 +1,8 @@
 export default {
+  langTitle: 'Notification language',
+  langDesc: 'Language for outbound notification default content (Lark/email), independent of the UI language.',
+  langSaved: 'Notification language saved',
+  langSaveFailed: 'Failed to save notification language',
   typeWebhookDesc: 'Custom HTTP POST',
   typeEmailLabel: 'Email',
   typeEmailDesc: 'SMTP delivery',

--- a/web/src/i18n/locales/es/settingsNotifications.ts
+++ b/web/src/i18n/locales/es/settingsNotifications.ts
@@ -1,4 +1,8 @@
 export default {
+  langTitle: 'Idioma de notificaciones',
+  langDesc: 'Idioma del contenido predeterminado de las notificaciones salientes (Lark/correo), independiente del idioma de la interfaz.',
+  langSaved: 'Idioma de notificaciones guardado',
+  langSaveFailed: 'Error al guardar el idioma de notificaciones',
   typeWebhookDesc: 'HTTP POST personalizado',
   typeEmailLabel: 'Correo',
   typeEmailDesc: 'Envío por SMTP',

--- a/web/src/i18n/locales/fr/settingsNotifications.ts
+++ b/web/src/i18n/locales/fr/settingsNotifications.ts
@@ -1,4 +1,8 @@
 export default {
+  langTitle: 'Langue des notifications',
+  langDesc: 'Langue du contenu par défaut des notifications sortantes (Lark/e-mail), indépendante de la langue de l’interface.',
+  langSaved: 'Langue des notifications enregistrée',
+  langSaveFailed: 'Échec de l’enregistrement de la langue des notifications',
   typeWebhookDesc: 'HTTP POST personnalisé',
   typeEmailLabel: 'E-mail',
   typeEmailDesc: 'Envoi SMTP',

--- a/web/src/i18n/locales/ja/settingsNotifications.ts
+++ b/web/src/i18n/locales/ja/settingsNotifications.ts
@@ -1,4 +1,8 @@
 export default {
+  langTitle: '通知の言語',
+  langDesc: '送信通知(Lark/メールなど)の既定文面の言語。UI 言語とは独立しています。',
+  langSaved: '通知の言語を保存しました',
+  langSaveFailed: '通知の言語の保存に失敗しました',
   typeWebhookDesc: 'カスタム HTTP POST',
   typeEmailLabel: 'メール',
   typeEmailDesc: 'SMTP 送信',

--- a/web/src/i18n/locales/ko/settingsNotifications.ts
+++ b/web/src/i18n/locales/ko/settingsNotifications.ts
@@ -1,4 +1,8 @@
 export default {
+  langTitle: '알림 언어',
+  langDesc: '발신 알림(Lark/이메일 등) 기본 문구의 언어로, UI 언어와 독립적입니다.',
+  langSaved: '알림 언어를 저장했습니다',
+  langSaveFailed: '알림 언어 저장에 실패했습니다',
   typeWebhookDesc: '사용자 지정 HTTP POST',
   typeEmailLabel: '이메일',
   typeEmailDesc: 'SMTP 발송',

--- a/web/src/i18n/locales/zh-CN/settingsNotifications.ts
+++ b/web/src/i18n/locales/zh-CN/settingsNotifications.ts
@@ -1,4 +1,8 @@
 export default {
+  langTitle: '通知语言',
+  langDesc: '外发通知(飞书/邮件等)默认文案的语言,与界面语言相互独立。',
+  langSaved: '通知语言已保存',
+  langSaveFailed: '保存通知语言失败',
   // 渠道类型
   typeWebhookDesc: '自定义 HTTP POST',
   typeEmailLabel: '邮件',

--- a/web/src/i18n/locales/zh-TW/settingsNotifications.ts
+++ b/web/src/i18n/locales/zh-TW/settingsNotifications.ts
@@ -1,4 +1,8 @@
 export default {
+  langTitle: '通知語言',
+  langDesc: '外發通知(飛書/郵件等)預設文案的語言,與介面語言相互獨立。',
+  langSaved: '通知語言已儲存',
+  langSaveFailed: '儲存通知語言失敗',
   typeWebhookDesc: '自訂 HTTP POST',
   typeEmailLabel: '郵件',
   typeEmailDesc: 'SMTP 寄信',

--- a/web/src/views/settings/SettingsNotifications.vue
+++ b/web/src/views/settings/SettingsNotifications.vue
@@ -34,6 +34,8 @@ import {
   createTemplate,
   updateTemplate,
   deleteTemplate,
+  getNotifyConfig,
+  setNotifyConfig,
   TEMPLATE_VARIABLES,
   type ChannelType,
   type NotificationChannel,
@@ -44,6 +46,7 @@ import {
   type NotificationTemplate,
 } from '../../api/notifications'
 import { listProjects, type Project } from '../../api/projects'
+import { SUPPORTED_LOCALES } from '../../i18n'
 
 // ─── types / metadata ──────────────────────────────────────────────────────────
 
@@ -60,6 +63,27 @@ interface TypeMeta {
 
 const { t } = useI18n()
 const toast = useToast()
+
+// 通知语言:外发通知(飞书/邮件)默认文案的语言,与界面语言解耦。
+const notifyLang = ref('zh-CN')
+const localeOptions = SUPPORTED_LOCALES
+async function loadNotifyConfig(): Promise<void> {
+  try {
+    const cfg = await getNotifyConfig()
+    if (cfg.language) notifyLang.value = cfg.language
+  } catch {
+    // 非致命:保持默认,不打断渠道页加载。
+  }
+}
+async function onNotifyLangChange(): Promise<void> {
+  try {
+    await setNotifyConfig(notifyLang.value)
+    toast.success(t('settingsNotifications.langSaved'))
+  } catch (err) {
+    toast.error(err instanceof HttpError ? err.message : t('settingsNotifications.langSaveFailed'))
+  }
+}
+onMounted(loadNotifyConfig)
 
 const TYPES = computed<TypeMeta[]>(() => [
   {
@@ -777,6 +801,22 @@ function configSummary(ch: NotificationChannel): string {
         </svg>
         {{ t('settingsNotifications.addChannel') }}
       </AppButton>
+    </div>
+
+    <!-- ─── 通知语言(外发文案语言,与界面语言解耦)─────────────────────────── -->
+    <div class="nt-lang">
+      <div class="nt-lang-text">
+        <span class="nt-lang-title">{{ t('settingsNotifications.langTitle') }}</span>
+        <span class="nt-lang-desc">{{ t('settingsNotifications.langDesc') }}</span>
+      </div>
+      <select
+        v-model="notifyLang"
+        class="nt-lang-select"
+        :aria-label="t('settingsNotifications.langTitle')"
+        @change="onNotifyLangChange"
+      >
+        <option v-for="l in localeOptions" :key="l.code" :value="l.code">{{ l.label }}</option>
+      </select>
     </div>
 
     <!-- ─── load error ──────────────────────────────────────────────────────── -->
@@ -1582,6 +1622,46 @@ function configSummary(ch: NotificationChannel): string {
   display: flex;
   flex-direction: column;
   gap: var(--card-gap);
+}
+
+/* ─── notification language ───────────────────────────────────────────────── */
+.nt-lang {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-card);
+}
+.nt-lang-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.nt-lang-title {
+  font-weight: 600;
+  color: var(--color-text);
+}
+.nt-lang-desc {
+  font-size: var(--text-caption);
+  color: var(--color-dim);
+}
+.nt-lang-select {
+  flex-shrink: 0;
+  padding: 7px 11px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  cursor: pointer;
+}
+.nt-lang-select:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 /* ─── section header ──────────────────────────────────────────────────────── */


### PR DESCRIPTION
## 背景
i18n 收尾(接 #114 前端、#115 后端 error+默认阶段名)。外发通知(飞书/邮件)默认文案此前是中文且跟界面语言无关 → 加「通知语言」全局设置,默认通知文案按该语言渲染。后台通知 worker 无请求上下文,故语言从持久化设置读取(与 UI 语言解耦)。

## 改动
- **迁移 0038** `notify_config` 单行表(sqlite + mysql,种子 `zh-CN`);迁移计数测试 36→37 同步。
- **notify 服务**:`notifyLanguage` 发送时读配置;`NotifyLanguage`/`SetNotifyLanguage`(校验受支持 locale)。`Payload` 加 `Lang`(deliver 兜底解析)。`EventPayload`/`eventLabel`/`eventTitle`/飞书字段标签与标题/邮件主题 经 `i18n.T(lang)` 本地化;默认文案 8 语言词条(`messages_notify.go`)。
- **API**:`GET`/`PUT /api/notifications/config`(`{language}`);非法 → `invalid_language`(错误消息本身也走 Part A 本地化)。
- **前端**:SettingsNotifications 顶部加通知语言下拉(8 语言)+ api。

## 验证
- `go test ./...` 39 包全过;前端 `typecheck`/`test`(321)绿。
- 服务级真测:`notify_config=en` → `RenderPayload(build_failed)` 产出 `"Build failed: Project demo, Branch main, Status failed, Duration 1.5s."`,title `[demo] Build failed`。
- API round-trip:GET `zh-CN` → PUT `en` 持久化 → GET `en`;PUT `en-US` → 422 `invalid_language`。
- 前端选择器:8 语言渲染、值持久化(截图确认)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)