### PR TITLE
fix(pipeline): 源节点显示项目源码信息 + 编辑器整页溢出 + 去冗余加任务按钮

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -154,6 +154,9 @@ func New(db *sql.DB) Service {
 func (s *service) Get(ctx context.Context, projectID string) (*Config, error) {
 	cfg, err := s.load(ctx, projectID)
 	if err == nil {
+		// 给 git_source 任务预填项目绑定的仓库/分支/凭据(字段留空时)+ 卡片摘要,
+		// 使画布源节点直接展示项目源码信息(经 YAML 导入/手编保存的 source 任务常为空)。
+		s.fillSourceDefaults(ctx, projectID, &cfg.Spec)
 		return cfg, nil
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
@@ -161,6 +164,56 @@ func (s *service) Get(ctx context.Context, projectID string) (*Config, error) {
 	}
 	// 首次访问无配置:惰性生成默认种子。
 	return s.createDefault(ctx, projectID)
+}
+
+// fillSourceDefaults 为 git_source 任务预填项目绑定的仓库/分支/凭据(仅当对应字段为空,
+// 不覆盖用户显式覆盖)并补上「仓库 · 分支」卡片摘要。展示层补全:让源节点直观显示项目源码;
+// 项目信息读取失败则静默跳过,不阻断流水线返回。
+func (s *service) fillSourceDefaults(ctx context.Context, projectID string, spec *Spec) {
+	var repoURL, branch, credID string
+	loaded := false
+	load := func() {
+		if loaded {
+			return
+		}
+		loaded = true
+		_ = s.db.QueryRowContext(ctx,
+			`SELECT repo_url, default_branch, credential_id FROM projects WHERE id = ?`, projectID,
+		).Scan(&repoURL, &branch, &credID)
+	}
+	asStr := func(v any) string { s, _ := v.(string); return strings.TrimSpace(s) }
+	for i := range spec.Stages {
+		for j := range spec.Stages[i].Jobs {
+			job := &spec.Stages[i].Jobs[j]
+			if job.Type != "git_source" {
+				continue
+			}
+			load()
+			if job.Config == nil {
+				job.Config = map[string]any{}
+			}
+			if repoURL != "" && asStr(job.Config["repoUrl"]) == "" {
+				job.Config["repoUrl"] = repoURL
+			}
+			if branch != "" && asStr(job.Config["branch"]) == "" {
+				job.Config["branch"] = branch
+			}
+			if credID != "" && asStr(job.Config["credentialId"]) == "" {
+				job.Config["credentialId"] = credID
+			}
+			if strings.TrimSpace(job.Summary) == "" {
+				b := branch
+				if b == "" {
+					b = "main"
+				}
+				if repoURL != "" {
+					job.Summary = repoURL + " · " + b
+				} else {
+					job.Summary = b + " · push/tag/PR"
+				}
+			}
+		}
+	}
 }
 
 func (s *service) Save(ctx context.Context, projectID string, spec Spec) (*Config, error) {

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -355,3 +355,66 @@ func TestRenderYAMLDeterministic(t *testing.T) {
 		t.Fatalf("yaml 渲染应确定性:\n%q\nvs\n%q", a, b)
 	}
 }
+
+// TestGetFillsSourceDefaults 验证:git_source 任务 config 为空时,Get 用项目绑定的
+// 仓库/分支/凭据预填(展示用),并补「仓库 · 分支」摘要(修复源节点不显示源码信息)。
+func TestGetFillsSourceDefaults(t *testing.T) {
+	svc, db, projID := newSvc(t)
+	var credID string
+	if err := db.QueryRow(`SELECT credential_id FROM projects WHERE id = ?`, projID).Scan(&credID); err != nil {
+		t.Fatalf("read project cred: %v", err)
+	}
+	// 存一条 source 任务 config/summary 全空的流水线。
+	spec := Spec{Stages: []Stage{
+		{Name: "源码", Kind: KindSource, Jobs: []Job{
+			{Name: "拉取", Type: "git_source", Config: map[string]any{}},
+		}},
+	}}
+	if _, err := svc.Save(context.Background(), projID, spec); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	cfg, err := svc.Get(context.Background(), projID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	job := cfg.Spec.Stages[0].Jobs[0]
+	if got, _ := job.Config["repoUrl"].(string); got != "https://gitee.com/acme/shop.git" {
+		t.Fatalf("repoUrl 未预填项目仓库, got %q", got)
+	}
+	if got, _ := job.Config["branch"].(string); got != "main" {
+		t.Fatalf("branch 未预填项目默认分支, got %q", got)
+	}
+	if got, _ := job.Config["credentialId"].(string); got != credID {
+		t.Fatalf("credentialId 未预填项目凭据, got %q want %q", got, credID)
+	}
+	if !strings.Contains(job.Summary, "gitee.com/acme/shop.git") || !strings.Contains(job.Summary, "main") {
+		t.Fatalf("summary 应含仓库 · 分支, got %q", job.Summary)
+	}
+}
+
+// TestGetDoesNotOverrideExplicitSource 验证:用户显式填了仓库/分支时,Get 不覆盖。
+func TestGetDoesNotOverrideExplicitSource(t *testing.T) {
+	svc, _, projID := newSvc(t)
+	spec := Spec{Stages: []Stage{
+		{Name: "源码", Kind: KindSource, Jobs: []Job{
+			{Name: "拉取", Type: "git_source", Config: map[string]any{
+				"repoUrl": "https://gitee.com/other/repo.git",
+				"branch":  "dev",
+			}},
+		}},
+	}}
+	if _, err := svc.Save(context.Background(), projID, spec); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	cfg, err := svc.Get(context.Background(), projID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	job := cfg.Spec.Stages[0].Jobs[0]
+	if got, _ := job.Config["repoUrl"].(string); got != "https://gitee.com/other/repo.git" {
+		t.Fatalf("显式 repoUrl 被覆盖, got %q", got)
+	}
+	if got, _ := job.Config["branch"].(string); got != "dev" {
+		t.Fatalf("显式 branch 被覆盖, got %q", got)
+	}
+}

--- a/web/src/components/pipeline/PipelineCanvas.vue
+++ b/web/src/components/pipeline/PipelineCanvas.vue
@@ -441,10 +441,7 @@ function handleDrawerUpdate(patch: Partial<PipelineJob>): void {
 .canvas-body {
   flex: 1;
   display: flex;
-  /* min-height 下限:画布上方还堆着 GitOps/PR 两条开关 bar + 下方风险面板,flex:1
-     分到的高度常被挤到只剩一两排节点高(用户反馈「画布太矮」)。给个可用下限,
-     不够时由 .tab-panel--canvas(overflow:auto)整体滚动,既不裁右侧抽屉也不裁风险面板。 */
-  min-height: 460px;
+  min-height: 0;
   overflow: hidden;
 }
 

--- a/web/src/components/pipeline/StageColumn.vue
+++ b/web/src/components/pipeline/StageColumn.vue
@@ -92,9 +92,6 @@ const anchorJob = computed<PipelineJob | null>(() => {
   return props.stage.jobs.length ? props.stage.jobs[props.stage.jobs.length - 1] : null
 })
 
-function addPlain(): void {
-  emit('add-job', [])
-}
 /** 串行节点:依赖锚点 job(出现在其右侧,串行其后)。 */
 function addSerial(): void {
   emit('add-job', anchorJob.value ? [anchorJob.value.id] : [])
@@ -254,12 +251,6 @@ function resetDrag(): void {
         </svg>
         {{ t('pipelineCanvas.condition') }}<span v-if="hasStageRules" class="stage-deps-count stage-deps-count--dot" aria-hidden="true"></span>
       </button>
-      <button
-        v-if="stage.kind !== 'source'"
-        class="stage-add-job"
-        :aria-label="t('pipelineCanvas.addJobAria', { name: stage.name })"
-        @click="addPlain"
-      >{{ t('pipelineCanvas.addJob') }}</button>
       <button
         v-if="stage.kind !== 'source'"
         class="stage-del"

--- a/web/src/views/ProjectPipeline.vue
+++ b/web/src/views/ProjectPipeline.vue
@@ -781,9 +781,16 @@ async function togglePrStatus(next: boolean): Promise<void> {
    * overflow:auto/hidden 的滚动真正生效。
    *
    * 底部只留一小段呼吸位(而非整段 --main-pad-bottom):编辑器是全幅工作面板,把原本
-   * ~90px 的底部留白还给画布,缓解「画布高度太窄」。顶部仍减 --main-pad-top 对齐父内边距。
+   * ~90px 的底部留白还给画布,缓解「画布高度太窄」。
+   *
+   * ⚠ 两处必须对齐父内边距,否则编辑器比视口高、整页滚动、底部风险面板划不到/被截:
+   *  ① 顶部减 .main-inner 的**完整** padding-top = calc(--main-pad-top + 38px)(见 AppShell);
+   *     原来只减了 --main-pad-top,漏掉 38px。
+   *  ② 用负 margin-bottom 收掉 .main-inner 的 padding-bottom(--main-pad-bottom,默认 90px,
+   *     是给普通页准备的),只留 20px 呼吸位 —— 否则那 90px 叠在定高面板下方又把文档顶出视口。
    */
-  height: calc(100vh - var(--main-pad-top) - 20px);
+  height: calc(100vh - var(--main-pad-top) - 38px - 20px);
+  margin-bottom: calc(20px - var(--main-pad-bottom));
   min-height: 0;
   gap: 0;
 }
@@ -1101,9 +1108,6 @@ async function togglePrStatus(next: boolean): Promise<void> {
 .tab-panel--canvas {
   display: flex;
   flex-direction: column;
-  /* 画布有 min-height 下限(见 PipelineCanvas .canvas-body);视口不够高时整个画布 tab
-     纵向滚动,而不是裁掉下方「AI 脚本风险标注」面板或把画布压扁。 */
-  overflow: auto;
 }
 
 /* Non-canvas panels: scrollable with standard padding */


### PR DESCRIPTION
## 三个流水线编辑器修复

### 1. 源节点不显示项目源码信息
`git_source` 节点经 YAML 导入/手编保存后 config 与 summary 为空,画布卡片只剩「拉取源码」、抽屉字段也空着(占位符是通用示例),看不出接的哪个仓库。
**修**:后端 `Get` 加载流水线时,给 summary 为空的 git_source 任务用**项目绑定的仓库/分支/凭据预填** config(仅当对应字段为空、不覆盖用户显式覆盖)+「仓库 · 分支」摘要(纯展示补全,不改库内 spec)。附 2 个后端测试(预填 + 不覆盖显式值)。

### 2. 编辑器整页溢出 → 底部风险面板/明暗切换划不到、被截
`pipeline-root` 定高 `calc` 漏减了 `.main-inner` 的**完整** padding-top(只减 `--main-pad-top`,漏掉 `+38px`),且没抵消其 `padding-bottom`(`--main-pad-bottom` 90px,给普通页用的)→ 编辑器比视口高 ~108px、整页滚动、底部内容跑出视口。
**修**:height 补减 38px + 负 `margin-bottom` 收掉父级多余底 padding(只留 20px)。真实视口 1333×716 下验证:文档高=视口、无溢出、风险面板与明暗切换完整可见。顺带还原上一版引入的 `canvas-body` min-height/overflow 实验(矮窗口下会把风险面板挤出视口/套出多条滚动条)。

### 3. 去掉冗余「+任务」按钮
阶段头部「+任务」与节点下方「+串行节点 / +并行节点」职能重叠(空阶段下三者等价)。去掉头部「+任务」,加节点统一走「+串行/+并行节点」(空阶段也能加首个节点,功能不变)。

## 验证
`gofmt`✅ / `go vet`✅ / `go build`✅ / `go test ./internal/pipeline`✅(含新增 2 例)/ 前端 `typecheck`✅ `lint`✅(0 error)`test`✅(330)`build`✅。布局在真实 1333×716 视口下逐项实测(无溢出、底部完整可见)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)