### PR TITLE
feat(gitops): 流水线即代码片2+3+4(配置来源可视化 + 仓库配置预览 + 文档)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -145,6 +145,56 @@ Open **Settings → System** and click "Check for updates" to query the latest r
 | `PIPEWRIGHT_ADMIN_PASSWORD` | Admin password on first launch | none (must be set) |
 | `PIPEWRIGHT_RUNNER` | Run executor: default DAG (orchestrates stages/script/deploy_ssh/notify per the canvas); set `legacy` to fall back to the old fixed flow | `dag` |
 
+## Pipeline as code (GitOps)
+
+Commit your pipeline structure to `.pipewright.yml` in the repo — **same source of truth as your code, reviewable in a PR, evolving per branch** — instead of relying on implicit drift in the canvas.
+
+- **Enable**: flip the "Pipeline as code" toggle on the project's pipeline page (per project).
+- **How it works**: once enabled, every run reads `.pipewright.yml` from the **repo root** on the **branch being built** (falling back to the project default branch when the branch is empty), and the pipeline spec in that file drives the run. Different branches can carry different `.pipewright.yml`. The file is fetched with the project's bound repo credential (ephemeral; no new exposure).
+- **Never breaks a run**: if the file is **missing** → falls back to the pipeline configured in the canvas (UI); if it exists but is **invalid YAML** → also falls back to the stored canvas config.
+- **Scope**: the YAML controls **pipeline structure only** (stages / jobs / `needs` / DAG layout). **Variables & cache, environments & credentials, and trigger rules** still come from the canvas (UI) settings — they are **not** in the YAML.
+- **Schema** is the same one used by the platform's "Import from YAML" (`version` + `stages` → `jobs`; a job uses a nested `script:` block for `image`/`commands`/`env`/`workdir`).
+
+```yaml
+version: 1
+stages:
+  - id: stg_src             # needs references stages by id, so cross-stage deps need an explicit id
+    name: Source
+    kind: source
+    jobs:
+      - name: Gitee source
+        type: git_source
+  - id: stg_build
+    name: Build
+    kind: build
+    needs: [stg_src]
+    jobs:
+      - name: Run tests
+        type: script
+        script:
+          image: golang:1.23
+          commands:
+            - go vet ./...
+            - go test ./...
+          env:
+            CGO_ENABLED: "0"
+          workdir: src/app
+  - id: stg_deploy
+    name: Deploy
+    kind: deploy
+    needs: [stg_build]
+    gate: true              # manual approval gate
+    when:
+      branches: [main, release/*]
+    jobs:
+      - name: SSH deploy
+        type: deploy_ssh
+        config:
+          targetEnv: prod
+```
+
+> You can also force pipeline-as-code on for **all projects** (ignoring the per-project toggle) via the global env var `PIPEWRIGHT_PAC_RUNTIME=1`, for back-compat / power users.
+
 ## Tech Stack
 
 - **Backend**: Go · Chi (routing) · modernc/sqlite (pure Go, no CGO) · go-git · NaCl secretbox (vault) · argon2id · golang.org/x/crypto/ssh (agentless deployment)

--- a/README.md
+++ b/README.md
@@ -145,6 +145,56 @@ make build          # 前端构建 → go:embed → 单个静态二进制 ./pipe
 | `PIPEWRIGHT_ADMIN_PASSWORD` | 首次启动管理员口令 | 无(须设置) |
 | `PIPEWRIGHT_RUNNER` | 运行执行器:默认 DAG(按画布 stages/script/deploy_ssh/notify 编排执行);设 `legacy` 回退旧版固定流程 | `dag` |
 
+## 流水线即代码(GitOps)
+
+把流水线结构写进仓库的 `.pipewright.yml`,**跟代码同源、走 PR 评审、按分支演进**——不再依赖画布配置的隐式漂移。
+
+- **开启**:在项目的流水线页打开「流水线即代码 / Pipeline as code」开关(按项目维度)。
+- **生效方式**:开启后,每次运行都从**本次构建分支**的**仓库根**读取 `.pipewright.yml`(分支为空时回退项目默认分支),用其中的流水线 spec 驱动本次运行;不同分支可携带各自的 `.pipewright.yml`。文件用项目绑定的仓库凭据临时拉取,无新增暴露面。
+- **永不卡住运行的回退**:文件**缺失** → 回退到画布(UI)里已配置的流水线;文件存在但 **YAML 非法** → 同样回退到已存的画布配置。
+- **作用范围**:YAML 只管**流水线结构**(阶段 / 任务 / `needs` / DAG 编排);**变量与缓存、环境与凭据、触发规则**仍来自画布(UI)设置,**不写在 YAML 里**。
+- **schema** 与平台「从 YAML 导入」用的是同一套(`version` + `stages` → `jobs`,job 用嵌套 `script:` 块写 `image`/`commands`/`env`/`workdir`)。
+
+```yaml
+version: 1
+stages:
+  - id: stg_src              # needs 按阶段 id 引用,故跨阶段依赖须显式写 id
+    name: 流水线源
+    kind: source
+    jobs:
+      - name: Gitee 源
+        type: git_source
+  - id: stg_build
+    name: 构建
+    kind: build
+    needs: [stg_src]
+    jobs:
+      - name: 运行测试
+        type: script
+        script:
+          image: golang:1.23
+          commands:
+            - go vet ./...
+            - go test ./...
+          env:
+            CGO_ENABLED: "0"
+          workdir: src/app
+  - id: stg_deploy
+    name: 部署
+    kind: deploy
+    needs: [stg_build]
+    gate: true               # 人工审批门
+    when:
+      branches: [main, release/*]
+    jobs:
+      - name: SSH 部署
+        type: deploy_ssh
+        config:
+          targetEnv: prod
+```
+
+> 也可用全局环境变量 `PIPEWRIGHT_PAC_RUNTIME=1` 对**所有项目**强制开启流水线即代码(无视各项目开关),供向后兼容 / 高级用户使用。
+
 ## 技术栈
 
 - **后端**:Go · Chi(路由)· modernc/sqlite(纯 Go,无 CGO)· go-git · NaCl secretbox(保险库)· argon2id · golang.org/x/crypto/ssh(免 Agent 部署)

--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -346,13 +346,13 @@ func main() {
 		// 装饰器始终挂载(每项目开关默认关 → 老项目行为不变,无需服务端 env)。历史全局开关
 		// PIPEWRIGHT_PAC_RUNTIME=1 保留为**全局强开**:无视每项目开关,对所有项目尝试覆盖。
 		pacGlobalOverride := strings.EqualFold(strings.TrimSpace(os.Getenv("PIPEWRIGHT_PAC_RUNTIME")), "1")
-		var specLoader dagrun.SpecLoader = pacloader.New(
+		var specLoader dagrun.SpecLoader = pacSpecLoader{pacloader.New(
 			pipelineSvc,
 			pacProjectLookup{projectSvc},
 			credVault, // vault.Vault 满足 TokenRevealer(Reveal)
 			pacBlobFetcher{httpapi.NewSourceReader()},
 			pacGlobalOverride,
-		)
+		)}
 		if pacGlobalOverride {
 			log.Printf("[pac] 全局强开:.pipewright.yml 覆盖对所有项目生效(PIPEWRIGHT_PAC_RUNTIME=1;无视每项目开关)")
 		}
@@ -523,6 +523,20 @@ func (b pacBlobFetcher) FetchBlob(ctx context.Context, repoURL, token, ref, file
 		return "", false, err
 	}
 	return blob.Content, blob.Degraded, nil
+}
+
+// pacSpecLoader 把 *pacloader.Loader 适配为 dagrun.SpecLoader:转换其同形的 SpecSource
+// (配置来源可见性 · Slice 2)。pacloader 不反向 import dagrun(避免环),故来源结构在 main 处转换。
+type pacSpecLoader struct{ inner *pacloader.Loader }
+
+func (l pacSpecLoader) Get(ctx context.Context, projectID, branch string) (*pipeline.Config, dagrun.SpecSource, error) {
+	cfg, src, err := l.inner.Get(ctx, projectID, branch)
+	return cfg, dagrun.SpecSource{
+		FromRepo:       src.FromRepo,
+		Ref:            src.Ref,
+		File:           src.File,
+		FallbackReason: src.FallbackReason,
+	}, err
 }
 
 // buildRunnerOption 按 PIPEWRIGHT_BUILDER 开关返回注入 pool 的运行执行器选项(Story 3-3/3-5)。

--- a/internal/build/builder_test.go
+++ b/internal/build/builder_test.go
@@ -96,6 +96,7 @@ func (s *fakeSink) SetFailureLog(_ context.Context, log string) error {
 	s.failureLog = log
 	return nil
 }
