### PR TITLE
feat(approval): 从通知直接审批(签名链接 + 公开确认页 + approval_required 事件)

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -113,6 +113,14 @@ func main() {
 	}
 	credVault := vault.New(st.DB, masterKey)
 
+	// 审批链接签名器(「从通知直接审批」):用 master key 做 HMAC 签发/校验审批 token。
+	// master key 缺失 → 禁用态(不签链接、公开页不可用),功能优雅关闭。
+	var approvalSignerKey []byte
+	if masterKey != nil {
+		approvalSignerKey = masterKey[:]
+	}
+	approvalSigner := approval.NewSigner(approvalSignerKey)
+
 	// 装配项目服务(Story 2.1):经 store 触库、经 vault 取凭据做 ls-remote 校验(进程内,用完即弃)。
 	// prober 传 nil → 使用默认 go-git ListRemote 实现(纯 Go,无宿主 git 依赖,不驻留)。
 	projectSvc := project.New(st.DB, credVault, nil)
@@ -328,8 +336,10 @@ func main() {
 		// 阶段执行体(Story 8-2):探测到容器 CLI → 注入真实阶段执行器(script 类型 job 在隔离
 		// 容器内真实跑命令,复用 Builder 的 cloner+driver);否则回退 stub(优雅降级,NFR-10)。
 		var dagOpts []dagrun.Option
-		// 审批门 hook(Story 8-4):Gate 阶段阻塞等待人工批准/拒绝。
-		dagOpts = append(dagOpts, dagrun.WithGate(httpapi.NewApprovalGate(runSvc, approvalCoord, approvalStore)))
+		// 审批门 hook(Story 8-4):Gate 阶段阻塞等待人工批准/拒绝。进入等待态后 best-effort 发
+		// 「需要审批」通知 + 签名审批链接(signer/PUBLIC_URL 未配则跳过通知,门行为不变)。
+		approvalNotifier := httpapi.NewApprovalNotifier(notifySvc, approvalSigner, strings.TrimSpace(os.Getenv("PIPEWRIGHT_PUBLIC_URL")))
+		dagOpts = append(dagOpts, dagrun.WithGate(httpapi.NewApprovalGate(runSvc, approvalCoord, approvalStore, approvalNotifier)))
 		if b, berr := build.NewBuilder(projectSvc, pipelineSettingsSvc, credVault, build.WithArtifactStore(artStore), build.WithArtifactLister(runSvc.ListArtifacts), build.WithImageGC(os.Getenv("PIPEWRIGHT_NO_IMAGE_GC") != "1"), build.WithCommitRecorder(func(ctx context.Context, runID, commit string) { _ = runSvc.SetCommit(ctx, runID, commit) }), build.WithStageDeployer(deploySvc), build.WithStageNotifier(notifySvc), clonerOpt, buildCacheOpt); berr == nil {
 			// runSvc 作测试报告持久层注入(Story 8-6 / FR-8-6):script 步骤产报告 → 解析 →
 			// 落库 → 质量门禁裁决(不过则阶段失败,阻断下游部署)。
@@ -474,7 +484,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithRefs(refsLister), httpapi.WithArtifactStore(artStore), httpapi.WithServers(targetSvc), httpapi.WithRunnerConfig(runnerSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithRetention(retentionSvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithChain(chainSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithConcurrency(concurrencySvc), httpapi.WithParameters(parameterSvc), httpapi.WithPromotion(promotionStore), httpapi.WithEnvironments(environmentsSvc), httpapi.WithDoraMetrics(doraMetricsSvc), httpapi.WithTemplates(templateSvc), httpapi.WithVariableGroups(varGroupSvc), httpapi.WithCustomNodes(customNodeSvc)),
+		Handler:           httpapi.New(webFS, authSvc, httpapi.WithVault(credVault), httpapi.WithProjects(projectSvc), httpapi.WithTriggers(triggerSvc), httpapi.WithPipelines(pipelineSvc), httpapi.WithPipelineSettings(pipelineSettingsSvc), httpapi.WithRuns(runSvc, pool), httpapi.WithWebhooks(webhookReceiver), httpapi.WithAudit(auditRec), httpapi.WithAccount(authSvc), httpapi.WithAISettings(aiSvc), httpapi.WithAIGenerate(repoAnalyzer), httpapi.WithRunDiff(runDiffer), httpapi.WithSource(sourceReader), httpapi.WithRefs(refsLister), httpapi.WithArtifactStore(artStore), httpapi.WithServers(targetSvc), httpapi.WithRunnerConfig(runnerSvc), httpapi.WithDeploy(deploySvc), httpapi.WithNotifications(notifySvc), httpapi.WithRetention(retentionSvc), httpapi.WithDiagnosisFeedback(feedbackSvc), httpapi.WithAnomaly(anomalySvc), httpapi.WithSecretSource(secretSrc), httpapi.WithOAuth(oauthSvc), httpapi.WithCron(cronSvc), httpapi.WithChain(chainSvc), httpapi.WithApprovals(approvalCoord, approvalStore), httpapi.WithApprovalLinks(approvalSigner), httpapi.WithConcurrency(concurrencySvc), httpapi.WithParameters(parameterSvc), httpapi.WithPromotion(promotionStore), httpapi.WithEnvironments(environmentsSvc), httpapi.WithDoraMetrics(doraMetricsSvc), httpapi.WithTemplates(templateSvc), httpapi.WithVariableGroups(varGroupSvc), httpapi.WithCustomNodes(customNodeSvc)),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		// WriteTimeout 置 0:SSE 长连接(/api/runs/{id}/events)不可被写超时切断;

--- a/internal/approval/link.go
+++ b/internal/approval/link.go
@@ -1,0 +1,110 @@
+package approval
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// link.go 实现「从通知直接审批」的签名链接(token-based auth):通知里携带一个签名 token,
+// 打开 {PUBLIC_URL}/approvals?token=<signed> 即可在不登录的前提下批准/拒绝该审批门。
+//
+// token 即认证(无会话):任何人持有有效 token 即可代审批,故签名必须用 master key 做 HMAC、
+// 带过期、常量时间比较;token 不入日志、不入页面。master key 缺失时签名器进入「禁用」态:
+// Sign 返回空串、Verify 恒 false——功能优雅关闭(不发链接 / 链接不可用),平台其余不受影响。
+//
+// token 形态(URL-safe,无 padding):
+//
+//	base64url(payload) + "." + base64url(HMAC-SHA256(key, payloadBytes))
+//
+// 其中 payload = "runID|stageID|expUnix"(expUnix 为过期时刻的 Unix 秒)。
+
+// Signer 用 master key 对审批链接 token 签名 / 校验。零值不可用,经 NewSigner 构造。
+type Signer struct {
+	key []byte
+}
+
+// NewSigner 构造签名器。key 为空(len==0)→ 禁用态:Sign 返回 ""、Verify 恒 ok=false。
+// 调用方(main)在 master key 缺失时传 nil 即可优雅关闭本功能。
+func NewSigner(key []byte) *Signer {
+	if len(key) == 0 {
+		return &Signer{key: nil}
+	}
+	// 复制一份,避免调用方持有的底层数组被外部改动影响签名稳定性。
+	cp := make([]byte, len(key))
+	copy(cp, key)
+	return &Signer{key: cp}
+}
+
+// Enabled 报告签名器是否可用(配置了 master key)。
+func (s *Signer) Enabled() bool {
+	return s != nil && len(s.key) > 0
+}
+
+// Sign 为 (runID, stageID) 签发一个在 exp 过期的 token。禁用态 → 返回空串。
+func (s *Signer) Sign(runID, stageID string, exp time.Time) string {
+	if !s.Enabled() {
+		return ""
+	}
+	payload := runID + "|" + stageID + "|" + strconv.FormatInt(exp.Unix(), 10)
+	payloadB := []byte(payload)
+	sig := s.mac(payloadB)
+	return b64(payloadB) + "." + b64(sig)
+}
+
+// Verify 校验 token,返回其承载的 runID/stageID 及是否有效。
+// 任何畸形(格式错、base64 错、签名不符、已过期)→ ok=false(返回的 runID/stageID 为空)。
+// 禁用态(无 key)→ 恒 ok=false。签名比较用 hmac.Equal(常量时间,防计时旁路)。
+func (s *Signer) Verify(token string) (runID, stageID string, ok bool) {
+	if !s.Enabled() {
+		return "", "", false
+	}
+	dot := strings.IndexByte(token, '.')
+	if dot <= 0 || dot == len(token)-1 {
+		return "", "", false
+	}
+	payloadB, err := unb64(token[:dot])
+	if err != nil {
+		return "", "", false
+	}
+	gotSig, err := unb64(token[dot+1:])
+	if err != nil {
+		return "", "", false
+	}
+	wantSig := s.mac(payloadB)
+	if !hmac.Equal(gotSig, wantSig) {
+		return "", "", false
+	}
+	// 校验通过后再解析 payload(签名先验,防解析未认证内容)。
+	parts := strings.Split(string(payloadB), "|")
+	if len(parts) != 3 {
+		return "", "", false
+	}
+	expUnix, perr := strconv.ParseInt(parts[2], 10, 64)
+	if perr != nil {
+		return "", "", false
+	}
+	if time.Now().After(time.Unix(expUnix, 0)) {
+		return "", "", false // 已过期。
+	}
+	return parts[0], parts[1], true
+}
+
+// mac 计算 payload 的 HMAC-SHA256(key 为 master key)。
+func (s *Signer) mac(payload []byte) []byte {
+	h := hmac.New(sha256.New, s.key)
+	h.Write(payload)
+	return h.Sum(nil)
+}
+
+// b64 / unb64 用 URL-safe 无 padding 的 base64(token 可直接进 URL query)。
+func b64(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func unb64(s string) ([]byte, error) {
+	return base64.RawURLEncoding.DecodeString(s)
+}

--- a/internal/approval/link_test.go
+++ b/internal/approval/link_test.go
@@ -1,0 +1,114 @@
+package approval
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func testKey() []byte {
+	k := make([]byte, 32)
+	for i := range k {
+		k[i] = byte(i + 1)
+	}
+	return k
+}
+
+// 往返:签名后能校验回原始 runID/stageID。
+func TestSignerRoundTrip(t *testing.T) {
+	s := NewSigner(testKey())
+	if !s.Enabled() {
+		t.Fatal("signer should be enabled with a key")
+	}
+	tok := s.Sign("run-123", "stage-deploy", time.Now().Add(time.Hour))
+	if tok == "" {
+		t.Fatal("Sign returned empty token for enabled signer")
+	}
+	runID, stageID, ok := s.Verify(tok)
+	if !ok {
+		t.Fatal("Verify failed for a valid round-trip token")
+	}
+	if runID != "run-123" || stageID != "stage-deploy" {
+		t.Fatalf("round-trip mismatch: got run=%q stage=%q", runID, stageID)
+	}
+}
+
+// 篡改 payload → ok=false。
+func TestSignerTamperedPayload(t *testing.T) {
+	s := NewSigner(testKey())
+	tok := s.Sign("run-1", "stage-1", time.Now().Add(time.Hour))
+	dot := strings.IndexByte(tok, '.')
+	// 用另一组 (runID,stageID) 的合法 payload 替换,但保留原签名 → 签名不符。
+	other := s.Sign("run-EVIL", "stage-EVIL", time.Now().Add(time.Hour))
+	otherDot := strings.IndexByte(other, '.')
+	forged := other[:otherDot] + tok[dot:]
+	if _, _, ok := s.Verify(forged); ok {
+		t.Fatal("Verify accepted a token with mismatched payload/signature")
+	}
+}
+
+// 篡改签名 → ok=false。
+func TestSignerTamperedSig(t *testing.T) {
+	s := NewSigner(testKey())
+	tok := s.Sign("run-1", "stage-1", time.Now().Add(time.Hour))
+	// 翻转签名段最后一个字符。
+	last := tok[len(tok)-1]
+	repl := byte('A')
+	if last == 'A' {
+		repl = 'B'
+	}
+	forged := tok[:len(tok)-1] + string(repl)
+	if _, _, ok := s.Verify(forged); ok {
+		t.Fatal("Verify accepted a token with tampered signature")
+	}
+}
+
+// 过期 → ok=false。
+func TestSignerExpired(t *testing.T) {
+	s := NewSigner(testKey())
+	tok := s.Sign("run-1", "stage-1", time.Now().Add(-time.Minute))
+	if _, _, ok := s.Verify(tok); ok {
+		t.Fatal("Verify accepted an expired token")
+	}
+}
+
+// 畸形 token → ok=false(无 panic)。
+func TestSignerMalformed(t *testing.T) {
+	s := NewSigner(testKey())
+	for _, bad := range []string{"", ".", "abc", "abc.", ".abc", "not-base64!.sig", "$$.$$"} {
+		if _, _, ok := s.Verify(bad); ok {
+			t.Fatalf("Verify accepted malformed token %q", bad)
+		}
+	}
+}
+
+// 不同 key 签发的 token → 校验失败(签名隔离)。
+func TestSignerWrongKey(t *testing.T) {
+	a := NewSigner(testKey())
+	other := make([]byte, 32)
+	for i := range other {
+		other[i] = 0xFF
+	}
+	b := NewSigner(other)
+	tok := a.Sign("run-1", "stage-1", time.Now().Add(time.Hour))
+	if _, _, ok := b.Verify(tok); ok {
+		t.Fatal("Verify with a different key accepted the token")
+	}
+}
+
+// 禁用态(nil key):Sign 返回 ""、Verify 恒 false。
+func TestSignerDisabled(t *testing.T) {
+	s := NewSigner(nil)
+	if s.Enabled() {
+		t.Fatal("nil-key signer must be disabled")
+	}
+	if tok := s.Sign("run-1", "stage-1", time.Now().Add(time.Hour)); tok != "" {
+		t.Fatalf("disabled signer Sign should return empty, got %q", tok)
+	}
+	// 即便给一个看似合法的 token,禁用态也恒 false。
+	enabled := NewSigner(testKey())
+	realTok := enabled.Sign("run-1", "stage-1", time.Now().Add(time.Hour))
+	if _, _, ok := s.Verify(realTok); ok {
+		t.Fatal("disabled signer Verify should always be false")
+	}
+}

--- a/internal/httpapi/approval_link.go
+++ b/internal/httpapi/approval_link.go
@@ -1,0 +1,201 @@
+package httpapi
+
+import (
+	"html/template"
+	"net/http"
+	"strings"
+
+	"github.com/huangchengsir/pipewright/internal/approval"
+	"github.com/huangchengsir/pipewright/internal/audit"
+)
+
+// approval_link.go 实现「从通知直接审批」的**公开**端点(无会话;token 即认证)。
+//
+// 安全姿态(SECURITY-SENSITIVE):
+//   - token 是 HMAC + 过期 + 常量时间比较签出的(见 internal/approval/link.go);任何持有有效
+//     token 者即可代该审批门做批准/拒绝——故这两个端点注册在 requireAuth / CSRF 组**之外**。
+//   - **GET 无任何副作用**:聊天/IM 客户端会预取链接(link preview),若 GET 即批准会被预取
+//     自动放行。GET 仅校验 token 并渲染确认页;真正解析门只在 POST /approvals/act。
+//   - 页面里所有动态值(runID/stageID)一律经 html/template 自动转义;页面/日志绝无 token、
+//     绝无任何密钥。
+//
+// 路由(均公开,不过 auth、不过 CSRF):
+//   - GET  /approvals?token=...   → 确认页(校验 + 展示 + 两个 POST 表单)
+//   - POST /approvals/act         → 解析门(form: token, decision=approve|reject)
+
+// approvalActor 是经签名链接审批时记入审计/决定的操作者标识(非登录会话)。
+const approvalActor = "通知链接审批"
+
+// approvalPageData 是确认页 / 结果页模板的渲染上下文(均为已转义文本)。
+type approvalPageData struct {
+	Title   string
+	Message string
+	// 以下仅确认页用。
+	ShowForm bool
+	Token    string // 注意:仅回填进隐藏表单字段(同源 POST 回来),不展示、不记录。
+	RunID    string
+	StageID  string
+}
+
+// approvalPageTmpl 是确认 / 结果 / 错误页共用的极简自包含 HTML 模板(无外链、无脚本)。
+// 所有插值点(.Title/.Message/.RunID/.StageID/.Token)经 html/template 上下文感知转义。
+var approvalPageTmpl = template.Must(template.New("approval").Parse(`<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex,nofollow">
+<title>{{.Title}}</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; margin: 0;
+         min-height: 100vh; display: grid; place-items: center; background: #f4f5f7; color: #1f2329; }
+  .card { background: #fff; border-radius: 12px; box-shadow: 0 8px 30px rgba(0,0,0,.08);
+          padding: 2rem 2.25rem; max-width: 28rem; width: calc(100% - 2rem); }
+  h1 { font-size: 1.25rem; margin: 0 0 1rem; }
+  .meta { font-size: .9rem; color: #5b6168; margin: .25rem 0; word-break: break-all; }
+  .meta b { color: #1f2329; font-weight: 600; }
+  .msg { font-size: 1rem; margin: .5rem 0 0; }
+  .actions { display: flex; gap: .75rem; margin-top: 1.5rem; }
+  button { flex: 1; padding: .7rem 1rem; border: 0; border-radius: 8px; font-size: 1rem;
+           cursor: pointer; font-weight: 600; }
+  .approve { background: #1f9d55; color: #fff; }
+  .reject  { background: #e5484d; color: #fff; }
+  form { flex: 1; margin: 0; }
+</style>
+</head>
+<body>
+  <main class="card">
+    <h1>{{.Title}}</h1>
+    {{if .ShowForm}}
+      <p class="meta">运行:<b>{{.RunID}}</b></p>
+      <p class="meta">阶段:<b>{{.StageID}}</b></p>
+      <p class="msg">{{.Message}}</p>
+      <div class="actions">
+        <form method="POST" action="/approvals/act">
+          <input type="hidden" name="token" value="{{.Token}}">
+          <input type="hidden" name="decision" value="approve">
+          <button type="submit" class="approve">批准</button>
+        </form>
+        <form method="POST" action="/approvals/act">
+          <input type="hidden" name="token" value="{{.Token}}">
+          <input type="hidden" name="decision" value="reject">
+          <button type="submit" class="reject">拒绝</button>
+        </form>
+      </div>
+    {{else}}
+      <p class="msg">{{.Message}}</p>
+    {{end}}
+  </main>
+</body>
+</html>`))
+
+// renderApprovalPage 渲染一张审批页(状态码 + 模板)。渲染失败时退化为纯文本(绝不 panic)。
+func renderApprovalPage(w http.ResponseWriter, status int, data approvalPageData) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Referrer-Policy", "no-referrer") // 防 token 经 Referer 外泄。
+	w.WriteHeader(status)
+	if err := approvalPageTmpl.Execute(w, data); err != nil {
+		_, _ = w.Write([]byte("操作完成,可关闭此页面。"))
+	}
+}
+
+// makeApprovalPageHandler 返回 GET /approvals?token=... 的处理器(公开;无副作用)。
+//
+// token 无效/过期 → 友好错误页;门已不在等待 → 已处理页;否则 → 确认页(两个 POST 表单)。
+func makeApprovalPageHandler(signer *approval.Signer, coord *approval.Coordinator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if signer == nil || !signer.Enabled() || coord == nil {
+			renderApprovalPage(w, http.StatusOK, approvalPageData{
+				Title: "审批链接不可用", Message: "服务端未启用签名链接审批,请登录平台处理。",
+			})
+			return
+		}
+		token := strings.TrimSpace(r.URL.Query().Get("token"))
+		runID, stageID, ok := signer.Verify(token)
+		if !ok {
+			renderApprovalPage(w, http.StatusBadRequest, approvalPageData{
+				Title: "链接无效", Message: "链接无效或已过期,请重新发起或登录平台处理。",
+			})
+			return
+		}
+		// GET 无副作用:仅查询门是否仍在等待。
+		if !coord.IsWaiting(approval.Key(runID, stageID)) {
+			renderApprovalPage(w, http.StatusOK, approvalPageData{
+				Title: "无需处理", Message: "该运行已处理或链接已失效。",
+			})
+			return
+		}
+		renderApprovalPage(w, http.StatusOK, approvalPageData{
+			Title:    "确认审批",
+			Message:  "请确认是否放行该审批门。",
+			ShowForm: true,
+			Token:    token,
+			RunID:    runID,
+			StageID:  stageID,
+		})
+	}
+}
+
+// makeApprovalActHandler 返回 POST /approvals/act 的处理器(公开;token 即认证;唯一有副作用入口)。
+//
+// 解析 form 的 token + decision(approve|reject)→ Verify → coord.Resolve。Resolve 为 false
+// (门已不在等待)→ 提示页;成功 → 审计(run.approve/run.reject)+ 结果页。
+// **不**在此调 store.Decide——门内 worker 收到决定后自行落库(与 UI 审批端点一致)。
+func makeApprovalActHandler(signer *approval.Signer, coord *approval.Coordinator, rec audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if signer == nil || !signer.Enabled() || coord == nil {
+			renderApprovalPage(w, http.StatusOK, approvalPageData{
+				Title: "审批链接不可用", Message: "服务端未启用签名链接审批,请登录平台处理。",
+			})
+			return
+		}
+		// 限请求体大小(防滥用);仅解析表单字段。
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<13)
+		if err := r.ParseForm(); err != nil {
+			renderApprovalPage(w, http.StatusBadRequest, approvalPageData{
+				Title: "请求无效", Message: "请求格式错误。",
+			})
+			return
+		}
+		token := strings.TrimSpace(r.PostFormValue("token"))
+		decision := strings.TrimSpace(r.PostFormValue("decision"))
+		runID, stageID, ok := signer.Verify(token)
+		if !ok {
+			renderApprovalPage(w, http.StatusBadRequest, approvalPageData{
+				Title: "链接无效", Message: "链接无效或已过期,请重新发起或登录平台处理。",
+			})
+			return
+		}
+		if decision != "approve" && decision != "reject" {
+			renderApprovalPage(w, http.StatusBadRequest, approvalPageData{
+				Title: "请求无效", Message: "未指定有效的审批决定。",
+			})
+			return
+		}
+		approved := decision == "approve"
+		key := approval.Key(runID, stageID)
+		if !coord.Resolve(key, approval.Decision{Approved: approved, Actor: approvalActor}) {
+			renderApprovalPage(w, http.StatusConflict, approvalPageData{
+				Title: "无需处理", Message: "该运行已不在等待审批(可能已被处理或已超时)。",
+			})
+			return
+		}
+		action := "run.approve"
+		title, msg := "已批准", "✅ 已批准,可关闭此页面。"
+		if !approved {
+			action = "run.reject"
+			title, msg = "已拒绝", "❌ 已拒绝,可关闭此页面。"
+		}
+		recordAudit(r.Context(), rec, audit.Entry{
+			Actor:      approvalActor,
+			Action:     action,
+			TargetType: "run",
+			TargetID:   runID,
+			Detail:     map[string]any{"stageId": stageID, "via": "notification_link"},
+			IP:         clientIP(r),
+		})
+		renderApprovalPage(w, http.StatusOK, approvalPageData{Title: title, Message: msg})
+	}
+}

--- a/internal/httpapi/approval_link_test.go
+++ b/internal/httpapi/approval_link_test.go
@@ -1,0 +1,210 @@
+package httpapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/huangchengsir/pipewright/internal/approval"
+)
+
+func newTestSigner() *approval.Signer {
+	k := make([]byte, 32)
+	for i := range k {
+		k[i] = byte(i + 7)
+	}
+	return approval.NewSigner(k)
+}
+
+// GET 必须无副作用:确认页渲染后,门仍在等待(不被自动解析)。
+func TestApprovalPageGetHasNoSideEffect(t *testing.T) {
+	signer := newTestSigner()
+	coord := approval.New()
+	key := approval.Key("run-1", "stage-1")
+	ch := coord.Wait(key) // 模拟门已在等待
+	_ = ch
+
+	tok := signer.Sign("run-1", "stage-1", time.Now().Add(time.Hour))
+	h := makeApprovalPageHandler(signer, coord)
+
+	req := httptest.NewRequest(http.MethodGet, "/approvals?token="+url.QueryEscape(tok), nil)
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET confirm page: want 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "确认审批") || !strings.Contains(body, "/approvals/act") {
+		t.Fatalf("confirm page missing expected content: %q", body)
+	}
+	// 关键:GET 没有解析门,门必须仍在等待。
+	if !coord.IsWaiting(key) {
+		t.Fatal("GET must NOT resolve the gate (no side effect) — but gate is no longer waiting")
+	}
+}
+
+// GET 对无效 token → 友好错误页(400)。
+func TestApprovalPageGetInvalidToken(t *testing.T) {
+	signer := newTestSigner()
+	coord := approval.New()
+	h := makeApprovalPageHandler(signer, coord)
+
+	req := httptest.NewRequest(http.MethodGet, "/approvals?token=garbage", nil)
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid token: want 400, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "链接无效或已过期") {
+		t.Fatalf("invalid token page missing friendly message: %q", rec.Body.String())
+	}
+}
+
+// POST approve 解析门:Resolve 后 worker 侧 channel 收到 Approved=true,页面回「已批准」。
+func TestApprovalActApproveResolvesGate(t *testing.T) {
+	signer := newTestSigner()
+	coord := approval.New()
+	key := approval.Key("run-9", "stage-deploy")
+	gateCh := coord.Wait(key)
+
+	tok := signer.Sign("run-9", "stage-deploy", time.Now().Add(time.Hour))
+	h := makeApprovalActHandler(signer, coord, nil) // nil 审计:recordAudit 静默跳过
+
+	form := url.Values{"token": {tok}, "decision": {"approve"}}
+	req := httptest.NewRequest(http.MethodPost, "/approvals/act", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST approve: want 200, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "已批准") {
+		t.Fatalf("approve result page missing 已批准: %q", rec.Body.String())
+	}
+	// 门内 worker 必须收到批准决定。
+	select {
+	case d := <-gateCh:
+		if !d.Approved {
+			t.Fatalf("gate received Approved=false, want true")
+		}
+		if d.Actor != approvalActor {
+			t.Fatalf("gate actor = %q, want %q", d.Actor, approvalActor)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("gate did not receive the approval decision")
+	}
+}
+
+// POST reject 解析门:worker 侧收到 Approved=false,页面回「已拒绝」。
+func TestApprovalActReject(t *testing.T) {
+	signer := newTestSigner()
+	coord := approval.New()
+	key := approval.Key("run-r", "stage-r")
+	gateCh := coord.Wait(key)
+
+	tok := signer.Sign("run-r", "stage-r", time.Now().Add(time.Hour))
+	h := makeApprovalActHandler(signer, coord, nil)
+
+	form := url.Values{"token": {tok}, "decision": {"reject"}}
+	req := httptest.NewRequest(http.MethodPost, "/approvals/act", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "已拒绝") {
+		t.Fatalf("reject: code=%d body=%q", rec.Code, rec.Body.String())
+	}
+	select {
+	case d := <-gateCh:
+		if d.Approved {
+			t.Fatal("gate received Approved=true on reject")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("gate did not receive the reject decision")
+	}
+}
+
+// POST 对未在等待的门 → 409「已不在等待」。
+func TestApprovalActNotWaiting(t *testing.T) {
+	signer := newTestSigner()
+	coord := approval.New() // 无任何等待者
+	tok := signer.Sign("run-x", "stage-x", time.Now().Add(time.Hour))
+	h := makeApprovalActHandler(signer, coord, nil)
+
+	form := url.Values{"token": {tok}, "decision": {"approve"}}
+	req := httptest.NewRequest(http.MethodPost, "/approvals/act", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("not-waiting gate: want 409, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "已不在等待审批") {
+		t.Fatalf("not-waiting page missing message: %q", rec.Body.String())
+	}
+}
+
+// POST 对无效 token → 400,且绝不解析任何门。
+func TestApprovalActInvalidToken(t *testing.T) {
+	signer := newTestSigner()
+	coord := approval.New()
+	key := approval.Key("run-1", "stage-1")
+	gateCh := coord.Wait(key)
+	h := makeApprovalActHandler(signer, coord, nil)
+
+	form := url.Values{"token": {"forged"}, "decision": {"approve"}}
+	req := httptest.NewRequest(http.MethodPost, "/approvals/act", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid token act: want 400, got %d", rec.Code)
+	}
+	select {
+	case <-gateCh:
+		t.Fatal("invalid token must NOT resolve the gate")
+	default:
+	}
+}
+
+// POST 对非法 decision → 400(防 GET 预取式自动操作之外的乱传)。
+func TestApprovalActBadDecision(t *testing.T) {
+	signer := newTestSigner()
+	coord := approval.New()
+	coord.Wait(approval.Key("run-1", "stage-1"))
+	tok := signer.Sign("run-1", "stage-1", time.Now().Add(time.Hour))
+	h := makeApprovalActHandler(signer, coord, nil)
+
+	form := url.Values{"token": {tok}, "decision": {"maybe"}}
+	req := httptest.NewRequest(http.MethodPost, "/approvals/act", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("bad decision: want 400, got %d", rec.Code)
+	}
+}
+
+// 禁用签名器(无 master key):页面提示不可用,绝不解析门。
+func TestApprovalDisabledSigner(t *testing.T) {
+	coord := approval.New()
+	coord.Wait(approval.Key("run-1", "stage-1"))
+	disabled := approval.NewSigner(nil)
+
+	get := makeApprovalPageHandler(disabled, coord)
+	reqG := httptest.NewRequest(http.MethodGet, "/approvals?token=whatever", nil)
+	recG := httptest.NewRecorder()
+	get(recG, reqG)
+	if !strings.Contains(recG.Body.String(), "未启用") {
+		t.Fatalf("disabled signer GET should show unavailable: %q", recG.Body.String())
+	}
+}

--- a/internal/httpapi/approvals.go
+++ b/internal/httpapi/approvals.go
@@ -25,8 +25,15 @@ import (
 // 审批人节奏可较慢,故取较长值;运行亦可经取消端点立即释放。
 const defaultGateTimeout = 24 * time.Hour
 
+// ApprovalNotifier 是审批门进入等待态后的 best-effort 通知钩子(供 main 注入)。
+// runID/stageID 用于签发签名链接;projectID 用于按项目维度路由通知。
+// 实现绝不阻塞 / 不返回错误冒泡(内部 best-effort、自带超时);nil 表示不发通知。
+type ApprovalNotifier func(ctx context.Context, projectID, projectName, runID, stageID string)
+
 // NewApprovalGate 构造注入 dagrun 的审批门 hook(供 main 装配)。
-func NewApprovalGate(runs run.Service, coord *approval.Coordinator, store *approval.Store) dagrun.GateFunc {
+// notifier 非 nil 时,在 run 进入 waiting_approval 后被 best-effort 调用(发「需要审批」通知 +
+// 签名审批链接);为 nil(或签名/PUBLIC_URL 未配)则不发通知,门行为不变。
+func NewApprovalGate(runs run.Service, coord *approval.Coordinator, store *approval.Store, notifier ApprovalNotifier) dagrun.GateFunc {
 	return func(ctx context.Context, r *run.Run, stage pipeline.Stage) (bool, error) {
 		key := approval.Key(r.ID, stage.ID)
 		_ = store.CreatePending(ctx, r.ID, stage.ID, stage.Name)
@@ -37,6 +44,11 @@ func NewApprovalGate(runs run.Service, coord *approval.Coordinator, store *appro
 		if err := runs.MarkWaitingApproval(ctx, r.ID); err != nil {
 			// 已终态/被取消:无法进入等待,退化失败让 worker 收尾。
 			return false, err
+		}
+
+		// best-effort 通知:进入等待态后发「需要审批」+ 签名链接。绝不阻塞门、绝不冒泡错误。
+		if notifier != nil {
+			notifier(ctx, r.ProjectID, r.ProjectName, r.ID, stage.ID)
 		}
 
 		var (

--- a/internal/httpapi/notify_hook.go
+++ b/internal/httpapi/notify_hook.go
@@ -3,9 +3,12 @@ package httpapi
 import (
 	"context"
 	"log"
+	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
+	"github.com/huangchengsir/pipewright/internal/approval"
 	"github.com/huangchengsir/pipewright/internal/notify"
 	"github.com/huangchengsir/pipewright/internal/run"
 )
@@ -77,6 +80,50 @@ func NewNotifyHook(runs run.Service, notifySvc notify.Service, secretSrc *RunSec
 		if err := notifySvc.RouteEventForProject(hookCtx, projectID, event, vars); err != nil {
 			log.Printf("[notify] run %s: 事件 %s 路由 best-effort 失败:%v", runID, event, err)
 		}
+	}
+}
+
+// approvalLinkTTL 是签名审批链接的有效期(审批人节奏可较慢,与门兜底超时一致)。
+const approvalLinkTTL = 24 * time.Hour
+
+// NewApprovalNotifier 构造审批门「需要审批」通知钩子(供 main 注入 NewApprovalGate)。
+//
+// run 进入 waiting_approval 后,本钩子 best-effort 地:签发签名审批链接(signer + publicURL)→
+// 构 TemplateVars(含 ActionURL)→ notifySvc.RouteEventForProject(EventApprovalRequired)。
+//   - signer 禁用(无 master key)/ publicURL 为空 / notifySvc 为 nil → 跳过(不发链接、不发通知),
+//     绝不阻塞门。
+//   - 自带超时(防慢渠道挂死 goroutine);RouteEventForProject 内部已 best-effort(未配路由不发)。
+//   - 链接、token 绝不写日志。
+func NewApprovalNotifier(notifySvc notify.Service, signer *approval.Signer, publicURL string) ApprovalNotifier {
+	base := strings.TrimRight(strings.TrimSpace(publicURL), "/")
+	if notifySvc == nil || signer == nil || !signer.Enabled() || base == "" {
+		// 依赖不全:返回 nil,门据此跳过通知(功能优雅关闭)。
+		return nil
+	}
+	return func(ctx context.Context, projectID, projectName, runID, stageID string) {
+		token := signer.Sign(runID, stageID, time.Now().Add(approvalLinkTTL))
+		if token == "" {
+			return // 签名器禁用(防御);不发链接。
+		}
+		link := base + "/approvals?token=" + url.QueryEscape(token)
+
+		vars := notify.TemplateVars{
+			Project:   projectName,
+			Status:    "waiting_approval",
+			Event:     notify.EventApprovalRequired,
+			RunID:     runID,
+			ActionURL: link,
+		}
+
+		// 异步发:门随后阻塞在 coord.Wait 上等待决定,通知不应拖慢进入等待。脱离父 ctx
+		// (run 取消不应中断已发起的通知)+ 自带 30s 超时(防慢渠道挂死 goroutine)。best-effort,绝不冒泡。
+		go func() {
+			hookCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+			defer cancel()
+			if err := notifySvc.RouteEventForProject(hookCtx, projectID, notify.EventApprovalRequired, vars); err != nil {
+				log.Printf("[notify] run %s: 审批通知路由 best-effort 失败:%v", runID, err)
+			}
+		}()
 	}
 }
 

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -86,6 +86,7 @@ type options struct {
 	oauth            oauth.Service
 	approvalCoord    *approval.Coordinator
 	approvalStore    *approval.Store
+	approvalSigner   *approval.Signer
 	promotionStore   *promotion.Store
 	environments     *environments.Service
 	doraMetrics      run.MetricsService
@@ -109,6 +110,13 @@ func WithApprovals(coord *approval.Coordinator, store *approval.Store) Option {
 		o.approvalCoord = coord
 		o.approvalStore = store
 	}
+}
+
+// WithApprovalLinks 注入审批链接签名器(「从通知直接审批」),挂载**公开**端点(豁免 requireAuth +
+// CSRF,token 即认证):GET /approvals(确认页,无副作用)+ POST /approvals/act(解析门)。
+// signer 为 nil / 禁用(无 master key)时,公开页提示「链接不可用」、不解析任何门。
+func WithApprovalLinks(signer *approval.Signer) Option {
+	return func(o *options) { o.approvalSigner = signer }
 }
 
 // WithPromotion 注入环境晋级流持久层(Story 8-7),挂载环境链配置 / 晋级触发 / 晋级历史路由。
@@ -376,6 +384,12 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 	// Webhook 接收(公开入口,Story 3.2):豁免 requireAuth + CSRF,靠签名校验。
 	// 必须在受保护 /api 组之外注册;限请求体大小在 handler 内(MaxBytesReader)。
 	r.Post("/api/webhooks/{token}", makeWebhookHandler(o.receiver))
+
+	// 从通知直接审批(公开入口,SECURITY-SENSITIVE):豁免 requireAuth + CSRF——token(HMAC+过期+
+	// 常量时间比较)即认证。GET 仅渲染确认页(无副作用,防 IM 预取自动放行);POST 才解析门。
+	// signer 为 nil/禁用时页面提示不可用、不解析任何门。
+	r.Get("/approvals", makeApprovalPageHandler(o.approvalSigner, o.approvalCoord))
+	r.Post("/approvals/act", makeApprovalActHandler(o.approvalSigner, o.approvalCoord, o.audit))
 
 	// 受保护 API 端点(除 /api/auth 与 /api/webhooks 外):requireAuth + 写方法 requireCSRF。
 	r.Route("/api", func(ar chi.Router) {

--- a/internal/i18n/messages_notify.go
+++ b/internal/i18n/messages_notify.go
@@ -12,16 +12,19 @@ func init() {
 		"部署失败":   {"zh-TW": "部署失敗", "en": "Deployment failed", "ja": "デプロイ失敗", "ko": "배포 실패", "es": "Despliegue fallido", "fr": "Déploiement échoué", "de": "Bereitstellung fehlgeschlagen"},
 		"已回滚":    {"zh-TW": "已回滾", "en": "Rolled back", "ja": "ロールバック済み", "ko": "롤백됨", "es": "Revertido", "fr": "Annulé", "de": "Zurückgerollt"},
 		"健康检查失败": {"zh-TW": "健康檢查失敗", "en": "Health check failed", "ja": "ヘルスチェック失敗", "ko": "상태 점검 실패", "es": "Comprobación de estado fallida", "fr": "Échec de la vérification de santé", "de": "Health-Check fehlgeschlagen"},
+		"需要审批":   {"zh-TW": "需要審批", "en": "Approval required", "ja": "承認が必要です", "ko": "승인 필요", "es": "Se requiere aprobación", "fr": "Approbation requise", "de": "Genehmigung erforderlich"},
 
 		// Field labels (notification body + feishu card field list).
-		"项目": {"zh-TW": "專案", "en": "Project", "ja": "プロジェクト", "ko": "프로젝트", "es": "Proyecto", "fr": "Projet", "de": "Projekt"},
-		"分支": {"zh-TW": "分支", "en": "Branch", "ja": "ブランチ", "ko": "브랜치", "es": "Rama", "fr": "Branche", "de": "Branch"},
-		"提交": {"zh-TW": "提交", "en": "Commit", "ja": "コミット", "ko": "커밋", "es": "Commit", "fr": "Commit", "de": "Commit"},
-		"状态": {"zh-TW": "狀態", "en": "Status", "ja": "ステータス", "ko": "상태", "es": "Estado", "fr": "Statut", "de": "Status"},
-		"耗时": {"zh-TW": "耗時", "en": "Duration", "ja": "所要時間", "ko": "소요 시간", "es": "Duración", "fr": "Durée", "de": "Dauer"},
-		"事件": {"zh-TW": "事件", "en": "Event", "ja": "イベント", "ko": "이벤트", "es": "Evento", "fr": "Événement", "de": "Ereignis"},
-		"来源": {"zh-TW": "來源", "en": "Source", "ja": "ソース", "ko": "소스", "es": "Origen", "fr": "Source", "de": "Quelle"},
-		"类型": {"zh-TW": "類型", "en": "Type", "ja": "種類", "ko": "유형", "es": "Tipo", "fr": "Type", "de": "Typ"},
+		"项目":     {"zh-TW": "專案", "en": "Project", "ja": "プロジェクト", "ko": "프로젝트", "es": "Proyecto", "fr": "Projet", "de": "Projekt"},
+		"分支":     {"zh-TW": "分支", "en": "Branch", "ja": "ブランチ", "ko": "브랜치", "es": "Rama", "fr": "Branche", "de": "Branch"},
+		"提交":     {"zh-TW": "提交", "en": "Commit", "ja": "コミット", "ko": "커밋", "es": "Commit", "fr": "Commit", "de": "Commit"},
+		"状态":     {"zh-TW": "狀態", "en": "Status", "ja": "ステータス", "ko": "상태", "es": "Estado", "fr": "Statut", "de": "Status"},
+		"耗时":     {"zh-TW": "耗時", "en": "Duration", "ja": "所要時間", "ko": "소요 시간", "es": "Duración", "fr": "Durée", "de": "Dauer"},
+		"事件":     {"zh-TW": "事件", "en": "Event", "ja": "イベント", "ko": "이벤트", "es": "Evento", "fr": "Événement", "de": "Ereignis"},
+		"来源":     {"zh-TW": "來源", "en": "Source", "ja": "ソース", "ko": "소스", "es": "Origen", "fr": "Source", "de": "Quelle"},
+		"类型":     {"zh-TW": "類型", "en": "Type", "ja": "種類", "ko": "유형", "es": "Tipo", "fr": "Type", "de": "Typ"},
+		"审批链接":   {"zh-TW": "審批連結", "en": "Approval link", "ja": "承認リンク", "ko": "승인 링크", "es": "Enlace de aprobación", "fr": "Lien d’approbation", "de": "Genehmigungslink"},
+		"点击前往审批": {"zh-TW": "點此前往審批", "en": "Click to review", "ja": "クリックして承認", "ko": "클릭하여 승인", "es": "Haga clic para revisar", "fr": "Cliquez pour examiner", "de": "Zum Prüfen klicken"},
 
 		// Titles / misc.
 		"Pipewright 通知": {"zh-TW": "Pipewright 通知", "en": "Pipewright notification", "ja": "Pipewright 通知", "ko": "Pipewright 알림", "es": "Notificación de Pipewright", "fr": "Notification Pipewright", "de": "Pipewright-Benachrichtigung"},

--- a/internal/notify/approval_event_test.go
+++ b/internal/notify/approval_event_test.go
@@ -1,0 +1,79 @@
+package notify
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// approval_required 必须是合法事件,且出现在冻结枚举列表里(供前端/路由消费)。
+func TestApprovalRequiredIsValidEvent(t *testing.T) {
+	if !validEvent(EventApprovalRequired) {
+		t.Fatal("approval_required should be a valid event")
+	}
+	found := false
+	for _, e := range Events() {
+		if e == EventApprovalRequired {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("approval_required missing from Events(): %v", Events())
+	}
+}
+
+// EventPayload 对 approval_required 产出非空标题/正文,且 event 字段正确。
+func TestApprovalRequiredEventPayload(t *testing.T) {
+	p := EventPayload("zh-CN", EventApprovalRequired, "proj", "", "", "waiting_approval", 0)
+	if p.Title == "" || p.Body == "" {
+		t.Fatalf("empty approval payload: %+v", p)
+	}
+	if p.Fields["event"] != EventApprovalRequired {
+		t.Fatalf("missing event field: %+v", p.Fields)
+	}
+	if !strings.Contains(p.Body, "需要审批") {
+		t.Fatalf("approval label missing from body: %q", p.Body)
+	}
+}
+
+// defaultPayload 携带 ActionURL 时,链接透出到 Fields[actionUrl] 与正文。
+func TestApprovalRequiredPayloadCarriesActionURL(t *testing.T) {
+	s, _, _ := newSvc(t, http.DefaultClient)
+	link := "https://ci.example.com/approvals?token=abc.def"
+	p := s.defaultPayload(ctx(), EventApprovalRequired, TemplateVars{
+		Project:   "proj",
+		Event:     EventApprovalRequired,
+		RunID:     "run-1",
+		ActionURL: link,
+	})
+	if p.Fields[fieldActionURL] != link {
+		t.Fatalf("action url not in fields: %+v", p.Fields)
+	}
+	if !strings.Contains(p.Body, link) {
+		t.Fatalf("action url not in body: %q", p.Body)
+	}
+}
+
+// 飞书卡片把 actionUrl 渲染为可点击 lark_md 链接 [text](url)。
+func TestFeishuCardRendersActionURLAsLink(t *testing.T) {
+	link := "https://ci.example.com/approvals?token=abc.def"
+	card := feishuCardFor(Payload{
+		Title:  "需要审批",
+		Body:   "请确认",
+		Fields: map[string]string{"project": "proj", fieldActionURL: link},
+		Lang:   "zh-CN",
+	})
+	var joined strings.Builder
+	for _, el := range card.Elements {
+		for _, f := range el.Fields {
+			joined.WriteString(f.Text.Content)
+			joined.WriteString("\n")
+		}
+		if el.Text != nil {
+			joined.WriteString(el.Text.Content)
+		}
+	}
+	if !strings.Contains(joined.String(), "]("+link+")") {
+		t.Fatalf("feishu card missing clickable link for actionUrl: %q", joined.String())
+	}
+}

--- a/internal/notify/feishu.go
+++ b/internal/notify/feishu.go
@@ -171,7 +171,8 @@ func (s *service) sendFeishu(ctx context.Context, ch *Channel, sealed []byte, pa
 }
 
 // feishuFieldOrder 字段在卡片里的展示顺序(业务可读优先,而非字母序);未列出的 key 追加在后、按字母序。
-var feishuFieldOrder = []string{"project", "branch", "commit", "status", "duration", "event"}
+// actionUrl(操作/审批链接)排在最后,作为卡片底部的行动入口。
+var feishuFieldOrder = []string{"project", "branch", "commit", "status", "duration", "event", fieldActionURL}
 
 // feishuFieldLabel 字段 key → 中文标签(卡片里展示更友好)。未知 key 原样用 key。
 func feishuFieldLabel(key, lang string) string {
@@ -192,6 +193,8 @@ func feishuFieldLabel(key, lang string) string {
 		return i18n.T(lang, "来源")
 	case "kind":
 		return i18n.T(lang, "类型")
+	case fieldActionURL:
+		return i18n.T(lang, "审批链接")
 	default:
 		return key
 	}
@@ -264,11 +267,18 @@ func feishuOrderedFields(fields map[string]string, lang string) []feishuCardFiel
 
 	out := make([]feishuCardField, 0, len(keys))
 	for _, k := range keys {
+		content := "**" + feishuFieldLabel(k, lang) + "**\n" + fields[k]
+		isShort := true
+		if k == fieldActionURL && strings.TrimSpace(fields[k]) != "" {
+			// 操作链接渲染为可点击 lark_md 链接(整行宽,作为卡片底部行动入口)。
+			content = "**" + feishuFieldLabel(k, lang) + "**\n[" + i18n.T(lang, "点击前往审批") + "](" + fields[k] + ")"
+			isShort = false
+		}
 		out = append(out, feishuCardField{
-			IsShort: true, // 半宽 → 两两并排成双列
+			IsShort: isShort, // 半宽 → 两两并排成双列;操作链接整行宽
 			Text: feishuCardText{
 				Tag:     "lark_md",
-				Content: "**" + feishuFieldLabel(k, lang) + "**\n" + fields[k],
+				Content: content,
 			},
 		})
 	}

--- a/internal/notify/router.go
+++ b/internal/notify/router.go
@@ -29,6 +29,8 @@ const (
 	EventRollback = "rollback"
 	// EventHealthCheckFailed 健康检查失败(Epic 4 细化)。
 	EventHealthCheckFailed = "health_check_failed"
+	// EventApprovalRequired 需要人工审批(run 进入 waiting_approval 时发,携带签名审批链接)。
+	EventApprovalRequired = "approval_required"
 )
 
 // 路由领域错误。
@@ -45,7 +47,7 @@ var (
 func validEvent(e string) bool {
 	switch e {
 	case EventBuildSucceeded, EventBuildFailed, EventDeploySucceeded,
-		EventDeployFailed, EventRollback, EventHealthCheckFailed:
+		EventDeployFailed, EventRollback, EventHealthCheckFailed, EventApprovalRequired:
 		return true
 	default:
 		return false
@@ -58,6 +60,7 @@ func Events() []string {
 		EventBuildSucceeded, EventBuildFailed,
 		EventDeploySucceeded, EventDeployFailed,
 		EventRollback, EventHealthCheckFailed,
+		EventApprovalRequired,
 	}
 }
 
@@ -477,6 +480,8 @@ func eventLabel(event, lang string) string {
 		return i18n.T(lang, "已回滚")
 	case EventHealthCheckFailed:
 		return i18n.T(lang, "健康检查失败")
+	case EventApprovalRequired:
+		return i18n.T(lang, "需要审批")
 	default:
 		return event
 	}

--- a/internal/notify/template.go
+++ b/internal/notify/template.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/huangchengsir/pipewright/internal/i18n"
 )
 
 // 模板领域错误。
@@ -67,6 +68,9 @@ type TemplateVars struct {
 	DurationMs   string
 	RunID        string
 	ErrorSummary string
+	// ActionURL 是一次性操作链接(目前用于 approval_required 事件的签名审批链接);
+	// 空 = 该事件无操作链接。渲染时占位名 {{actionUrl}};并透出到 Payload.Fields["审批链接"]/正文。
+	ActionURL string
 }
 
 // asMap 把 TemplateVars 展开为占位名 → 值的映射(冻结占位名)。
@@ -80,6 +84,7 @@ func (v TemplateVars) asMap() map[string]string {
 		"durationMs":   v.DurationMs,
 		"runId":        v.RunID,
 		"errorSummary": v.ErrorSummary,
+		"actionUrl":    v.ActionURL,
 	}
 }
 
@@ -273,6 +278,8 @@ func (s *service) RenderPayload(ctx context.Context, event, channelID string, va
 }
 
 // defaultPayload 用 TemplateVars 还原 EventPayload 入参,产出平台默认 Payload(按通知语言本地化)。
+// 若 vars 携带 ActionURL(如 approval_required 的签名审批链接),则透出到 Payload.Fields[操作链接键]
+// 与正文(供各渠道渲染为可点击链接)。
 func (s *service) defaultPayload(ctx context.Context, event string, vars TemplateVars) Payload {
 	var durationMs int64
 	if vars.DurationMs != "" {
@@ -280,8 +287,22 @@ func (s *service) defaultPayload(ctx context.Context, event string, vars Templat
 			durationMs = d
 		}
 	}
-	return EventPayload(s.notifyLanguage(ctx), event, vars.Project, vars.Branch, vars.Commit, vars.Status, durationMs)
+	lang := s.notifyLanguage(ctx)
+	p := EventPayload(lang, event, vars.Project, vars.Branch, vars.Commit, vars.Status, durationMs)
+	if url := strings.TrimSpace(vars.ActionURL); url != "" {
+		if p.Fields == nil {
+			p.Fields = map[string]string{}
+		}
+		p.Fields[fieldActionURL] = url
+		// 正文追加一行可点击提示(飞书 lark_md / 纯文本均可读)。
+		label := i18n.T(lang, "审批链接")
+		p.Body = strings.TrimRight(p.Body, "。.") + bodySeparator(lang) + label + bodySeparator(lang) + url
+	}
+	return p
 }
+
+// fieldActionURL 是 Payload.Fields 里承载操作链接的键(各渠道据此渲染为可点击链接)。
+const fieldActionURL = "actionUrl"
 
 // varsFields 把 TemplateVars 展开为 Payload.Fields(仅非空项),供 webhook/email 透出结构化键值。
 func varsFields(vars TemplateVars) map[string]string {

--- a/web/src/api/notifications.ts
+++ b/web/src/api/notifications.ts
@@ -133,6 +133,7 @@ export type NotificationEvent =
   | 'deploy_failed'
   | 'rollback'
   | 'health_check_failed'
+  | 'approval_required'
 
 /** GET response item — an event→channel mapping. */
 export interface NotificationRoute {

--- a/web/src/i18n/locales/de/settingsNotifications.ts
+++ b/web/src/i18n/locales/de/settingsNotifications.ts
@@ -129,6 +129,8 @@ export default {
   evRollbackDesc: 'Auf die vorherige Version zurückgesetzt',
   evHealthCheckFailed: 'Health-Check fehlgeschlagen',
   evHealthCheckFailedDesc: 'Der Health-Check nach dem Deployment ist nicht bestanden',
+  evApprovalRequired: 'Genehmigung erforderlich',
+  evApprovalRequiredDesc: 'Ein Lauf hat ein manuelles Genehmigungs-Gate erreicht und wartet auf Genehmigung oder Ablehnung',
 
   routesTitle: 'Ereignisrouten',
   routesDescPre: 'Konfigurieren Sie, welche Ereignisse über welche Kanäle benachrichtigen. ',

--- a/web/src/i18n/locales/en/settingsNotifications.ts
+++ b/web/src/i18n/locales/en/settingsNotifications.ts
@@ -129,6 +129,8 @@ export default {
   evRollbackDesc: 'Rolled back to the previous version',
   evHealthCheckFailed: 'Health Check Failed',
   evHealthCheckFailedDesc: 'Post-deploy health check did not pass',
+  evApprovalRequired: 'Approval Required',
+  evApprovalRequiredDesc: 'A run reached a manual approval gate and awaits approve or reject',
 
   routesTitle: 'Event Routes',
   routesDescPre: 'Configure which events notify which channels. ',

--- a/web/src/i18n/locales/es/settingsNotifications.ts
+++ b/web/src/i18n/locales/es/settingsNotifications.ts
@@ -129,6 +129,8 @@ export default {
   evRollbackDesc: 'Revertido a la versión anterior',
   evHealthCheckFailed: 'Comprobación de estado fallida',
   evHealthCheckFailedDesc: 'La comprobación de estado posterior al despliegue no pasó',
+  evApprovalRequired: 'Se requiere aprobación',
+  evApprovalRequiredDesc: 'Una ejecución llegó a una puerta de aprobación manual y espera aprobación o rechazo',
 
   routesTitle: 'Rutas de eventos',
   routesDescPre: 'Configura qué eventos notifican por qué canales. ',

--- a/web/src/i18n/locales/fr/settingsNotifications.ts
+++ b/web/src/i18n/locales/fr/settingsNotifications.ts
@@ -129,6 +129,8 @@ export default {
   evRollbackDesc: 'Restauré à la version précédente',
   evHealthCheckFailed: 'Échec du contrôle de santé',
   evHealthCheckFailedDesc: 'Le contrôle de santé après déploiement n’a pas réussi',
+  evApprovalRequired: 'Approbation requise',
+  evApprovalRequiredDesc: 'Une exécution a atteint une porte d’approbation manuelle et attend approbation ou refus',
 
   routesTitle: 'Routes d’événements',
   routesDescPre: 'Configurez quels événements notifient quels canaux. ',

--- a/web/src/i18n/locales/ja/settingsNotifications.ts
+++ b/web/src/i18n/locales/ja/settingsNotifications.ts
@@ -129,6 +129,8 @@ export default {
   evRollbackDesc: '前のバージョンにロールバック済み',
   evHealthCheckFailed: 'ヘルスチェック失敗',
   evHealthCheckFailedDesc: 'デプロイ後のヘルスチェックが通過しませんでした',
+  evApprovalRequired: '承認が必要です',
+  evApprovalRequiredDesc: '実行が手動承認ゲートに到達し、承認または却下を待っています',
 
   routesTitle: 'イベントルート',
   routesDescPre: '「どのイベントをどのチャンネルで通知するか」を設定します。',

--- a/web/src/i18n/locales/ko/settingsNotifications.ts
+++ b/web/src/i18n/locales/ko/settingsNotifications.ts
@@ -129,6 +129,8 @@ export default {
   evRollbackDesc: '이전 버전으로 롤백됨',
   evHealthCheckFailed: '상태 점검 실패',
   evHealthCheckFailedDesc: '배포 후 상태 점검을 통과하지 못함',
+  evApprovalRequired: '승인 필요',
+  evApprovalRequiredDesc: '실행이 수동 승인 게이트에 도달하여 승인 또는 거부를 기다리는 중',
 
   routesTitle: '이벤트 라우트',
   routesDescPre: '"어떤 이벤트를 어떤 채널로 알릴지"를 구성합니다. ',

--- a/web/src/i18n/locales/zh-CN/settingsNotifications.ts
+++ b/web/src/i18n/locales/zh-CN/settingsNotifications.ts
@@ -133,6 +133,8 @@ export default {
   evRollbackDesc: '已回滚到上一版本',
   evHealthCheckFailed: '健康检查失败',
   evHealthCheckFailedDesc: '部署后健康检查未通过',
+  evApprovalRequired: '需要审批',
+  evApprovalRequiredDesc: '运行进入人工审批门,等待批准或拒绝',
 
   // 事件路由区
   routesTitle: '事件路由',

--- a/web/src/i18n/locales/zh-TW/settingsNotifications.ts
+++ b/web/src/i18n/locales/zh-TW/settingsNotifications.ts
@@ -128,6 +128,8 @@ export default {
   evRollbackDesc: '已回滾到上一版本',
   evHealthCheckFailed: '健康檢查失敗',
   evHealthCheckFailedDesc: '部署後健康檢查未通過',
+  evApprovalRequired: '需要審批',
+  evApprovalRequiredDesc: '執行進入人工審批門,等待批准或拒絕',
 
   routesTitle: '事件路由',
   routesDescPre: '設定「哪些事件經哪些管道通知」。',

--- a/web/src/views/settings/SettingsNotifications.vue
+++ b/web/src/views/settings/SettingsNotifications.vue
@@ -448,6 +448,7 @@ const EVENTS = computed<EventMeta[]>(() => [
   { id: 'deploy_failed', label: t('settingsNotifications.evDeployFailed'), desc: t('settingsNotifications.evDeployFailedDesc') },
   { id: 'rollback', label: t('settingsNotifications.evRollback'), desc: t('settingsNotifications.evRollbackDesc') },
   { id: 'health_check_failed', label: t('settingsNotifications.evHealthCheckFailed'), desc: t('settingsNotifications.evHealthCheckFailedDesc') },
+  { id: 'approval_required', label: t('settingsNotifications.evApprovalRequired'), desc: t('settingsNotifications.evApprovalRequiredDesc') },
 ])
 
 const routesLoadState = ref<LoadState>('loading')


### PR DESCRIPTION
让审批人**无需登录平台**,直接从飞书/钉钉/邮件通知里点击放行流水线审批门。

## 背景
此前运行卡在人工审批门(`waiting_approval`)时**不发任何通知**,审批只能进 UI 点。本 PR:运行进审批门 → 发带**签名链接**的通知 → 点链接打开确认页 → 批准/拒绝直接放行。

## 设计(签名链接,非飞书 App 回调)
- **链接签名** `internal/approval/link.go`:HMAC-SHA256(master key)签 `runID|stageID|expUnix` → `base64url(payload).base64url(sig)`。verify-先于-parse、`hmac.Equal` 常量时间比较、24h 过期、master key 缺失则禁用(优雅关闭)。
- **公开端点** `internal/httpapi/approval_link.go`(无会话,token 即认证,注册在 requireAuth/CSRF 组外):
  - `GET /approvals?token=` —— **零副作用**,仅校验 + 渲染确认页(防 IM 预取链接误批准);`html/template` 转义、`X-Content-Type-Options: nosniff` + `Referrer-Policy: no-referrer`(防 token 经 Referer 外泄)
  - `POST /approvals/act` —— **唯一 resolve 入口**,token+decision → `coord.Resolve`,审计 `via=notification_link`
- **`approval_required` 事件**:notify 新增事件 + 默认文案 i18n ×8;`TemplateVars.ActionURL` 串进 Payload,飞书卡片渲成可点 lark_md 链接。审批门 `MarkWaitingApproval` 后 best-effort 发该事件到项目路由渠道。前端通知路由 UI 加该事件 ×8。

## 自检
- 后端 `go build/vet/test ./...` 全绿、`gofmt` 空(已 rebase 到含 retention 的 master,`main.go`/`router.go` 冲突已解,合体构建通过)
- 前端 typecheck/lint 0 错、321 测试过
- 测试:signer 7 例(篡改/过期/错 key/禁用)+ 公开 handler 8 例(**GET 无副作用**/POST 批准拒绝/not-waiting 409/非法 token/禁用)+ notify 事件 4 例
- **真机端到端**:gate 流水线 → `waiting_approval` → 通知(本地 webhook sink 收到带 `/approvals?token=` 的卡片)→ GET 确认页(状态不变,防预取)→ POST 批准 → 门释放 → run 跑到 **success** → `run_approvals` 记 `通知链接审批`

🤖 Generated with [Claude Code](https://claude.com/claude-code)