### PR TITLE
feat: 完成半成品——企业微信/钉钉通知 + PR 状态检查产品化

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -359,23 +359,28 @@ func main() {
 		runnerOpts = []run.PoolOption{run.WithRunner(dagrun.New(specLoader, dagOpts...))}
 	}
 
-	// 终态钩子:通知(Story 5.2);PIPEWRIGHT_PR_STATUS=1 时再叠加「PR 状态回写」(Story 8-9 / FR-8-9):
-	// run 终态 → 据项目仓库识别 GitHub/Gitee → 经项目凭据回写该 commit 的提交状态(PR 检查)。
-	// **默认关闭**(避免意外往用户真实仓库回写);开启时 best-effort,失败仅记日志不阻断 run 终态。
+	// 终态钩子:通知(Story 5.2)+「PR 状态回写」(Story 8-9 / FR-8-9):run 终态 → 据项目仓库
+	// 识别 GitHub/Gitee → 经项目凭据回写该 commit 的提交状态(PR 检查)。
+	//
+	// PR 回写钩子**始终挂载**,但仅对**开启了 PR 状态检查**的项目(每项目开关 projects.pr_status_enabled)
+	// 生效——老项目默认关 → 行为不变(不会意外往真实仓库回写),且无需服务端 env 即可逐项目启用。
+	// 历史全局开关 PIPEWRIGHT_PR_STATUS=1 保留为**全局强开**:无视每项目开关,对所有项目回写(向后兼容)。
+	// API base 可经 env 覆盖(GitHub/Gitee 企业版自托管;空则用公有云默认),无论是否全局强开均生效。
+	// best-effort:失败仅记日志,不阻断 run 终态。
 	terminalHook := httpapi.NewNotifyHook(runSvc, notifySvc, secretSrc)
-	if strings.EqualFold(strings.TrimSpace(os.Getenv("PIPEWRIGHT_PR_STATUS")), "1") {
-		// API base 可经 env 覆盖(GitHub/Gitee 企业版自托管;空则用公有云默认)。
-		reporter := prstatus.NewReporter(&http.Client{Timeout: 10 * time.Second}).WithBaseURLs(
-			strings.TrimSpace(os.Getenv("PIPEWRIGHT_PR_STATUS_GITHUB_BASE")),
-			strings.TrimSpace(os.Getenv("PIPEWRIGHT_PR_STATUS_GITEE_BASE")))
-		prHook := httpapi.NewPRStatusHook(runSvc, projectSvc, credVault, reporter,
-			strings.TrimSpace(os.Getenv("PIPEWRIGHT_PUBLIC_URL")))
-		notify := terminalHook
-		terminalHook = func(ctx context.Context, runID, finalStatus string) {
-			notify(ctx, runID, finalStatus)
-			prHook(ctx, runID, finalStatus)
-		}
-		log.Printf("[prstatus] PR 状态回写已启用(PIPEWRIGHT_PR_STATUS=1;GitHub/Gitee,经项目凭据,best-effort)")
+	prStatusGlobalOverride := strings.EqualFold(strings.TrimSpace(os.Getenv("PIPEWRIGHT_PR_STATUS")), "1")
+	reporter := prstatus.NewReporter(&http.Client{Timeout: 10 * time.Second}).WithBaseURLs(
+		strings.TrimSpace(os.Getenv("PIPEWRIGHT_PR_STATUS_GITHUB_BASE")),
+		strings.TrimSpace(os.Getenv("PIPEWRIGHT_PR_STATUS_GITEE_BASE")))
+	prHook := httpapi.NewPRStatusHook(runSvc, projectSvc, credVault, reporter,
+		strings.TrimSpace(os.Getenv("PIPEWRIGHT_PUBLIC_URL")), prStatusGlobalOverride)
+	notify := terminalHook
+	terminalHook = func(ctx context.Context, runID, finalStatus string) {
+		notify(ctx, runID, finalStatus)
+		prHook(ctx, runID, finalStatus)
+	}
+	if prStatusGlobalOverride {
+		log.Printf("[prstatus] 全局强开:PR 状态回写对所有项目生效(PIPEWRIGHT_PR_STATUS=1;无视每项目开关)")
 	}
 
 	// 流水线串联终态钩子(FR-8-11):复用同一终态槽,叠加到 terminalHook 之上。

--- a/internal/httpapi/notifications.go
+++ b/internal/httpapi/notifications.go
@@ -56,6 +56,13 @@ func toChannelDTO(c *notify.Channel) channelDTO {
 		// 飞书:回显 webhook 地址 + 是否已配签名密钥(密钥本身绝不回显)。
 		cfg.URL = c.Config.URL
 		cfg.HasPassword = c.HasSecret
+	case notify.TypeWecom:
+		// 企业微信群机器人:仅回显 webhook 地址(无密钥)。
+		cfg.URL = c.Config.URL
+	case notify.TypeDingtalk:
+		// 钉钉群机器人:回显 webhook 地址 + 是否已配加签密钥(密钥本身绝不回显)。
+		cfg.URL = c.Config.URL
+		cfg.HasPassword = c.HasSecret
 	case notify.TypeEmail:
 		cfg.SMTPHost = c.Config.SMTPHost
 		cfg.SMTPPort = c.Config.SMTPPort

--- a/internal/httpapi/notifications_test.go
+++ b/internal/httpapi/notifications_test.go
@@ -199,11 +199,23 @@ func TestTestChannelRealWebhookPOST(t *testing.T) {
 	}
 }
 
-func TestTestPlaceholderTypeNotImplemented(t *testing.T) {
-	srv, client, csrf := setupNotifyServer(t, nil)
+// 企业微信群机器人:经 HTTP API 创建 + test 应真发并成功(end-to-end,经 deliver 分派)。
+func TestWecomChannelTestSendsEndToEnd(t *testing.T) {
+	var hit int
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hit++
+		_, _ = w.Write([]byte(`{"errcode":0,"errmsg":"ok"}`))
+	}))
+	defer stub.Close()
+
+	srv, client, csrf := setupNotifyServer(t, stub.Client())
 	base := srv.URL + "/api/notifications/channels"
 	resp := doJSON(t, client, http.MethodPost, base, csrf,
-		`{"name":"wc","type":"wecom","enabled":true,"config":{}}`)
+		`{"name":"wc","type":"wecom","enabled":true,"config":{"url":"`+stub.URL+`/cgi-bin/webhook/send?key=k"}}`)
+	if resp.StatusCode != http.StatusCreated {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create status = %d (%s)", resp.StatusCode, raw)
+	}
 	created := decodeMap(t, resp)
 	resp.Body.Close()
 	id, _ := created["id"].(string)
@@ -214,12 +226,25 @@ func TestTestPlaceholderTypeNotImplemented(t *testing.T) {
 	}
 	m := decodeMap(t, resp)
 	resp.Body.Close()
