### PR TITLE
feat(deploy): 部署步骤回流目标机真实命令+输出;git_source 展示源码信息

### DIFF
--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/huangchengsir/pipewright/internal/dag"
 	"github.com/huangchengsir/pipewright/internal/dagrun"
+	"github.com/huangchengsir/pipewright/internal/deploy"
 	"github.com/huangchengsir/pipewright/internal/notify"
 	"github.com/huangchengsir/pipewright/internal/pipeline"
 	"github.com/huangchengsir/pipewright/internal/project"
@@ -126,7 +127,14 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 		if !needsBuild && len(deployJobs) == 0 && len(notifyJobs) == 0 && len(stage.Post) == 0 {
 			for _, jb := range stage.Jobs {
 				_ = rep.JobRunning(ctx, jb.ID)
-				_ = rep.JobReporter(jb.ID).Log(ctx, streamStdout, fmt.Sprintf("· %s(%s)— 真实执行未接入;本阶段放行", jb.Name, jb.Type))
+				jr := rep.JobReporter(jb.ID)
+				if strings.TrimSpace(jb.Type) == "git_source" {
+					for _, line := range gitSourceLogLines(jb, r) {
+						_ = jr.Log(ctx, streamStdout, line)
+					}
+				} else {
+					_ = jr.Log(ctx, streamStdout, fmt.Sprintf("· %s(%s)— 真实执行未接入;本阶段放行", jb.Name, jb.Type))
+				}
 				_ = rep.JobDone(ctx, jb.ID, run.StepSuccess)
 			}
 			if len(stage.Jobs) == 0 {
@@ -595,7 +603,9 @@ func (b *Builder) runDeployJob(ctx context.Context, rep dagrun.StageReporter, jb
 		stratLabel = "rolling(默认)"
 	}
 	_ = rep.Log(ctx, streamStdout, fmt.Sprintf("→ SSH 部署本次产物到服务器 %s(策略 %s)…", serverID, stratLabel))
-	results, err := b.deployer.DeployForStage(ctx, runID, []string{serverID}, cfg, strategy)
+	// 把目标机真实执行的命令 + stdout/stderr 实时回流到本部署步骤日志(脱敏由 sink 侧 Masker 兜底)。
+	dctx := deploy.WithCmdLog(ctx, func(stream, text string) { _ = rep.Log(ctx, stream, text) })
+	results, err := b.deployer.DeployForStage(dctx, runID, []string{serverID}, cfg, strategy)
 	if err != nil {
 		_ = rep.Log(ctx, streamStderr, "部署失败:"+err.Error())
 		return ErrBuildFailed
@@ -945,6 +955,43 @@ func cfgString(cfg map[string]any, key string) string {
 		return strings.TrimSpace(v)
 	}
 	return ""
+}
+
+// gitSourceLogLines 为 git_source 节点拼出可读的源码信息(仓库 / 分支 / 提交 / 凭据)。
+// 注:git_source 是 go-git 库克隆(非 shell 命令),真实检出发生在构建阶段各 job 工作区,
+// 此处展示「本阶段引用的源」让步骤日志不再是空占位。绝不回显凭据值,只标注是否已绑定。
+func gitSourceLogLines(jb pipeline.Job, r *run.Run) []string {
+	repo := cfgString(jb.Config, "repoUrl")
+	branch := cfgString(jb.Config, "branch")
+	if branch == "" {
+		branch = strings.TrimSpace(r.Trigger.Branch)
+	}
+	if branch == "" {
+		branch = "(默认分支)"
+	}
+	commit := strings.TrimSpace(r.Trigger.Commit)
+	lines := []string{}
+	if repo != "" {
+		lines = append(lines, "· 源码仓库:"+repo)
+	}
+	branchLine := "· 分支:" + branch
+	if commit != "" {
+		if len(commit) > 12 {
+			commit = commit[:12]
+		}
+		branchLine += "   · 提交:" + commit
+	} else {
+		branchLine += "   · 提交:构建阶段克隆时解析 HEAD"
+	}
+	lines = append(lines, branchLine)
+	if cfgString(jb.Config, "credentialId") != "" {
+		lines = append(lines, "· 凭据:已绑定(经保险库,绝不回显)")
+	}
+	lines = append(lines, "· 实际克隆在构建阶段各 job 工作区执行(go-git 浅克隆)")
+	if len(lines) == 0 {
+		lines = append(lines, fmt.Sprintf("· %s(git_source)", jb.Name))
+	}
+	return lines
 }
 
 // splitCommands 把多行命令字符串拆成逐行命令(trim 尾随 CR、剔空行)。

--- a/internal/deploy/cmdlog.go
+++ b/internal/deploy/cmdlog.go
@@ -1,0 +1,96 @@
+// cmdlog.go:把部署链路在目标机真实执行的命令 + 其 stdout/stderr 实时回流到运行步骤日志,
+// 让 deploy_ssh 步骤像 Jenkins 控制台一样看得到「具体执行了什么」(此前仅一行结果摘要)。
+//
+// 脱敏分两道:① 命令回显时对紧跟 -e/--env/--build-arg 的 K=V、--password 的值就地打码(第一道);
+// ② 文本最终经 sink 侧 per-run Masker 兜底脱敏(与构建日志同一机制,绝无明文 secret 落库/出网)。
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/huangchengsir/pipewright/internal/target"
+)
+
+const (
+	cmdStreamStdout = "stdout"
+	cmdStreamStderr = "stderr"
+)
+
+// CmdLogFunc 接收一行待写入运行日志的部署命令/输出(stream = stdout | stderr)。
+type CmdLogFunc func(stream, text string)
+
+type cmdLogKey struct{}
+
+// WithCmdLog 把命令日志回调挂到 ctx:部署链路每条远程命令 + 其输出经它实时回流。
+// fn 为 nil → 原样返回(不需要命令级日志的调用方,如 /runs/{id}/deploy 端点,无副作用)。
+func WithCmdLog(ctx context.Context, fn CmdLogFunc) context.Context {
+	if fn == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, cmdLogKey{}, fn)
+}
+
+func cmdLogFrom(ctx context.Context) CmdLogFunc {
+	if fn, ok := ctx.Value(cmdLogKey{}).(CmdLogFunc); ok && fn != nil {
+		return fn
+	}
+	return func(string, string) {}
+}
+
+// exec 包裹 targets.Exec:执行前回显命令、执行后回流 stdout/stderr 到 ctx 的命令日志(若挂了)。
+// 返回值与 targets.Exec 完全一致,不改变任何控制流(无 ctx 日志时 = 纯透传)。
+func (s *service) exec(ctx context.Context, serverID string, cmd []string) (*target.ExecResult, error) {
+	lg := cmdLogFrom(ctx)
+	lg(cmdStreamStdout, "$ "+displayCmd(cmd))
+	out, err := s.targets.Exec(ctx, serverID, cmd)
+	if err != nil {
+		lg(cmdStreamStderr, "  ✗ "+humanExecError(err))
+		return out, err
+	}
+	if out != nil {
+		if t := strings.Trim(out.Stdout, "\r\n"); strings.TrimSpace(t) != "" {
+			lg(cmdStreamStdout, t)
+		}
+		if t := strings.Trim(out.Stderr, "\r\n"); strings.TrimSpace(t) != "" {
+			lg(cmdStreamStderr, t)
+		}
+		if out.ExitCode != 0 {
+			lg(cmdStreamStderr, fmt.Sprintf("  ✗ 退出码 %d", out.ExitCode))
+		}
+	}
+	return out, err
+}
+
+// displayCmd 把 array 命令拼为可读单行;对敏感参数值就地打码(第一道脱敏)。
+//   - sh -c <script> [args...]:直接展示脚本本体(docker build/run 等,可读性最佳;
+//     脚本内 secret 由 sink 侧 Masker 兜底)。
+//   - 其余:逐 token 拼接,紧跟 -e/--env/--build-arg 的 K=V → K=***,--password 的值 → ***。
+func displayCmd(cmd []string) string {
+	if len(cmd) >= 3 && cmd[0] == "sh" && cmd[1] == "-c" {
+		return strings.TrimSpace(cmd[2])
+	}
+	out := make([]string, len(cmd))
+	for i, tok := range cmd {
+		out[i] = tok
+		if i == 0 {
+			continue
+		}
+		switch cmd[i-1] {
+		case "-e", "--env", "--build-arg", "--arg":
+			out[i] = maskAssign(tok)
+		case "--password", "--password-stdin":
+			out[i] = "***"
+		}
+	}
+	return strings.Join(out, " ")
+}
+
+// maskAssign 把 "K=V" → "K=***"(只暴露 key);无 '=' 原样返回。
+func maskAssign(kv string) string {
+	if i := strings.IndexByte(kv, '='); i >= 0 {
+		return kv[:i+1] + "***"
+	}
+	return kv
+}