+func (s *fakeSink) SetSpecSource(_ context.Context, _ run.SpecSource) error { return nil }
 func (s *fakeSink) Log(_ context.Context, stream string, ordinal int, line string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -969,10 +969,11 @@ type reporterSink struct {
 	rep dagrun.StageReporter
 }
 
-func (s *reporterSink) Plan(context.Context, []run.StepDecl) error  { return nil }
-func (s *reporterSink) StepRunning(context.Context, int) error      { return nil }
-func (s *reporterSink) StepDone(context.Context, int, string) error { return nil }
-func (s *reporterSink) SetFailureLog(context.Context, string) error { return nil }
+func (s *reporterSink) Plan(context.Context, []run.StepDecl) error          { return nil }
+func (s *reporterSink) StepRunning(context.Context, int) error              { return nil }
+func (s *reporterSink) StepDone(context.Context, int, string) error         { return nil }
+func (s *reporterSink) SetFailureLog(context.Context, string) error         { return nil }
+func (s *reporterSink) SetSpecSource(context.Context, run.SpecSource) error { return nil }
 func (s *reporterSink) Log(ctx context.Context, stream string, _ int, line string) error {
 	return s.rep.Log(ctx, stream, line)
 }

--- a/internal/dagrun/dagrun.go
+++ b/internal/dagrun/dagrun.go
@@ -31,8 +31,22 @@ import (
 // branch 是本次运行的目标分支(run.Trigger.Branch),供「流水线即代码」按运行分支取
 // `.pipewright.yml`(FR-8-12);库内 loader(pipeline.Service,分支无关)可经 SpecLoaderFunc
 // 包成此契约并忽略 branch。branch 为空(如无分支的手动运行)时,实现应退化为既有默认分支行为。
+//
+// 返回值除 spec 外还报告其来源(SpecSource):本次运行由仓库 `.pipewright.yml` 还是库内
+// (网页)配置驱动,供运行详情如实展示「配置来源」(Slice 2)。
 type SpecLoader interface {
-	Get(ctx context.Context, projectID, branch string) (*pipeline.Config, error)
+	Get(ctx context.Context, projectID, branch string) (*pipeline.Config, SpecSource, error)
+}
+
+// SpecSource 描述「本次运行的流水线 spec 来自哪里」(配置来源可见性):
+//   - FromRepo=true:由仓库根 `.pipewright.yml` 驱动(GitOps),Ref=取用分支/ref、File=文件名。
+//   - FromRepo=false:由库内(网页编辑)配置驱动;若是「本想用仓库但回退了」,FallbackReason
+//     记回退原因(disabled|no_file|invalid_yaml|degraded|empty|lookup_failed),否则为空。
+type SpecSource struct {
+	FromRepo       bool
+	Ref            string
+	File           string
+	FallbackReason string
 }
 
 // SpecLoaderFunc 把任意「按 projectID 取配置」的库内 loader(如 pipeline.Service.Get,分支无关)
@@ -40,9 +54,10 @@ type SpecLoader interface {
 // 接进 branch 感知的 dagrun 内核,而不改动其公有 2 参签名(其它调用方不受影响)。
 type SpecLoaderFunc func(ctx context.Context, projectID string) (*pipeline.Config, error)
 
-// Get 实现 SpecLoader:忽略 branch,委托底层分支无关的 loader。
-func (f SpecLoaderFunc) Get(ctx context.Context, projectID, _ string) (*pipeline.Config, error) {
-	return f(ctx, projectID)
+// Get 实现 SpecLoader:忽略 branch,委托底层分支无关的 loader。来源恒为库内配置(FromRepo=false)。
+func (f SpecLoaderFunc) Get(ctx context.Context, projectID, _ string) (*pipeline.Config, SpecSource, error) {
+	cfg, err := f(ctx, projectID)
+	return cfg, SpecSource{FromRepo: false}, err
 }
 
 // StageReporter 给 StageExecutor 上报「本阶段」的日志/产物(自动关联到该阶段的 run_steps 序号)。
@@ -140,10 +155,13 @@ func New(loader SpecLoader, opts ...Option) *Runner {
 // StepSink 非并发安全约定:本 Runner 用单一 mutex 串行化所有 sink 调用,即便阶段并行执行,
 // 对 sink 的 Plan/StepRunning/StepDone/Log/EmitArtifact 也互斥,安全复用既有持久化管道。
 func (r *Runner) Run(ctx context.Context, rn *run.Run, sink run.StepSink) error {
-	cfg, err := r.loader.Get(ctx, rn.ProjectID, rn.Trigger.Branch)
+	cfg, src, err := r.loader.Get(ctx, rn.ProjectID, rn.Trigger.Branch)
 	if err != nil {
 		return fmt.Errorf("dagrun: load pipeline spec: %w", err)
 	}
+	// 配置来源可见性(Slice 2):本次运行由仓库 `.pipewright.yml` 还是库内(网页)配置驱动,
+	// 经 sink 持久化到运行记录,供运行详情如实展示。best-effort:落库失败仅忽略,不阻断运行。
+	_ = sink.SetSpecSource(ctx, toSinkSpecSource(src))
 	// 矩阵展开(P1):把声明了 Matrix 的阶段在纯调度层展开成笛卡尔积的并行 cell 子阶段,
 	// 并重映射 needs(下游等所有 cell)。无 matrix 阶段时原样返回。展开后阶段集作为后续
 	// 建图 / stageByID / 上报 / 执行的权威集——不改 dag 的并发与失败语义。
@@ -400,6 +418,15 @@ func (j *jobReporter) JobDone(ctx context.Context, _, status string) error {
 }
 
 func (j *jobReporter) JobReporter(string) StageReporter { return j }
+
+// toSinkSpecSource 把 dagrun.SpecSource 映射为 run.SpecSource(领域层搬运形状,经 sink 落库)。
+// FromRepo → "repo";否则 "stored"(并带回退原因)。
+func toSinkSpecSource(s SpecSource) run.SpecSource {
+	if s.FromRepo {
+		return run.SpecSource{Source: run.SpecSourceRepo, Ref: s.Ref, File: s.File}
+	}
+	return run.SpecSource{Source: run.SpecSourceStored, Fallback: s.FallbackReason}
+}
 
 // summarize 汇总各终态计数(用于失败错误信息,不含敏感内容)。
 func summarize(res dag.Result) map[dag.Status]int { return res.Counts() }

--- a/internal/dagrun/dagrun_test.go
+++ b/internal/dagrun/dagrun_test.go
@@ -16,6 +16,7 @@ import (
 
 type fakeLoader struct {
 	cfg        *pipeline.Config
+	src        SpecSource // 默认零值 = FromRepo:false(库内配置),按需覆盖以测来源透传
 	gotBranch  string
 	gotProject string
 }
@@ -23,7 +24,7 @@ type fakeLoader struct {
 func (f *fakeLoader) Get(_ context.Context, projectID string, branch string) (*pipeline.Config, SpecSource, error) {
 	f.gotProject = projectID
 	f.gotBranch = branch
-	return f.cfg, SpecSource{FromRepo: false}, nil
+	return f.cfg, f.src, nil
 }
 
 // fakeSink 记录 StepSink 调用(dagrun 已串行化调用,这里再加锁防御)。
@@ -33,6 +34,7 @@ type fakeSink struct {
 	running []int
 	done    map[int]string
 	logs    []string
+	specSrc *run.SpecSource // 捕获 SetSpecSource 入参(nil = 未调用)
 }
 
 func newFakeSink() *fakeSink { return &fakeSink{done: map[int]string{}} }
@@ -58,8 +60,14 @@ func (s *fakeSink) StepDone(_ context.Context, ord int, status string) error {
 	s.done[ord] = status
 	return nil
 }
-func (s *fakeSink) SetFailureLog(_ context.Context, _ string) error         { return nil }
-func (s *fakeSink) SetSpecSource(_ context.Context, _ run.SpecSource) error { return nil }
+func (s *fakeSink) SetFailureLog(_ context.Context, _ string) error { return nil }
+func (s *fakeSink) SetSpecSource(_ context.Context, src run.SpecSource) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := src
+	s.specSrc = &cp
+	return nil
+}
 func (s *fakeSink) Log(_ context.Context, _ string, _ int, line string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -70,6 +78,37 @@ func (s *fakeSink) EmitArtifact(_ context.Context, _ run.Artifact) error { retur
 
 func cfgWith(stages ...pipeline.Stage) *pipeline.Config {
 	return &pipeline.Config{Spec: pipeline.Spec{Stages: stages}}
+}
+
+// TestRunnerForwardsSpecSourceToSink 验证 Runner.Run 把 loader 返回的配置来源(Slice 2)
+// 经 SetSpecSource 透传给 sink:FromRepo → run.SpecSourceRepo + ref/file;回退 → stored + 原因。
+func TestRunnerForwardsSpecSourceToSink(t *testing.T) {
+	cfg := cfgWith(pipeline.Stage{ID: "src", Name: "源"})
+
+	// 仓库来源:loader 返回 FromRepo → sink 应收到 Source=repo + ref/file。
+	sink := newFakeSink()
+	repoLoader := &fakeLoader{cfg: cfg, src: SpecSource{FromRepo: true, Ref: "feature/x", File: ".pipewright.yml"}}
+	if err := New(repoLoader).Run(context.Background(),
+		&run.Run{ProjectID: "p", Trigger: run.Trigger{Type: "manual", Branch: "feature/x"}}, sink); err != nil {
+		t.Fatalf("Run 失败: %v", err)
+	}
+	if sink.specSrc == nil {
+		t.Fatal("Runner 未调用 SetSpecSource")
+	}
+	if sink.specSrc.Source != run.SpecSourceRepo || sink.specSrc.Ref != "feature/x" || sink.specSrc.File != ".pipewright.yml" {
+		t.Fatalf("仓库来源透传错误: %+v", *sink.specSrc)
+	}
+
+	// 库内回退:loader 返回 FromRepo=false + 原因 → sink 应收到 Source=stored + Fallback。
+	sink2 := newFakeSink()
+	storedLoader := &fakeLoader{cfg: cfg, src: SpecSource{FallbackReason: "invalid_yaml"}}
+	if err := New(storedLoader).Run(context.Background(),
+		&run.Run{ProjectID: "p", Trigger: run.Trigger{Type: "manual", Branch: "main"}}, sink2); err != nil {
+		t.Fatalf("Run 失败: %v", err)
+	}
+	if sink2.specSrc == nil || sink2.specSrc.Source != run.SpecSourceStored || sink2.specSrc.Fallback != "invalid_yaml" {
+		t.Fatalf("库内回退来源透传错误: %+v", sink2.specSrc)
+	}
 }
 
 func TestRunnerWhenSkipsStageAndDownstreamWithoutFailing(t *testing.T) {

--- a/internal/dagrun/dagrun_test.go
+++ b/internal/dagrun/dagrun_test.go
@@ -20,10 +20,10 @@ type fakeLoader struct {
 	gotProject string
 }
 
-func (f *fakeLoader) Get(_ context.Context, projectID string, branch string) (*pipeline.Config, error) {
+func (f *fakeLoader) Get(_ context.Context, projectID string, branch string) (*pipeline.Config, SpecSource, error) {
 	f.gotProject = projectID
 	f.gotBranch = branch
-	return f.cfg, nil
+	return f.cfg, SpecSource{FromRepo: false}, nil
 }
 
 // fakeSink 记录 StepSink 调用(dagrun 已串行化调用,这里再加锁防御)。
@@ -58,7 +58,8 @@ func (s *fakeSink) StepDone(_ context.Context, ord int, status string) error {
 	s.done[ord] = status
 	return nil
 }
-func (s *fakeSink) SetFailureLog(_ context.Context, _ string) error { return nil }
+func (s *fakeSink) SetFailureLog(_ context.Context, _ string) error         { return nil }
+func (s *fakeSink) SetSpecSource(_ context.Context, _ run.SpecSource) error { return nil }
 func (s *fakeSink) Log(_ context.Context, _ string, _ int, line string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -268,12 +269,15 @@ func TestSpecLoaderFuncIgnoresBranchAndDelegates(t *testing.T) {
 		gotProject = projectID
 		return cfg, nil
 	})
-	got, err := adapter.Get(context.Background(), "proj-y", "any-branch")
+	got, src, err := adapter.Get(context.Background(), "proj-y", "any-branch")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
 	if got != cfg {
 		t.Errorf("应委托底层返回同一 cfg")
+	}
+	if src.FromRepo {
+		t.Errorf("SpecLoaderFunc 来源应为库内配置(FromRepo=false),实际 %+v", src)
 	}
 	if gotProject != "proj-y" {
 		t.Errorf("应透传 projectID=proj-y,实际 %q", gotProject)

--- a/internal/httpapi/pac_preview.go
+++ b/internal/httpapi/pac_preview.go
@@ -1,0 +1,131 @@
+package httpapi
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/huangchengsir/pipewright/internal/pipelineyaml"
+	"github.com/huangchengsir/pipewright/internal/project"
+)
+
+// pacPreviewFile 是「流水线即代码」预览/校验的固定目标文件名(与 pacloader.DefaultFile 同语义;
+// 此处内联常量避免 httpapi 反向 import pacloader)。
+const pacPreviewFile = ".pipewright.yml"
+
+// ---- PAC 预览/校验契约 DTO(冻结;camelCase) ----
+//
+// {found, valid, ref, file, error, stageCount, stages:[{name,kind,jobCount}]}
+// 绝不回显仓库 URL 凭据 / 任何 secret;解析失败 found=true valid=false error=<message> stages=[]。
+
+type pacStageSummaryDTO struct {
+	Name     string `json:"name"`
+	Kind     string `json:"kind"`
+	JobCount int    `json:"jobCount"`
+}
+
+type pacPreviewDTO struct {
+	Found      bool                 `json:"found"`
+	Valid      bool                 `json:"valid"`
+	Ref        string               `json:"ref"`
+	File       string               `json:"file"`
+	Error      string               `json:"error"`
+	StageCount int                  `json:"stageCount"`
+	Stages     []pacStageSummaryDTO `json:"stages"`
+}
+
+// makePacPreviewHandler 返回 GET /api/projects/{id}/pac/preview?ref=<ref> handler(认证;只读)。
+//
+// 在「依赖」仓库 .pipewright.yml 驱动运行之前,让用户主动按 ref 拉取并校验它——看清运行时会用到的
+// 配置摘要,并把 YAML 错误显式呈现(运行时是静默回退,无反馈)。镜像 pacloader 的拉取语义:
+//   - ref 省略 → 项目默认分支;
+//   - token 经保险库尽力解(取不到则空 token 试公开仓库,与 pacloader 一致);
+//   - 文件不存在 → 200 found=false;克隆降级 → 200 found=false(无法判定);
+//   - 解析/校验失败 → 200 found=true valid=false error=<message> stages=[];
+//   - 成功 → found=true valid=true + 阶段摘要(name/kind/jobCount)。
+//
+// 绝不把仓库 URL 凭据 / 任何 secret 写入响应或 error。项目不存在 → 404;所需服务未初始化 → 503。
+func makePacPreviewHandler(d sourceDeps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if d.projects == nil || d.reader == nil {
+			writeError(w, http.StatusServiceUnavailable, "internal", "源码读取所需服务未初始化")
+			return
+		}
+
+		id := chi.URLParam(r, "id")
+		proj, err := d.projects.Get(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, project.ErrNotFound) {
+				writeError(w, http.StatusNotFound, "project_not_found", "项目不存在")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "internal", "服务器内部错误")
+			return
+		}
+
+		ref := strings.TrimSpace(r.URL.Query().Get("ref"))
+		if ref == "" {
+			ref = strings.TrimSpace(proj.DefaultBranch)
+		}
+
+		out := pacPreviewDTO{Ref: ref, File: pacPreviewFile, Stages: []pacStageSummaryDTO{}}
+
+		if strings.TrimSpace(proj.RepoURL) == "" {
+			// 未配置仓库:无从拉取,按「文件不存在」呈现(found=false),不报错。
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+
+		// 取仓库凭据(进程内取用即弃;取不到不致命 → 空 token 试公开仓库,与 pacloader 一致)。
+		token := ""
+		if d.vault != nil && strings.TrimSpace(proj.CredentialID) != "" {
+			if t, terr := d.vault.Get(proj.CredentialID); terr == nil {
+				token = t
+			}
+		}
+
+		blob, berr := d.reader.Blob(r.Context(), proj.RepoURL, token, ref, pacPreviewFile)
+		if berr != nil {
+			// 文件不存在 / 克隆失败 → found=false(运行时此路径会回退库内配置)。
+			// 绝不外泄底层错误(可能含 URL 凭据);valid=false、error 留空(非 YAML 问题)。
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		if blob.Degraded {
+			// 克隆降级:无法判定文件是否存在 → found=false(不误报)。
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		if blob.Binary || strings.TrimSpace(blob.Content) == "" {
+			// 二进制 / 空文件:视作未提供有效配置(found=false)。
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+
+		// 文件存在。
+		out.Found = true
+
+		cfg, perr := pipelineyaml.Parse([]byte(blob.Content))
+		if perr != nil {
+			// YAML 非法 → found=true valid=false + 解析错误消息(pipelineyaml/pipeline 的错误不含密钥)。
+			out.Valid = false
+			out.Error = perr.Error()
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+
+		out.Valid = true
+		stages := make([]pacStageSummaryDTO, 0, len(cfg.Spec.Stages))
+		for _, st := range cfg.Spec.Stages {
+			stages = append(stages, pacStageSummaryDTO{
+				Name:     st.Name,
+				Kind:     st.Kind,
+				JobCount: len(st.Jobs),
+			})
+		}
+		out.Stages = stages
+		out.StageCount = len(stages)
+		writeJSON(w, http.StatusOK, out)
+	}
+}

--- a/internal/httpapi/pac_preview_test.go
+++ b/internal/httpapi/pac_preview_test.go
@@ -1,0 +1,111 @@
+package httpapi
+
+import (
+	"net/http"
+	"testing"
+)
+
+const validPacYAML = `stages:
+  - name: 源码
+    kind: source
+    jobs:
+      - name: checkout
+        type: source
+  - name: 构建
+    kind: build
+    jobs:
+      - name: compile
+        type: script
+        script:
+          commands:
+            - make build
+      - name: package
+        type: script
+        script:
+          commands:
+            - make package
+`
+
+// TestPacPreviewValid 验证按默认分支拉取合法 .pipewright.yml → found=true valid=true + 阶段摘要。
+func TestPacPreviewValid(t *testing.T) {
+	url := makeBareSourceRepo(t, map[string]string{".pipewright.yml": validPacYAML})
+	srv, client, csrf, projID := setupSourceServer(t, url)
+
+	code, m, raw := getJSON(t, client, srv.URL+"/api/projects/"+projID+"/pac/preview", csrf)
+	if code != http.StatusOK {
+		t.Fatalf("preview status=%d: %s", code, raw)
+	}
+	if m["found"] != true || m["valid"] != true {
+		t.Fatalf("应 found=true valid=true, got %s", raw)
+	}
+	if m["ref"] != "main" {
+		t.Fatalf("ref 应默认默认分支 main, got %v", m["ref"])
+	}
+	if m["file"] != ".pipewright.yml" {
+		t.Fatalf("file 应为 .pipewright.yml, got %v", m["file"])
+	}
+	if sc, _ := m["stageCount"].(float64); sc != 2 {
+		t.Fatalf("stageCount 应为 2, got %v (%s)", m["stageCount"], raw)
+	}
+	stages, ok := m["stages"].([]any)
+	if !ok || len(stages) != 2 {
+		t.Fatalf("stages 应有 2 项, got %s", raw)
+	}
+	build, _ := stages[1].(map[string]any)
+	if build["kind"] != "build" {
+		t.Fatalf("第二阶段 kind 应为 build, got %v", build["kind"])
+	}
+	if jc, _ := build["jobCount"].(float64); jc != 2 {
+		t.Fatalf("build 阶段 jobCount 应为 2, got %v", build["jobCount"])
+	}
+	if m["error"] != "" {
+		t.Fatalf("合法配置 error 应为空, got %v", m["error"])
+	}
+}
+
+// TestPacPreviewInvalid 验证非法 YAML → found=true valid=false error 非空 stages=[]。
+func TestPacPreviewInvalid(t *testing.T) {
+	url := makeBareSourceRepo(t, map[string]string{
+		".pipewright.yml": "stages:\n  - name: x\n    kind: not_a_real_kind\n",
+	})
+	srv, client, csrf, projID := setupSourceServer(t, url)
+
+	code, m, raw := getJSON(t, client, srv.URL+"/api/projects/"+projID+"/pac/preview", csrf)
+	if code != http.StatusOK {
+		t.Fatalf("preview status=%d: %s", code, raw)
+	}
+	if m["found"] != true || m["valid"] != false {
+		t.Fatalf("非法 YAML 应 found=true valid=false, got %s", raw)
+	}
+	if es, _ := m["error"].(string); es == "" {
+		t.Fatalf("非法 YAML error 应非空, got %s", raw)
+	}
+	if stages, ok := m["stages"].([]any); !ok || len(stages) != 0 {
+		t.Fatalf("非法 YAML stages 应为 [], got %s", raw)
+	}
+}
+
+// TestPacPreviewNotFound 验证仓库无 .pipewright.yml → found=false(不报错)。
+func TestPacPreviewNotFound(t *testing.T) {
+	url := makeBareSourceRepo(t, map[string]string{"README.md": "# hi\n"})
+	srv, client, csrf, projID := setupSourceServer(t, url)
+
+	code, m, raw := getJSON(t, client, srv.URL+"/api/projects/"+projID+"/pac/preview", csrf)
+	if code != http.StatusOK {
+		t.Fatalf("preview status=%d: %s", code, raw)
+	}
+	if m["found"] != false {
+		t.Fatalf("无文件应 found=false, got %s", raw)
+	}
+}
+
+// TestPacPreviewProjectNotFound 验证未知项目 → 404 project_not_found。
+func TestPacPreviewProjectNotFound(t *testing.T) {
+	url := makeBareSourceRepo(t, map[string]string{".pipewright.yml": validPacYAML})
+	srv, client, csrf, _ := setupSourceServer(t, url)
+
+	code, _, _ := getJSON(t, client, srv.URL+"/api/projects/no-such-id/pac/preview", csrf)
+	if code != http.StatusNotFound {
+		t.Fatalf("未知项目应 404, got %d", code)
+	}
+}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -592,6 +592,11 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		ar.Get("/projects/{id}/source/tree", makeSourceTreeHandler(srcDeps))
 		ar.Get("/projects/{id}/source/blob", makeSourceBlobHandler(srcDeps))
 
+		// 「流水线即代码」预览/校验(GitOps Slice 3):按 ref 拉取仓库 .pipewright.yml 并校验,
+		// 让用户在依赖它驱动运行之前看清运行时会用到的配置摘要、显式捕获 YAML 错误(运行时静默回退)。
+		// 复用 srcDeps(projects + vault + SourceReader);/pac/preview 比 /projects/{id} 多两段,不会被吞;GET 过 auth。
+		ar.Get("/projects/{id}/pac/preview", makePacPreviewHandler(srcDeps))
+
 		// 列仓库分支/tag(代码管理区 · Story 8-18):供前端触发时分支/commit 下拉。o.refsLister 为 nil → 503。
 		ar.Get("/projects/{id}/refs", makeListRefsHandler(p, v, o.refsLister))
 		ar.Get("/projects/{id}/commits", makeListCommitsHandler(p, v, o.refsLister))

--- a/internal/httpapi/runs.go
+++ b/internal/httpapi/runs.go
@@ -38,6 +38,13 @@ type runDetailDTO struct {
 	StartedAt   *string     `json:"startedAt"`
 	FinishedAt  *string     `json:"finishedAt"`
 	DurationMs  *int64      `json:"durationMs"`
+	// 配置来源(GitOps 配置来源可见性 · Slice 2):本次运行由仓库 `.pipewright.yml`("repo")还是
+	// 库内网页配置("stored")驱动;""=未记录(老运行)。SpecSourceRef/File 在 repo 来源时有值;
+	// SpecSourceFallback 在 stored 来源且「本想用仓库但回退」时记原因(no_file|invalid_yaml|…)。
+	SpecSource         string `json:"specSource"`
+	SpecSourceRef      string `json:"specSourceRef"`
+	SpecSourceFile     string `json:"specSourceFile"`
+	SpecSourceFallback string `json:"specSourceFallback"`
 	// artifacts:Story 3.4 填(构建产物契约 / FR-6);成功/有产物时为数组,否则 []。形状冻结。
 	Artifacts []artifactDTO `json:"artifacts"`
 	// targets:Epic 4(Story 4.2)填(SSH 部署执行 / FR-10)。部署过 → 数组;否则 null。
@@ -144,9 +151,15 @@ func toRunDetailDTO(r *run.Run, artifacts []run.Artifact, targets []run.DeployTa
 		StartedAt:   rfc3339Ptr(r.StartedAt),
 		FinishedAt:  rfc3339Ptr(r.FinishedAt),
 		DurationMs:  durationMs(r.StartedAt, r.FinishedAt),
-		Artifacts:   toArtifactDTOs(artifacts), // Story 3.4 填(FR-6);无产物 → []
-		Targets:     targetsSlot,               // Story 4.2 填(部署过 → 数组;否则 null);形状冻结
-		Diagnosis:   diagnosis,                 // Story 7.2 填(无诊断 → nil);形状冻结
+
+		SpecSource:         r.SpecSource.Source, // Slice 2:配置来源可见性("repo"/"stored"/"")
+		SpecSourceRef:      r.SpecSource.Ref,
+		SpecSourceFile:     r.SpecSource.File,
+		SpecSourceFallback: r.SpecSource.Fallback,
+
+		Artifacts: toArtifactDTOs(artifacts), // Story 3.4 填(FR-6);无产物 → []
+		Targets:   targetsSlot,               // Story 4.2 填(部署过 → 数组;否则 null);形状冻结
+		Diagnosis: diagnosis,                 // Story 7.2 填(无诊断 → nil);形状冻结
 	}
 }
 

--- a/internal/pacloader/pacloader.go
+++ b/internal/pacloader/pacloader.go
@@ -31,9 +31,28 @@ import (
 // DefaultFile 是仓库根「流水线即代码」文件名。
 const DefaultFile = ".pipewright.yml"
 
-// SpecLoader 是被装饰的库内加载器契约(与 dagrun.SpecLoader 同形,避免反向 import dagrun)。
+// 回退原因枚举(配置来源可见性 · Slice 2):tryOverride 未命中覆盖时,据此分类「为何回退库内配置」。
+const (
+	fallbackDisabled = "disabled"      // 每项目开关关闭且非全局强开
+	fallbackNoFile   = "no_file"       // 仓库无 .pipewright.yml / 拉取报错(多数项目的正常路径)
+	fallbackInvalid  = "invalid_yaml"  // YAML 解析/校验失败
+	fallbackDegraded = "degraded"      // 克隆降级,无法读文件
+	fallbackEmpty    = "empty"         // 文件存在但内容为空
+	fallbackLookup   = "lookup_failed" // 项目查询失败 / 缺仓库地址 / 缺依赖
+)
+
+// SpecLoader 是被装饰的库内加载器契约(与 dagrun.SpecLoader 的库内 2 参形态同形,避免反向 import dagrun)。
 type SpecLoader interface {
 	Get(ctx context.Context, projectID string) (*pipeline.Config, error)
+}
+
+// SpecSource 描述本次运行 spec 的来源(与 dagrun.SpecSource 同形,避免反向 import dagrun)。
+// FromRepo=true:仓库 `.pipewright.yml` 驱动(Ref/File 有值);否则库内配置(FallbackReason 记回退原因)。
+type SpecSource struct {
+	FromRepo       bool
+	Ref            string
+	File           string
+	FallbackReason string
 }
 
 // ProjectInfo 是覆盖装饰器拉取 `.pipewright.yml` 所需的项目最小视图。
@@ -82,31 +101,34 @@ func New(inner SpecLoader, projects ProjectLookup, tokens TokenRevealer, blobs B
 
 // Get 实现 dagrun.SpecLoader:尝试用**运行分支**的 `.pipewright.yml` 覆盖(分支为空时退化为
 // 默认分支);任何问题都回退到 inner(库内配置)。绝不把 YAML 问题冒泡给调用方。
-func (l *Loader) Get(ctx context.Context, projectID, branch string) (*pipeline.Config, error) {
-	if cfg, ok := l.tryOverride(ctx, projectID, branch); ok {
-		return cfg, nil
+func (l *Loader) Get(ctx context.Context, projectID, branch string) (*pipeline.Config, SpecSource, error) {
+	cfg, refOrReason, ok := l.tryOverride(ctx, projectID, branch)
+	if ok {
+		return cfg, SpecSource{FromRepo: true, Ref: refOrReason, File: DefaultFile}, nil
 	}
-	return l.inner.Get(ctx, projectID)
+	inner, err := l.inner.Get(ctx, projectID)
+	return inner, SpecSource{FromRepo: false, FallbackReason: refOrReason}, err
 }
 
-// tryOverride 尝试从运行分支(空则默认分支)拉取并解析 `.pipewright.yml`;成功返回 (cfg,true)。
-// 任何环节失败返回 (nil,false)(调用方回退)。失败只记 debug 原因(无密钥)。
-func (l *Loader) tryOverride(ctx context.Context, projectID, branch string) (*pipeline.Config, bool) {
+// tryOverride 尝试从运行分支(空则默认分支)拉取并解析 `.pipewright.yml`;成功返回 (cfg,ref,true)。
+// 任何环节失败返回 (nil,reason,false):reason 为回退原因枚举(配置来源可见性 · Slice 2),
+// 调用方据此填 SpecSource.FallbackReason。失败只记 debug 原因(无密钥)。
+func (l *Loader) tryOverride(ctx context.Context, projectID, branch string) (cfg *pipeline.Config, refOrReason string, ok bool) {
 	if l.projects == nil || l.blobs == nil {
-		return nil, false
+		return nil, fallbackLookup, false
 	}
 
 	info, err := l.projects.Lookup(ctx, projectID)
 	if err != nil {
 		debugf("项目 %s 查询失败,回退库内配置", projectID)
-		return nil, false
+		return nil, fallbackLookup, false
 	}
 	// 每项目开关:未开启「流水线即代码」且非全局强开 → 不覆盖,用库内配置。
 	if !info.PacEnabled && !l.globalOverride {
-		return nil, false
+		return nil, fallbackDisabled, false
 	}
 	if strings.TrimSpace(info.RepoURL) == "" {
-		return nil, false
+		return nil, fallbackLookup, false
 	}
 
 	// 取仓库凭据明文(进程内取用即弃;取不到不致命 → 空 token 尝试公开仓库)。
@@ -127,24 +149,24 @@ func (l *Loader) tryOverride(ctx context.Context, projectID, branch string) (*pi
 	if ferr != nil {
 		// 文件不存在 / 克隆失败 → 回退(正常路径:多数项目没有 .pipewright.yml)。
 		debugf("项目 %s 未读到 %s(回退库内配置)", projectID, DefaultFile)
-		return nil, false
+		return nil, fallbackNoFile, false
 	}
 	if degraded {
 		debugf("项目 %s 仓库克隆降级,无法读 %s(回退库内配置)", projectID, DefaultFile)
-		return nil, false
+		return nil, fallbackDegraded, false
 	}
 	if strings.TrimSpace(content) == "" {
-		return nil, false
+		return nil, fallbackEmpty, false
 	}
 
-	cfg, perr := pipelineyaml.Parse([]byte(content))
+	parsed, perr := pipelineyaml.Parse([]byte(content))
 	if perr != nil {
 		// YAML 非法 → 回退(绝不让坏 YAML 中断运行)。错误不含密钥但仍只记 debug。
 		debugf("项目 %s 的 %s 解析/校验失败,回退库内配置", projectID, DefaultFile)
-		return nil, false
+		return nil, fallbackInvalid, false
 	}
 	debugf("项目 %s 命中仓库 %s(分支 %s),用其驱动本次运行", projectID, DefaultFile, ref)
-	return &cfg, true
+	return &parsed, ref, true
 }
 
 // debugf 记录回退原因(诊断用)。绝不打印 token / 仓库 URL 凭据。

--- a/internal/pacloader/pacloader_test.go
+++ b/internal/pacloader/pacloader_test.go
@@ -117,7 +117,7 @@ func TestGet_ValidRepoYAML_UsesRepoSpec(t *testing.T) {
 	l := newLoader(stored, fakeProjects{info: defaultInfo()}, tokens, blobs)
 
 	// 空运行分支 → 退化为默认分支 main(与历史行为一致)。
-	cfg, err := l.Get(context.Background(), "proj-1", "")
+	cfg, src, err := l.Get(context.Background(), "proj-1", "")
 	if err != nil {
 		t.Fatalf("意外错误: %v", err)
 	}
@@ -126,6 +126,10 @@ func TestGet_ValidRepoYAML_UsesRepoSpec(t *testing.T) {
 	}
 	if stored.called != 0 {
 		t.Fatalf("命中仓库 YAML 时不应回退库内 loader,called=%d", stored.called)
+	}
+	// 来源应为仓库:FromRepo=true、Ref=默认分支 main、File=.pipewright.yml。
+	if !src.FromRepo || src.Ref != "main" || src.File != DefaultFile {
+		t.Errorf("来源应为仓库(FromRepo=true,Ref=main,File=%s),实际 %+v", DefaultFile, src)
 	}
 	// 空分支 → 默认分支拉取正确文件,并把凭据明文透传给拉取器。
 	if blobs.gotRef != "main" {
@@ -151,7 +155,7 @@ func TestGet_RunBranch_FetchesFromRunBranchNotDefault(t *testing.T) {
 	// 默认分支是 main;本次运行在 feature/awesome 上。
 	l := newLoader(stored, fakeProjects{info: defaultInfo()}, &fakeTokens{token: "tk"}, blobs)
 
-	cfg, err := l.Get(context.Background(), "proj-1", "feature/awesome")
+	cfg, src, err := l.Get(context.Background(), "proj-1", "feature/awesome")
 	if err != nil {
 		t.Fatalf("意外错误: %v", err)
 	}
@@ -164,6 +168,10 @@ func TestGet_RunBranch_FetchesFromRunBranchNotDefault(t *testing.T) {
 	if blobs.gotRef == "main" {
 		t.Errorf("绝不应回落到默认分支 main(运行分支非空)")
 	}
+	// 来源应为仓库,Ref=运行分支 feature/awesome。
+	if !src.FromRepo || src.Ref != "feature/awesome" {
+		t.Errorf("来源应为仓库且 Ref=feature/awesome,实际 %+v", src)
+	}
 }
 
 // ─── (b) 文件不存在 → 用库内配置 ────────────────────────────────────────────────
@@ -174,7 +182,7 @@ func TestGet_FileMissing_FallsBackToStored(t *testing.T) {
 	blobs := &fakeBlobs{err: errors.New("source: path not found")}
 	l := newLoader(stored, fakeProjects{info: defaultInfo()}, &fakeTokens{}, blobs)
 
-	cfg, err := l.Get(context.Background(), "proj-1", "")
+	cfg, src, err := l.Get(context.Background(), "proj-1", "")
 	if err != nil {
 		t.Fatalf("文件缺失不应报错(应回退): %v", err)
 	}
@@ -183,6 +191,10 @@ func TestGet_FileMissing_FallsBackToStored(t *testing.T) {
 	}
 	if stored.called != 1 {
 		t.Fatalf("应恰好回退一次库内 loader,called=%d", stored.called)
+	}
+	// 来源应为库内配置,回退原因 no_file。
+	if src.FromRepo || src.FallbackReason != fallbackNoFile {
+		t.Errorf("来源应为库内且回退原因 %s,实际 %+v", fallbackNoFile, src)
 	}
 }
 
@@ -193,7 +205,7 @@ func TestGet_FetchError_FallsBackNoError(t *testing.T) {
 	blobs := &fakeBlobs{err: errors.New("source: clone failed")}
 	l := newLoader(stored, fakeProjects{info: defaultInfo()}, &fakeTokens{}, blobs)
 
-	cfg, err := l.Get(context.Background(), "proj-1", "")
+	cfg, _, err := l.Get(context.Background(), "proj-1", "")
 	if err != nil {
 		t.Fatalf("拉取失败绝不应冒泡给调用方: %v", err)
 	}
@@ -208,7 +220,7 @@ func TestGet_DegradedClone_FallsBack(t *testing.T) {
 	blobs := &fakeBlobs{content: "", degraded: true}
 	l := newLoader(stored, fakeProjects{info: defaultInfo()}, &fakeTokens{}, blobs)
 
-	cfg, err := l.Get(context.Background(), "proj-1", "")
+	cfg, _, err := l.Get(context.Background(), "proj-1", "")
 	if err != nil {
 		t.Fatalf("降级不应报错: %v", err)
 	}
@@ -224,7 +236,7 @@ func TestGet_InvalidYAML_FallsBackToStored(t *testing.T) {
 	blobs := &fakeBlobs{content: "this: : is not valid pipewright yaml\n  - broken"}
 	l := newLoader(stored, fakeProjects{info: defaultInfo()}, &fakeTokens{}, blobs)
 
-	cfg, err := l.Get(context.Background(), "proj-1", "")
+	cfg, _, err := l.Get(context.Background(), "proj-1", "")
 	if err != nil {
 		t.Fatalf("非法 YAML 绝不应中断运行: %v", err)
 	}
@@ -239,7 +251,7 @@ func TestGet_ProjectLookupError_FallsBack(t *testing.T) {
 	stored := &storedLoader{cfg: storedCfg()}
 	l := newLoader(stored, fakeProjects{err: errors.New("not found")}, &fakeTokens{}, &fakeBlobs{content: validYAML})
 
-	cfg, _ := l.Get(context.Background(), "proj-1", "")
+	cfg, _, _ := l.Get(context.Background(), "proj-1", "")
 	if firstStage(cfg) != "stored-pipeline" {
 		t.Fatalf("项目查询失败应回退库内,实际 name=%q", firstStage(cfg))
 	}
@@ -251,7 +263,7 @@ func TestGet_EmptyRepoURL_FallsBack(t *testing.T) {
 	info.RepoURL = "  "
 	l := newLoader(stored, fakeProjects{info: info}, &fakeTokens{}, &fakeBlobs{content: validYAML})
 
-	cfg, _ := l.Get(context.Background(), "proj-1", "")
+	cfg, _, _ := l.Get(context.Background(), "proj-1", "")
 	if firstStage(cfg) != "stored-pipeline" {
 		t.Fatalf("空仓库地址应回退库内,实际 name=%q", firstStage(cfg))
 	}
@@ -261,7 +273,7 @@ func TestGet_EmptyContent_FallsBack(t *testing.T) {
 	stored := &storedLoader{cfg: storedCfg()}
 	l := newLoader(stored, fakeProjects{info: defaultInfo()}, &fakeTokens{}, &fakeBlobs{content: "   \n"})
 
-	cfg, _ := l.Get(context.Background(), "proj-1", "")
+	cfg, _, _ := l.Get(context.Background(), "proj-1", "")
 	if firstStage(cfg) != "stored-pipeline" {
 		t.Fatalf("空文件应回退库内,实际 name=%q", firstStage(cfg))
 	}
@@ -271,7 +283,7 @@ func TestGet_NilDeps_PurePassthrough(t *testing.T) {
 	stored := &storedLoader{cfg: storedCfg()}
 	l := New(stored, nil, nil, nil, false)
 
-	cfg, err := l.Get(context.Background(), "proj-1", "")
+	cfg, _, err := l.Get(context.Background(), "proj-1", "")
 	if err != nil {
 		t.Fatalf("意外错误: %v", err)
 	}
@@ -287,12 +299,16 @@ func TestGet_PacDisabled_FallsBackToStored(t *testing.T) {
 	info.PacEnabled = false
 	l := New(stored, fakeProjects{info: info}, &fakeTokens{token: "t"}, &fakeBlobs{content: validYAML}, false)
 
-	cfg, err := l.Get(context.Background(), "proj-1", "main")
+	cfg, src, err := l.Get(context.Background(), "proj-1", "main")
 	if err != nil {
 		t.Fatalf("意外错误: %v", err)
 	}
 	if firstStage(cfg) != "stored-pipeline" || stored.called != 1 {
 		t.Fatalf("开关关闭应回退库内,不读仓库;name=%q called=%d", firstStage(cfg), stored.called)
+	}
+	// 来源应为库内配置,回退原因 disabled(开关关闭)。
+	if src.FromRepo || src.FallbackReason != fallbackDisabled {
+		t.Errorf("来源应为库内且回退原因 %s,实际 %+v", fallbackDisabled, src)
 	}
 }
 
@@ -303,12 +319,15 @@ func TestGet_GlobalOverride_IgnoresPerProjectFlag(t *testing.T) {
 	info.PacEnabled = false
 	l := New(stored, fakeProjects{info: info}, &fakeTokens{token: "t"}, &fakeBlobs{content: validYAML}, true)
 
-	cfg, err := l.Get(context.Background(), "proj-1", "main")
+	cfg, src, err := l.Get(context.Background(), "proj-1", "main")
 	if err != nil {
 		t.Fatalf("意外错误: %v", err)
 	}
 	if firstStage(cfg) != "from-repo" {
 		t.Fatalf("全局强开应用仓库 YAML 驱动(name=from-repo),实际 name=%q", firstStage(cfg))
+	}
+	if !src.FromRepo {
+		t.Errorf("全局强开命中仓库时来源应为仓库(FromRepo=true),实际 %+v", src)
 	}
 }
 
@@ -319,7 +338,7 @@ func TestGet_TokenRevealError_TriesPublicWithEmptyToken(t *testing.T) {
 	blobs := &fakeBlobs{content: validYAML}
 	l := newLoader(stored, fakeProjects{info: defaultInfo()}, tokens, blobs)
 
-	cfg, err := l.Get(context.Background(), "proj-1", "")
+	cfg, _, err := l.Get(context.Background(), "proj-1", "")
 	if err != nil {
 		t.Fatalf("意外错误: %v", err)
 	}

--- a/internal/run/pool.go
+++ b/internal/run/pool.go
@@ -596,6 +596,20 @@ func (d *dbStepSink) SetFailureLog(_ context.Context, logText string) error {
 	return nil
 }
 
+// SetSpecSource 持久化驱动本次运行的流水线配置来源(GitOps 配置来源可见性)到 pipeline_runs。
+// 用后台 ctx 落库;参数化 SQL。best-effort:落库失败返回 error 由调用方忽略,不阻断运行。
+func (d *dbStepSink) SetSpecSource(_ context.Context, src SpecSource) error {
+	_, err := d.svc.db.ExecContext(context.Background(),
+		`UPDATE pipeline_runs
+		   SET spec_source = ?, spec_source_ref = ?, spec_source_file = ?, spec_source_fallback = ?
+		 WHERE id = ?`,
+		src.Source, src.Ref, src.File, src.Fallback, d.runID)
+	if err != nil {
+		return fmt.Errorf("run: set spec source: %w", err)
+	}
+	return nil
+}
+
 // Log 实现 StepSink.Log(Story 3.6):**先脱敏**(注入的 mask.Masker)→ 落 run_logs(分配
 // run 内单调 seq)→ 经事件总线发 EventLog(text 已脱敏)。AC-SEC-04:落库/出网前一律 Scrub,
 // 桩假 secret 在 run_logs 表/SSE 中一律 [MASKED]、绝无明文。

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -160,7 +160,32 @@ type Run struct {
 	// Diagnosis 是已持久化的 AI 诊断(失败且已诊断时非 nil;否则 nil → run-detail diagnosis=null)。
 	// 领域层只搬运形状(由 ai 层生成、httpapi 层落库),run 包不 import ai(经 hook 解耦)。
 	Diagnosis *Diagnosis
+
+	// SpecSource 是驱动本次运行的流水线配置来源(GitOps 配置来源可见性):
+	// 仓库 `.pipewright.yml`(repo)或库内网页配置(stored)。由 Runner 在加载 spec 时经
+	// StepSink.SetSpecSource 持久化,经 Get 回读供运行详情展示。
+	SpecSource SpecSource
 }
+
+// SpecSource 记录「本次运行的流水线 spec 来自哪里」(配置来源可见性)。
+//   - Source="repo":由仓库根 `.pipewright.yml` 驱动;Ref=取用分支/ref、File=文件名。
+//   - Source="stored":由库内(网页编辑)配置驱动;Fallback 非空表示「本想用仓库但回退了」,
+//     其值为回退原因(disabled|no_file|invalid_yaml|degraded|empty|lookup_failed)。
+//   - Source="":未记录(老运行 / 桩 runner 未上报),前端按未知处理(不展示徽标)。
+type SpecSource struct {
+	Source   string // "" | repo | stored
+	Ref      string
+	File     string
+	Fallback string
+}
+
+// 配置来源枚举(DB 存小写串)。
+const (
+	// SpecSourceRepo 表示由仓库 `.pipewright.yml` 驱动(GitOps)。
+	SpecSourceRepo = "repo"
+	// SpecSourceStored 表示由库内(网页编辑)配置驱动。
+	SpecSourceStored = "stored"
+)
 
 // 诊断状态枚举(对齐冻结 run-detail diagnosis 子 DTO 的 status)。
 const (

--- a/internal/run/runner.go
+++ b/internal/run/runner.go
@@ -20,6 +20,10 @@ type StepSink interface {
 	// SetFailureLog 报告本次运行的失败日志原文(脱敏前;持久化到 run.failure_log,
 	// 供后续 AI 诊断消费)。Runner 在失败路径调用;best-effort,失败不应阻断 run 终态。
 	SetFailureLog(ctx context.Context, log string) error
+	// SetSpecSource 报告驱动本次运行的流水线配置来源(仓库 `.pipewright.yml` / 库内网页配置;
+	// 持久化到 pipeline_runs,供运行详情展示「配置来源」)。Runner 在加载 spec 后调用;
+	// best-effort,失败不应阻断运行。
+	SetSpecSource(ctx context.Context, src SpecSource) error
 	// Log 报告一行运行日志(Story 3.6)。worker 侧实现负责**先脱敏**→落 run_logs(分配
 	// run 内单调 seq)→ 经事件总线发 EventLog。stream ∈ stdout|stderr;stepOrdinal 关联
 	// 步骤(-1 表示运行级);line 为单行文本(无尾换行)。3-3 真实构建只经此接口喂行、不改形状。

--- a/internal/run/service.go
+++ b/internal/run/service.go
@@ -291,7 +291,8 @@ func (s *service) Get(ctx context.Context, id string) (*Run, error) {
 		        pr.created_at, pr.started_at, pr.finished_at,
 		        pr.failure_log, pr.diagnosis_json, pr.params_json,
 		        pr.chain_source_run_id, pr.chain_depth,
-		        pr.resolved_environment, pr.resolved_target_server_ids
+		        pr.resolved_environment, pr.resolved_target_server_ids,
+		        pr.spec_source, pr.spec_source_ref, pr.spec_source_file, pr.spec_source_fallback
 		 FROM pipeline_runs pr
 		 LEFT JOIN projects p ON p.id = pr.project_id
 		 WHERE pr.id = ?`, id,
@@ -300,7 +301,8 @@ func (s *service) Get(ctx context.Context, id string) (*Run, error) {
 		&createdStr, &startedStr, &finishStr,
 		&failureLog, &diagnosisJSON, &paramsJSON,
 		&r.Trigger.ChainSourceRunID, &r.Trigger.ChainDepth,
-		&r.Trigger.ResolvedEnvironment, &targetIDsJSON)
+		&r.Trigger.ResolvedEnvironment, &targetIDsJSON,
+		&r.SpecSource.Source, &r.SpecSource.Ref, &r.SpecSource.File, &r.SpecSource.Fallback)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound

--- a/internal/run/spec_source_test.go
+++ b/internal/run/spec_source_test.go
@@ -1,0 +1,56 @@
+package run
+
+import (
+	"context"
+	"testing"
+)
+
+// TestSpecSourceRoundTrip 证 Slice 2 持久化链路:dbStepSink.SetSpecSource 写入 pipeline_runs
+// 的 spec_source* 列,service.Get 如实回读到 Run.SpecSource(仓库来源 + 库内回退两态)。
+func TestSpecSourceRoundTrip(t *testing.T) {
+	db := testDB(t)
+	svc := New(db)
+	projID := seedProject(t, db)
+
+	rn, err := svc.Create(context.Background(), projID, Trigger{Type: TriggerManual, Branch: "feature/x"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// 新建运行默认无来源。
+	got, err := svc.Get(context.Background(), rn.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.SpecSource.Source != "" {
+		t.Fatalf("新建运行不应有 spec_source, got %q", got.SpecSource.Source)
+	}
+
+	sink := &dbStepSink{svc: svc.(*service), runID: rn.ID}
+
+	// 仓库来源写入 → 回读 repo + ref + file。
+	if err := sink.SetSpecSource(context.Background(),
+		SpecSource{Source: SpecSourceRepo, Ref: "feature/x", File: ".pipewright.yml"}); err != nil {
+		t.Fatalf("SetSpecSource(repo): %v", err)
+	}
+	got, err = svc.Get(context.Background(), rn.ID)
+	if err != nil {
+		t.Fatalf("Get(repo): %v", err)
+	}
+	if got.SpecSource.Source != SpecSourceRepo || got.SpecSource.Ref != "feature/x" || got.SpecSource.File != ".pipewright.yml" {
+		t.Fatalf("仓库来源回读错误: %+v", got.SpecSource)
+	}
+
+	// 库内回退写入 → 回读 stored + fallback(ref/file 清空)。
+	if err := sink.SetSpecSource(context.Background(),
+		SpecSource{Source: SpecSourceStored, Fallback: "invalid_yaml"}); err != nil {
+		t.Fatalf("SetSpecSource(stored): %v", err)
+	}
+	got, err = svc.Get(context.Background(), rn.ID)
+	if err != nil {
+		t.Fatalf("Get(stored): %v", err)
+	}
+	if got.SpecSource.Source != SpecSourceStored || got.SpecSource.Fallback != "invalid_yaml" {
+		t.Fatalf("库内回退来源回读错误: %+v", got.SpecSource)
+	}
+}

--- a/internal/store/migrations/mysql/0040_run_spec_source.sql
+++ b/internal/store/migrations/mysql/0040_run_spec_source.sql
@@ -1,0 +1,7 @@
+-- 0040 pipeline_runs.spec_source*(MySQL):记录驱动本次运行的流水线配置来源(GitOps 配置来源可见性 · Slice 2)。
+-- spec_source: "" | repo | stored —— repo=仓库根 .pipewright.yml 驱动;stored=库内(网页)配置驱动;""=未记录(老运行)。
+-- spec_source_ref/file: repo 来源时取用的分支/ref 与文件名;spec_source_fallback: stored 来源回退原因。
+ALTER TABLE pipeline_runs ADD COLUMN spec_source VARCHAR(32) NOT NULL DEFAULT '';
+ALTER TABLE pipeline_runs ADD COLUMN spec_source_ref VARCHAR(255) NOT NULL DEFAULT '';
+ALTER TABLE pipeline_runs ADD COLUMN spec_source_file VARCHAR(255) NOT NULL DEFAULT '';
+ALTER TABLE pipeline_runs ADD COLUMN spec_source_fallback VARCHAR(64) NOT NULL DEFAULT '';

--- a/internal/store/migrations/sqlite/0040_run_spec_source.sql
+++ b/internal/store/migrations/sqlite/0040_run_spec_source.sql
@@ -1,0 +1,8 @@
+-- 0040 pipeline_runs.spec_source*:记录驱动本次运行的流水线配置来源(GitOps 配置来源可见性 · Slice 2)。
+-- spec_source: "" | repo | stored —— repo=仓库根 .pipewright.yml 驱动;stored=库内(网页)配置驱动;""=未记录(老运行)。
+-- spec_source_ref/file: repo 来源时取用的分支/ref 与文件名(.pipewright.yml)。
+-- spec_source_fallback: stored 来源且「本想用仓库但回退」时的原因(disabled|no_file|invalid_yaml|degraded|empty|lookup_failed)。
+ALTER TABLE pipeline_runs ADD COLUMN spec_source TEXT NOT NULL DEFAULT '';
+ALTER TABLE pipeline_runs ADD COLUMN spec_source_ref TEXT NOT NULL DEFAULT '';
+ALTER TABLE pipeline_runs ADD COLUMN spec_source_file TEXT NOT NULL DEFAULT '';
+ALTER TABLE pipeline_runs ADD COLUMN spec_source_fallback TEXT NOT NULL DEFAULT '';

--- a/internal/storetest/dialect_integration_test.go
+++ b/internal/storetest/dialect_integration_test.go
@@ -19,8 +19,8 @@ func TestMigrationsApplied(t *testing.T) {
 		if err := st.DB.QueryRowContext(ctx, `SELECT COUNT(1) FROM schema_migrations`).Scan(&n); err != nil {
 			t.Fatalf("count migrations: %v", err)
 		}
-		if n != 38 {
-			t.Fatalf("应用迁移数 = %d, 期望 38", n)
+		if n != 39 {
+			t.Fatalf("应用迁移数 = %d, 期望 39", n)
 		}
 		// 核心领域表存在(随手验一张)。
 		if _, err := st.DB.ExecContext(ctx, `SELECT 1 FROM audit_log WHERE 1=0`); err != nil {

--- a/web/src/api/projects.ts
+++ b/web/src/api/projects.ts
@@ -89,3 +89,36 @@ export async function updateProject(id: string, input: UpdateProjectInput): Prom
 export async function deleteProject(id: string): Promise<void> {
   return http.delete<void>(`/api/projects/${id}`)
 }
+
+/** One stage's summary from a previewed `.pipewright.yml` (no secrets). */
+export interface PacStageSummary {
+  name: string
+  kind: string
+  jobCount: number
+}
+
+/**
+ * Result of previewing/validating the repo's `.pipewright.yml` at a chosen ref.
+ * - found=false: the file does not exist at that ref (or repo unreadable) — runs fall back to the UI pipeline.
+ * - found=true, valid=false: the file exists but failed to parse/validate; `error` carries the
+ *   server's human-readable, secret-free message; `stages` is empty.
+ * - found=true, valid=true: `stages`/`stageCount` summarize what the runtime would use.
+ */
+export interface PacPreviewResult {
+  found: boolean
+  valid: boolean
+  ref: string
+  file: string
+  error: string
+  stageCount: number
+  stages: PacStageSummary[]
+}
+
+/**
+ * Fetch & validate the repo's `.pipewright.yml` at `ref` (defaults to the project's default
+ * branch when omitted). Read-only; never returns secrets or the repo URL credentials.
+ */
+export async function previewPacConfig(id: string, ref?: string): Promise<PacPreviewResult> {
+  const qs = ref && ref.trim() ? `?ref=${encodeURIComponent(ref.trim())}` : ''
+  return http.get<PacPreviewResult>(`/api/projects/${id}/pac/preview${qs}`)
+}

--- a/web/src/api/runs.ts
+++ b/web/src/api/runs.ts
@@ -153,6 +153,12 @@ export interface RunDetail {
   startedAt: string | null
   finishedAt: string | null
   durationMs: number | null
+  // Config-source visibility (GitOps · Slice 2): which spec drove this run.
+  // 'repo' = repo .pipewright.yml; 'stored' = stored UI config; '' = unrecorded (old runs).
+  specSource: '' | 'repo' | 'stored'
+  specSourceRef: string             // branch/ref used when specSource === 'repo'
+  specSourceFile: string            // file name (.pipewright.yml) when specSource === 'repo'
+  specSourceFallback: string        // fallback reason when stored config replaced an intended repo spec
   artifacts: ArtifactDTO[]          // Story 3-4 fills (FR-6) — empty [] when no artifacts
   targets: DeployTarget[] | null    // Story 4-2 fills (FR-10) — deployed ⇒ array, else null
   diagnosis: DiagnosisDTO | null    // Epic 7 fills — slot owner: Story 7.x (Story 7-2 defines shape)

--- a/web/src/components/pipeline/PacPreviewModal.vue
+++ b/web/src/components/pipeline/PacPreviewModal.vue
@@ -1,0 +1,396 @@
+<script setup lang="ts">
+/**
+ * PacPreviewModal — fetch & validate the repo's `.pipewright.yml` at a chosen ref
+ * BEFORE relying on it to drive runs (GitOps Slice 3).
+ *
+ * At runtime, an invalid `.pipewright.yml` is silently ignored (the run falls back to the stored
+ * UI pipeline) with no feedback. This modal gives that feedback up front: pick a ref, fetch, and
+ * see whether the file is found, whether it is valid, the parse error if not, and a summary of the
+ * stages the runtime would use. Read-only — it never saves anything and never reveals secrets.
+ */
+import { ref, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { previewPacConfig, type PacPreviewResult } from '../../api/projects'
+import { HttpError } from '../../api/http'
+
+const props = defineProps<{
+  projectId: string
+  /** Project default branch — pre-fills the ref input. */
+  defaultBranch: string
+}>()
+
+const { t } = useI18n()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+}>()
+
+const refInput = ref(props.defaultBranch ?? '')
+const busy = ref(false)
+const errorMsg = ref('')
+const result = ref<PacPreviewResult | null>(null)
+
+async function runPreview(): Promise<void> {
+  if (busy.value) return
+  busy.value = true
+  errorMsg.value = ''
+  result.value = null
+  try {
+    result.value = await previewPacConfig(props.projectId, refInput.value)
+  } catch (err) {
+    if (err instanceof HttpError) {
+      errorMsg.value = err.status === 0
+        ? t('projectPipeline.pacPreviewConnFailed')
+        : (err.apiError?.message ?? t('projectPipeline.pacPreviewFailed', { status: err.status }))
+    } else {
+      errorMsg.value = t('projectPipeline.pacPreviewFailedRetry')
+    }
+  } finally {
+    busy.value = false
+  }
+}
+
+function onBackdrop(e: MouseEvent): void {
+  if (e.target === e.currentTarget) emit('close')
+}
+
+// Auto-run on open against the default branch so the user sees a result immediately.
+onMounted(() => {
+  void runPreview()
+})
+</script>
+
+<template>
+  <div class="pp-backdrop" role="dialog" aria-modal="true" aria-labelledby="pp-title" @mousedown="onBackdrop">
+    <div class="pp-modal">
+      <header class="pp-head">
+        <div>
+          <h2 id="pp-title" class="pp-title">{{ t('projectPipeline.pacPreviewTitle') }}</h2>
+          <p class="pp-sub">
+            {{ t('projectPipeline.pacPreviewSub') }}
+            <code>.pipewright.yml</code>
+          </p>
+        </div>
+        <button class="pp-close" :aria-label="t('projectPipeline.pacPreviewCloseAria')" @click="emit('close')">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12"/></svg>
+        </button>
+      </header>
+
+      <div class="pp-body">
+        <div class="pp-ref-row">
+          <label for="pp-ref" class="pp-label">{{ t('projectPipeline.pacPreviewRefLabel') }}</label>
+          <input
+            id="pp-ref"
+            v-model="refInput"
+            class="pp-ref-input"
+            type="text"
+            spellcheck="false"
+            autocomplete="off"
+            :placeholder="defaultBranch || 'main'"
+            :disabled="busy"
+            @keydown.enter.prevent="runPreview"
+          />
+          <button class="pp-btn pp-btn--primary" :disabled="busy" @click="runPreview">
+            <span v-if="busy" class="pp-spin" aria-hidden="true"/>
+            {{ t('projectPipeline.pacPreviewFetch') }}
+          </button>
+        </div>
+
+        <!-- request-level error (network / unexpected) -->
+        <div v-if="errorMsg" class="pp-banner pp-banner--error" role="alert">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h.01"/></svg>
+          <span>{{ errorMsg }}</span>
+        </div>
+
+        <!-- result -->
+        <template v-else-if="result">
+          <!-- not found -->
+          <div v-if="!result.found" class="pp-banner pp-banner--warn" role="status">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h.01"/></svg>
+            <span>{{ t('projectPipeline.pacPreviewNotFound', { ref: result.ref }) }}</span>
+          </div>
+
+          <!-- found but invalid -->
+          <template v-else-if="!result.valid">
+            <div class="pp-banner pp-banner--error" role="alert">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h.01"/></svg>
+              <span>{{ t('projectPipeline.pacPreviewInvalid', { ref: result.ref }) }}</span>
+            </div>
+            <pre v-if="result.error" class="pp-error-detail">{{ result.error }}</pre>
+          </template>
+
+          <!-- found and valid -->
+          <template v-else>
+            <div class="pp-banner pp-banner--ok" role="status">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>
+              <span>{{ t('projectPipeline.pacPreviewValid', { ref: result.ref, count: result.stageCount }) }}</span>
+            </div>
+            <ul v-if="result.stages.length" class="pp-stages">
+              <li v-for="(stage, i) in result.stages" :key="i" class="pp-stage">
+                <span class="pp-stage-name">{{ stage.name }}</span>
+                <span class="pp-stage-kind">{{ stage.kind }}</span>
+                <span class="pp-stage-jobs">{{ t('projectPipeline.pacPreviewJobCount', { count: stage.jobCount }) }}</span>
+              </li>
+            </ul>
+          </template>
+        </template>
+      </div>
+
+      <footer class="pp-foot">
+        <button class="pp-btn" @click="emit('close')">{{ t('projectPipeline.pacPreviewCloseBtn') }}</button>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.pp-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: oklch(0% 0 0 / 0.42);
+  backdrop-filter: blur(2px);
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.pp-modal {
+  width: min(620px, 100%);
+  max-height: min(86vh, 720px);
+  display: flex;
+  flex-direction: column;
+  background: var(--color-card);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded-card);
+  box-shadow: 0 24px 64px oklch(0% 0 0 / 0.36);
+  overflow: hidden;
+}
+
+.pp-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.pp-title {
+  font-size: 1.02rem;
+  font-weight: 700;
+  color: var(--color-text);
+  letter-spacing: -0.01em;
+}
+
+.pp-sub {
+  margin-top: 4px;
+  font-size: 0.8rem;
+  color: var(--color-faint);
+  line-height: 1.5;
+}
+
+.pp-sub code {
+  font-family: var(--font-mono, monospace);
+  background: var(--color-inset);
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 0.92em;
+}
+
+.pp-close {
+  margin-left: auto;
+  flex: none;
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border: none;
+  background: none;
+  color: var(--color-faint);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: color var(--duration-fast), background-color var(--duration-fast);
+}
+
+.pp-close:hover { color: var(--color-text); background: var(--color-inset); }
+.pp-close:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
+
+.pp-body {
+  padding: 16px 20px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.pp-ref-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pp-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-dim);
+  flex: none;
+}
+
+.pp-ref-input {
+  flex: 1;
+  height: 34px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.82rem;
+  color: var(--color-text);
+  background: var(--color-canvas, var(--color-inset));
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded-md);
+  padding: 0 12px;
+}
+
+.pp-ref-input:focus { outline: none; border-color: var(--color-primary); box-shadow: 0 0 0 3px var(--color-primary-soft); }
+.pp-ref-input:disabled { opacity: 0.6; }
+
+.pp-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  padding: 9px 12px;
+  border-radius: var(--rounded-md);
+  border: 1px solid transparent;
+}
+
+.pp-banner--error {
+  background: var(--color-red-soft);
+  border-color: var(--color-red-line);
+  color: var(--color-red);
+}
+
+.pp-banner--ok {
+  background: var(--color-green-soft);
+  border-color: var(--color-green-line);
+  color: var(--color-green);
+}
+
+.pp-banner--warn {
+  background: var(--color-amber-soft, var(--color-inset));
+  border-color: var(--color-amber-line, var(--color-border-strong));
+  color: var(--color-amber, var(--color-dim));
+}
+
+.pp-banner svg { flex: none; margin-top: 2px; }
+
+.pp-error-detail {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.76rem;
+  line-height: 1.5;
+  color: var(--color-red);
+  background: var(--color-red-soft);
+  border: 1px solid var(--color-red-line);
+  border-radius: var(--rounded-md);
+  padding: 10px 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.pp-stages {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.pp-stage {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: var(--color-inset);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-md);
+  font-size: 0.82rem;
+}
+
+.pp-stage-name {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.pp-stage-kind {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.72rem;
+  color: var(--color-cyan);
+  background: var(--color-card-2);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 1px 6px;
+}
+
+.pp-stage-jobs {
+  margin-left: auto;
+  font-size: 0.76rem;
+  color: var(--color-faint);
+}
+
+.pp-foot {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 14px 20px;
+  border-top: 1px solid var(--color-border);
+}
+
+.pp-btn {
+  height: 34px;
+  font-size: 0.83rem;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-card-2);
+  color: var(--color-text);
+  border-radius: var(--rounded);
+  padding: 0 14px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  transition: border-color var(--duration-fast), background-color var(--duration-fast);
+}
+
+.pp-btn:hover:not(:disabled) { border-color: var(--color-faint); }
+.pp-btn:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
+.pp-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+.pp-btn--primary {
+  background: var(--color-primary);
+  color: #fff;
+  border-color: transparent;
+  font-weight: 600;
+  flex: none;
+}
+
+.pp-btn--primary:hover:not(:disabled) { background: var(--color-primary-press); }
+
+.pp-spin {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  border-top-color: currentColor;
+  border-radius: var(--rounded-full);
+  animation: pp-spin 0.7s linear infinite;
+}
+
+@keyframes pp-spin { to { transform: rotate(360deg); } }
+
+@media (prefers-reduced-motion: reduce) {
+  .pp-spin { animation: none; }
+}
+</style>

--- a/web/src/i18n/locales/de/projectPipeline.ts
+++ b/web/src/i18n/locales/de/projectPipeline.ts
@@ -17,6 +17,22 @@ export default {
   pacOffHint: 'Wenn aktiviert, liest jeder Lauf .pipewright.yml aus dem Repository-Stamm im Lauf-Branch (Rückfall auf diese Konfiguration, wenn fehlend oder ungültig).',
   pacToggleFailed: 'Umschalten fehlgeschlagen. Bitte erneut versuchen.',
 
+  // ─── Repository-Konfiguration vorschauen (GitOps · .pipewright.yml an einer Ref abrufen & prüfen) ──
+  pacPreviewBtn: 'Repo-Konfig vorschauen',
+  pacPreviewTitle: 'Repository-Konfiguration vorschauen',
+  pacPreviewSub: 'Datei des Repositorys an einem Branch/Tag/Commit abrufen und prüfen:',
+  pacPreviewCloseAria: 'Vorschau schließen',
+  pacPreviewCloseBtn: 'Schließen',
+  pacPreviewRefLabel: 'Branch / Tag / Commit',
+  pacPreviewFetch: 'Abrufen & prüfen',
+  pacPreviewNotFound: 'Keine .pipewright.yml unter {ref} gefunden; Läufe greifen auf die hier konfigurierte Pipeline zurück.',
+  pacPreviewInvalid: 'Die .pipewright.yml unter {ref} hat die Prüfung nicht bestanden; Läufe greifen stillschweigend auf die hier konfigurierte Pipeline zurück:',
+  pacPreviewValid: 'Die .pipewright.yml unter {ref} ist gültig mit {count} Stufe(n); Läufe verwenden sie.',
+  pacPreviewJobCount: '{count} Job(s)',
+  pacPreviewConnFailed: 'Verbindung fehlgeschlagen. Netzwerk prüfen und erneut versuchen.',
+  pacPreviewFailed: 'Vorschau fehlgeschlagen ({status}). Bitte erneut versuchen.',
+  pacPreviewFailedRetry: 'Vorschau fehlgeschlagen. Bitte erneut versuchen.',
+
   // ─── Symbolleisten-Schaltflächen ────────────────────────────────
   aiGenerate: 'Pipeline per KI generieren',
   importYaml: 'Aus YAML importieren',

--- a/web/src/i18n/locales/de/runDetail.ts
+++ b/web/src/i18n/locales/de/runDetail.ts
@@ -34,6 +34,12 @@ export default {
   triggerManual: 'Manuell',
   commitUnresolved: 'Nicht ermittelt',
 
+  // Badge für Konfigurationsquelle (GitOps · Slice 2)
+  metaSpecSource: 'Konfigurationsquelle',
+  specSourceRepo: 'Repository {ref} · {file}',
+  specSourceStored: 'Web-Konfiguration',
+  specSourceFallbackHint: 'Repository-Datei fehlt oder ist ungültig; auf Web-Konfiguration zurückgegriffen',
+
   pipelineProgress: 'Pipeline-Fortschritt',
   pipelineComplete: 'Pipeline abgeschlossen',
   pipelineFailed: 'Pipeline fehlgeschlagen',

--- a/web/src/i18n/locales/en/projectPipeline.ts
+++ b/web/src/i18n/locales/en/projectPipeline.ts
@@ -17,6 +17,22 @@ export default {
   pacOffHint: 'When on, each run reads .pipewright.yml from the repo root on the run branch (falling back to this config if missing or invalid).',
   pacToggleFailed: 'Failed to toggle. Please try again.',
 
+  // ─── Preview repo config (GitOps · fetch & validate .pipewright.yml at a ref) ───
+  pacPreviewBtn: 'Preview repo config',
+  pacPreviewTitle: 'Preview repo config',
+  pacPreviewSub: 'Fetch and validate the repo file at a branch/tag/commit:',
+  pacPreviewCloseAria: 'Close preview',
+  pacPreviewCloseBtn: 'Close',
+  pacPreviewRefLabel: 'Branch / tag / commit',
+  pacPreviewFetch: 'Fetch & validate',
+  pacPreviewNotFound: 'No .pipewright.yml found at {ref}; runs will fall back to the pipeline configured here.',
+  pacPreviewInvalid: 'The .pipewright.yml at {ref} failed validation; runs will silently fall back to the pipeline configured here:',
+  pacPreviewValid: 'The .pipewright.yml at {ref} is valid with {count} stage(s); runs will use it.',
+  pacPreviewJobCount: '{count} job(s)',
+  pacPreviewConnFailed: 'Connection failed. Check your network and retry.',
+  pacPreviewFailed: 'Preview failed ({status}). Please try again.',
+  pacPreviewFailedRetry: 'Preview failed. Please try again.',
+
   // ─── toolbar buttons ────────────────────────────────────────────
   aiGenerate: 'AI Generate Pipeline',
   importYaml: 'Import from YAML',

--- a/web/src/i18n/locales/en/runDetail.ts
+++ b/web/src/i18n/locales/en/runDetail.ts
@@ -34,6 +34,12 @@ export default {
   triggerManual: 'Manual',
   commitUnresolved: 'Unresolved',
 
+  // Config-source badge (GitOps · Slice 2)
+  metaSpecSource: 'Config source',
+  specSourceRepo: 'Repo {ref} · {file}',
+  specSourceStored: 'Web config',
+  specSourceFallbackHint: 'Repo file missing or invalid; fell back to the web config',
+
   pipelineProgress: 'Pipeline progress',
   pipelineComplete: 'Pipeline complete',
   pipelineFailed: 'Pipeline failed',

--- a/web/src/i18n/locales/es/projectPipeline.ts
+++ b/web/src/i18n/locales/es/projectPipeline.ts
@@ -17,6 +17,22 @@ export default {
   pacOffHint: 'Cuando está activo, cada ejecución lee .pipewright.yml desde la raíz del repositorio en la rama de ejecución (con reserva a esta configuración si falta o no es válido).',
   pacToggleFailed: 'No se pudo cambiar. Inténtalo de nuevo.',
 
+  // ─── Previsualizar configuración del repositorio (GitOps · obtener y validar .pipewright.yml en un ref) ──
+  pacPreviewBtn: 'Previsualizar config del repo',
+  pacPreviewTitle: 'Previsualizar configuración del repositorio',
+  pacPreviewSub: 'Obtén y valida el archivo del repositorio en una rama/etiqueta/commit:',
+  pacPreviewCloseAria: 'Cerrar la previsualización',
+  pacPreviewCloseBtn: 'Cerrar',
+  pacPreviewRefLabel: 'Rama / etiqueta / commit',
+  pacPreviewFetch: 'Obtener y validar',
+  pacPreviewNotFound: 'No se encontró .pipewright.yml en {ref}; las ejecuciones recurrirán al pipeline configurado aquí.',
+  pacPreviewInvalid: 'El .pipewright.yml en {ref} no superó la validación; las ejecuciones recurrirán silenciosamente al pipeline configurado aquí:',
+  pacPreviewValid: 'El .pipewright.yml en {ref} es válido con {count} etapa(s); las ejecuciones lo usarán.',
+  pacPreviewJobCount: '{count} trabajo(s)',
+  pacPreviewConnFailed: 'Error de conexión. Revisa tu red e inténtalo de nuevo.',
+  pacPreviewFailed: 'Error en la previsualización ({status}). Inténtalo de nuevo.',
+  pacPreviewFailedRetry: 'Error en la previsualización. Inténtalo de nuevo.',
+
   // ─── botones de la barra de herramientas ────────────────────────
   aiGenerate: 'Generar pipeline con IA',
   importYaml: 'Importar desde YAML',

--- a/web/src/i18n/locales/es/runDetail.ts
+++ b/web/src/i18n/locales/es/runDetail.ts
@@ -34,6 +34,12 @@ export default {
   triggerManual: 'Manual',
   commitUnresolved: 'No obtenido',
 
+  // Insignia de origen de configuración (GitOps · Slice 2)
+  metaSpecSource: 'Origen de configuración',
+  specSourceRepo: 'Repositorio {ref} · {file}',
+  specSourceStored: 'Configuración web',
+  specSourceFallbackHint: 'El archivo del repositorio falta o no es válido; se recurrió a la configuración web',
+
   pipelineProgress: 'Progreso del pipeline',
   pipelineComplete: 'Pipeline completado',
   pipelineFailed: 'Pipeline fallido',

--- a/web/src/i18n/locales/fr/projectPipeline.ts
+++ b/web/src/i18n/locales/fr/projectPipeline.ts
@@ -17,6 +17,22 @@ export default {
   pacOffHint: "Une fois activé, chaque exécution lit .pipewright.yml à la racine du dépôt sur la branche d'exécution (repli sur cette configuration si absent ou invalide).",
   pacToggleFailed: 'Échec du basculement. Veuillez réessayer.',
 
+  // ─── Aperçu de la config du dépôt (GitOps · récupérer et valider .pipewright.yml à une réf) ──
+  pacPreviewBtn: 'Aperçu de la config du dépôt',
+  pacPreviewTitle: 'Aperçu de la configuration du dépôt',
+  pacPreviewSub: 'Récupérez et validez le fichier du dépôt à une branche/un tag/un commit :',
+  pacPreviewCloseAria: "Fermer l'aperçu",
+  pacPreviewCloseBtn: 'Fermer',
+  pacPreviewRefLabel: 'Branche / tag / commit',
+  pacPreviewFetch: 'Récupérer et valider',
+  pacPreviewNotFound: "Aucun .pipewright.yml trouvé à {ref} ; les exécutions se rabattront sur le pipeline configuré ici.",
+  pacPreviewInvalid: "Le .pipewright.yml à {ref} a échoué à la validation ; les exécutions se rabattront silencieusement sur le pipeline configuré ici :",
+  pacPreviewValid: 'Le .pipewright.yml à {ref} est valide avec {count} étape(s) ; les exécutions l\'utiliseront.',
+  pacPreviewJobCount: '{count} tâche(s)',
+  pacPreviewConnFailed: 'Échec de la connexion. Vérifiez votre réseau et réessayez.',
+  pacPreviewFailed: "Échec de l'aperçu ({status}). Veuillez réessayer.",
+  pacPreviewFailedRetry: "Échec de l'aperçu. Veuillez réessayer.",
+
   // ─── boutons de la barre d'outils ───────────────────────────────
   aiGenerate: 'Générer le pipeline par IA',
   importYaml: 'Importer depuis YAML',

--- a/web/src/i18n/locales/fr/runDetail.ts
+++ b/web/src/i18n/locales/fr/runDetail.ts
@@ -34,6 +34,12 @@ export default {
   triggerManual: 'Manuel',
   commitUnresolved: 'Non récupéré',
 
+  // Badge de source de configuration (GitOps · Slice 2)
+  metaSpecSource: 'Source de configuration',
+  specSourceRepo: 'Dépôt {ref} · {file}',
+  specSourceStored: 'Configuration web',
+  specSourceFallbackHint: 'Fichier du dépôt manquant ou invalide ; repli sur la configuration web',
+
   pipelineProgress: 'Progression du pipeline',
   pipelineComplete: 'Pipeline terminé',
   pipelineFailed: 'Pipeline en échec',

--- a/web/src/i18n/locales/ja/projectPipeline.ts
+++ b/web/src/i18n/locales/ja/projectPipeline.ts
@@ -17,6 +17,22 @@ export default {
   pacOffHint: '有効にすると、各実行は実行ブランチのリポジトリルートの .pipewright.yml を読み込んで駆動します(ない/不正な場合はこの設定にフォールバック)。',
   pacToggleFailed: '切り替えに失敗しました。再試行してください。',
 
+  // ─── リポジトリ設定のプレビュー(GitOps · ref を指定して .pipewright.yml を取得・検証)──
+  pacPreviewBtn: 'リポジトリ設定をプレビュー',
+  pacPreviewTitle: 'リポジトリ設定のプレビュー',
+  pacPreviewSub: 'ブランチ/タグ/コミットを指定してリポジトリのファイルを取得・検証します:',
+  pacPreviewCloseAria: 'プレビューを閉じる',
+  pacPreviewCloseBtn: '閉じる',
+  pacPreviewRefLabel: 'ブランチ / タグ / コミット',
+  pacPreviewFetch: '取得して検証',
+  pacPreviewNotFound: '{ref} に .pipewright.yml が見つかりません。実行時はここで設定したパイプラインにフォールバックします。',
+  pacPreviewInvalid: '{ref} の .pipewright.yml は検証に失敗しました。実行時はここで設定したパイプラインに静かにフォールバックします:',
+  pacPreviewValid: '{ref} の .pipewright.yml は検証に成功しました(ステージ数 {count})。実行時はこれが使用されます。',
+  pacPreviewJobCount: 'ジョブ {count} 件',
+  pacPreviewConnFailed: '接続に失敗しました。ネットワークを確認して再試行してください。',
+  pacPreviewFailed: 'プレビューに失敗しました({status})。再試行してください。',
+  pacPreviewFailedRetry: 'プレビューに失敗しました。再試行してください。',
+
   // ─── ツールバーボタン ───────────────────────────────────────────
   aiGenerate: 'AI でパイプライン生成',
   importYaml: 'YAML からインポート',

--- a/web/src/i18n/locales/ja/runDetail.ts
+++ b/web/src/i18n/locales/ja/runDetail.ts
@@ -34,6 +34,12 @@ export default {
   triggerManual: '手動',
   commitUnresolved: '取得できず',
 
+  // 設定ソースのバッジ(GitOps · Slice 2)
+  metaSpecSource: '設定ソース',
+  specSourceRepo: 'リポジトリ {ref} · {file}',
+  specSourceStored: 'Web 設定',
+  specSourceFallbackHint: 'リポジトリのファイルが見つからないか無効なため、Web 設定にフォールバックしました',
+
   pipelineProgress: 'パイプラインの進行',
   pipelineComplete: 'パイプライン完了',
   pipelineFailed: 'パイプライン失敗',

--- a/web/src/i18n/locales/ko/projectPipeline.ts
+++ b/web/src/i18n/locales/ko/projectPipeline.ts
@@ -17,6 +17,22 @@ export default {
   pacOffHint: '켜면 각 실행이 실행 브랜치의 저장소 루트 .pipewright.yml을 읽어 구동합니다(없거나 유효하지 않으면 이 설정으로 폴백).',
   pacToggleFailed: '전환에 실패했습니다. 다시 시도하세요.',
 
+  // ─── 저장소 구성 미리보기 (GitOps · ref 지정해 .pipewright.yml 가져와 검증) ──
+  pacPreviewBtn: '저장소 구성 미리보기',
+  pacPreviewTitle: '저장소 구성 미리보기',
+  pacPreviewSub: '브랜치/태그/커밋을 지정해 저장소의 파일을 가져와 검증합니다:',
+  pacPreviewCloseAria: '미리보기 닫기',
+  pacPreviewCloseBtn: '닫기',
+  pacPreviewRefLabel: '브랜치 / 태그 / 커밋',
+  pacPreviewFetch: '가져와 검증',
+  pacPreviewNotFound: '{ref}에서 .pipewright.yml을 찾을 수 없습니다. 실행 시 여기서 구성한 파이프라인으로 폴백합니다.',
+  pacPreviewInvalid: '{ref}의 .pipewright.yml 검증에 실패했습니다. 실행 시 여기서 구성한 파이프라인으로 조용히 폴백합니다:',
+  pacPreviewValid: '{ref}의 .pipewright.yml 검증에 성공했습니다(스테이지 {count}개). 실행 시 이를 사용합니다.',
+  pacPreviewJobCount: '작업 {count}개',
+  pacPreviewConnFailed: '연결에 실패했습니다. 네트워크를 확인하고 다시 시도하세요.',
+  pacPreviewFailed: '미리보기에 실패했습니다({status}). 다시 시도하세요.',
+  pacPreviewFailedRetry: '미리보기에 실패했습니다. 다시 시도하세요.',
+
   // ─── 툴바 버튼 ──────────────────────────────────────────────────
   aiGenerate: 'AI 파이프라인 생성',
   importYaml: 'YAML에서 가져오기',

--- a/web/src/i18n/locales/ko/runDetail.ts
+++ b/web/src/i18n/locales/ko/runDetail.ts
@@ -34,6 +34,12 @@ export default {
   triggerManual: '수동',
   commitUnresolved: '가져오지 못함',
 
+  // 구성 소스 배지(GitOps · Slice 2)
+  metaSpecSource: '구성 소스',
+  specSourceRepo: '저장소 {ref} · {file}',
+  specSourceStored: '웹 구성',
+  specSourceFallbackHint: '저장소 파일이 없거나 유효하지 않아 웹 구성으로 폴백했습니다',
+
   pipelineProgress: '파이프라인 진행',
   pipelineComplete: '파이프라인 완료',
   pipelineFailed: '파이프라인 실패',

--- a/web/src/i18n/locales/zh-CN/projectPipeline.ts
+++ b/web/src/i18n/locales/zh-CN/projectPipeline.ts
@@ -17,6 +17,22 @@ export default {
   pacOffHint: '开启后,每次运行按运行分支读取仓库根 .pipewright.yml 驱动(缺失或非法则回退此处配置)。',
   pacToggleFailed: '切换失败,请重试。',
 
+  // ─── 预览仓库配置(GitOps · 按 ref 拉取并校验 .pipewright.yml)────────
+  pacPreviewBtn: '预览仓库配置',
+  pacPreviewTitle: '预览仓库配置',
+  pacPreviewSub: '按分支/标签/提交拉取并校验仓库中的',
+  pacPreviewCloseAria: '关闭预览',
+  pacPreviewCloseBtn: '关闭',
+  pacPreviewRefLabel: '分支 / 标签 / 提交',
+  pacPreviewFetch: '拉取并校验',
+  pacPreviewNotFound: '在 {ref} 未找到 .pipewright.yml,运行时将回退到此处库内配置。',
+  pacPreviewInvalid: '{ref} 的 .pipewright.yml 校验失败,运行时将静默回退到此处库内配置:',
+  pacPreviewValid: '{ref} 的 .pipewright.yml 校验通过,共 {count} 个阶段;运行时将用它驱动。',
+  pacPreviewJobCount: '{count} 个任务',
+  pacPreviewConnFailed: '连接失败,请检查网络后重试。',
+  pacPreviewFailed: '预览失败({status}),请重试。',
+  pacPreviewFailedRetry: '预览失败,请重试。',
+
   // ─── 工具栏按钮 ─────────────────────────────────────────────────
   aiGenerate: 'AI 生成流水线',
   importYaml: '从 YAML 导入',

--- a/web/src/i18n/locales/zh-CN/runDetail.ts
+++ b/web/src/i18n/locales/zh-CN/runDetail.ts
@@ -38,6 +38,12 @@ export default {
   triggerManual: '手动',
   commitUnresolved: '未取到',
 
+  // 配置来源徽标(GitOps · Slice 2)
+  metaSpecSource: '配置来源',
+  specSourceRepo: '仓库 {ref} · {file}',
+  specSourceStored: '网页配置',
+  specSourceFallbackHint: '仓库文件缺失或无效,已回退到网页配置',
+
   // 区块标题
   pipelineProgress: '流水线进度',
   pipelineComplete: '流水线完成',

--- a/web/src/i18n/locales/zh-TW/projectPipeline.ts
+++ b/web/src/i18n/locales/zh-TW/projectPipeline.ts
@@ -17,6 +17,22 @@ export default {
   pacOffHint: '開啟後,每次執行依執行分支讀取倉庫根 .pipewright.yml 驅動(缺失或非法則回退此處設定)。',
   pacToggleFailed: '切換失敗,請重試。',
 
+  // ─── 預覽倉庫設定(GitOps · 按 ref 拉取並校驗 .pipewright.yml)────────
+  pacPreviewBtn: '預覽倉庫設定',
+  pacPreviewTitle: '預覽倉庫設定',
+  pacPreviewSub: '按分支/標籤/提交拉取並校驗倉庫中的',
+  pacPreviewCloseAria: '關閉預覽',
+  pacPreviewCloseBtn: '關閉',
+  pacPreviewRefLabel: '分支 / 標籤 / 提交',
+  pacPreviewFetch: '拉取並校驗',
+  pacPreviewNotFound: '在 {ref} 未找到 .pipewright.yml,執行時將回退到此處庫內設定。',
+  pacPreviewInvalid: '{ref} 的 .pipewright.yml 校驗失敗,執行時將靜默回退到此處庫內設定:',
+  pacPreviewValid: '{ref} 的 .pipewright.yml 校驗通過,共 {count} 個階段;執行時將用它驅動。',
+  pacPreviewJobCount: '{count} 個任務',
+  pacPreviewConnFailed: '連線失敗,請檢查網路後重試。',
+  pacPreviewFailed: '預覽失敗({status}),請重試。',
+  pacPreviewFailedRetry: '預覽失敗,請重試。',
+
   // ─── 工具列按鈕 ─────────────────────────────────────────────────
   aiGenerate: 'AI 生成流水線',
   importYaml: '從 YAML 匯入',

--- a/web/src/i18n/locales/zh-TW/runDetail.ts
+++ b/web/src/i18n/locales/zh-TW/runDetail.ts
@@ -34,6 +34,12 @@ export default {
   triggerManual: '手動',
   commitUnresolved: '未取到',
 
+  // 設定來源徽章(GitOps · Slice 2)
+  metaSpecSource: '設定來源',
+  specSourceRepo: '倉庫 {ref} · {file}',
+  specSourceStored: '網頁設定',
+  specSourceFallbackHint: '倉庫檔案缺失或無效,已回退到網頁設定',
+
   pipelineProgress: '流水線進度',
   pipelineComplete: '流水線完成',
   pipelineFailed: '流水線失敗',

--- a/web/src/views/ProjectPipeline.vue
+++ b/web/src/views/ProjectPipeline.vue
@@ -31,6 +31,7 @@ import AIGenerateWizard from '../components/pipeline/AIGenerateWizard.vue'
 import RiskAnnotationPanel from '../components/pipeline/RiskAnnotationPanel.vue'
 import YamlImportModal from '../components/pipeline/YamlImportModal.vue'
 import TemplatePickerModal from '../components/pipeline/TemplatePickerModal.vue'
+import PacPreviewModal from '../components/pipeline/PacPreviewModal.vue'
 
 // ─── Route ────────────────────────────────────────────────────────────────────
 
@@ -382,6 +383,11 @@ const pacEnabled = computed(() => project.value?.pacEnabled ?? false)
 const pacToggling = ref(false)
 const pacError = ref('')
 
+// 预览仓库配置:按 ref 拉取并校验仓库 .pipewright.yml(只读;依赖它驱动运行前先看清/捕错)。
+const pacPreviewOpen = ref(false)
+const pacHasRepo = computed(() => !!project.value?.repoUrl?.trim())
+const pacDefaultBranch = computed(() => project.value?.defaultBranch ?? '')
+
 async function togglePac(next: boolean): Promise<void> {
   if (!project.value || pacToggling.value) return
   pacToggling.value = true
@@ -526,18 +532,31 @@ async function togglePac(next: boolean): Promise<void> {
         </span>
         <span v-if="pacError" class="pac-bar-err" role="alert">{{ pacError }}</span>
       </div>
-      <button
-        type="button"
-        class="pac-switch"
+      <div class="pac-bar-actions">
+        <button
+          v-if="pacHasRepo"
+          type="button"
+          class="pac-preview-btn"
+          @click="pacPreviewOpen = true"
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/>
+          </svg>
+          {{ t('projectPipeline.pacPreviewBtn') }}
+        </button>
+        <button
+          type="button"
+          class="pac-switch"
         :class="{ 'pac-switch--on': pacEnabled }"
         role="switch"
         :aria-checked="pacEnabled"
         :aria-label="t('projectPipeline.pacTitle')"
         :disabled="pacToggling || !project"
-        @click="togglePac(!pacEnabled)"
-      >
-        <span class="pac-switch-knob" aria-hidden="true"/>
-      </button>
+          @click="togglePac(!pacEnabled)"
+        >
+          <span class="pac-switch-knob" aria-hidden="true"/>
+        </button>
+      </div>
     </div>
 
     <!-- ─── Tab body: panels + optional validation side-drawer ─────────────── -->
@@ -685,6 +704,14 @@ async function togglePac(next: boolean): Promise<void> {
       :stages="editStages"
       @close="templateModalOpen = false"
       @applied="handleTemplateApplied"
+    />
+
+    <!-- ─── Preview repo .pipewright.yml at a ref (GitOps Slice 3) ───────── -->
+    <PacPreviewModal
+      v-if="pacPreviewOpen"
+      :project-id="projectId"
+      :default-branch="pacDefaultBranch"
+      @close="pacPreviewOpen = false"
     />
 
   </div>
@@ -952,6 +979,34 @@ async function togglePac(next: boolean): Promise<void> {
 }
 .pac-bar-desc { font-size: 0.78rem; color: var(--color-faint); }
 .pac-bar-err { font-size: 0.78rem; color: var(--color-danger, #e5484d); }
+
+.pac-bar-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: none;
+}
+
+.pac-preview-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 12px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  color: var(--color-text);
+  background: var(--color-card-2);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded);
+  cursor: pointer;
+  transition: border-color var(--duration-fast), background-color var(--duration-fast);
+}
+
+.pac-preview-btn:hover { border-color: var(--color-faint); }
+.pac-preview-btn:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
+.pac-preview-btn svg { flex: none; color: var(--color-faint); }
 
 .pac-switch {
   position: relative;

--- a/web/src/views/RunDetail.vue
+++ b/web/src/views/RunDetail.vue
@@ -219,6 +219,31 @@ const healthCheckValid = computed(() => {
 // 是否已部署过(run.targets 非空 → 已有部署结果)。
 const hasDeployed = computed(() => !!run.value?.targets && run.value.targets.length > 0)
 
+// 配置来源徽标(GitOps 配置来源可见性 · Slice 2):本次运行由仓库 .pipewright.yml 还是网页配置驱动。
+// specSource 为空(老运行 / 桩 runner 未上报)→ null,不展示徽标。
+const specSourceBadge = computed(() => {
+  const src = run.value?.specSource
+  if (src === 'repo') {
+    return {
+      kind: 'repo' as const,
+      label: t('runDetail.specSourceRepo', {
+        ref: run.value?.specSourceRef || '',
+        file: run.value?.specSourceFile || '.pipewright.yml',
+      }),
+      hint: '',
+    }
+  }
+  if (src === 'stored') {
+    return {
+      kind: 'stored' as const,
+      label: t('runDetail.specSourceStored'),
+      // 回退原因非空 → 「本想用仓库但回退」的轻提示(tooltip)。
+      hint: run.value?.specSourceFallback ? t('runDetail.specSourceFallbackHint') : '',
+    }
+  }
+  return null
+})
+
 async function ensureDeployServers(): Promise<void> {
   if (deployServersLoaded.value) return
   try {
@@ -724,6 +749,18 @@ function nodeClass(status: StepStatus): string {
           <div class="meta-item">
             <span class="meta-key">{{ t('runDetail.metaTrigger') }}</span>
             <span class="meta-val">{{ run.trigger.type === 'webhook' ? 'Webhook' : t('runDetail.triggerManual') }} · {{ run.trigger.actor }}</span>
+          </div>
+          <div v-if="specSourceBadge" class="meta-item">
+            <span class="meta-key">{{ t('runDetail.metaSpecSource') }}</span>
+            <span
+              class="spec-source-badge"
+              :class="`spec-source-badge--${specSourceBadge.kind}`"
+              :title="specSourceBadge.hint || undefined"
+            >
+              <span class="spec-source-badge-dot" aria-hidden="true" />
+              {{ specSourceBadge.label }}
+              <span v-if="specSourceBadge.hint" class="spec-source-badge-hint" aria-hidden="true">⚠</span>
+            </span>
           </div>
           <div class="meta-item">
             <span class="meta-key">{{ t('runDetail.metaStarted') }}</span>
@@ -1478,6 +1515,43 @@ function nodeClass(status: StepStatus): string {
 }
 
 .mono { font-family: var(--font-mono); }
+
+/* ─── spec-source badge (GitOps config-source visibility · Slice 2) ───────── */
+.spec-source-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 9px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1.5;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+.spec-source-badge-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex: none;
+}
+/* repo: GitOps 来源,蓝色强调(来源可信、可追溯)。 */
+.spec-source-badge--repo {
+  color: var(--color-accent, #2563eb);
+  background: color-mix(in oklab, var(--color-accent, #2563eb) 12%, transparent);
+  border-color: color-mix(in oklab, var(--color-accent, #2563eb) 28%, transparent);
+}
+/* stored: 网页配置来源,中性色。 */
+.spec-source-badge--stored {
+  color: var(--color-dim);
+  background: color-mix(in oklab, var(--color-dim) 12%, transparent);
+  border-color: color-mix(in oklab, var(--color-dim) 24%, transparent);
+}
+.spec-source-badge-hint {
+  font-size: 0.72rem;
+  cursor: help;
+}
 
 /* ─── state section wrapper ──────────────────────────────────────────────── */
 .state-section {


### PR DESCRIPTION
GitOps「流水线即代码」产品化的后三个分片(承接 #118 每项目开关)。三个分片并行开发(隔离 worktree),文件互不相交,合并零冲突。

## 片2 · 运行配置来源可视化
让每次运行**记录并展示**它用的是仓库 `.pipewright.yml` 还是网页配置——解决"YAML 写错会静默回退、且看不出这次用了哪份"的盲区。
- `dagrun.SpecLoader.Get` 增第三返回值 `SpecSource{FromRepo,Ref,File,FallbackReason}`;`pacloader` 给出真实来源(命中/回退原因 disabled|no_file|invalid_yaml|degraded|empty|lookup_failed)
- 迁移 0040:`pipeline_runs` 增 `spec_source/_ref/_file/_fallback`(sqlite+mysql);`Runner.Run` 经 `StepSink.SetSpecSource` 回写;run 详情 DTO 暴露
- RunDetail 元信息条加来源徽章:「配置来源:仓库 `<ref>` · .pipewright.yml」/「网页配置」(回退态带提示);runDetail i18n ×8

## 片3 · 仓库配置预览/校验
依赖仓库配置前,先选 ref 拉取 `.pipewright.yml` 实时校验、看阶段摘要。
- 新端点 `GET /api/projects/{id}/pac/preview?ref=`(只读;缺失/降级→found=false;非法→valid=false+error;成功→阶段摘要;不泄漏凭据)+ 4 个单测
- ProjectPipeline「预览仓库配置」按钮 + `PacPreviewModal.vue`;projectPipeline i18n ×8

## 片4 · 文档
README 中英各加「流水线即代码(GitOps)」一节:启用方式、仓库根文件、按分支读取、回退规则、作用范围(只接管流水线结构,变量/环境/凭据/触发仍在 UI)、示例 + 全局 `PIPEWRIGHT_PAC_RUNTIME=1`。示例 `.pipewright.yml` 经真解析器 `pipelineyaml.Parse` 验证可解析。

## 自检(合并分支上)
- 后端 `go build/vet/test ./...` 全绿、`gofmt -l` 空;前端 `vue-tsc` 0 错、`eslint` 0 错、`vitest` 321 通过
- **真机端到端**:run-repo 详情显示「仓库 feature/x · .pipewright.yml」徽章、run-stored 显示「网页配置」;预览弹窗渲染 + 端点对不可达仓库优雅返回 found=false、缺项目 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)