-	if m["ok"] != false {
-		t.Fatalf("占位 type test 应 ok=false: %v", m)
+	if m["ok"] != true {
+		t.Fatalf("企微 test 应 ok=true: %v", m)
 	}
-	errStr, _ := m["error"].(string)
-	if !strings.Contains(errStr, "not_implemented") {
-		t.Fatalf("应人读 not_implemented: %v", m)
+	if hit != 1 {
+		t.Fatalf("企微机器人应收到 1 次 POST,得 %d", hit)
+	}
+}
+
+// 缺 URL 的 wecom/dingtalk 创建应被拒(配置校验:URL 必填)。
+func TestWecomDingtalkRequireURLViaAPI(t *testing.T) {
+	srv, client, csrf := setupNotifyServer(t, nil)
+	base := srv.URL + "/api/notifications/channels"
+	for _, ty := range []string{"wecom", "dingtalk"} {
+		resp := doJSON(t, client, http.MethodPost, base, csrf,
+			`{"name":"x","type":"`+ty+`","enabled":true,"config":{}}`)
+		if resp.StatusCode == http.StatusCreated {
+			t.Fatalf("%s 缺 URL 不应创建成功(应 4xx)", ty)
+		}
+		resp.Body.Close()
 	}
 }
 

--- a/internal/httpapi/projects.go
+++ b/internal/httpapi/projects.go
@@ -15,33 +15,35 @@ import (
 // projectDTO 是项目对外响应体(冻结契约;camelCase;无明文/无密文)。
 // lastRunStatus / targetServers 本期为占位(null / []),数据由后续 story 填。
 type projectDTO struct {
-	ID             string   `json:"id"`
-	Name           string   `json:"name"`
-	RepoURL        string   `json:"repoUrl"`
-	DefaultBranch  string   `json:"defaultBranch"`
-	CredentialID   string   `json:"credentialId"`
-	CredentialName string   `json:"credentialName"`
-	PacEnabled     bool     `json:"pacEnabled"`
-	LastRunStatus  *string  `json:"lastRunStatus"`
-	TargetServers  []string `json:"targetServers"`
-	CreatedAt      string   `json:"createdAt"`
-	UpdatedAt      string   `json:"updatedAt"`
+	ID              string   `json:"id"`
+	Name            string   `json:"name"`
+	RepoURL         string   `json:"repoUrl"`
+	DefaultBranch   string   `json:"defaultBranch"`
+	CredentialID    string   `json:"credentialId"`
+	CredentialName  string   `json:"credentialName"`
+	PacEnabled      bool     `json:"pacEnabled"`
+	PRStatusEnabled bool     `json:"prStatusEnabled"`
+	LastRunStatus   *string  `json:"lastRunStatus"`
+	TargetServers   []string `json:"targetServers"`
+	CreatedAt       string   `json:"createdAt"`
+	UpdatedAt       string   `json:"updatedAt"`
 }
 
 // toProjectDTO 把领域 Project 转为契约 DTO。
 func toProjectDTO(p *project.Project) projectDTO {
 	return projectDTO{
-		ID:             p.ID,
-		Name:           p.Name,
-		RepoURL:        p.RepoURL,
-		DefaultBranch:  p.DefaultBranch,
-		CredentialID:   p.CredentialID,
-		CredentialName: p.CredentialName,
-		PacEnabled:     p.PacEnabled,
-		LastRunStatus:  nil,        // 本期占位:尚无运行
-		TargetServers:  []string{}, // 本期占位:空集合
-		CreatedAt:      p.CreatedAt.UTC().Format(time.RFC3339),
-		UpdatedAt:      p.UpdatedAt.UTC().Format(time.RFC3339),
+		ID:              p.ID,
+		Name:            p.Name,
+		RepoURL:         p.RepoURL,
+		DefaultBranch:   p.DefaultBranch,
+		CredentialID:    p.CredentialID,
+		CredentialName:  p.CredentialName,
+		PacEnabled:      p.PacEnabled,
+		PRStatusEnabled: p.PRStatusEnabled,
+		LastRunStatus:   nil,        // 本期占位:尚无运行
+		TargetServers:   []string{}, // 本期占位:空集合
+		CreatedAt:       p.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:       p.UpdatedAt.UTC().Format(time.RFC3339),
 	}
 }
 
@@ -162,20 +164,22 @@ func makeUpdateProjectHandler(svc project.Service, aud audit.Recorder) http.Hand
 		id := chi.URLParam(r, "id")
 		r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
 		var req struct {
-			Name          *string `json:"name"`
-			DefaultBranch *string `json:"defaultBranch"`
-			CredentialID  *string `json:"credentialId"`
-			PacEnabled    *bool   `json:"pacEnabled"`
+			Name            *string `json:"name"`
+			DefaultBranch   *string `json:"defaultBranch"`
+			CredentialID    *string `json:"credentialId"`
+			PacEnabled      *bool   `json:"pacEnabled"`
+			PRStatusEnabled *bool   `json:"prStatusEnabled"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "bad_request", "请求体格式错误")
 			return
 		}
 		p, err := svc.Update(r.Context(), id, project.UpdateInput{
-			Name:          req.Name,
-			DefaultBranch: req.DefaultBranch,
-			CredentialID:  req.CredentialID,
-			PacEnabled:    req.PacEnabled,
+			Name:            req.Name,
+			DefaultBranch:   req.DefaultBranch,
+			CredentialID:    req.CredentialID,
+			PacEnabled:      req.PacEnabled,
+			PRStatusEnabled: req.PRStatusEnabled,
 		})
 		if err != nil {
 			writeProjectError(w, err)

--- a/internal/httpapi/prstatus.go
+++ b/internal/httpapi/prstatus.go
@@ -19,12 +19,17 @@ import (
 
 // NewPRStatusHook 构造 PR 状态回写终态钩子。publicBaseURL 为平台对外访问地址(用于 target_url;
 // 空则不带链接)。token 经 vault 即取即用,绝不进 URL/日志。
+//
+// 钩子始终挂载,但仅在该 run 的项目**开启了 PR 状态检查**(projects.pr_status_enabled)时才回写;
+// globalOverride=true(历史全局 env PIPEWRIGHT_PR_STATUS=1)则无视每项目开关,对所有项目回写。
+// 默认(开关关 + 无全局强开)→ 不回写,行为与历史 env 未设时一致。
 func NewPRStatusHook(
 	runs run.Service,
 	projects project.Service,
 	v vault.Vault,
 	reporter *prstatus.Reporter,
 	publicBaseURL string,
+	globalOverride bool,
 ) func(ctx context.Context, runID, finalStatus string) {
 	publicBaseURL = strings.TrimRight(strings.TrimSpace(publicBaseURL), "/")
 	return func(ctx context.Context, runID, finalStatus string) {
@@ -38,6 +43,10 @@ func NewPRStatusHook(
 		}
 		proj, err := projects.Get(ctx, r.ProjectID)
 		if err != nil {
+			return
+		}
+		// 每项目开关门控:未开启且无全局强开 → 静默跳过(老项目默认行为)。
+		if !globalOverride && !proj.PRStatusEnabled {
 			return
 		}
 		target, ok := prstatus.Detect(proj.RepoURL)

--- a/internal/httpapi/prstatus_test.go
+++ b/internal/httpapi/prstatus_test.go
@@ -1,0 +1,106 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/huangchengsir/pipewright/internal/project"
+	"github.com/huangchengsir/pipewright/internal/prstatus"
+	"github.com/huangchengsir/pipewright/internal/run"
+	"github.com/huangchengsir/pipewright/internal/store"
+	"github.com/huangchengsir/pipewright/internal/vault"
+)
+
+// stubProberPR 是不触网的远端探测桩(本测试只走 SQL 种子 + Get/Update,实际不会被调用)。
+type stubProberPR struct{}
+
+func (stubProberPR) Probe(_ context.Context, _ /*repoURL*/ string, _ string) (string, error) {
+	return "main", nil
+}
+
+// prStatusHookFixture 起一个把所有平台 API 收编到本地的 httptest server,并装好真 run/project/vault
+// 服务 + 经种子建一个 GitHub 项目(带可 Reveal 的凭据)与一个带 commit 的成功 run。
+// 返回:hits(server 命中计数指针)、runID、projID、project.Service、reporter。
+func prStatusHookFixture(t *testing.T) (*int32, string, string, project.Service, *prstatus.Reporter, run.Service, vault.Vault) {
+	t.Helper()
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"state":"success"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	st, err := store.Open(t.TempDir() + "/prstatus.db")
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	v := vault.New(st.DB, testMasterKey())
+	// 真凭据(git_token),Reveal 取得明文 token(否则钩子会因无凭据静默跳过)。
+	cred, err := v.Create(vault.CreateInput{Name: "gh", Type: vault.TypeGitToken, Secret: "ghp_token_xyz"})
+	if err != nil {
+		t.Fatalf("vault.Create: %v", err)
+	}
+
+	projSvc := project.New(st.DB, v, stubProberPR{})
+	// 直接 SQL 种子项目(GitHub 仓库 → Detect 命中;默认 pr_status_enabled=0)。
+	projID := "proj-prstatus"
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := st.DB.Exec(
+		`INSERT INTO projects (id, name, repo_url, default_branch, credential_id, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		projID, "demo", "https://github.com/acme/demo.git", "main", cred.ID, now, now,
+	); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+
+	runSvc := run.New(st.DB)
+	r, err := runSvc.Create(context.Background(), projID,
+		run.Trigger{Type: run.TriggerManual, Branch: "main", Commit: "abcdef1234567890"})
+	if err != nil {
+		t.Fatalf("run.Create: %v", err)
+	}
+
+	reporter := prstatus.NewReporter(srv.Client()).WithBaseURLs(srv.URL, srv.URL)
+	return &hits, r.ID, projID, projSvc, reporter, runSvc, v
+}
+
+// TestPRStatusHookGatedByProjectFlag 断言:flag 关 + 无全局强开 → 不回写;flag 开 → 回写。
+func TestPRStatusHookGatedByProjectFlag(t *testing.T) {
+	hits, runID, _, projSvc, reporter, runSvc, v := prStatusHookFixture(t)
+
+	// 1) flag 关 + globalOverride=false → 不应命中平台 API。
+	hook := NewPRStatusHook(runSvc, projSvc, v, reporter, "https://pw.example.com", false)
+	hook(context.Background(), runID, run.StatusSuccess)
+	if got := atomic.LoadInt32(hits); got != 0 {
+		t.Fatalf("flag 关 + 无全局强开应跳过回写, 但平台 API 被命中 %d 次", got)
+	}
+
+	// 2) 开启每项目 PR 状态开关 → 应命中平台 API 一次。
+	on := true
+	if _, err := projSvc.Update(context.Background(), "proj-prstatus", project.UpdateInput{PRStatusEnabled: &on}); err != nil {
+		t.Fatalf("Update flag on: %v", err)
+	}
+	hook(context.Background(), runID, run.StatusSuccess)
+	if got := atomic.LoadInt32(hits); got != 1 {
+		t.Fatalf("flag 开后应回写一次, 平台 API 命中 = %d, want 1", got)
+	}
+}
+
+// TestPRStatusHookGlobalOverride 断言:flag 关但 globalOverride=true → 仍回写(向后兼容全局强开)。
+func TestPRStatusHookGlobalOverride(t *testing.T) {
+	hits, runID, _, projSvc, reporter, runSvc, v := prStatusHookFixture(t)
+
+	// flag 默认关,但全局强开 → 应命中平台 API。
+	hook := NewPRStatusHook(runSvc, projSvc, v, reporter, "https://pw.example.com", true)
+	hook(context.Background(), runID, run.StatusSuccess)
+	if got := atomic.LoadInt32(hits); got != 1 {
+		t.Fatalf("全局强开应无视每项目开关回写一次, 平台 API 命中 = %d, want 1", got)
+	}
+}

--- a/internal/notify/dingtalk.go
+++ b/internal/notify/dingtalk.go
@@ -1,0 +1,158 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/huangchengsir/pipewright/internal/i18n"
+)
+
+// 钉钉自定义群机器人投递。
+//
+// 配置 = 群机器人 webhook 地址(复用 ChannelConfig.URL)+ 可选加签密钥(走 vault 加密,
+// 与 email SMTP 密码同一套 write-only 密文模式)。报文形状为钉钉 markdown:
+//
+//	{"msgtype":"markdown","markdown":{"title":"<标题>","text":"<markdown 正文>"}}
+//
+// 可选加签:机器人「安全设置」选「加签」时,配置里存密钥。投递按钉钉规范:
+//   - timestamp = 当前毫秒时间戳(字符串)
+//   - stringToSign = "{timestamp}\n{secret}"
+//   - sign = urlEncode( base64( HMAC-SHA256(key=secret, message=stringToSign) ) )
+//   - 把 &timestamp=...&sign=... 附到 webhook URL query 上。
+//
+// 成功判定:钉钉即便参数/签名错误也常回 HTTP 200,但 body 内 errcode!=0,必须解析判定。
+// SSRF 收口与通用 webhook 一致(投递前再校验一次 URL,CheckRedirect 每跳复校)。
+
+// dingtalkMarkdownBody 是钉钉群机器人 markdown 消息体。
+type dingtalkMarkdownBody struct {
+	MsgType  string              `json:"msgtype"` // 恒 "markdown"
+	Markdown dingtalkMarkdownObj `json:"markdown"`
+}
+
+type dingtalkMarkdownObj struct {
+	Title string `json:"title"`
+	Text  string `json:"text"`
+}
+
+// dingtalkResp 是钉钉机器人返回体(只取判定/人读所需字段)。
+type dingtalkResp struct {
+	ErrCode int    `json:"errcode"`
+	ErrMsg  string `json:"errmsg"`
+}
+
+// sendDingtalk 经注入的 *http.Client POST markdown 消息到钉钉群机器人 webhook。
+//   - SSRF 收口:投递前再校验一次 URL(与保存时一致;CheckRedirect 每跳复校)。
+//   - 超时:注入 client.Timeout 兜底 + 另套 8s context。
+//   - 成功判定:HTTP 2xx **且** 返回 JSON errcode==0(钉钉参数错也回 200,必须看 errcode)。
+//   - sealed 非空:解密为加签密钥,按钉钉规范算 timestamp+sign 附到 URL query。
+func (s *service) sendDingtalk(ctx context.Context, ch *Channel, sealed []byte, payload Payload) error {
+	target := ch.Config.URL
+	if !validWebhookURL(target) {
+		return fmt.Errorf("钉钉 webhook 地址不被允许:仅 http/https,且不可指向云元数据/链路本地地址")
+	}
+
+	// 可选加签:机器人「安全设置」选「加签」时,配置里存了密钥(密文)。
+	if len(sealed) > 0 {
+		secret, err := s.openSecret(sealed)
+		if err != nil {
+			return fmt.Errorf("钉钉加签密钥不可用:保险库未配置或密文损坏")
+		}
+		if strings.TrimSpace(secret) != "" {
+			ts := strconv.FormatInt(time.Now().UnixMilli(), 10)
+			sign := dingtalkSign(ts, secret)
+			signed, serr := appendDingtalkSign(target, ts, sign)
+			if serr != nil {
+				return fmt.Errorf("钉钉 webhook 地址非法,无法附加签名")
+			}
+			target = signed
+		}
+	}
+
+	title := strings.TrimSpace(payload.Title)
+	if title == "" {
+		title = i18n.T(payload.Lang, "Pipewright 通知")
+	}
+	body := dingtalkMarkdownBody{
+		MsgType: "markdown",
+		Markdown: dingtalkMarkdownObj{
+			Title: title,
+			Text:  renderMarkdownBody(payload),
+		},
+	}
+
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("钉钉载荷序列化失败")
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, target, bytes.NewReader(raw))
+	if err != nil {
+		return fmt.Errorf("钉钉请求构造失败:地址可能非法")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "Pipewright-notify/1")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return mapWebhookTransportError(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxWebhookRespBytes))
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("钉钉接收端返回非 2xx 状态:HTTP %d", resp.StatusCode)
+	}
+
+	// 钉钉参数/签名错误也回 HTTP 200,必须解析 errcode 才能判定真成功(否则误报成功、群里收不到)。
+	var dr dingtalkResp
+	if err := json.Unmarshal(respBody, &dr); err != nil {
+		return fmt.Errorf("钉钉返回体无法解析,投递结果未知")
+	}
+	if dr.ErrCode != 0 {
+		msg := strings.TrimSpace(dr.ErrMsg)
+		if msg == "" {
+			return fmt.Errorf("钉钉机器人拒收:errcode=%d", dr.ErrCode)
+		}
+		return fmt.Errorf("钉钉机器人拒收:errcode=%d %s", dr.ErrCode, msg)
+	}
+	return nil
+}
+
+// dingtalkSign 按钉钉规范算加签:stringToSign = "{timestamp}\n{secret}",
+// sign = base64( HMAC-SHA256(key=secret, message=stringToSign) )。
+// 注意 key 是密钥本身、message 是 stringToSign(与飞书的 key=stringToSign 相反)。
+// 返回的是尚未 URL 编码的 base64;附到 URL query 时由 url.Values 编码。
+func dingtalkSign(timestamp, secret string) string {
+	stringToSign := timestamp + "\n" + secret
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte(stringToSign))
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+// appendDingtalkSign 把 timestamp + sign 作为 query 参数附到 webhook URL 上(sign 经 URL 编码)。
+func appendDingtalkSign(raw, timestamp, sign string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	q.Set("timestamp", timestamp)
+	q.Set("sign", sign)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -39,11 +39,11 @@ const (
 	TypeWebhook = "webhook"
 	// TypeEmail 邮件:经 SMTP 发信(密码 write-only,vault 加密)。
 	TypeEmail = "email"
-	// TypeWecom 企业微信(本期占位:保存合法,Send 返回 not_implemented)。
+	// TypeWecom 企业微信群机器人:POST markdown 到 URL(群机器人无需签名密钥)。
 	TypeWecom = "wecom"
-	// TypeDingtalk 钉钉(本期占位)。
+	// TypeDingtalk 钉钉自定义群机器人:POST markdown 到 URL(可选加签密钥 write-only,vault 加密)。
 	TypeDingtalk = "dingtalk"
-	// TypeFeishu 飞书(本期占位)。
+	// TypeFeishu 飞书自定义机器人:POST 交互卡片到 URL(可选签名密钥 write-only,vault 加密)。
 	TypeFeishu = "feishu"
 )
 
@@ -455,8 +455,12 @@ func (s *service) deliver(ctx context.Context, ch *Channel, sealed []byte, paylo
 		return s.sendEmail(ctx, ch, sealed, payload)
 	case TypeFeishu:
 		return s.sendFeishu(ctx, ch, sealed, payload)
+	case TypeWecom:
+		return s.sendWecom(ctx, ch, payload)
+	case TypeDingtalk:
+		return s.sendDingtalk(ctx, ch, sealed, payload)
 	default:
-		// wecom / dingtalk:本期占位,人读提示(绝不 panic)。
+		// 未知 type(理论不可达,validType 已收口);人读提示(绝不 panic)。
 		return fmt.Errorf("该渠道类型(%s)暂未实现发送(not_implemented),敬请后续版本支持", ch.Type)
 	}
 }
@@ -559,8 +563,9 @@ func normalizeConfig(t string, c Config) Config {
 			To:       strings.TrimSpace(c.To),
 			Username: strings.TrimSpace(c.Username),
 		}
-	case TypeFeishu:
-		// 飞书自定义机器人:复用 URL 字段存 webhook hook 地址(签名密钥走 vault Secret)。
+	case TypeFeishu, TypeWecom, TypeDingtalk:
+		// 飞书 / 企业微信 / 钉钉群机器人:复用 URL 字段存 webhook hook 地址。
+		// 飞书/钉钉的(可选)签名密钥走 vault Secret;企微群机器人无需密钥。
 		return Config{URL: strings.TrimSpace(c.URL)}
 	default:
 		return Config{}
@@ -583,8 +588,8 @@ func validateConfig(t string, c Config) error {
 			return ErrInvalidConfig
 		}
 		return nil
-	case TypeFeishu:
-		// 飞书机器人 webhook 地址必填,且过同一套 SSRF 收口(拒云元数据/链路本地)。
+	case TypeFeishu, TypeWecom, TypeDingtalk:
+		// 飞书 / 企业微信 / 钉钉机器人 webhook 地址必填,且过同一套 SSRF 收口(拒云元数据/链路本地)。
 		if c.URL == "" {
 			return ErrInvalidConfig
 		}
@@ -593,7 +598,7 @@ func validateConfig(t string, c Config) error {
 		}
 		return nil
 	default:
-		// wecom/dingtalk:本期占位,不强制 config(保存合法)。
+		// 未知 type(理论不可达,validType 已收口);不强制 config。
 		return nil
 	}
 }

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -270,25 +270,6 @@ func TestEmailNoPasswordNoAuth(t *testing.T) {
 	}
 }
 