--- a/internal/deploy/cmdlog_test.go
+++ b/internal/deploy/cmdlog_test.go
@@ -1,0 +1,67 @@
+package deploy
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/huangchengsir/pipewright/internal/target"
+)
+
+func TestDisplayCmd(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  []string
+		want string
+	}{
+		{"sh -c shows script", []string{"sh", "-c", "docker build -t app .\ndocker run app", "/cur"}, "docker build -t app .\ndocker run app"},
+		{"mask -e KV", []string{"docker", "run", "-e", "DB_PASSWORD=s3cr3t", "-p", "8080:8080", "app"}, "docker run -e DB_PASSWORD=*** -p 8080:8080 app"},
+		{"mask --env KV", []string{"docker", "run", "--env", "TOKEN=abc", "app"}, "docker run --env TOKEN=*** app"},
+		{"mask --password value", []string{"docker", "login", "--password", "hunter2", "reg.io"}, "docker login --password *** reg.io"},
+		{"port not masked", []string{"docker", "run", "-p", "443:443", "app"}, "docker run -p 443:443 app"},
+		{"plain join", []string{"tar", "xf", "deployctx.tar"}, "tar xf deployctx.tar"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := displayCmd(c.cmd); got != c.want {
+				t.Fatalf("displayCmd(%v) = %q, want %q", c.cmd, got, c.want)
+			}
+		})
+	}
+}
+
+// TestExecStreamsToCmdLog 验证:挂了 WithCmdLog → s.exec 把命令 + stdout/stderr 回流;未挂 → 不 panic、纯透传。
+func TestExecStreamsToCmdLog(t *testing.T) {
+	tgt := &stubTarget{
+		servers: map[string]*target.Server{},
+		execFn: func(_ string, _ []string) (*target.ExecResult, error) {
+			return &target.ExecResult{Stdout: "BUILD SUCCESS\n", Stderr: "", ExitCode: 0}, nil
+		},
+	}
+	svc := New(tgt, nil).(*service)
+
+	var mu sync.Mutex
+	var lines []string
+	ctx := WithCmdLog(context.Background(), func(stream, text string) {
+		mu.Lock()
+		defer mu.Unlock()
+		lines = append(lines, stream+"|"+text)
+	})
+
+	if _, err := svc.exec(ctx, "srv1", []string{"sh", "-c", "docker build -t app .", "/cur"}); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "stdout|$ docker build -t app .") {
+		t.Fatalf("command not echoed: %q", joined)
+	}
+	if !strings.Contains(joined, "stdout|BUILD SUCCESS") {
+		t.Fatalf("stdout not streamed: %q", joined)
+	}
+
+	// 未挂 cmdlog:纯透传,不 panic、不记录。
+	if _, err := svc.exec(context.Background(), "srv1", []string{"echo", "hi"}); err != nil {
+		t.Fatalf("exec without sink: %v", err)
+	}
+}

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -605,7 +605,7 @@ func (s *service) deployOne(ctx context.Context, srv *target.Server, a run.Artif
 	defer cancel()
 
 	for _, cmd := range cmds {
-		out, eerr := s.targets.Exec(execCtx, srv.ID, cmd)
+		out, eerr := s.exec(execCtx, srv.ID, cmd)
 		if eerr != nil {
 			finish := time.Now().UTC()
 			res.Status = run.TargetFailed

--- a/internal/deploy/healthcheck.go
+++ b/internal/deploy/healthcheck.go
@@ -140,7 +140,7 @@ func (hc *HealthCheck) probeCommand() ([]string, error) {
 
 // runHealthCheck 在指定目标机上做健康探测:重试 N 次 + 间隔 + 单次 ctx 超时。
 //
-// 经注入的 s.targets.Exec(同部署链路)执行 array 命令。任一次尝试「无执行错误且退出码为 0」
+// 经注入的 s.exec(同部署链路)执行 array 命令。任一次尝试「无执行错误且退出码为 0」
 // 即判通过,返回 nil;否则间隔后重试;重试耗尽仍失败 → 返回人读错误(绝无明文密钥)。
 // 外层 ctx 取消 / 超时 → 立即停止并返回。
 func (s *service) runHealthCheck(ctx context.Context, serverID string, hc *HealthCheck) error {
@@ -160,7 +160,7 @@ func (s *service) runHealthCheck(ctx context.Context, serverID string, hc *Healt
 		}
 
 		attemptCtx, cancel := context.WithTimeout(ctx, timeout)
-		out, eerr := s.targets.Exec(attemptCtx, serverID, cmd)
+		out, eerr := s.exec(attemptCtx, serverID, cmd)
 		cancel()
 
 		switch {

--- a/internal/deploy/image_release.go
+++ b/internal/deploy/image_release.go
@@ -165,7 +165,7 @@ func (s *service) rollbackImage(ctx context.Context, srv *target.Server, res Tar
 		{"docker", "rm", "-f", st.name},
 		dockerRunCmd(st.name, st.runArgs, st.prevImage),
 	} {
-		if _, e := s.targets.Exec(ctx, srv.ID, cmd); e != nil {
+		if _, e := s.exec(ctx, srv.ID, cmd); e != nil {
 			rbErr = e
 			break
 		}
@@ -189,7 +189,7 @@ func (s *service) fleetRollbackImageOne(ctx context.Context, srv *target.Server,
 		{"docker", "rm", "-f", st.name},
 		dockerRunCmd(st.name, st.runArgs, st.prevImage),
 	} {
-		if _, e := s.targets.Exec(execCtx, srv.ID, cmd); e != nil {
+		if _, e := s.exec(execCtx, srv.ID, cmd); e != nil {
 			rbErr = e
 			break
 		}
@@ -206,7 +206,7 @@ func (s *service) fleetRollbackImageOne(ctx context.Context, srv *target.Server,
 
 // readContainerImage 读同名容器当前所用镜像(docker inspect);无容器 / 读失败 → ""。
 func (s *service) readContainerImage(ctx context.Context, serverID, name string) string {
-	out, err := s.targets.Exec(ctx, serverID, []string{"docker", "inspect", "--format", "{{.Config.Image}}", name})
+	out, err := s.exec(ctx, serverID, []string{"docker", "inspect", "--format", "{{.Config.Image}}", name})
 	if err != nil || out == nil || out.ExitCode != 0 {
 		return ""
 	}

--- a/internal/deploy/release.go
+++ b/internal/deploy/release.go
@@ -301,7 +301,7 @@ func (s *service) rollback(ctx context.Context, srv *target.Server, res TargetRe
 	// 回滚:把 current 软链原子切回上一发布(code-review P2:同样 ln tmp + mv -T,避免回滚窗口)。
 	var rbErr error
 	for _, cmd := range atomicSymlinkCmds(prev, current) {
-		if _, e := s.targets.Exec(ctx, srv.ID, cmd); e != nil {
+		if _, e := s.exec(ctx, srv.ID, cmd); e != nil {
 			rbErr = e
 			break
 		}
@@ -322,7 +322,7 @@ func (s *service) rollback(ctx context.Context, srv *target.Server, res TargetRe
 // readCurrentRelease 经 readlink 读 current 软链指向的发布绝对路径(无软链 / 读失败 → "")。
 // 用于回滚目标探测;首次部署时 current 不存在 → 返回 ""(无可回滚)。
 func (s *service) readCurrentRelease(ctx context.Context, serverID, current string) string {
-	out, err := s.targets.Exec(ctx, serverID, []string{"readlink", current})
+	out, err := s.exec(ctx, serverID, []string{"readlink", current})
 	if err != nil || out == nil || out.ExitCode != 0 {
 		return ""
 	}
@@ -358,7 +358,7 @@ func (s *service) pruneReleases(ctx context.Context, serverID, releasesDir, curR
 		`  n=$((n+1)); ` +
 		`  if [ "$n" -gt "$keep" ]; then rm -rf "$dir/$d"; fi; ` +
 		`done`
-	_, _ = s.targets.Exec(ctx, serverID, []string{
+	_, _ = s.exec(ctx, serverID, []string{
 		"sh", "-c", script, releasesDir, strconv.Itoa(keep), curRunID, prevName,
 	})
 }
@@ -378,7 +378,7 @@ func atomicSymlinkCmds(target, link string) [][]string {
 // 全部成功 → ("", true)。供 deployReleaseOne 的放置 / 切换阶段复用。
 func (s *service) runStep(ctx context.Context, serverID string, cmds [][]string) (string, bool) {
 	for _, cmd := range cmds {
-		out, eerr := s.targets.Exec(ctx, serverID, cmd)
+		out, eerr := s.exec(ctx, serverID, cmd)
 		if eerr != nil {
 			return humanExecError(eerr), false
 		}

--- a/internal/deploy/strategy.go
+++ b/internal/deploy/strategy.go
@@ -295,7 +295,7 @@ func (s *service) fleetRollbackOne(ctx context.Context, srv *target.Server, st r
 
 	var rbErr error
 	for _, cmd := range atomicSymlinkCmds(st.prev, st.current) {
-		if _, e := s.targets.Exec(execCtx, srv.ID, cmd); e != nil {
+		if _, e := s.exec(execCtx, srv.ID, cmd); e != nil {
 			rbErr = e
 			break
 		}


### PR DESCRIPTION
## 背景
运行详情里点开 **deploy_ssh** 步骤只看到一行结果摘要(「零停机部署完成 →…」),看不到目标机上真正执行了哪些命令;**git_source** 步骤是空占位「真实执行未接入」。

## 改动
- **部署命令实时回流**:`deploy.WithCmdLog`(ctx 携带回调)+ `s.exec` 包裹 `targets.Exec`,把每条远程命令(`tar`/`docker build`/`docker run`/软链切换/健康探测…)及其 stdout/stderr 流回该部署步骤日志,像 Jenkins 控制台。
  - **脱敏两道**:① 命令回显对 `-e`/`--env`/`--build-arg` 的 `K=V` 与 `--password` 值就地打码;② 文本最终经 **sink 侧 per-run Masker** 兜底(与构建日志同机制,绝无明文 secret 落库/出网)。
  - 未挂 `WithCmdLog` 的调用方(`/runs/{id}/deploy` 端点)**纯透传、行为不变**。
- **git_source**:占位行改为展示 源码仓库 / 分支 / 提交 / 凭据已绑定,并说明实际克隆在构建阶段各 job 工作区执行(go-git 浅克隆,库调用非 shell 命令)。

## 测试
- 新增 `displayCmd` 脱敏表驱动(sh -c 展示脚本 / -e KV 打码 / --password 打码 / 端口不打码)+ `s.exec` 回流与无 sink 透传。
- `go vet` 净、`gofmt` 净、deploy/build/httpapi 全套通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)