### PR TITLE
feat(vault): 编辑弹窗内按需查看凭据明文(审计留痕)+ 去列表复制按钮 + 修删除弹窗按钮贴边

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -32,6 +32,7 @@ const (
 	ActionCredentialCreate   = "credential_create"
 	ActionCredentialUpdate   = "credential_update"
 	ActionCredentialDelete   = "credential_delete"
+	ActionCredentialReveal   = "credential_reveal"
 	ActionTriggerSecretReset = "trigger_secret_reset"
 	ActionProjectCreate      = "project_create"
 	ActionProjectUpdate      = "project_update"

--- a/internal/httpapi/credentials.go
+++ b/internal/httpapi/credentials.go
@@ -162,6 +162,33 @@ func makeUpdateCredentialHandler(v vault.Vault, aud audit.Recorder) http.Handler
 	}
 }
 
+// makeRevealCredentialHandler 返回 POST /api/credentials/{id}/reveal handler。
+// 解密并回传明文(仅此一处对外暴露明文);每次查看追加 credential_reveal 审计,
+// 谁在何时看过哪条凭据均留痕。POST + 登录态 + CSRF(写方法路由),不做成可预取的 GET。
+func makeRevealCredentialHandler(v vault.Vault, aud audit.Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if v == nil {
+			writeError(w, http.StatusServiceUnavailable, "vault_unconfigured", "保险库未配置 master key")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		secret, err := v.Reveal(id)
+		if err != nil {
+			writeVaultError(w, err)
+			return
+		}
+		recordAudit(r.Context(), aud, audit.Entry{
+			Actor:      auditActor,
+			Action:     audit.ActionCredentialReveal,
+			TargetType: audit.TargetCredential,
+			TargetID:   id,
+			IP:         clientIP(r),
+		})
+		// 仅回传明文,绝不进日志/诊断;detail 不含 secret。
+		writeJSON(w, http.StatusOK, map[string]string{"secret": secret})
+	}
+}
+
 // makeDeleteCredentialHandler 返回 DELETE /api/credentials/{id} handler。
 // 删除成功后追加 credential_delete 审计。
 func makeDeleteCredentialHandler(v vault.Vault, aud audit.Recorder) http.HandlerFunc {

--- a/internal/httpapi/credentials_test.go
+++ b/internal/httpapi/credentials_test.go
@@ -183,6 +183,49 @@ func TestPatchAndDelete(t *testing.T) {
 	assertErrCode(t, delAgain, "credential_not_found")
 }
 
+// TestRevealCredential 验证 POST /credentials/{id}/reveal 回传明文、要 CSRF、不存在 → 404。
+func TestRevealCredential(t *testing.T) {
+	srv, client, csrf := setupVaultServer(t)
+	const secret = "ghp_revealme_9876"
+	resp := doJSON(t, client, http.MethodPost, srv.URL+"/api/credentials", csrf,
+		`{"name":"tok","type":"git_token","scope":"s","secret":"`+secret+`"}`)
+	raw, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	var created map[string]any
+	_ = json.Unmarshal(raw, &created)
+	id, _ := created["id"].(string)
+	if id == "" {
+		t.Fatalf("no id in create response: %s", raw)
+	}
+
+	// 无 CSRF → 403(写方法)。
+	noCSRF := doJSON(t, client, http.MethodPost, srv.URL+"/api/credentials/"+id+"/reveal", "", "")
+	noCSRF.Body.Close()
+	if noCSRF.StatusCode != http.StatusForbidden {
+		t.Fatalf("reveal without CSRF status = %d, want 403", noCSRF.StatusCode)
+	}
+
+	// 正常查看 → 200 + 明文。
+	revealResp := doJSON(t, client, http.MethodPost, srv.URL+"/api/credentials/"+id+"/reveal", csrf, "")
+	defer revealResp.Body.Close()
+	if revealResp.StatusCode != http.StatusOK {
+		t.Fatalf("reveal status = %d, want 200", revealResp.StatusCode)
+	}
+	var body map[string]string
+	_ = json.NewDecoder(revealResp.Body).Decode(&body)
+	if body["secret"] != secret {
+		t.Fatalf("reveal secret = %q, want %q", body["secret"], secret)
+	}
+
+	// 不存在 → 404。
+	missing := doJSON(t, client, http.MethodPost, srv.URL+"/api/credentials/nope/reveal", csrf, "")
+	defer missing.Body.Close()
+	if missing.StatusCode != http.StatusNotFound {
+		t.Fatalf("reveal missing status = %d, want 404", missing.StatusCode)
+	}
+	assertErrCode(t, missing, "credential_not_found")
+}
+
 // TestVaultUnconfiguredEndpoint 验证未配置 master key 时端点返回 503 vault_unconfigured。
 func TestVaultUnconfiguredEndpoint(t *testing.T) {
 	st := testStoreAuth(t)

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -418,6 +418,8 @@ func New(webFS fs.FS, authn auth.Authenticator, opts ...Option) http.Handler {
 		ar.Post("/credentials", makeCreateCredentialHandler(v, aud))
 		ar.Patch("/credentials/{id}", makeUpdateCredentialHandler(v, aud))
 		ar.Delete("/credentials/{id}", makeDeleteCredentialHandler(v, aud))
+		// 查看明文(POST + auth + CSRF;每次留 credential_reveal 审计)。
+		ar.Post("/credentials/{id}/reveal", makeRevealCredentialHandler(v, aud))
 
 		// 项目接入与列表(Story 2.1)。p 为 nil 时 handler 返回 503。
 		// test-clone 须在 {id} 路由之前注册,否则被 /projects/{id} 吞掉。

--- a/web/src/api/credentials.ts
+++ b/web/src/api/credentials.ts
@@ -1,14 +1,14 @@
 /**
  * Credentials API — aligns to frozen 1.3 contract.
  *
- * GET    /api/credentials           → Credential[]
- * POST   /api/credentials           → Credential  (needs CSRF)
- * PATCH  /api/credentials/:id       → Credential  (needs CSRF)
- * DELETE /api/credentials/:id       → 204          (needs CSRF)
+ * GET    /api/credentials            → Credential[]
+ * POST   /api/credentials            → Credential  (needs CSRF)
+ * PATCH  /api/credentials/:id        → Credential  (needs CSRF)
+ * DELETE /api/credentials/:id        → 204          (needs CSRF)
+ * POST   /api/credentials/:id/reveal → { secret }   (needs CSRF; audited)
  *
- * The API never returns plaintext secrets; only maskedValue is exposed.
- * "Copying a credential" means copying the id or name (the reference handle),
- * never the secret.
+ * List/get never return plaintext — only maskedValue is exposed. Plaintext is
+ * returned solely by the explicit, audited reveal endpoint.
  */
 
 import { http } from './http'
@@ -58,4 +58,13 @@ export async function updateCredential(
 
 export async function deleteCredential(id: string): Promise<void> {
   return http.delete<void>(`/api/credentials/${id}`)
+}
+
+/**
+ * Reveal the plaintext secret on explicit demand (POST + CSRF; audited server-side
+ * as `credential_reveal`). The only endpoint that returns plaintext — use sparingly.
+ */
+export async function revealCredential(id: string): Promise<string> {
+  const res = await http.post<{ secret: string }>(`/api/credentials/${id}/reveal`, {})
+  return res.secret
 }

--- a/web/src/i18n/locales/de/settingsVault.ts
+++ b/web/src/i18n/locales/de/settingsVault.ts
@@ -1,6 +1,6 @@
 export default {
   title: 'Anmeldedaten-Tresor',
-  desc: 'Alle Geheimnisse werden mit NaCl secretbox verschlüsselt und auf dieser Instanz gespeichert. Sie werden beim Schreiben maskiert und können nie wieder ausgelesen werden. Pipelines referenzieren sie über den Geltungsbereich, und sie gelangen nie in Protokolle oder den Diagnosekontext.',
+  desc: 'Alle Geheimnisse werden mit NaCl secretbox verschlüsselt und auf dieser Instanz gespeichert, im Ruhezustand maskiert. Das Anzeigen von Klartext ist hier eine explizite, auditierte Aktion. Pipelines referenzieren sie über den Geltungsbereich, und sie gelangen nie in Protokolle oder den Diagnosekontext.',
   addCredential: 'Anmeldedaten hinzufügen',
 
   providerCustom: 'Eigene',
@@ -36,16 +36,16 @@ export default {
   typeSshPassword: 'SSH-Passwort',
   typeRegistry: 'Registry',
 
-  maskTitle: 'Maskierter Wert (Klartext kann nicht aufgedeckt werden)',
+  maskTitle: 'Maskierter Wert (im Bearbeiten anzeigbar)',
   maskAria: 'Maskiert: {value}',
   allProjects: 'Alle Projekte',
   never: 'Nie',
   neverUsed: 'Nie verwendet',
   idleTag: 'Inaktiv',
 
-  copiedReference: 'Referenz kopiert',
-  copyReferenceTitle: 'Anmeldedaten-Referenz kopieren (ID, kein Klartext)',
-  copyReferenceAria: 'Referenz der Anmeldedaten {name} kopieren',
+  revealCurrent: 'Aktuelles anzeigen',
+  hideCurrent: 'Verbergen',
+  revealFailed: 'Geheimnis konnte nicht angezeigt werden',
   editTitle: '{name} bearbeiten',
   editAria: 'Anmeldedaten {name} bearbeiten',
   deleteTitle: '{name} löschen',

--- a/web/src/i18n/locales/en/settingsVault.ts
+++ b/web/src/i18n/locales/en/settingsVault.ts
@@ -1,6 +1,6 @@
 export default {
   title: 'Credential Vault',
-  desc: 'All secrets are encrypted with NaCl secretbox and stored on this instance. They are masked on write and can never be read back. Pipelines reference them by scope, and they never reach logs or diagnostic context.',
+  desc: 'All secrets are encrypted with NaCl secretbox and stored on this instance, masked at rest. Revealing plaintext is an explicit, audited action here. Pipelines reference them by scope, and they never reach logs or diagnostic context.',
   addCredential: 'Add credential',
 
   providerCustom: 'Custom',
@@ -36,16 +36,16 @@ export default {
   typeSshPassword: 'SSH password',
   typeRegistry: 'Registry',
 
-  maskTitle: 'Masked value (plaintext cannot be revealed)',
+  maskTitle: 'Masked value (reveal it in Edit)',
   maskAria: 'Masked: {value}',
   allProjects: 'All projects',
   never: 'Never',
   neverUsed: 'Never used',
   idleTag: 'Idle',
 
-  copiedReference: 'Reference copied',
-  copyReferenceTitle: 'Copy credential reference (ID, not plaintext)',
-  copyReferenceAria: 'Copy the reference for credential {name}',
+  revealCurrent: 'Reveal current',
+  hideCurrent: 'Hide',
+  revealFailed: 'Failed to reveal secret',
   editTitle: 'Edit {name}',
   editAria: 'Edit credential {name}',
   deleteTitle: 'Delete {name}',

--- a/web/src/i18n/locales/es/settingsVault.ts
+++ b/web/src/i18n/locales/es/settingsVault.ts
@@ -1,6 +1,6 @@
 export default {
   title: 'Bóveda de credenciales',
-  desc: 'Todos los secretos se cifran con NaCl secretbox y se almacenan en esta instancia. Se enmascaran al guardarse y nunca pueden volver a leerse. Las canalizaciones los referencian por ámbito y nunca llegan a los registros ni al contexto de diagnóstico.',
+  desc: 'Todos los secretos se cifran con NaCl secretbox y se almacenan en esta instancia, enmascarados en reposo. Mostrar el texto plano es una acción explícita y auditada aquí. Las canalizaciones los referencian por ámbito y nunca llegan a los registros ni al contexto de diagnóstico.',
   addCredential: 'Añadir credencial',
 
   providerCustom: 'Propio',
@@ -36,16 +36,16 @@ export default {
   typeSshPassword: 'Contraseña SSH',
   typeRegistry: 'Registro',
 
-  maskTitle: 'Valor enmascarado (el texto plano no puede revelarse)',
+  maskTitle: 'Valor enmascarado (puedes verlo al editar)',
   maskAria: 'Enmascarado: {value}',
   allProjects: 'Todos los proyectos',
   never: 'Nunca',
   neverUsed: 'Nunca usada',
   idleTag: 'Inactiva',
 
-  copiedReference: 'Referencia copiada',
-  copyReferenceTitle: 'Copiar referencia de la credencial (ID, no texto plano)',
-  copyReferenceAria: 'Copiar la referencia de la credencial {name}',
+  revealCurrent: 'Mostrar actual',
+  hideCurrent: 'Ocultar',
+  revealFailed: 'No se pudo mostrar el secreto',
   editTitle: 'Editar {name}',
   editAria: 'Editar la credencial {name}',
   deleteTitle: 'Eliminar {name}',

--- a/web/src/i18n/locales/fr/settingsVault.ts
+++ b/web/src/i18n/locales/fr/settingsVault.ts
@@ -1,6 +1,6 @@
 export default {
   title: 'Coffre d’identifiants',
-  desc: 'Tous les secrets sont chiffrés avec NaCl secretbox et stockés sur cette instance. Ils sont masqués à l’écriture et ne peuvent jamais être relus. Les pipelines les référencent par portée et ils n’apparaissent jamais dans les journaux ni le contexte de diagnostic.',
+  desc: 'Tous les secrets sont chiffrés avec NaCl secretbox et stockés sur cette instance, masqués au repos. Afficher le texte en clair est une action explicite et auditée ici. Les pipelines les référencent par portée et ils n’apparaissent jamais dans les journaux ni le contexte de diagnostic.',
   addCredential: 'Ajouter un identifiant',
 
   providerCustom: 'Personnalisé',
@@ -36,16 +36,16 @@ export default {
   typeSshPassword: 'Mot de passe SSH',
   typeRegistry: 'Registre',
 
-  maskTitle: 'Valeur masquée (le texte en clair ne peut pas être révélé)',
+  maskTitle: 'Valeur masquée (affichable dans Modifier)',
   maskAria: 'Masqué : {value}',
   allProjects: 'Tous les projets',
   never: 'Jamais',
   neverUsed: 'Jamais utilisé',
   idleTag: 'Inactif',
 
-  copiedReference: 'Référence copiée',
-  copyReferenceTitle: 'Copier la référence de l’identifiant (ID, pas le texte en clair)',
-  copyReferenceAria: 'Copier la référence de l’identifiant {name}',
+  revealCurrent: 'Afficher l’actuel',
+  hideCurrent: 'Masquer',
+  revealFailed: 'Échec de l’affichage du secret',
   editTitle: 'Modifier {name}',
   editAria: 'Modifier l’identifiant {name}',
   deleteTitle: 'Supprimer {name}',

--- a/web/src/i18n/locales/ja/settingsVault.ts
+++ b/web/src/i18n/locales/ja/settingsVault.ts
@@ -1,6 +1,6 @@
 export default {
   title: '認証情報の保管庫',
-  desc: 'すべてのシークレットは NaCl secretbox で暗号化され、本インスタンスに保存されます。保存時にマスクされ、書き込み後は読み出せません。パイプラインはスコープで参照し、ログや診断コンテキストには一切含まれません。',
+  desc: 'すべてのシークレットは NaCl secretbox で暗号化され、本インスタンスに保存され、保存時にマスクされます。平文の表示はこのページでの明示的な操作で、監査に記録されます。パイプラインはスコープで参照し、ログや診断コンテキストには一切含まれません。',
   addCredential: '認証情報を追加',
 
   providerCustom: '自前',
@@ -36,16 +36,16 @@ export default {
   typeSshPassword: 'SSH パスワード',
   typeRegistry: 'レジストリ',
 
-  maskTitle: 'マスク値（平文は展開できません）',
+  maskTitle: 'マスク値（編集画面で平文を表示できます）',
   maskAria: 'マスク: {value}',
   allProjects: 'すべてのプロジェクト',
   never: 'なし',
   neverUsed: '未使用',
   idleTag: '休眠',
 
-  copiedReference: '参照をコピーしました',
-  copyReferenceTitle: '認証情報の参照（ID、平文ではない）をコピー',
-  copyReferenceAria: '認証情報 {name} の参照をコピー',
+  revealCurrent: '現在の平文を表示',
+  hideCurrent: '隠す',
+  revealFailed: '平文の表示に失敗しました',
   editTitle: '{name} を編集',
   editAria: '認証情報 {name} を編集',
   deleteTitle: '{name} を削除',

--- a/web/src/i18n/locales/ko/settingsVault.ts
+++ b/web/src/i18n/locales/ko/settingsVault.ts
@@ -1,6 +1,6 @@
 export default {
   title: '자격 증명 볼트',
-  desc: '모든 시크릿은 NaCl secretbox로 암호화되어 이 인스턴스에 저장됩니다. 저장 시 마스킹되며 기록 후에는 다시 읽을 수 없습니다. 파이프라인은 범위로 참조하며, 로그나 진단 컨텍스트에 절대 포함되지 않습니다.',
+  desc: '모든 시크릿은 NaCl secretbox로 암호화되어 이 인스턴스에 저장되며 저장 시 마스킹됩니다. 평문 보기는 이 페이지에서의 명시적 작업이며 감사 로그에 기록됩니다. 파이프라인은 범위로 참조하며, 로그나 진단 컨텍스트에 절대 포함되지 않습니다.',
   addCredential: '자격 증명 추가',
 
   providerCustom: '직접 구축',
@@ -36,16 +36,16 @@ export default {
   typeSshPassword: 'SSH 비밀번호',
   typeRegistry: '레지스트리',
 
-  maskTitle: '마스킹 값(평문으로 펼칠 수 없음)',
+  maskTitle: '마스킹 값(편집에서 평문 보기 가능)',
   maskAria: '마스킹: {value}',
   allProjects: '모든 프로젝트',
   never: '없음',
   neverUsed: '사용한 적 없음',
   idleTag: '유휴',
 
-  copiedReference: '참조 복사됨',
-  copyReferenceTitle: '자격 증명 참조(ID, 평문 아님) 복사',
-  copyReferenceAria: '자격 증명 {name}의 참조 복사',
+  revealCurrent: '현재 평문 보기',
+  hideCurrent: '숨기기',
+  revealFailed: '평문 보기에 실패했습니다',
   editTitle: '{name} 편집',
   editAria: '자격 증명 {name} 편집',
   deleteTitle: '{name} 삭제',

--- a/web/src/i18n/locales/zh-CN/settingsVault.ts
+++ b/web/src/i18n/locales/zh-CN/settingsVault.ts
@@ -1,6 +1,6 @@
 export default {
   title: '凭据保险库',
-  desc: '所有密钥经 NaCl secretbox 加密后存于本实例,落库即掩码、写入后不可读出。流水线按作用域引用,绝不进日志或诊断上下文。',
+  desc: '所有密钥经 NaCl secretbox 加密后存于本实例,落库即掩码;查看明文需在此页显式操作并留审计。流水线按作用域引用,绝不进日志或诊断上下文。',
   addCredential: '添加凭据',
 
   providerCustom: '自建',
@@ -36,16 +36,16 @@ export default {
   typeSshPassword: 'SSH 密码',
   typeRegistry: '镜像仓库',
 
-  maskTitle: '掩码值（不可展开明文）',
+  maskTitle: '掩码值（编辑中可查看明文）',
   maskAria: '掩码: {value}',
   allProjects: '全部项目',
   never: '从未',
   neverUsed: '从未使用',
   idleTag: '闲置',
 
-  copiedReference: '已复制引用',
-  copyReferenceTitle: '复制凭据引用（ID，非明文）',
-  copyReferenceAria: '复制凭据 {name} 的引用',
+  revealCurrent: '查看当前明文',
+  hideCurrent: '隐藏明文',
+  revealFailed: '查看明文失败',
   editTitle: '编辑 {name}',
   editAria: '编辑凭据 {name}',
   deleteTitle: '删除 {name}',

--- a/web/src/i18n/locales/zh-TW/settingsVault.ts
+++ b/web/src/i18n/locales/zh-TW/settingsVault.ts
@@ -1,6 +1,6 @@
 export default {
   title: '憑證保險庫',
-  desc: '所有密鑰經 NaCl secretbox 加密後存於本實例,落庫即遮罩、寫入後不可讀出。流水線依作用域引用,絕不進入日誌或診斷上下文。',
+  desc: '所有密鑰經 NaCl secretbox 加密後存於本實例,落庫即遮罩;檢視明文需在此頁顯式操作並留審計。流水線依作用域引用,絕不進入日誌或診斷上下文。',
   addCredential: '新增憑證',
 
   providerCustom: '自建',
@@ -36,16 +36,16 @@ export default {
   typeSshPassword: 'SSH 密碼',
   typeRegistry: '映像倉庫',
 
-  maskTitle: '遮罩值（不可展開明文）',
+  maskTitle: '遮罩值（編輯中可檢視明文）',
   maskAria: '遮罩: {value}',
   allProjects: '全部專案',
   never: '從未',
   neverUsed: '從未使用',
   idleTag: '閒置',
 
-  copiedReference: '已複製引用',
-  copyReferenceTitle: '複製憑證引用（ID,非明文）',
-  copyReferenceAria: '複製憑證 {name} 的引用',
+  revealCurrent: '檢視目前明文',
+  hideCurrent: '隱藏明文',
+  revealFailed: '檢視明文失敗',
   editTitle: '編輯 {name}',
   editAria: '編輯憑證 {name}',
   deleteTitle: '刪除 {name}',

--- a/web/src/views/settings/SettingsVault.vue
+++ b/web/src/views/settings/SettingsVault.vue
@@ -5,6 +5,7 @@ import {
   createCredential,
   updateCredential,
   deleteCredential,
+  revealCredential,
 } from '../../api/credentials'
 import type { Credential, CredentialType, CreateCredentialInput, UpdateCredentialInput } from '../../api/credentials'
 import { HttpError } from '../../api/http'
@@ -57,9 +58,11 @@ const deletingCredential = ref<Credential | null>(null)
 const deleteSubmitting = ref(false)
 const deleteBanner = ref('')
 
-// ─── copy feedback ──────────────────────────────────────────────────────────
+// ─── reveal current plaintext inside the edit modal (on-demand, audited) ──────
 
-const copiedId = ref<string | null>(null)
+// Current plaintext while shown in the edit modal; null = hidden. Cleared on close.
+const editRevealed = ref<string | null>(null)
+const editRevealing = ref(false)
 
 // ─── OAuth connect (enabled providers only) ──────────────────────────────────
 
@@ -218,6 +221,7 @@ function openEditModal(c: Credential): void {
   editingId.value = c.id
   // secret is intentionally blank — user must re-enter to rotate
   form.value = { name: c.name, type: c.type, scope: c.scope, secret: '' }
+  editRevealed.value = null
   clearFormErrors()
   formBanner.value = ''
   modalOpen.value = true
@@ -226,8 +230,9 @@ function openEditModal(c: Credential): void {
 function closeModal(): void {
   if (formSubmitting.value) return
   modalOpen.value = false
-  // Clear secret immediately when modal closes
+  // Clear secret + any revealed plaintext immediately when modal closes
   form.value.secret = ''
+  editRevealed.value = null
 }
 
 // ─── form validation ─────────────────────────────────────────────────────────
@@ -343,18 +348,22 @@ async function confirmDelete(): Promise<void> {
   }
 }
 
-// ─── copy reference (id — not plaintext) ───────────────────────────────────
+// ─── reveal / hide current plaintext in the edit modal (audited server-side) ──
 
-async function copyReference(c: Credential): Promise<void> {
+async function toggleEditReveal(): Promise<void> {
+  // Already shown → hide and drop the plaintext from memory.
+  if (editRevealed.value !== null) {
+    editRevealed.value = null
+    return
+  }
+  if (!editingId.value || editRevealing.value) return
+  editRevealing.value = true
   try {
-    // Copy the credential ID as the reference handle — never the secret
-    await navigator.clipboard.writeText(c.id)
-    copiedId.value = c.id
-    setTimeout(() => {
-      if (copiedId.value === c.id) copiedId.value = null
-    }, 1800)
-  } catch {
-    // clipboard API not available — silently ignore
+    editRevealed.value = await revealCredential(editingId.value)
+  } catch (err) {
+    toast.error(err instanceof HttpError ? err.message : t('settingsVault.revealFailed'))
+  } finally {
+    editRevealing.value = false
   }
 }
 </script>
@@ -507,10 +516,9 @@ async function copyReference(c: Credential): Promise<void> {
             </svg>
           </span>
 
-          <!-- Name + masked value -->
+          <!-- Name + masked value — never plaintext in the list -->
           <div class="cred-name">
             <strong class="cred-label">{{ cred.name }}</strong>
-            <!-- maskedValue in JetBrains Mono — never plaintext, not interactive -->
             <span class="cred-mask mono" :title="t('settingsVault.maskTitle')" :aria-label="t('settingsVault.maskAria', { value: cred.maskedValue })">{{ cred.maskedValue }}</span>
           </div>
 
@@ -539,22 +547,6 @@ async function copyReference(c: Credential): Promise<void> {
 
           <!-- Actions -->
           <span class="cred-ops">
-            <!-- Copy reference (id, not secret) -->
-            <button
-              class="op-btn"
-              :class="{ 'op-btn--copied': copiedId === cred.id }"
-              :title="copiedId === cred.id ? t('settingsVault.copiedReference') : t('settingsVault.copyReferenceTitle')"
-              :aria-label="t('settingsVault.copyReferenceAria', { name: cred.name })"
-              @click="copyReference(cred)"
-            >
-              <svg v-if="copiedId !== cred.id" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9">
-                <rect x="9" y="9" width="13" height="13" rx="2"/>
-                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
-              </svg>
-              <svg v-else width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2">
-                <path d="M20 6 9 17l-5-5"/>
-              </svg>
-            </button>
             <!-- Edit -->
             <button
               class="op-btn"
@@ -703,10 +695,34 @@ async function copyReference(c: Credential): Promise<void> {
 
           <!-- Secret — password type, never echoed back -->
           <div class="field">
-            <label class="field-label" for="cred-secret">
-              {{ modalMode === 'add' ? t('settingsVault.fieldSecret') : t('settingsVault.fieldSecretNew') }}
-              <span v-if="modalMode === 'edit'" class="field-optional">{{ t('settingsVault.secretOptionalEdit') }}</span>
-            </label>
+            <div class="field-label-row">
+              <label class="field-label" for="cred-secret">
+                {{ modalMode === 'add' ? t('settingsVault.fieldSecret') : t('settingsVault.fieldSecretNew') }}
+                <span v-if="modalMode === 'edit'" class="field-optional">{{ t('settingsVault.secretOptionalEdit') }}</span>
+              </label>
+              <!-- Reveal current plaintext (edit only; audited server-side) -->
+              <button
+                v-if="modalMode === 'edit'"
+                type="button"
+                class="reveal-current-btn"
+                :class="{ 'reveal-current-btn--active': editRevealed !== null }"
+                :disabled="editRevealing"
+                @click="toggleEditReveal"
+              >
+                <svg v-if="editRevealed !== null" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9">
+                  <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/>
+                  <path d="M1 1l22 22"/>
+                </svg>
+                <svg v-else width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9">
+                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+                  <circle cx="12" cy="12" r="3"/>
+                </svg>
+                {{ editRevealed !== null ? t('settingsVault.hideCurrent') : t('settingsVault.revealCurrent') }}
+              </button>
+            </div>
+
+            <!-- Current plaintext, read-only — shown only while explicitly revealed -->
+            <div v-if="modalMode === 'edit' && editRevealed !== null" class="current-secret mono">{{ editRevealed }}</div>
 <!-- SSH 私钥是多行 PEM/OpenSSH 文本:必须用 textarea,单行 <input> 会按 HTML 规范清除换行
                  → 私钥结构破坏、ssh.ParsePrivateKey 失败「凭据不是可用的 SSH 私钥」。令牌/镜像仓库仍用
                  password input(单行密文 + 掩码输入)。 -->
@@ -822,7 +838,7 @@ async function copyReference(c: Credential): Promise<void> {
           </div>
         </div>
 
-        <div class="modal-footer">
+        <div class="modal-footer modal-footer--standalone">
           <button
             type="button"
             class="btn-secondary"
@@ -1279,11 +1295,6 @@ async function copyReference(c: Credential): Promise<void> {
   outline-offset: 2px;
 }
 
-.op-btn--copied {
-  color: var(--color-green);
-  border-color: var(--color-green-line);
-}
-
 .op-btn--danger:hover {
   color: var(--color-red);
   border-color: var(--color-red-line);
@@ -1562,6 +1573,12 @@ async function copyReference(c: Credential): Promise<void> {
   padding-top: 4px;
 }
 
+/* Footer as a direct child of .modal (no padded wrapper) — give it surround padding
+   so the buttons don't hug the modal's bottom/right edge. */
+.modal-footer--standalone {
+  padding: 4px 20px 20px;
+}
+
 /* ─── form fields ─────────────────────────────────────────────────────────── */
 .field {
   display: flex;
@@ -1578,6 +1595,67 @@ async function copyReference(c: Credential): Promise<void> {
 .field-optional {
   font-weight: 400;
   color: var(--color-faint);
+}
+
+/* Secret label row: label on the left, reveal-current toggle pushed right. */
+.field-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.reveal-current-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 9px;
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--color-dim);
+  background: var(--color-inset);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded);
+  cursor: pointer;
+  transition:
+    color var(--duration-fast),
+    border-color var(--duration-fast),
+    background-color var(--duration-fast);
+}
+
+.reveal-current-btn:hover {
+  color: var(--color-text);
+  border-color: var(--color-faint);
+}
+
+.reveal-current-btn--active {
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.reveal-current-btn:disabled {
+  opacity: 0.55;
+  cursor: progress;
+}
+
+.reveal-current-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/* Read-only current plaintext shown while revealed; selectable for manual copy. */
+.current-secret {
+  font-size: 0.74rem;
+  color: var(--color-text);
+  background: var(--color-inset);
+  border: 1px dashed var(--color-border-strong);
+  border-radius: var(--rounded);
+  padding: 8px 12px;
+  word-break: break-all;
+  white-space: pre-wrap;
+  user-select: text;
+  max-height: 160px;
+  overflow: auto;
 }
 
 .field-input {


### PR DESCRIPTION
## 背景
凭据保险库此前明文「写入后不可读出」,用户无法核对已存的密钥值。本 PR 在保留掩码默认的前提下,加按需查看,并顺手清理两个交互问题。

## 改动
- **按需查看明文(审计留痕)**
  - 后端新增 `POST /api/credentials/{id}/reveal`(登录态 + CSRF,**非可预取的 GET**),复用已有 `vault.Reveal` 解密;每次查看写一条 `credential_reveal` 审计(谁/何时/哪条),明文仅此一处对外返回,不进日志/诊断。
  - 前端把「查看」收进**编辑弹窗**(明确的编辑上下文,避免在列表行直接暴露被旁观/录屏);点「查看当前明文」才显示只读明文,再点收回;关闭弹窗即清除内存中的明文。
- **列表行去掉「复制引用(ID)」按钮** —— 普通场景用不上且易被误解为「复制密码」,仅留编辑/删除。
- **修删除确认弹窗 footer 按钮贴边** —— footer 是 `.modal` 直接子节点、缺四周内边距,按钮紧贴右/下边框。
- 顶部说明与 `maskTitle` 文案据实更新(8 语言),不再宣称「不可读出」。

## 安全
明文出口收敛为单一显式接口:`POST + CSRF + 审计`。列表/详情/列表接口仍只返回掩码,绝不回传明文。

## 测试
- 后端:新增 `TestRevealCredential`(回传明文 / 无 CSRF→403 / 不存在→404);`go vet`/`build`/`test`/`gofmt` 全过。
- 前端:`typecheck` 净、`lint` 0 error、`test` 330 全过(含 i18n 编译回归)。
- 本地 lab 实例端到端实测:列表仅 编辑/删除;编辑弹窗 `查看当前明文`→显示只读明文→收回;删除弹窗按钮四周留白;审计日志出现 `credential_reveal`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)