-// ── not_implemented 占位 type 保存合法、Send 人读 ────────────────────────────
-
-func TestPlaceholderTypesSaveButSendNotImplemented(t *testing.T) {
-	s, _, _ := newSvc(t, http.DefaultClient)
-	for _, ty := range []string{TypeWecom, TypeDingtalk} {
-		ch, err := s.Create(ctx(), CreateInput{Name: ty, Type: ty, Enabled: true})
-		if err != nil {
-			t.Fatalf("占位 type %s 应保存合法: %v", ty, err)
-		}
-		res, err := s.Test(ctx(), ch.ID)
-		if err != nil {
-			t.Fatalf("Test %s: %v", ty, err)
-		}
-		if res.OK || !strings.Contains(res.Error, "not_implemented") {
-			t.Fatalf("%s 应回 not_implemented 人读: %+v", ty, res)
-		}
-	}
-}
-
 func TestInvalidTypeRejected(t *testing.T) {
 	s, _, _ := newSvc(t, http.DefaultClient)
 	if _, err := s.Create(ctx(), CreateInput{Name: "x", Type: "slack"}); err != ErrInvalidType {

--- a/internal/notify/wecom.go
+++ b/internal/notify/wecom.go
@@ -1,0 +1,160 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/huangchengsir/pipewright/internal/i18n"
+)
+
+// 企业微信群机器人投递。
+//
+// 配置 = 群机器人 webhook 地址(复用 ChannelConfig.URL),群机器人本身不需签名密钥
+// (鉴权靠 URL 内置的 key 参数)。报文形状为企微 markdown:
+//
+//	{"msgtype":"markdown","markdown":{"content":"<渲染后的 markdown 正文>"}}
+//
+// 成功判定:与飞书同理,企微即便参数错误也常回 HTTP 200,但 body 内 errcode!=0。
+// 必须解析返回 JSON 的 errcode(0=成功,非 0=失败,人读 errmsg 透出),否则会误报成功、群里收不到。
+// SSRF 收口与通用 webhook 一致(投递前再校验一次 URL,CheckRedirect 每跳复校)。
+
+// wecomMarkdownBody 是企微群机器人 markdown 消息体。
+type wecomMarkdownBody struct {
+	MsgType  string           `json:"msgtype"` // 恒 "markdown"
+	Markdown wecomMarkdownObj `json:"markdown"`
+}
+
+type wecomMarkdownObj struct {
+	Content string `json:"content"`
+}
+
+// wecomResp 是企微机器人返回体(只取判定/人读所需字段)。
+type wecomResp struct {
+	ErrCode int    `json:"errcode"`
+	ErrMsg  string `json:"errmsg"`
+}
+
+// sendWecom 经注入的 *http.Client POST markdown 消息到企微群机器人 webhook。
+//   - SSRF 收口:投递前再校验一次 URL(与保存时一致;CheckRedirect 每跳复校)。
+//   - 超时:注入 client.Timeout 兜底 + 另套 8s context。
+//   - 成功判定:HTTP 2xx **且** 返回 JSON errcode==0(企微参数错也回 200,必须看 errcode)。
+//   - 群机器人无需签名,故不取用 sealed(无敏感字段)。
+func (s *service) sendWecom(ctx context.Context, ch *Channel, payload Payload) error {
+	target := ch.Config.URL
+	if !validWebhookURL(target) {
+		return fmt.Errorf("企业微信 webhook 地址不被允许:仅 http/https,且不可指向云元数据/链路本地地址")
+	}
+
+	body := wecomMarkdownBody{
+		MsgType:  "markdown",
+		Markdown: wecomMarkdownObj{Content: renderMarkdownBody(payload)},
+	}
+
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("企业微信载荷序列化失败")
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, target, bytes.NewReader(raw))
+	if err != nil {
+		return fmt.Errorf("企业微信请求构造失败:地址可能非法")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "Pipewright-notify/1")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return mapWebhookTransportError(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxWebhookRespBytes))
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("企业微信接收端返回非 2xx 状态:HTTP %d", resp.StatusCode)
+	}
+
+	// 企微参数错误也回 HTTP 200,必须解析 errcode 才能判定真成功(否则误报成功、群里收不到)。
+	var wr wecomResp
+	if err := json.Unmarshal(respBody, &wr); err != nil {
+		return fmt.Errorf("企业微信返回体无法解析,投递结果未知")
+	}
+	if wr.ErrCode != 0 {
+		msg := strings.TrimSpace(wr.ErrMsg)
+		if msg == "" {
+			return fmt.Errorf("企业微信机器人拒收:errcode=%d", wr.ErrCode)
+		}
+		return fmt.Errorf("企业微信机器人拒收:errcode=%d %s", wr.ErrCode, msg)
+	}
+	return nil
+}
+
+// ─── 通用 markdown 正文渲染(企微 / 钉钉共用) ───────────────────────────────────
+//
+// 把 Payload(标题 + 正文 + 结构化字段)拼成一段 markdown:
+//   - 标题:一级标题 "# {Title}"。
+//   - 正文:原样一段。
+//   - 字段:按业务顺序(复用 feishuFieldOrder)逐行 "**标签**:值",中文/locale 标签复用 feishuFieldLabel。
+//
+// 钉钉/企微 markdown 语法基本一致,故共用一份渲染。标题另由各自的 title 字段透出。
+func renderMarkdownBody(p Payload) string {
+	var b strings.Builder
+	title := strings.TrimSpace(p.Title)
+	if title == "" {
+		title = i18n.T(p.Lang, "Pipewright 通知")
+	}
+	b.WriteString("# ")
+	b.WriteString(title)
+	b.WriteString("\n")
+
+	if body := strings.TrimSpace(p.Body); body != "" {
+		b.WriteString("\n")
+		b.WriteString(body)
+		b.WriteString("\n")
+	}
+
+	if fields := orderedFieldKeys(p.Fields); len(fields) > 0 {
+		b.WriteString("\n")
+		for _, k := range fields {
+			b.WriteString("**")
+			b.WriteString(feishuFieldLabel(k, p.Lang))
+			b.WriteString("**:")
+			b.WriteString(p.Fields[k])
+			b.WriteString("\n")
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// orderedFieldKeys 返回字段 key 的稳定展示顺序(业务顺序优先,复用 feishuFieldOrder;其余字母序)。
+func orderedFieldKeys(fields map[string]string) []string {
+	if len(fields) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(fields))
+	keys := make([]string, 0, len(fields))
+	for _, k := range feishuFieldOrder {
+		if _, ok := fields[k]; ok {
+			keys = append(keys, k)
+			seen[k] = true
+		}
+	}
+	rest := make([]string, 0)
+	for k := range fields {
+		if !seen[k] {
+			rest = append(rest, k)
+		}
+	}
+	sort.Strings(rest)
+	return append(keys, rest...)
+}

--- a/internal/notify/wecom_dingtalk_test.go
+++ b/internal/notify/wecom_dingtalk_test.go
@@ -1,0 +1,325 @@
+package notify
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// ── 企业微信群机器人 ──────────────────────────────────────────────────────────
+
+// 企微成功:返回 {errcode:0} → Test 成功;POST 体须是 {msgtype:markdown,markdown:{content}}。
+func TestWecomSendSuccess(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		gotBody []byte
+		gotCT   string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		gotBody = body
+		gotCT = r.Header.Get("Content-Type")
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"errcode":0,"errmsg":"ok"}`))
+	}))
+	defer srv.Close()
+
+	s, _, _ := newSvc(t, srv.Client())
+	ch, err := s.Create(ctx(), CreateInput{
+		Name: "ops-wecom", Type: TypeWecom, Enabled: true,
+		Config: Config{URL: srv.URL + "/cgi-bin/webhook/send?key=abc"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	res, err := s.Test(ctx(), ch.ID)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("企微 test 应成功: %+v", res)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !strings.Contains(gotCT, "application/json") {
+		t.Fatalf("Content-Type 应为 json: %q", gotCT)
+	}
+	var sent wecomMarkdownBody
+	if err := json.Unmarshal(gotBody, &sent); err != nil {
+		t.Fatalf("POST 体应为合法 JSON: %s", gotBody)
+	}
+	if sent.MsgType != "markdown" {
+		t.Fatalf("msgtype 应为 markdown,得 %q", sent.MsgType)
+	}
+	if !strings.Contains(sent.Markdown.Content, "# Pipewright 测试通知") {
+		t.Fatalf("markdown content 应含标题: %q", sent.Markdown.Content)
+	}
+	if !strings.Contains(sent.Markdown.Content, "测试通知") {
+		t.Fatalf("markdown content 应含正文: %q", sent.Markdown.Content)
+	}
+	// 测试载荷字段(source/kind)应渲染入正文。
+	if !strings.Contains(sent.Markdown.Content, "Pipewright") {
+		t.Fatalf("markdown content 应含字段值: %q", sent.Markdown.Content)
+	}
+}
+
+// 关键回归守卫:企微参数错误也回 HTTP 200,但 body 内 errcode!=0 → 必须判失败。
+func TestWecomRejectedHTTP200ButErrcodeNonZero(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK) // HTTP 200
+		_, _ = w.Write([]byte(`{"errcode":93000,"errmsg":"invalid webhook url"}`))
+	}))
+	defer srv.Close()
+
+	s, _, _ := newSvc(t, srv.Client())
+	ch, _ := s.Create(ctx(), CreateInput{
+		Name: "bad", Type: TypeWecom, Enabled: true,
+		Config: Config{URL: srv.URL + "/hook"},
+	})
+	res, err := s.Test(ctx(), ch.ID)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	if res.OK {
+		t.Fatalf("企微 errcode!=0 应判失败(不可因 HTTP 200 误报成功)")
+	}
+	if !strings.Contains(res.Error, "93000") || !strings.Contains(res.Error, "invalid webhook url") {
+		t.Fatalf("错误应人读含 errcode 与 errmsg: %q", res.Error)
+	}
+}
+
+// 企微 webhook 地址必填。
+func TestWecomRequiresURL(t *testing.T) {
+	s, _, _ := newSvc(t, http.DefaultClient)
+	if _, err := s.Create(ctx(), CreateInput{Name: "x", Type: TypeWecom, Enabled: true}); err != ErrInvalidConfig {
+		t.Fatalf("企微缺 URL 应 ErrInvalidConfig,得: %v", err)
+	}
+}
+
+// 企微地址同样过 SSRF 收口(拒云元数据)。
+func TestWecomSSRFBlocked(t *testing.T) {
+	s, _, _ := newSvc(t, http.DefaultClient)
+	_, err := s.Create(ctx(), CreateInput{
+		Name: "evil", Type: TypeWecom, Enabled: true,
+		Config: Config{URL: "http://169.254.169.254/hook"},
+	})
+	if err != ErrSSRFBlocked {
+		t.Fatalf("企微 169.254 应被 SSRF 拒绝,得: %v", err)
+	}
+}
+
+// ── 钉钉自定义群机器人 ────────────────────────────────────────────────────────
+
+// 钉钉成功(无加签):返回 {errcode:0} → Test 成功;POST 体须是 {msgtype:markdown,markdown:{title,text}};
+// 未配密钥不应带 timestamp/sign query。
+func TestDingtalkSendSuccessNoSign(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		gotBody  []byte
+		gotQuery string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		gotBody = body
+		gotQuery = r.URL.RawQuery
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"errcode":0,"errmsg":"ok"}`))
+	}))
+	defer srv.Close()
+
+	s, _, _ := newSvc(t, srv.Client())
+	ch, err := s.Create(ctx(), CreateInput{
+		Name: "ops-ding", Type: TypeDingtalk, Enabled: true,
+		Config: Config{URL: srv.URL + "/robot/send?access_token=abc"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	res, err := s.Test(ctx(), ch.ID)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("钉钉 test 应成功: %+v", res)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	var sent dingtalkMarkdownBody
+	if err := json.Unmarshal(gotBody, &sent); err != nil {
+		t.Fatalf("POST 体应为合法 JSON: %s", gotBody)
+	}
+	if sent.MsgType != "markdown" {
+		t.Fatalf("msgtype 应为 markdown,得 %q", sent.MsgType)
+	}
+	if sent.Markdown.Title != "Pipewright 测试通知" {
+		t.Fatalf("钉钉 markdown.title 应为测试标题,得 %q", sent.Markdown.Title)
+	}
+	if !strings.Contains(sent.Markdown.Text, "# Pipewright 测试通知") {
+		t.Fatalf("钉钉 markdown.text 应含标题: %q", sent.Markdown.Text)
+	}
+	// 未配密钥:不应携带 timestamp/sign(原 query access_token 保留)。
+	if strings.Contains(gotQuery, "timestamp=") || strings.Contains(gotQuery, "sign=") {
+		t.Fatalf("未配密钥不应带 timestamp/sign,query=%q", gotQuery)
+	}
+	if !strings.Contains(gotQuery, "access_token=abc") {
+		t.Fatalf("原有 query 应保留,query=%q", gotQuery)
+	}
+}
+
+// 关键回归守卫:钉钉参数/签名错误也回 HTTP 200,但 body 内 errcode!=0 → 必须判失败。
+func TestDingtalkRejectedHTTP200ButErrcodeNonZero(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK) // HTTP 200
+		_, _ = w.Write([]byte(`{"errcode":310000,"errmsg":"sign not match"}`))
+	}))
+	defer srv.Close()
+
+	s, _, _ := newSvc(t, srv.Client())
+	ch, _ := s.Create(ctx(), CreateInput{
+		Name: "bad", Type: TypeDingtalk, Enabled: true,
+		Config: Config{URL: srv.URL + "/hook"},
+	})
+	res, err := s.Test(ctx(), ch.ID)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	if res.OK {
+		t.Fatalf("钉钉 errcode!=0 应判失败(不可因 HTTP 200 误报成功)")
+	}
+	if !strings.Contains(res.Error, "310000") || !strings.Contains(res.Error, "sign not match") {
+		t.Fatalf("错误应人读含 errcode 与 errmsg: %q", res.Error)
+	}
+}
+
+// 配了加签密钥 → URL query 带 timestamp + sign,且 sign 与钉钉规范算法一致。
+func TestDingtalkSignsWhenSecretConfigured(t *testing.T) {
+	var (
+		mu        sync.Mutex
+		gotTS     string
+		gotSign   string
+		gotAccess string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotTS = r.URL.Query().Get("timestamp")
+		gotSign = r.URL.Query().Get("sign")
+		gotAccess = r.URL.Query().Get("access_token")
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"errcode":0,"errmsg":"ok"}`))
+	}))
+	defer srv.Close()
+
+	const secret = "SECabc123signsecret"
+	s, _, _ := newSvc(t, srv.Client())
+	ch, err := s.Create(ctx(), CreateInput{
+		Name: "signed-ding", Type: TypeDingtalk, Enabled: true,
+		Config: Config{URL: srv.URL + "/robot/send?access_token=tok"}, Secret: secret,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	res, err := s.Test(ctx(), ch.ID)
+	if err != nil || !res.OK {
+		t.Fatalf("带加签应成功: %+v err=%v", res, err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotTS == "" || gotSign == "" {
+		t.Fatalf("配密钥应带 timestamp+sign query: ts=%q sign=%q", gotTS, gotSign)
+	}
+	if gotAccess != "tok" {
+		t.Fatalf("原有 access_token query 应保留,得 %q", gotAccess)
+	}
+	// 服务端从 URL 解码得到的 sign 必须等于按相同 timestamp + secret 重算的规范签名。
+	want := dingtalkSign(gotTS, secret)
+	if gotSign != want {
+		t.Fatalf("sign 与钉钉规范算法不一致: got %q want %q", gotSign, want)
+	}
+}
+
+// 钉钉缺密钥不影响保存(密钥可选);加签密钥 write-only —— HasSecret 反映存在但不回明文。
+func TestDingtalkSecretWriteOnly(t *testing.T) {
+	s, _, _ := newSvc(t, http.DefaultClient)
+	ch, err := s.Create(ctx(), CreateInput{
+		Name: "ding", Type: TypeDingtalk, Enabled: true,
+		Config: Config{URL: "https://oapi.dingtalk.com/robot/send?access_token=tok"},
+		Secret: "topsecret",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !ch.HasSecret {
+		t.Fatalf("配了密钥 HasSecret 应为 true")
+	}
+	got, err := s.Get(ctx(), ch.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.HasSecret {
+		t.Fatalf("Get 视图 HasSecret 应为 true")
+	}
+	// 视图结构里绝无密钥明文字段(Config 不含 secret;仅 HasSecret 布尔)。
+	blob, _ := json.Marshal(got)
+	if strings.Contains(string(blob), "topsecret") {
+		t.Fatalf("渠道视图绝不应含密钥明文: %s", blob)
+	}
+}
+
+// 钉钉规范签名:key=secret、message="{ts}\n{secret}"(与飞书的 key=stringToSign 相反)。
+func TestDingtalkSignAlgorithm(t *testing.T) {
+	// 固定输入断言确定性输出(防算法被误改回飞书式)。
+	got := dingtalkSign("1600000000000", "thesecret")
+	// 与飞书签名(key/message 互换)对比应不同 —— 守卫不可混淆两套算法。
+	feishu, _ := feishuSign("1600000000000", "thesecret")
+	if got == feishu {
+		t.Fatalf("钉钉签名不应等于飞书签名(key/message 互换): %q", got)
+	}
+	if got == "" {
+		t.Fatalf("签名不应为空")
+	}
+}
+
+// 通用 markdown 渲染:标题一级标题 + 正文 + 字段按业务顺序逐行(中文标签)。
+func TestRenderMarkdownBody(t *testing.T) {
+	md := renderMarkdownBody(Payload{
+		Title:  "部署成功",
+		Body:   "aireboot @ staging",
+		Fields: map[string]string{"status": "success", "branch": "main", "event": "deploy_succeeded"},
+		Lang:   "zh-CN",
+	})
+	if !strings.HasPrefix(md, "# 部署成功") {
+		t.Fatalf("应以一级标题起: %q", md)
+	}
+	if !strings.Contains(md, "aireboot @ staging") {
+		t.Fatalf("应含正文: %q", md)
+	}
+	for _, want := range []string{"**分支**:main", "**状态**:success", "**事件**:deploy_succeeded"} {
+		if !strings.Contains(md, want) {
+			t.Fatalf("应含字段行 %q,得:\n%s", want, md)
+		}
+	}
+	// 业务顺序:分支在状态前、状态在事件前。
+	if strings.Index(md, "**分支**") > strings.Index(md, "**状态**") {
+		t.Fatalf("业务顺序:分支应在状态前:\n%s", md)
+	}
+	if strings.Index(md, "**状态**") > strings.Index(md, "**事件**") {
+		t.Fatalf("业务顺序:状态应在事件前:\n%s", md)
+	}
+	// 空载荷:仍产默认标题,不 panic。
+	if !strings.HasPrefix(renderMarkdownBody(Payload{}), "# Pipewright 通知") {
+		t.Fatalf("空载荷应产默认标题")
+	}
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -63,8 +63,11 @@ type Project struct {
 	// PacEnabled 是「流水线即代码」开关(GitOps · FR-8-12):开启后运行时按运行分支读仓库根
 	// .pipewright.yml 驱动该 run(缺失/非法回退库内配置)。默认 false。
 	PacEnabled bool
-	CreatedAt  time.Time
-	UpdatedAt  time.Time
+	// PRStatusEnabled 是「PR 状态检查」开关(Story 8-9 / FR-8-9):开启后 run 终态据项目仓库识别
+	// GitHub/Gitee,经项目凭据回写该 commit 的提交状态(PR 检查)。默认 false。
+	PRStatusEnabled bool
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
 }
 
 // CreateInput 是创建项目的入参。
@@ -82,6 +85,8 @@ type UpdateInput struct {
 	CredentialID  *string
 	// PacEnabled 切换「流水线即代码」开关;nil 表示不修改。
 	PacEnabled *bool
+	// PRStatusEnabled 切换「PR 状态检查」开关;nil 表示不修改。
+	PRStatusEnabled *bool
 }
 
 // TestCloneResult 是测试连接的结果(成功时携探测到的默认分支)。
@@ -251,7 +256,7 @@ func (s *service) ListPaged(ctx context.Context, page, pageSize int) (*ListResul
 	offset := (page - 1) * pageSize
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT p.id, p.name, p.repo_url, p.default_branch, p.credential_id,
-		        COALESCE(c.name, ''), p.pac_enabled, p.created_at, p.updated_at
+		        COALESCE(c.name, ''), p.pac_enabled, p.pr_status_enabled, p.created_at, p.updated_at
 		 FROM projects p
 		 LEFT JOIN credentials c ON c.id = p.credential_id
 		 ORDER BY p.created_at DESC, p.id
@@ -280,7 +285,7 @@ func (s *service) ListPaged(ctx context.Context, page, pageSize int) (*ListResul
 func (s *service) Get(ctx context.Context, id string) (*Project, error) {
 	row := s.db.QueryRowContext(ctx,
 		`SELECT p.id, p.name, p.repo_url, p.default_branch, p.credential_id,
-		        COALESCE(c.name, ''), p.pac_enabled, p.created_at, p.updated_at
+		        COALESCE(c.name, ''), p.pac_enabled, p.pr_status_enabled, p.created_at, p.updated_at
 		 FROM projects p
 		 LEFT JOIN credentials c ON c.id = p.credential_id
 		 WHERE p.id = ?`, id,
@@ -298,10 +303,10 @@ func (s *service) Get(ctx context.Context, id string) (*Project, error) {
 func (s *service) Update(ctx context.Context, id string, in UpdateInput) (*Project, error) {
 	// 先取当前行(需 repo_url + credential_id 以便在改绑凭据时重做校验)。
 	var name, repoURL, defaultBranch, credentialID string
-	var pacInt int
+	var pacInt, prStatusInt int
 	err := s.db.QueryRowContext(ctx,
-		`SELECT name, repo_url, default_branch, credential_id, pac_enabled FROM projects WHERE id = ?`, id,
-	).Scan(&name, &repoURL, &defaultBranch, &credentialID, &pacInt)
+		`SELECT name, repo_url, default_branch, credential_id, pac_enabled, pr_status_enabled FROM projects WHERE id = ?`, id,
+	).Scan(&name, &repoURL, &defaultBranch, &credentialID, &pacInt, &prStatusInt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
@@ -309,6 +314,7 @@ func (s *service) Update(ctx context.Context, id string, in UpdateInput) (*Proje
 		return nil, fmt.Errorf("project: load: %w", err)
 	}
 	pacEnabled := pacInt != 0
+	prStatusEnabled := prStatusInt != 0
 
 	if in.Name != nil {
 		if *in.Name == "" {
@@ -332,15 +338,22 @@ func (s *service) Update(ctx context.Context, id string, in UpdateInput) (*Proje
 	if in.PacEnabled != nil {
 		pacEnabled = *in.PacEnabled
 	}
+	if in.PRStatusEnabled != nil {
+		prStatusEnabled = *in.PRStatusEnabled
+	}
 
 	pacInt = 0
 	if pacEnabled {
 		pacInt = 1
 	}
+	prStatusInt = 0
+	if prStatusEnabled {
+		prStatusInt = 1
+	}
 	nowStr := time.Now().UTC().Format(time.RFC3339)
 	_, err = s.db.ExecContext(ctx,
-		`UPDATE projects SET name = ?, default_branch = ?, credential_id = ?, pac_enabled = ?, updated_at = ? WHERE id = ?`,
-		name, defaultBranch, credentialID, pacInt, nowStr, id,
+		`UPDATE projects SET name = ?, default_branch = ?, credential_id = ?, pac_enabled = ?, pr_status_enabled = ?, updated_at = ? WHERE id = ?`,
+		name, defaultBranch, credentialID, pacInt, prStatusInt, nowStr, id,
 	)
 	if err != nil {
 		if isForeignKeyErr(err) {
@@ -398,14 +411,15 @@ type scanner interface {
 func scanProject(sc scanner) (*Project, error) {
 	var p Project
 	var createdStr, updatedStr string
-	var pacInt int
+	var pacInt, prStatusInt int
 	if err := sc.Scan(
 		&p.ID, &p.Name, &p.RepoURL, &p.DefaultBranch, &p.CredentialID,
-		&p.CredentialName, &pacInt, &createdStr, &updatedStr,
+		&p.CredentialName, &pacInt, &prStatusInt, &createdStr, &updatedStr,
 	); err != nil {
 		return nil, err
 	}
 	p.PacEnabled = pacInt != 0
+	p.PRStatusEnabled = prStatusInt != 0
 	created, err := time.Parse(time.RFC3339, createdStr)
 	if err != nil {
 		return nil, fmt.Errorf("project: parse created_at: %w", err)

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -194,6 +194,60 @@ func TestUpdateRename(t *testing.T) {
 	}
 }
 
+// TestUpdatePRStatusEnabledRoundTrip 断言 pr_status_enabled 经 Update 设置后能从 Get 读回,
+// 且默认 false、可关回、与无关字段更新互不串扰。
+func TestUpdatePRStatusEnabledRoundTrip(t *testing.T) {
+	db := testDB(t)
+	v := vault.New(db, testMasterKey())
+	svc := New(db, v, &stubProber{branch: "main"})
+	credID := newCred(t, v, "tok")
+	p, err := svc.Create(context.Background(), CreateInput{Name: "x", RepoURL: "https://gitee.com/a/b.git", CredentialID: credID})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// 默认应为 false。
+	if p.PRStatusEnabled {
+		t.Fatalf("新建项目 PRStatusEnabled 应默认 false, got true")
+	}
+
+	// 开启 → Get 读回应为 true。
+	on := true
+	updated, err := svc.Update(context.Background(), p.ID, UpdateInput{PRStatusEnabled: &on})
+	if err != nil {
+		t.Fatalf("Update on: %v", err)
+	}
+	if !updated.PRStatusEnabled {
+		t.Fatalf("Update 后返回的 PRStatusEnabled 应为 true")
+	}
+	got, err := svc.Get(context.Background(), p.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.PRStatusEnabled {
+		t.Fatalf("Get 读回的 PRStatusEnabled 应为 true(持久化失败)")
+	}
+
+	// 更新无关字段(改名)不应影响已开启的 PR 状态开关。
+	newName := "renamed"
+	updated, err = svc.Update(context.Background(), p.ID, UpdateInput{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update rename: %v", err)
+	}
+	if !updated.PRStatusEnabled {
+		t.Fatalf("更新无关字段不应清除 PRStatusEnabled,got false")
+	}
+
+	// 关回 → false。
+	off := false
+	updated, err = svc.Update(context.Background(), p.ID, UpdateInput{PRStatusEnabled: &off})
+	if err != nil {
+		t.Fatalf("Update off: %v", err)
+	}
+	if updated.PRStatusEnabled {
+		t.Fatalf("关闭后 PRStatusEnabled 应为 false")
+	}
+}
+
 func TestUpdateRebindCredentialReprobes(t *testing.T) {
 	db := testDB(t)
 	v := vault.New(db, testMasterKey())

--- a/internal/prstatus/reporter.go
+++ b/internal/prstatus/reporter.go
@@ -16,6 +16,17 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
+)
+
+// userAgent 是回写请求的 User-Agent(GitHub API 要求带 UA;显式标识本服务)。
+const userAgent = "Pipewright"
+
+// 默认重试参数:提交状态回写是 best-effort,瞬时失败(网络抖动 / 5xx / 429 / 偶发 422)
+// 重试几次显著提升落地率;非瞬时(4xx 鉴权/校验,如 401/404)不重试,快速失败。
+const (
+	defaultMaxAttempts = 3
+	defaultBackoff     = 500 * time.Millisecond
 )
 
 // Platform 是受支持的代码平台。
@@ -85,6 +96,8 @@ type Reporter struct {
 	client        *http.Client
 	githubAPIBase string
 	giteeAPIBase  string
+	maxAttempts   int
+	backoff       time.Duration
 }
 
 // NewReporter 构造 Reporter。client 为 nil 用默认;API base 缺省指向真实平台,测试可经 With* 覆盖。
@@ -96,7 +109,25 @@ func NewReporter(client *http.Client) *Reporter {
 		client:        client,
 		githubAPIBase: "https://api.github.com",
 		giteeAPIBase:  "https://gitee.com/api/v5",
+		maxAttempts:   defaultMaxAttempts,
+		backoff:       defaultBackoff,
 	}
+}
+
+// WithRetry 覆盖重试次数与退避间隔(attempts<1 归一为 1;测试常用 backoff=0 免等待)。
+func (r *Reporter) WithRetry(attempts int, backoff time.Duration) *Reporter {
+	if attempts < 1 {
+		attempts = 1
+	}
+	r.maxAttempts = attempts
+	r.backoff = backoff
+	return r
+}
+
+// isTransient 判定 HTTP 状态码是否值得重试:429(限流)、5xx(服务端)、422(经验上 GitHub
+// 偶发瞬时校验失败,见真机测试)。401/403/404 等非瞬时 → 不重试,快速失败。
+func isTransient(code int) bool {
+	return code == http.StatusTooManyRequests || code >= 500 || code == http.StatusUnprocessableEntity
 }
 
 // WithBaseURLs 覆盖平台 API base(测试注入 stub server)。
@@ -142,25 +173,52 @@ func (r *Reporter) Report(ctx context.Context, t Target, sha, state, description
 	if err != nil {
 		return fmt.Errorf("prstatus: marshal: %w", err)
 	}
-	req, err = http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(buf))
-	if err != nil {
-		return fmt.Errorf("prstatus: new request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "token "+token)
-	if t.Platform == GitHub {
-		req.Header.Set("Accept", "application/vnd.github+json")
-	}
 
-	resp, err := r.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("prstatus: post status: %w", err)
+	// best-effort 重试:瞬时失败(网络/429/5xx/422)退避后重试,提升偶发抖动下的落地率;
+	// 非瞬时失败(鉴权/校验)立即返回。每次都用新 reader 重建请求(body 可重读)。
+	attempts := r.maxAttempts
+	if attempts < 1 {
+		attempts = 1
 	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("prstatus: %s status post got HTTP %d", t.Platform, resp.StatusCode)
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		req, err = http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(buf))
+		if err != nil {
+			return fmt.Errorf("prstatus: new request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "token "+token)
+		req.Header.Set("User-Agent", userAgent)
+		if t.Platform == GitHub {
+			req.Header.Set("Accept", "application/vnd.github+json")
+		}
+
+		resp, derr := r.client.Do(req)
+		if derr != nil {
+			lastErr = fmt.Errorf("prstatus: post status: %w", derr) // 网络错误:可重试
+		} else {
+			code := resp.StatusCode
+			_ = resp.Body.Close()
+			if code >= 200 && code < 300 {
+				return nil
+			}
+			lastErr = fmt.Errorf("prstatus: %s status post got HTTP %d", t.Platform, code)
+			if !isTransient(code) {
+				return lastErr // 非瞬时:快速失败,不重试
+			}
+		}
+		// 瞬时失败且仍有重试次数 → 退避后再试(响应 ctx 取消)。
+		if attempt < attempts {
+			if r.backoff > 0 {
+				select {
+				case <-time.After(r.backoff):
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+		}
 	}
-	return nil
+	return lastErr
 }
 
 // StateForRunStatus 把运行终态映射为提交状态(success→success,其余终态→failure)。

--- a/internal/prstatus/reporter_test.go
+++ b/internal/prstatus/reporter_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -126,6 +127,73 @@ func TestReportNon2xxErrors(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "bad") {
 		t.Error("错误信息不应含 token")
+	}
+}
+
+func TestReportRetriesTransientThenSucceeds(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&hits, 1) < 3 { // 前两次瞬时 5xx,第三次成功
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+	rep := NewReporter(srv.Client()).WithBaseURLs(srv.URL, "").WithRetry(3, 0)
+	if err := rep.Report(context.Background(), Target{Platform: GitHub, Owner: "o", Repo: "r"}, "sha", StateSuccess, "", "", "tok"); err != nil {
+		t.Fatalf("瞬时失败后应重试成功, got %v", err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 3 {
+		t.Fatalf("应重试到第 3 次成功, hits=%d", got)
+	}
+}
+
+func TestReportRetriesExhaustOn422(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusUnprocessableEntity)
+	}))
+	defer srv.Close()
+	rep := NewReporter(srv.Client()).WithBaseURLs(srv.URL, "").WithRetry(3, 0)
+	if err := rep.Report(context.Background(), Target{Platform: GitHub, Owner: "o", Repo: "r"}, "sha", StateSuccess, "", "", "tok"); err == nil {
+		t.Fatal("持续 422 应最终返回错误")
+	}
+	if got := atomic.LoadInt32(&hits); got != 3 {
+		t.Fatalf("422 瞬时类应重试满 3 次, hits=%d", got)
+	}
+}
+
+func TestReportNoRetryOnAuthError(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	rep := NewReporter(srv.Client()).WithBaseURLs(srv.URL, "").WithRetry(3, 0)
+	if err := rep.Report(context.Background(), Target{Platform: GitHub, Owner: "o", Repo: "r"}, "sha", StateSuccess, "", "", "tok"); err == nil {
+		t.Fatal("401 应返回错误")
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("401 非瞬时不应重试, hits=%d", got)
+	}
+}
+
+func TestReportSendsUserAgent(t *testing.T) {
+	var gotUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		gotUA = req.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+	rep := NewReporter(srv.Client()).WithBaseURLs(srv.URL, "")
+	if err := rep.Report(context.Background(), Target{Platform: GitHub, Owner: "o", Repo: "r"}, "sha", StateSuccess, "", "", "tok"); err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	if gotUA != "Pipewright" {
+		t.Fatalf("User-Agent = %q, want Pipewright", gotUA)
 	}
 }
 

--- a/internal/store/migrations/mysql/0041_project_pr_status_enabled.sql
+++ b/internal/store/migrations/mysql/0041_project_pr_status_enabled.sql
@@ -1,0 +1,3 @@
+-- 0041 projects.pr_status_enabled(MySQL):每项目「PR 状态检查」开关(Story 8-9 / FR-8-9 产品化)。
+-- 开启后 run 终态据项目仓库识别 GitHub/Gitee,经项目凭据回写该 commit 的提交状态(PR 检查)。默认 0。
+ALTER TABLE projects ADD COLUMN pr_status_enabled TINYINT NOT NULL DEFAULT 0;

--- a/internal/store/migrations/sqlite/0041_project_pr_status_enabled.sql
+++ b/internal/store/migrations/sqlite/0041_project_pr_status_enabled.sql
@@ -1,0 +1,5 @@
+-- 0041 projects.pr_status_enabled:每项目「PR 状态检查」开关(Story 8-9 / FR-8-9 产品化)。
+-- 开启后,run 终态时据项目仓库识别 GitHub/Gitee,经项目凭据回写该 commit 的提交状态(PR 检查)。
+-- 默认 0(关闭)→ 老项目行为不变,不会意外往真实仓库回写。历史全局 env PIPEWRIGHT_PR_STATUS=1
+-- 仍可全局强开(无视每项目开关)。best-effort:失败仅记日志,绝不影响运行终态。
+ALTER TABLE projects ADD COLUMN pr_status_enabled INTEGER NOT NULL DEFAULT 0;

--- a/internal/storetest/dialect_integration_test.go
+++ b/internal/storetest/dialect_integration_test.go
@@ -19,8 +19,8 @@ func TestMigrationsApplied(t *testing.T) {
 		if err := st.DB.QueryRowContext(ctx, `SELECT COUNT(1) FROM schema_migrations`).Scan(&n); err != nil {
 			t.Fatalf("count migrations: %v", err)
 		}
-		if n != 39 {
-			t.Fatalf("应用迁移数 = %d, 期望 39", n)
+		if n != 40 {
+			t.Fatalf("应用迁移数 = %d, 期望 40", n)
 		}
 		// 核心领域表存在(随手验一张)。
 		if _, err := st.DB.ExecContext(ctx, `SELECT 1 FROM audit_log WHERE 1=0`); err != nil {

--- a/web/src/api/projects.ts
+++ b/web/src/api/projects.ts
@@ -36,6 +36,12 @@ export interface Project {
    * to the stored UI pipeline if the file is missing or invalid). FR-8-12.
    */
   pacEnabled: boolean
+  /**
+   * PR status checks toggle (Story 8-9 / FR-8-9). When true, on a run reaching a
+   * terminal status Pipewright detects the repo platform (GitHub/Gitee) and writes
+   * back the commit status (PR check) using the project credential. Best-effort.
+   */
+  prStatusEnabled: boolean
   /** null until pipeline runs exist (Story 2.x). */
   lastRunStatus: RunStatus | null
   /** Empty until servers are bound (Story 2.x). */
@@ -58,6 +64,8 @@ export interface UpdateProjectInput {
   credentialId?: string
   /** Toggle pipeline-as-code (GitOps) for this project. */
   pacEnabled?: boolean
+  /** Toggle PR status checks (commit status writeback) for this project. */
+  prStatusEnabled?: boolean
 }
 
 export interface TestCloneResult {

--- a/web/src/i18n/locales/de/projectPipeline.ts
+++ b/web/src/i18n/locales/de/projectPipeline.ts
@@ -17,6 +17,12 @@ export default {
   pacOffHint: 'Wenn aktiviert, liest jeder Lauf .pipewright.yml aus dem Repository-Stamm im Lauf-Branch (Rückfall auf diese Konfiguration, wenn fehlend oder ungültig).',
   pacToggleFailed: 'Umschalten fehlgeschlagen. Bitte erneut versuchen.',
 
+  // ─── PR-Statusprüfungen (Commit-Status-Rückschreibung · Story 8-9 / FR-8-9) ─
+  prStatusTitle: 'PR-Statusprüfungen',
+  prStatusOnHint: 'Wenn ein Lauf endet, erkennt Pipewright die Repository-Plattform (GitHub/Gitee) und schreibt den Erfolgs-/Fehlerstatus des Commits mit den Projektanmeldedaten als PR-Prüfung zurück (nach bestem Bemühen; Fehler beeinflussen den Lauf nie).',
+  prStatusOffHint: 'Wenn aktiviert, erkennt das Ende eines Laufs die Repository-Plattform (GitHub/Gitee) und schreibt den Commit-Status mit den Projektanmeldedaten als PR-Prüfung zurück (nach bestem Bemühen).',
+  prStatusToggleFailed: 'Umschalten fehlgeschlagen. Bitte erneut versuchen.',
+
   // ─── Repository-Konfiguration vorschauen (GitOps · .pipewright.yml an einer Ref abrufen & prüfen) ──
   pacPreviewBtn: 'Repo-Konfig vorschauen',
   pacPreviewTitle: 'Repository-Konfiguration vorschauen',

--- a/web/src/i18n/locales/de/settingsNotifications.ts
+++ b/web/src/i18n/locales/de/settingsNotifications.ts
@@ -9,7 +9,9 @@ export default {
   typeFeishuLabel: 'Lark',
   typeFeishuDesc: 'Benutzerdefinierter Bot',
   typeWecomLabel: 'WeCom',
+  typeWecomDesc: 'Gruppen-Bot',
   typeDingtalkLabel: 'DingTalk',
+  typeDingtalkDesc: 'Gruppen-Bot',
   comingSoon: 'Demnächst verfügbar',
   notImplemented: 'Versand nicht implementiert',
 
@@ -38,6 +40,18 @@ export default {
   signSecret: 'Signaturschlüssel (optional)',
   signSecretHint: 'Nur ausfüllen, wenn beim Bot die „Signaturprüfung“ aktiviert ist; wird nach dem Speichern nie erneut angezeigt',
   signSecretPlaceholder: 'Leer lassen, wenn beim Bot die Signaturprüfung nicht aktiviert ist',
+
+  wecomUrl: 'Webhook-URL des WeCom-Bots',
+  wecomUrlHint:
+    'Webhook-URL der WeCom-Gruppe unter „Gruppeneinstellungen → Gruppen-Bots → Bot hinzufügen“ (qyapi.weixin.qq.com/cgi-bin/webhook/send?key=…)',
+
+  dingtalkUrl: 'Webhook-URL des DingTalk-Bots',
+  dingtalkUrlHint:
+    'Webhook-URL der DingTalk-Gruppe unter „Gruppeneinstellungen → Gruppenassistent → Bot hinzufügen → Benutzerdefiniert“ (oapi.dingtalk.com/robot/send?access_token=…)',
+  dingtalkSignSecret: 'Signaturschlüssel (optional)',
+  dingtalkSignSecretHint: 'Nur ausfüllen, wenn in den „Sicherheitseinstellungen“ des Bots „Signiert“ gewählt ist; wird nach dem Speichern nie erneut angezeigt',
+  dingtalkSignSecretPlaceholder: 'Leer lassen, wenn der Bot „Signiert“ nicht verwendet',
+
   secretStoredHint: 'Konfiguriert ••••(leer lassen zum Beibehalten)',
   secretStoredPlaceholder: 'Konfiguriert ••••(leer = unverändert)',
 
@@ -74,6 +88,8 @@ export default {
   valNameRequired: 'Bitte geben Sie einen Kanalnamen ein',
   valWebhookUrlRequired: 'Bitte geben Sie die Webhook-URL ein',
   valFeishuUrlRequired: 'Bitte geben Sie die Webhook-URL des Lark-Bots ein',
+  valWecomUrlRequired: 'Bitte geben Sie die Webhook-URL des WeCom-Bots ein',
+  valDingtalkUrlRequired: 'Bitte geben Sie die Webhook-URL des DingTalk-Bots ein',
   valSmtpHostRequired: 'Bitte geben Sie den SMTP-Host ein',
   valPortInvalid: 'Bitte geben Sie einen gültigen Port ein',
   valFromRequired: 'Bitte geben Sie den Absender ein',

--- a/web/src/i18n/locales/en/projectPipeline.ts
+++ b/web/src/i18n/locales/en/projectPipeline.ts
@@ -17,6 +17,12 @@ export default {
   pacOffHint: 'When on, each run reads .pipewright.yml from the repo root on the run branch (falling back to this config if missing or invalid).',
   pacToggleFailed: 'Failed to toggle. Please try again.',
 
+  // ─── PR status checks (commit status writeback · Story 8-9 / FR-8-9) ─
+  prStatusTitle: 'PR status checks',
+  prStatusOnHint: 'When a run finishes, Pipewright detects the repo platform (GitHub/Gitee) and writes the commit success/failure back as a PR check using the project credential (best-effort; failures never affect the run).',
+  prStatusOffHint: 'When on, finishing a run detects the repo platform (GitHub/Gitee) and writes the commit status back as a PR check using the project credential (best-effort).',
+  prStatusToggleFailed: 'Failed to toggle. Please try again.',
+
   // ─── Preview repo config (GitOps · fetch & validate .pipewright.yml at a ref) ───
   pacPreviewBtn: 'Preview repo config',
   pacPreviewTitle: 'Preview repo config',

--- a/web/src/i18n/locales/en/settingsNotifications.ts
+++ b/web/src/i18n/locales/en/settingsNotifications.ts
@@ -9,7 +9,9 @@ export default {
   typeFeishuLabel: 'Lark',
   typeFeishuDesc: 'Custom bot',
   typeWecomLabel: 'WeCom',
+  typeWecomDesc: 'Group bot',
   typeDingtalkLabel: 'DingTalk',
+  typeDingtalkDesc: 'Group bot',
   comingSoon: 'Coming soon',
   notImplemented: 'Sending not implemented',
 
@@ -38,6 +40,18 @@ export default {
   signSecret: 'Sign Secret (optional)',
   signSecretHint: 'Fill in only when the bot has “signature verification” enabled; never echoed once saved',
   signSecretPlaceholder: 'Leave blank if signature verification is off',
+
+  wecomUrl: 'WeCom Bot Webhook URL',
+  wecomUrlHint:
+    'Webhook URL from the WeCom group “Group settings → Group bots → Add bot” (qyapi.weixin.qq.com/cgi-bin/webhook/send?key=…)',
+
+  dingtalkUrl: 'DingTalk Bot Webhook URL',
+  dingtalkUrlHint:
+    'Webhook URL from the DingTalk group “Group settings → Group assistant → Add bot → Custom” (oapi.dingtalk.com/robot/send?access_token=…)',
+  dingtalkSignSecret: 'Sign Secret (optional)',
+  dingtalkSignSecretHint: 'Fill in only when the bot’s “Security settings” use “Signed”; never echoed once saved',
+  dingtalkSignSecretPlaceholder: 'Leave blank if the bot does not use “Signed”',
+
   secretStoredHint: 'Stored ••••(leave blank to keep)',
   secretStoredPlaceholder: 'Stored ••••(blank = unchanged)',
 
@@ -74,6 +88,8 @@ export default {
   valNameRequired: 'Please enter a channel name',
   valWebhookUrlRequired: 'Please enter the Webhook URL',
   valFeishuUrlRequired: 'Please enter the Lark bot Webhook URL',
+  valWecomUrlRequired: 'Please enter the WeCom bot Webhook URL',
+  valDingtalkUrlRequired: 'Please enter the DingTalk bot Webhook URL',
   valSmtpHostRequired: 'Please enter the SMTP host',
   valPortInvalid: 'Please enter a valid port',
   valFromRequired: 'Please enter the From address',

--- a/web/src/i18n/locales/es/projectPipeline.ts
+++ b/web/src/i18n/locales/es/projectPipeline.ts
@@ -17,6 +17,12 @@ export default {
   pacOffHint: 'Cuando está activo, cada ejecución lee .pipewright.yml desde la raíz del repositorio en la rama de ejecución (con reserva a esta configuración si falta o no es válido).',
   pacToggleFailed: 'No se pudo cambiar. Inténtalo de nuevo.',
 
+  // ─── Comprobaciones de estado de PR (escritura de estado de commit · Story 8-9 / FR-8-9) ─
+  prStatusTitle: 'Comprobaciones de estado de PR',
+  prStatusOnHint: 'Al terminar una ejecución, Pipewright detecta la plataforma del repositorio (GitHub/Gitee) y escribe el estado de éxito/fallo del commit como comprobación de PR usando la credencial del proyecto (con el mejor esfuerzo; los fallos nunca afectan a la ejecución).',
+  prStatusOffHint: 'Cuando está activo, al terminar una ejecución se detecta la plataforma del repositorio (GitHub/Gitee) y se escribe el estado del commit como comprobación de PR usando la credencial del proyecto (con el mejor esfuerzo).',
+  prStatusToggleFailed: 'No se pudo cambiar. Inténtalo de nuevo.',
+
   // ─── Previsualizar configuración del repositorio (GitOps · obtener y validar .pipewright.yml en un ref) ──
   pacPreviewBtn: 'Previsualizar config del repo',
   pacPreviewTitle: 'Previsualizar configuración del repositorio',

--- a/web/src/i18n/locales/es/settingsNotifications.ts
+++ b/web/src/i18n/locales/es/settingsNotifications.ts
@@ -9,7 +9,9 @@ export default {
   typeFeishuLabel: 'Lark',
   typeFeishuDesc: 'Bot personalizado',
   typeWecomLabel: 'WeCom',
+  typeWecomDesc: 'Bot de grupo',
   typeDingtalkLabel: 'DingTalk',
+  typeDingtalkDesc: 'Bot de grupo',
   comingSoon: 'Próximamente',
   notImplemented: 'Envío no implementado',
 
@@ -38,6 +40,18 @@ export default {
   signSecret: 'Clave de firma (opcional)',
   signSecretHint: 'Rellénala solo si el bot tiene activada la «verificación de firma»; nunca se vuelve a mostrar tras guardarla',
   signSecretPlaceholder: 'Déjalo en blanco si el bot no tiene la verificación de firma activada',
+
+  wecomUrl: 'URL del Webhook del bot de WeCom',
+  wecomUrlHint:
+    'URL del Webhook del grupo de WeCom en «Configuración del grupo → Bots del grupo → Añadir bot» (qyapi.weixin.qq.com/cgi-bin/webhook/send?key=…)',
+
+  dingtalkUrl: 'URL del Webhook del bot de DingTalk',
+  dingtalkUrlHint:
+    'URL del Webhook del grupo de DingTalk en «Configuración del grupo → Asistente del grupo → Añadir bot → Personalizado» (oapi.dingtalk.com/robot/send?access_token=…)',
+  dingtalkSignSecret: 'Clave de firma (opcional)',
+  dingtalkSignSecretHint: 'Rellénala solo si en la «configuración de seguridad» del bot se eligió «Firmado»; nunca se vuelve a mostrar tras guardarla',
+  dingtalkSignSecretPlaceholder: 'Déjalo en blanco si el bot no usa «Firmado»',
+
   secretStoredHint: 'Configurada ••••(deja en blanco para mantener)',
   secretStoredPlaceholder: 'Configurada ••••(en blanco = sin cambios)',
 
@@ -74,6 +88,8 @@ export default {
   valNameRequired: 'Introduce un nombre de canal',
   valWebhookUrlRequired: 'Introduce la URL del Webhook',
   valFeishuUrlRequired: 'Introduce la URL del Webhook del bot de Lark',
+  valWecomUrlRequired: 'Introduce la URL del Webhook del bot de WeCom',
+  valDingtalkUrlRequired: 'Introduce la URL del Webhook del bot de DingTalk',
   valSmtpHostRequired: 'Introduce el host SMTP',
   valPortInvalid: 'Introduce un puerto válido',
   valFromRequired: 'Introduce el remitente',

--- a/web/src/i18n/locales/fr/projectPipeline.ts
+++ b/web/src/i18n/locales/fr/projectPipeline.ts
@@ -17,6 +17,12 @@ export default {
   pacOffHint: "Une fois activé, chaque exécution lit .pipewright.yml à la racine du dépôt sur la branche d'exécution (repli sur cette configuration si absent ou invalide).",
   pacToggleFailed: 'Échec du basculement. Veuillez réessayer.',
 
+  // ─── Vérifications de statut de PR (réécriture du statut de commit · Story 8-9 / FR-8-9) ─
+  prStatusTitle: 'Vérifications de statut de PR',
+  prStatusOnHint: "À la fin d'une exécution, Pipewright détecte la plateforme du dépôt (GitHub/Gitee) et réécrit le statut de réussite/échec du commit en tant que vérification de PR à l'aide de l'identifiant du projet (au mieux ; les échecs n'affectent jamais l'exécution).",
+  prStatusOffHint: "Une fois activé, la fin d'une exécution détecte la plateforme du dépôt (GitHub/Gitee) et réécrit le statut du commit en tant que vérification de PR à l'aide de l'identifiant du projet (au mieux).",
+  prStatusToggleFailed: 'Échec du basculement. Veuillez réessayer.',
+
   // ─── Aperçu de la config du dépôt (GitOps · récupérer et valider .pipewright.yml à une réf) ──
   pacPreviewBtn: 'Aperçu de la config du dépôt',
   pacPreviewTitle: 'Aperçu de la configuration du dépôt',

--- a/web/src/i18n/locales/fr/settingsNotifications.ts
+++ b/web/src/i18n/locales/fr/settingsNotifications.ts
@@ -9,7 +9,9 @@ export default {
   typeFeishuLabel: 'Lark',
   typeFeishuDesc: 'Bot personnalisé',
   typeWecomLabel: 'WeCom',
+  typeWecomDesc: 'Bot de groupe',
   typeDingtalkLabel: 'DingTalk',
+  typeDingtalkDesc: 'Bot de groupe',
   comingSoon: 'Bientôt disponible',
   notImplemented: 'Envoi non implémenté',
 
@@ -38,6 +40,18 @@ export default {
   signSecret: 'Clé de signature (facultatif)',
   signSecretHint: 'À renseigner uniquement si le bot a activé la « vérification de signature » ; jamais réaffichée après enregistrement',
   signSecretPlaceholder: 'Laissez vide si le bot n’a pas activé la vérification de signature',
+
+  wecomUrl: 'URL du Webhook du bot WeCom',
+  wecomUrlHint:
+    'URL du Webhook du groupe WeCom dans « Paramètres du groupe → Bots de groupe → Ajouter un bot » (qyapi.weixin.qq.com/cgi-bin/webhook/send?key=…)',
+
+  dingtalkUrl: 'URL du Webhook du bot DingTalk',
+  dingtalkUrlHint:
+    'URL du Webhook du groupe DingTalk dans « Paramètres du groupe → Assistant de groupe → Ajouter un bot → Personnalisé » (oapi.dingtalk.com/robot/send?access_token=…)',
+  dingtalkSignSecret: 'Clé de signature (facultatif)',
+  dingtalkSignSecretHint: 'À renseigner uniquement si les « paramètres de sécurité » du bot utilisent « Signé » ; jamais réaffichée après enregistrement',
+  dingtalkSignSecretPlaceholder: 'Laissez vide si le bot n’utilise pas « Signé »',
+
   secretStoredHint: 'Configurée ••••(laisser vide pour conserver)',
   secretStoredPlaceholder: 'Configurée ••••(vide = inchangée)',
 
@@ -74,6 +88,8 @@ export default {
   valNameRequired: 'Veuillez saisir un nom de canal',
   valWebhookUrlRequired: 'Veuillez saisir l’URL du Webhook',
   valFeishuUrlRequired: 'Veuillez saisir l’URL du Webhook du bot Lark',
+  valWecomUrlRequired: 'Veuillez saisir l’URL du Webhook du bot WeCom',
+  valDingtalkUrlRequired: 'Veuillez saisir l’URL du Webhook du bot DingTalk',
   valSmtpHostRequired: 'Veuillez saisir l’hôte SMTP',
   valPortInvalid: 'Veuillez saisir un port valide',
   valFromRequired: 'Veuillez saisir l’expéditeur',

--- a/web/src/i18n/locales/ja/projectPipeline.ts
+++ b/web/src/i18n/locales/ja/projectPipeline.ts
@@ -17,6 +17,12 @@ export default {
   pacOffHint: '有効にすると、各実行は実行ブランチのリポジトリルートの .pipewright.yml を読み込んで駆動します(ない/不正な場合はこの設定にフォールバック)。',
   pacToggleFailed: '切り替えに失敗しました。再試行してください。',
 
+  // ─── PR ステータスチェック(コミットステータス書き戻し · Story 8-9 / FR-8-9)─
+  prStatusTitle: 'PR ステータスチェック',
+  prStatusOnHint: '実行終了時にプロジェクトのリポジトリから GitHub/Gitee を識別し、プロジェクトの認証情報でそのコミットの成功/失敗ステータスを PR チェックとして書き戻します(ベストエフォート。失敗しても実行には影響しません)。',
+  prStatusOffHint: '有効にすると、実行終了時にリポジトリから GitHub/Gitee を識別し、プロジェクトの認証情報でコミットステータスを PR チェックとして書き戻します(ベストエフォート)。',
+  prStatusToggleFailed: '切り替えに失敗しました。再試行してください。',
+
   // ─── リポジトリ設定のプレビュー(GitOps · ref を指定して .pipewright.yml を取得・検証)──
   pacPreviewBtn: 'リポジトリ設定をプレビュー',
   pacPreviewTitle: 'リポジトリ設定のプレビュー',

--- a/web/src/i18n/locales/ja/settingsNotifications.ts
+++ b/web/src/i18n/locales/ja/settingsNotifications.ts
@@ -9,7 +9,9 @@ export default {
   typeFeishuLabel: 'Lark',
   typeFeishuDesc: 'カスタムボット',
   typeWecomLabel: 'WeCom',
+  typeWecomDesc: 'グループボット',
   typeDingtalkLabel: 'DingTalk',
+  typeDingtalkDesc: 'グループボット',
   comingSoon: '近日対応',
   notImplemented: '送信は未実装',
 
@@ -38,6 +40,18 @@ export default {
   signSecret: '署名シークレット（任意）',
   signSecretHint: 'ボットで「署名検証」を有効にした場合のみ入力。保存後は再表示されません',
   signSecretPlaceholder: 'ボットで署名検証が無効なら空のまま',
+
+  wecomUrl: 'WeCom ボット Webhook URL',
+  wecomUrlHint:
+    'WeCom グループの「グループ設定 → グループボット → ボットを追加」の Webhook URL（qyapi.weixin.qq.com/cgi-bin/webhook/send?key=…）',
+
+  dingtalkUrl: 'DingTalk ボット Webhook URL',
+  dingtalkUrlHint:
+    'DingTalk グループの「グループ設定 → グループアシスタント → ボットを追加 → カスタム」の Webhook URL（oapi.dingtalk.com/robot/send?access_token=…）',
+  dingtalkSignSecret: '署名シークレット（任意）',
+  dingtalkSignSecretHint: 'ボットの「セキュリティ設定」で「署名」を選んだ場合のみ入力。保存後は再表示されません',
+  dingtalkSignSecretPlaceholder: 'ボットで「署名」を選んでいなければ空のまま',
+
   secretStoredHint: '設定済み ••••（空欄で保持）',
   secretStoredPlaceholder: '設定済み ••••（空欄で変更なし）',
 
@@ -74,6 +88,8 @@ export default {
   valNameRequired: 'チャンネル名を入力してください',
   valWebhookUrlRequired: 'Webhook URL を入力してください',
   valFeishuUrlRequired: 'Lark ボットの Webhook URL を入力してください',
+  valWecomUrlRequired: 'WeCom ボットの Webhook URL を入力してください',
+  valDingtalkUrlRequired: 'DingTalk ボットの Webhook URL を入力してください',
   valSmtpHostRequired: 'SMTP ホストを入力してください',
   valPortInvalid: '有効なポートを入力してください',
   valFromRequired: '送信元を入力してください',

--- a/web/src/i18n/locales/ko/projectPipeline.ts
+++ b/web/src/i18n/locales/ko/projectPipeline.ts
@@ -17,6 +17,12 @@ export default {
   pacOffHint: '켜면 각 실행이 실행 브랜치의 저장소 루트 .pipewright.yml을 읽어 구동합니다(없거나 유효하지 않으면 이 설정으로 폴백).',
   pacToggleFailed: '전환에 실패했습니다. 다시 시도하세요.',
 
+  // ─── PR 상태 검사(커밋 상태 회신 · Story 8-9 / FR-8-9)──────────────
+  prStatusTitle: 'PR 상태 검사',
+  prStatusOnHint: '실행이 끝나면 프로젝트 저장소에서 GitHub/Gitee를 식별하고, 프로젝트 자격 증명으로 해당 커밋의 성공/실패 상태를 PR 검사로 회신합니다(최선 노력. 실패해도 실행에는 영향 없음).',
+  prStatusOffHint: '켜면 실행이 끝날 때 저장소에서 GitHub/Gitee를 식별하고, 프로젝트 자격 증명으로 커밋 상태를 PR 검사로 회신합니다(최선 노력).',
+  prStatusToggleFailed: '전환에 실패했습니다. 다시 시도하세요.',
+
   // ─── 저장소 구성 미리보기 (GitOps · ref 지정해 .pipewright.yml 가져와 검증) ──
   pacPreviewBtn: '저장소 구성 미리보기',
   pacPreviewTitle: '저장소 구성 미리보기',

--- a/web/src/i18n/locales/ko/settingsNotifications.ts
+++ b/web/src/i18n/locales/ko/settingsNotifications.ts
@@ -9,7 +9,9 @@ export default {
   typeFeishuLabel: 'Lark',
   typeFeishuDesc: '사용자 지정 봇',
   typeWecomLabel: 'WeCom',
+  typeWecomDesc: '그룹 봇',
   typeDingtalkLabel: 'DingTalk',
+  typeDingtalkDesc: '그룹 봇',
   comingSoon: '곧 지원',
   notImplemented: '발송 미구현',
 
@@ -38,6 +40,18 @@ export default {
   signSecret: '서명 키(선택)',
   signSecretHint: '봇에서 "서명 검증"을 켠 경우에만 입력하세요. 저장 후에는 다시 표시되지 않습니다',
   signSecretPlaceholder: '봇에서 서명 검증을 켜지 않았다면 비워 두세요',
+
+  wecomUrl: 'WeCom 봇 Webhook 주소',
+  wecomUrlHint:
+    'WeCom 그룹의 "그룹 설정 → 그룹 봇 → 봇 추가"의 Webhook 주소(qyapi.weixin.qq.com/cgi-bin/webhook/send?key=…)',
+
+  dingtalkUrl: 'DingTalk 봇 Webhook 주소',
+  dingtalkUrlHint:
+    'DingTalk 그룹의 "그룹 설정 → 그룹 도우미 → 봇 추가 → 사용자 지정"의 Webhook 주소(oapi.dingtalk.com/robot/send?access_token=…)',
+  dingtalkSignSecret: '서명 키(선택)',
+  dingtalkSignSecretHint: '봇의 "보안 설정"에서 "서명 추가"를 선택한 경우에만 입력하세요. 저장 후에는 다시 표시되지 않습니다',
+  dingtalkSignSecretPlaceholder: '봇에서 "서명 추가"를 선택하지 않았다면 비워 두세요',
+
   secretStoredHint: '설정됨 ••••(비워 두면 유지)',
   secretStoredPlaceholder: '설정됨 ••••(비워 두면 변경 없음)',
 
@@ -74,6 +88,8 @@ export default {
   valNameRequired: '채널 이름을 입력하세요',
   valWebhookUrlRequired: 'Webhook 주소를 입력하세요',
   valFeishuUrlRequired: 'Lark 봇 Webhook 주소를 입력하세요',
+  valWecomUrlRequired: 'WeCom 봇 Webhook 주소를 입력하세요',
+  valDingtalkUrlRequired: 'DingTalk 봇 Webhook 주소를 입력하세요',
   valSmtpHostRequired: 'SMTP 호스트를 입력하세요',
   valPortInvalid: '유효한 포트를 입력하세요',
   valFromRequired: '보내는 사람을 입력하세요',

--- a/web/src/i18n/locales/zh-CN/projectPipeline.ts
+++ b/web/src/i18n/locales/zh-CN/projectPipeline.ts
@@ -17,6 +17,12 @@ export default {
   pacOffHint: '开启后,每次运行按运行分支读取仓库根 .pipewright.yml 驱动(缺失或非法则回退此处配置)。',
   pacToggleFailed: '切换失败,请重试。',
 
+  // ─── PR 状态检查(提交状态回写 · Story 8-9 / FR-8-9)────────────────
+  prStatusTitle: 'PR 状态检查',
+  prStatusOnHint: '运行结束时据项目仓库识别 GitHub/Gitee,经项目凭据把该 commit 的成功/失败状态回写为 PR 检查(尽力而为,失败不影响运行)。',
+  prStatusOffHint: '开启后,运行结束时据项目仓库识别 GitHub/Gitee,经项目凭据将该 commit 的状态回写为 PR 检查(尽力而为)。',
+  prStatusToggleFailed: '切换失败,请重试。',
+
   // ─── 预览仓库配置(GitOps · 按 ref 拉取并校验 .pipewright.yml)────────
   pacPreviewBtn: '预览仓库配置',
   pacPreviewTitle: '预览仓库配置',

--- a/web/src/i18n/locales/zh-CN/settingsNotifications.ts
+++ b/web/src/i18n/locales/zh-CN/settingsNotifications.ts
@@ -10,7 +10,9 @@ export default {
   typeFeishuLabel: '飞书',
   typeFeishuDesc: '自定义机器人',
   typeWecomLabel: '企业微信',
+  typeWecomDesc: '群机器人',
   typeDingtalkLabel: '钉钉',
+  typeDingtalkDesc: '群机器人',
   comingSoon: '即将支持',
   notImplemented: '未实现发送',
 
@@ -39,6 +41,18 @@ export default {
   signSecret: '签名密钥(可选)',
   signSecretHint: '仅当机器人开启「签名校验」时填写;写入后绝不回显',
   signSecretPlaceholder: '机器人未开启签名校验则留空',
+
+  wecomUrl: '企业微信机器人 Webhook 地址',
+  wecomUrlHint:
+    '企业微信群「群设置 → 群机器人 → 添加机器人」的 Webhook 地址(qyapi.weixin.qq.com/cgi-bin/webhook/send?key=…)',
+
+  dingtalkUrl: '钉钉机器人 Webhook 地址',
+  dingtalkUrlHint:
+    '钉钉群「群设置 → 智能群助手 → 添加机器人 → 自定义」的 Webhook 地址(oapi.dingtalk.com/robot/send?access_token=…)',
+  dingtalkSignSecret: '加签密钥(可选)',
+  dingtalkSignSecretHint: '仅当机器人「安全设置」选「加签」时填写;写入后绝不回显',
+  dingtalkSignSecretPlaceholder: '机器人未选「加签」则留空',
+
   secretStoredHint: '已配置 ••••(留空则保留)',
   secretStoredPlaceholder: '已配置 ••••(留空不变)',
 
@@ -76,6 +90,8 @@ export default {
   valNameRequired: '请填写渠道名称',
   valWebhookUrlRequired: '请填写 Webhook 地址',
   valFeishuUrlRequired: '请填写飞书机器人 Webhook 地址',
+  valWecomUrlRequired: '请填写企业微信机器人 Webhook 地址',
+  valDingtalkUrlRequired: '请填写钉钉机器人 Webhook 地址',
   valSmtpHostRequired: '请填写 SMTP 主机',
   valPortInvalid: '请填写有效端口',
   valFromRequired: '请填写发件人',

--- a/web/src/i18n/locales/zh-TW/projectPipeline.ts
+++ b/web/src/i18n/locales/zh-TW/projectPipeline.ts
@@ -17,6 +17,12 @@ export default {
   pacOffHint: '開啟後,每次執行依執行分支讀取倉庫根 .pipewright.yml 驅動(缺失或非法則回退此處設定)。',
   pacToggleFailed: '切換失敗,請重試。',
 
+  // ─── PR 狀態檢查(提交狀態回寫 · Story 8-9 / FR-8-9)────────────────
+  prStatusTitle: 'PR 狀態檢查',
+  prStatusOnHint: '執行結束時依專案倉庫識別 GitHub/Gitee,經專案憑證將該 commit 的成功/失敗狀態回寫為 PR 檢查(盡力而為,失敗不影響執行)。',
+  prStatusOffHint: '開啟後,執行結束時依專案倉庫識別 GitHub/Gitee,經專案憑證將該 commit 的狀態回寫為 PR 檢查(盡力而為)。',
+  prStatusToggleFailed: '切換失敗,請重試。',
+
   // ─── 預覽倉庫設定(GitOps · 按 ref 拉取並校驗 .pipewright.yml)────────
   pacPreviewBtn: '預覽倉庫設定',
   pacPreviewTitle: '預覽倉庫設定',

--- a/web/src/i18n/locales/zh-TW/settingsNotifications.ts
+++ b/web/src/i18n/locales/zh-TW/settingsNotifications.ts
@@ -9,7 +9,9 @@ export default {
   typeFeishuLabel: 'Lark',
   typeFeishuDesc: '自訂機器人',
   typeWecomLabel: 'WeCom',
+  typeWecomDesc: '群組機器人',
   typeDingtalkLabel: 'DingTalk',
+  typeDingtalkDesc: '群組機器人',
   comingSoon: '即將支援',
   notImplemented: '尚未實作傳送',
 
@@ -37,6 +39,18 @@ export default {
   signSecret: '簽章密鑰(選填)',
   signSecretHint: '僅當機器人開啟「簽章驗證」時填寫;寫入後絕不回顯',
   signSecretPlaceholder: '機器人未開啟簽章驗證則留空',
+
+  wecomUrl: 'WeCom 機器人 Webhook 位址',
+  wecomUrlHint:
+    'WeCom 群組「群組設定 → 群組機器人 → 新增機器人」的 Webhook 位址(qyapi.weixin.qq.com/cgi-bin/webhook/send?key=…)',
+
+  dingtalkUrl: 'DingTalk 機器人 Webhook 位址',
+  dingtalkUrlHint:
+    'DingTalk 群組「群組設定 → 智慧群助手 → 新增機器人 → 自訂」的 Webhook 位址(oapi.dingtalk.com/robot/send?access_token=…)',
+  dingtalkSignSecret: '加簽密鑰(選填)',
+  dingtalkSignSecretHint: '僅當機器人「安全設定」選「加簽」時填寫;寫入後絕不回顯',
+  dingtalkSignSecretPlaceholder: '機器人未選「加簽」則留空',
+
   secretStoredHint: '已設定 ••••(留空則保留)',
   secretStoredPlaceholder: '已設定 ••••(留空不變)',
 
@@ -73,6 +87,8 @@ export default {
   valNameRequired: '請填寫管道名稱',
   valWebhookUrlRequired: '請填寫 Webhook 位址',
   valFeishuUrlRequired: '請填寫 Lark 機器人 Webhook 位址',
+  valWecomUrlRequired: '請填寫 WeCom 機器人 Webhook 位址',
+  valDingtalkUrlRequired: '請填寫 DingTalk 機器人 Webhook 位址',
   valSmtpHostRequired: '請填寫 SMTP 主機',
   valPortInvalid: '請填寫有效連接埠',
   valFromRequired: '請填寫寄件人',

--- a/web/src/views/ProjectPipeline.vue
+++ b/web/src/views/ProjectPipeline.vue
@@ -404,6 +404,29 @@ async function togglePac(next: boolean): Promise<void> {
     pacToggling.value = false
   }
 }
+
+// ─── PR status checks toggle (Story 8-9 / FR-8-9) ─────────────────────────────
+// 开启后 run 终态据项目仓库识别 GitHub/Gitee,经项目凭据回写该 commit 的提交状态(PR 检查)。
+const prStatusEnabled = computed(() => project.value?.prStatusEnabled ?? false)
+const prStatusToggling = ref(false)
+const prStatusError = ref('')
+
+async function togglePrStatus(next: boolean): Promise<void> {
+  if (!project.value || prStatusToggling.value) return
+  prStatusToggling.value = true
+  prStatusError.value = ''
+  const prev = project.value.prStatusEnabled
+  project.value = { ...project.value, prStatusEnabled: next } // optimistic
+  try {
+    const updated = await updateProject(projectId.value, { prStatusEnabled: next })
+    project.value = updated
+  } catch {
+    project.value = { ...project.value, prStatusEnabled: prev } // rollback
+    prStatusError.value = t('projectPipeline.prStatusToggleFailed')
+  } finally {
+    prStatusToggling.value = false
+  }
+}
 </script>
 
 <template>
@@ -557,6 +580,34 @@ async function togglePac(next: boolean): Promise<void> {
           <span class="pac-switch-knob" aria-hidden="true"/>
         </button>
       </div>
+    </div>
+
+    <!-- ─── PR status checks (commit status writeback · Story 8-9 / FR-8-9) ── -->
+    <div class="pac-bar" :class="{ 'pac-bar--on': prStatusEnabled }">
+      <div class="pac-bar-text">
+        <span class="pac-bar-title">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M9 12l2 2 4-4"/><circle cx="12" cy="12" r="9"/>
+          </svg>
+          {{ t('projectPipeline.prStatusTitle') }}
+        </span>
+        <span class="pac-bar-desc">
+          {{ prStatusEnabled ? t('projectPipeline.prStatusOnHint') : t('projectPipeline.prStatusOffHint') }}
+        </span>
+        <span v-if="prStatusError" class="pac-bar-err" role="alert">{{ prStatusError }}</span>
+      </div>
+      <button
+        type="button"
+        class="pac-switch"
+        :class="{ 'pac-switch--on': prStatusEnabled }"
+        role="switch"
+        :aria-checked="prStatusEnabled"
+        :aria-label="t('projectPipeline.prStatusTitle')"
+        :disabled="prStatusToggling || !project"
+        @click="togglePrStatus(!prStatusEnabled)"
+      >
+        <span class="pac-switch-knob" aria-hidden="true"/>
+      </button>
     </div>
 
     <!-- ─── Tab body: panels + optional validation side-drawer ─────────────── -->

--- a/web/src/views/settings/SettingsNotifications.vue
+++ b/web/src/views/settings/SettingsNotifications.vue
@@ -8,8 +8,9 @@
  *   - email SMTP password: WRITE-ONLY — never echoed; masked placeholder when stored
  *   - Test send with ok/latency/error result
  *   - Delete with confirm
- *   - feishu: custom-bot webhook (url + optional sign secret); sends {msg_type,content}
- *   - wecom/dingtalk shown as "soon" placeholders (saveable, test=not_implemented)
+ *   - feishu: custom-bot webhook (url + optional sign secret); sends interactive card
+ *   - wecom: group-robot webhook (url only); sends markdown
+ *   - dingtalk: group-robot webhook (url + optional sign secret); sends markdown
  *
  * Reuses: FormField / AppButton tokens from 1-6. No new UI libraries.
  * Animation: transform/opacity + prefers-reduced-motion. Sensitive fields never
@@ -110,8 +111,22 @@ const TYPES = computed<TypeMeta[]>(() => [
     glyphStyle: 'background:oklch(72% 0.15 200 / 0.16);color:oklch(56% 0.13 220)',
     implemented: true,
   },
-  { id: 'wecom', label: t('settingsNotifications.typeWecomLabel'), desc: t('settingsNotifications.comingSoon'), glyph: '企', glyphStyle: 'background:var(--color-inset);color:var(--color-faint)', implemented: false },
-  { id: 'dingtalk', label: t('settingsNotifications.typeDingtalkLabel'), desc: t('settingsNotifications.comingSoon'), glyph: '钉', glyphStyle: 'background:var(--color-inset);color:var(--color-faint)', implemented: false },
+  {
+    id: 'wecom',
+    label: t('settingsNotifications.typeWecomLabel'),
+    desc: t('settingsNotifications.typeWecomDesc'),
+    glyph: '企',
+    glyphStyle: 'background:oklch(72% 0.16 145 / 0.16);color:oklch(52% 0.15 150)',
+    implemented: true,
+  },
+  {
+    id: 'dingtalk',
+    label: t('settingsNotifications.typeDingtalkLabel'),
+    desc: t('settingsNotifications.typeDingtalkDesc'),
+    glyph: '钉',
+    glyphStyle: 'background:oklch(70% 0.15 250 / 0.16);color:oklch(54% 0.16 255)',
+    implemented: true,
+  },
 ])
 
 function typeMeta(ty: ChannelType): TypeMeta {
@@ -176,6 +191,8 @@ const saving = ref(false)
 const isEmail = computed(() => form.type === 'email')
 const isWebhook = computed(() => form.type === 'webhook')
 const isFeishu = computed(() => form.type === 'feishu')
+const isWecom = computed(() => form.type === 'wecom')
+const isDingtalk = computed(() => form.type === 'dingtalk')
 const selectedTypeMeta = computed(() => typeMeta(form.type))
 
 function resetForm(): void {
@@ -255,6 +272,16 @@ function validate(): boolean {
       fieldErrors.url = t('settingsNotifications.valFeishuUrlRequired')
       ok = false
     }
+  } else if (isWecom.value) {
+    if (!form.url.trim()) {
+      fieldErrors.url = t('settingsNotifications.valWecomUrlRequired')
+      ok = false
+    }
+  } else if (isDingtalk.value) {
+    if (!form.url.trim()) {
+      fieldErrors.url = t('settingsNotifications.valDingtalkUrlRequired')
+      ok = false
+    }
   } else if (isEmail.value) {
     if (!form.smtpHost.trim()) {
       fieldErrors.smtpHost = t('settingsNotifications.valSmtpHostRequired')
@@ -283,6 +310,16 @@ function buildConfig(): ChannelConfigInput {
   }
   if (isFeishu.value) {
     // 飞书:url=机器人 webhook 地址;password=可选签名密钥(机器人开启「签名校验」时填)。
+    const cfg: ChannelConfigInput = { url: form.url.trim() }
+    if (form.password) cfg.password = form.password
+    return cfg
+  }
+  if (isWecom.value) {
+    // 企业微信群机器人:仅 url(群机器人无需签名密钥)。
+    return { url: form.url.trim() }
+  }
+  if (isDingtalk.value) {
+    // 钉钉群机器人:url=机器人 webhook 地址;password=可选加签密钥(安全设置选「加签」时填)。
     const cfg: ChannelConfigInput = { url: form.url.trim() }
     if (form.password) cfg.password = form.password
     return cfg
@@ -771,7 +808,9 @@ function httpMessage(err: unknown, fallback: string): string {
 }
 
 function configSummary(ch: NotificationChannel): string {
-  if (ch.type === 'webhook') return ch.config.url ?? ''
+  if (ch.type === 'webhook' || ch.type === 'feishu' || ch.type === 'wecom' || ch.type === 'dingtalk') {
+    return ch.config.url ?? ''
+  }
   if (ch.type === 'email') {
     const port = ch.config.smtpPort ? `:${ch.config.smtpPort}` : ''
     return `${ch.config.smtpHost ?? ''}${port} → ${ch.config.to ?? ''}`
@@ -961,6 +1000,78 @@ function configSummary(ch: NotificationChannel): string {
                         type="password"
                         class="field-input field-input--mono"
                         :placeholder="hasStoredPassword ? t('settingsNotifications.secretStoredPlaceholder') : t('settingsNotifications.signSecretPlaceholder')"
+                        autocomplete="new-password"
+                        :aria-describedby="ariaDescribedby"
+                        :disabled="saving"
+                      />
+                    </template>
+                  </FormField>
+                </div>
+              </template>
+
+              <!-- Wecom (企业微信群机器人) fields -->
+              <div v-else-if="isWecom" class="config-row">
+                <FormField
+                  :label="t('settingsNotifications.wecomUrl')"
+                  field-id="nt-wc-url"
+                  :error="fieldErrors.url"
+                  :hint="t('settingsNotifications.wecomUrlHint')"
+                  required
+                >
+                  <template #default="{ fieldId, ariaDescribedby }">
+                    <input
+                      :id="fieldId"
+                      v-model="form.url"
+                      type="url"
+                      class="field-input field-input--mono"
+                      :class="{ 'field-input--error': fieldErrors.url }"
+                      placeholder="https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=…"
+                      :aria-describedby="ariaDescribedby"
+                      :disabled="saving"
+                      @input="fieldErrors.url = ''"
+                    />
+                  </template>
+                </FormField>
+              </div>
+
+              <!-- Dingtalk (钉钉群机器人) fields -->
+              <template v-else-if="isDingtalk">
+                <div class="config-row">
+                  <FormField
+                    :label="t('settingsNotifications.dingtalkUrl')"
+                    field-id="nt-dt-url"
+                    :error="fieldErrors.url"
+                    :hint="t('settingsNotifications.dingtalkUrlHint')"
+                    required
+                  >
+                    <template #default="{ fieldId, ariaDescribedby }">
+                      <input
+                        :id="fieldId"
+                        v-model="form.url"
+                        type="url"
+                        class="field-input field-input--mono"
+                        :class="{ 'field-input--error': fieldErrors.url }"
+                        placeholder="https://oapi.dingtalk.com/robot/send?access_token=…"
+                        :aria-describedby="ariaDescribedby"
+                        :disabled="saving"
+                        @input="fieldErrors.url = ''"
+                      />
+                    </template>
+                  </FormField>
+                </div>
+                <div class="config-row">
+                  <FormField
+                    :label="t('settingsNotifications.dingtalkSignSecret')"
+                    field-id="nt-dt-secret"
+                    :hint="hasStoredPassword ? t('settingsNotifications.secretStoredHint') : t('settingsNotifications.dingtalkSignSecretHint')"
+                  >
+                    <template #default="{ fieldId, ariaDescribedby }">
+                      <input
+                        :id="fieldId"
+                        v-model="form.password"
+                        type="password"
+                        class="field-input field-input--mono"
+                        :placeholder="hasStoredPassword ? t('settingsNotifications.secretStoredPlaceholder') : t('settingsNotifications.dingtalkSignSecretPlaceholder')"
                         autocomplete="new-password"
                         :aria-describedby="ariaDescribedby"
                         :disabled="saving"


### PR DESCRIPTION
两个"差最后一截"的功能(都有现成地基),并行开发(隔离 worktree)、文件互不相交、零冲突集成。

## 1 · 企业微信 + 钉钉群机器人通知
此前这两个渠道**类型**能保存,但 `deliver` 返回 `not_implemented`。现实现真发送(对标飞书质量):
- `internal/notify/wecom.go`:企业微信群机器人 markdown 推送(`{"msgtype":"markdown",...}`),复用 SSRF 护栏客户端,`errcode != 0`/非 2xx 判失败
- `internal/notify/dingtalk.go`:钉钉群机器人 markdown 推送,**可选加签**(HMAC-SHA256:`base64(HMAC(secret, "{ts}\n{secret}"))` 附 `&timestamp&sign`),secret 走 vault 写时加密/绝不回显(同邮件密码)
- 接入 `deliver` 分派 + 配置校验(要求 URL);DTO 回传 URL/hasPassword
- 前端 `SettingsNotifications.vue`:启用两类型的配置输入(URL;钉钉加签密钥),移除"暂未实现"提示 + i18n ×8
- **真测**(httptest):markdown 形状、errcode≠0 不误判成功、**实测签名数学一致**、secret 写时加密只读、SSRF 拦截

## 2 · PR 状态检查产品化(每项目开关)
`internal/prstatus`(回写 GitHub/Gitee commit status)此前**只在全局 env `PIPEWRIGHT_PR_STATUS=1` 后、默认关、无 UI**。照 GitOps 开关(#118)套路产品化:
- 迁移 0041 `projects.pr_status_enabled`(sqlite+mysql 默认 0);project/DTO/UpdateInput 贯穿
- PR 状态钩子**始终挂载**,按项目标志判定写回(`PIPEWRIGHT_PR_STATUS=1` 保留为全局强开,向后兼容)
- 流水线页第二条开关条「PR 状态检查」(乐观更新+回滚)+ projectPipeline i18n ×8
- **真测**:项目存储往返;钩子按标志门控(httptest 数命中:关→0、开→1、全局强开→1)

## 自检(合并分支上)
- 后端 `go build/vet/test ./...` 全绿、`gofmt` 空;前端 typecheck/lint 0 错、321 测试过
- **真机端到端**:PR 状态开关 渲染→PATCH→DB(`pr_status_enabled=1`)→刷新保持;通知设置 5 类型(含企业微信/钉钉)可选,钉钉显示「加签密钥(可选)」写时加密、企业微信仅 URL,均带真实机器人配置指引

🤖 Generated with [Claude Code](https://claude.com/claude-code)