### PR TITLE
test(approval): 修签名篡改测试偶发假失败

### DIFF
--- a/internal/approval/link_test.go
+++ b/internal/approval/link_test.go
@@ -51,13 +51,15 @@ func TestSignerTamperedPayload(t *testing.T) {
 func TestSignerTamperedSig(t *testing.T) {
 	s := NewSigner(testKey())
 	tok := s.Sign("run-1", "stage-1", time.Now().Add(time.Hour))
-	// 翻转签名段最后一个字符。
-	last := tok[len(tok)-1]
+	// 翻转签名段**首字符**:base64 首字符编码首字节高 6 位,翻转必改解码字节。
+	// (末字符含非有效尾比特,翻转可能解出同字节 → 与原签名等价、不可靠;曾致 CI 偶发假失败。)
+	dot := strings.IndexByte(tok, '.')
+	sigFirst := tok[dot+1]
 	repl := byte('A')
-	if last == 'A' {
+	if sigFirst == 'A' {
 		repl = 'B'
 	}
-	forged := tok[:len(tok)-1] + string(repl)
+	forged := tok[:dot+1] + string(repl) + tok[dot+2:]
 	if _, _, ok := s.Verify(forged); ok {
 		t.Fatal("Verify accepted a token with tampered signature")
 	}


### PR DESCRIPTION
`TestSignerTamperedSig` 在 CI(#122 master)偶发失败、本地常过。

**根因(测试缺陷,非产品 bug)**:测试翻转签名 token 的**末字符**;base64url 末字符含非有效尾比特,翻转后可能解出与原签名**相同的字节**,Verify 正确地接受 → 测试假失败。token 的 `exp` 随 `time.Now()` 变 → 签名随之变 → 偶发。

**修复**:改翻转签名段**首字符**(编码首字节高 6 位,翻转必改解码字节),确定性。`go test -count=200` 稳过。签名器逻辑无误。

🤖 Generated with [Claude Code](https://claude.com/claude-code)