### PR TITLE
feat(anomaly): 异常检测定时自动跑 + 命中走通知渠道 + 冷却去重

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -474,7 +474,12 @@ func main() {
 	// 装配可配置异常检测服务(Story 6.5;FR-23):按阈值规则对服务器指标做检测,命中产告警入库。
 	// 检测复用 6-1 指标采集(NewAnomalyCollector 适配 collectServerMetrics);不可达/指标 null 的
 	// 服务器跳过(不误报)。复用已装配的 targetSvc(采集),无新顶层依赖;无 init 副作用/不起轮询。
-	anomalySvc := anomaly.New(st.DB, httpapi.NewAnomalyCollector(targetSvc))
+	// 告警去重窗口(同「服务器×规则条件」最小间隔):env PIPEWRIGHT_ANOMALY_COOLDOWN(秒)覆盖,默认 600s。
+	anomalyCooldown := envDurationSeconds("PIPEWRIGHT_ANOMALY_COOLDOWN", 600*time.Second)
+	anomalySvc := anomaly.New(st.DB, httpapi.NewAnomalyCollector(targetSvc),
+		anomaly.WithNotifier(httpapi.NewAnomalyNotifier(notifySvc)),
+		anomaly.WithCooldown(anomalyCooldown),
+	)
 
 	// 装配多 provider OAuth 凭据接入服务(连接 Gitee/GitHub/GitLab/自建):复用 vault secretbox 加密
 	// OAuth 应用 client_secret(密文入库);OAuth 拿到的 access_token 经 vault.Create 存成 git_token 凭据,
@@ -497,6 +502,27 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	// 异常检测定时器(Story 6.5 增强):周期性 Check → 命中产告警 + best-effort 通知(去重已在服务内)。
+	// 间隔 env PIPEWRIGHT_ANOMALY_INTERVAL(秒)覆盖,默认 60s;置 "0" 关闭定时(仍可手动「立即检测」)。
+	// 无 enabled 规则时 Check 提前返回(不采集),故空载零开销。随 ctx 取消(停机)退出。
+	if anomalyInterval := envDurationSeconds("PIPEWRIGHT_ANOMALY_INTERVAL", 60*time.Second); anomalyInterval > 0 {
+		go func() {
+			ticker := time.NewTicker(anomalyInterval)
+			defer ticker.Stop()
+			log.Printf("[anomaly] 定时检测已启用,间隔 %s", anomalyInterval)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					if _, err := anomalySvc.Check(ctx); err != nil && ctx.Err() == nil {
+						log.Printf("[anomaly] 定时检测失败(已跳过本轮):%v", err)
+					}
+				}
+			}
+		}()
+	}
+
 	go func() {
 		log.Printf("pipewright listening on %s", cfg.Addr)
 		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -517,6 +543,24 @@ func main() {
 	retentionSweeper.Stop()
 	pool.Stop(shutdownCtx)
 	log.Printf("[run] worker pool stopped")
+}
+
+// envDurationSeconds 读取 name 环境变量(整数秒)为 time.Duration;未设/非法 → def。
+// 显式 "0"(或负)→ 0(调用方据此关闭对应定时任务)。
+func envDurationSeconds(name string, def time.Duration) time.Duration {
+	v := strings.TrimSpace(os.Getenv(name))
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		log.Printf("[config] %s=%q 非法(应为整数秒),用默认 %s", name, v, def)
+		return def
+	}
+	if n <= 0 {
+		return 0
+	}
+	return time.Duration(n) * time.Second
 }
 
 // ── 「流水线即代码」运行时覆盖适配器(FR-8-12)──────────────────────────────────

--- a/internal/anomaly/anomaly.go
+++ b/internal/anomaly/anomaly.go
@@ -150,16 +150,50 @@ type Service interface {
 	ListAlerts(ctx context.Context, serverID string, limit int) ([]*Alert, error)
 }
 
+// Notifier 抽象「告警产生时发一次通知」(注入便于测试;nil = 不发)。实现侧 best-effort:
+// 自带超时、失败仅记日志,绝不阻断检测主流程。
+type Notifier interface {
+	NotifyAlert(ctx context.Context, a *Alert)
+}
+
+// defaultCooldown 是同一「服务器 × 规则条件」两次告警之间的最小间隔:窗口内重复命中不再
+// 产告警/发通知,避免「CPU 持续越限 → 每个检测周期刷屏」。
+const defaultCooldown = 10 * time.Minute
+
 // service 是 store + collector 支撑的 Service 实现。
 type service struct {
 	db        *sql.DB
 	collector MetricsCollector
+	notifier  Notifier      // nil = 不发通知(命中仍入库 + 列表可见)
+	cooldown  time.Duration // 同条件去重窗口;<=0 视为 defaultCooldown
+}
+
+// Option 配置可选依赖(通知器 / 去重窗口);默认零依赖、defaultCooldown。
+type Option func(*service)
+
+// WithNotifier 注入告警通知器:每条**新**告警(通过去重窗口后)发一次通知。
+func WithNotifier(n Notifier) Option { return func(s *service) { s.notifier = n } }
+
+// WithCooldown 设置同条件去重窗口;d<=0 回退 defaultCooldown。
+func WithCooldown(d time.Duration) Option {
+	return func(s *service) {
+		if d > 0 {
+			s.cooldown = d
+		}
+	}
 }
 
 // New 构造 Service。collector 复用 6-1 采集(httpapi 适配注入);为 nil 时 Check 返回空结果
 // (无采集源 → 不误报)。不在此做任何重活(无 init 副作用)。
-func New(db *sql.DB, collector MetricsCollector) Service {
-	return &service{db: db, collector: collector}
+func New(db *sql.DB, collector MetricsCollector, opts ...Option) Service {
+	s := &service{db: db, collector: collector, cooldown: defaultCooldown}
+	for _, opt := range opts {
+		opt(s)
+	}
+	if s.cooldown <= 0 {
+		s.cooldown = defaultCooldown
+	}
+	return s
 }
 
 const defaultAlertLimit = 100
@@ -295,14 +329,43 @@ func (s *service) Check(ctx context.Context) ([]*Alert, error) {
 			if !evaluate(rule.Operator, *pv, rule.Threshold) {
 				continue
 			}
+			// 去重:同「服务器 × 规则条件」在 cooldown 窗口内已有告警 → 跳过(不入库、不发通知),
+			// 避免持续越限时每个检测周期刷屏。
+			recent, err := s.hasRecentAlert(ctx, snap.ServerID, rule)
+			if err != nil {
+				return nil, err
+			}
+			if recent {
+				continue
+			}
 			alert, err := s.recordAlert(ctx, rule, snap, *pv)
 			if err != nil {
 				return nil, err
 			}
 			out = append(out, alert)
+			// 命中新告警 → 发一次通知(best-effort,实现侧不阻断;未注入则无操作)。
+			if s.notifier != nil {
+				s.notifier.NotifyAlert(ctx, alert)
+			}
 		}
 	}
 	return out, nil
+}
+
+// hasRecentAlert 报告同「服务器 × 规则条件(metric+operator+threshold)」在 cooldown 窗口内
+// 是否已有告警(去重)。查询/扫描失败 → 返回错误(由 Check 上抛,保持既有错误传播语义)。
+func (s *service) hasRecentAlert(ctx context.Context, serverID string, rule *Rule) (bool, error) {
+	cutoff := time.Now().UTC().Add(-s.cooldown).Format(time.RFC3339)
+	var n int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(1) FROM anomaly_alerts
+		 WHERE server_id = ? AND metric = ? AND operator = ? AND threshold = ? AND created_at >= ?`,
+		serverID, rule.Metric, rule.Operator, rule.Threshold, cutoff,
+	).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("anomaly: check recent alert: %w", err)
+	}
+	return n > 0, nil
 }
 
 // evaluate 求值 value <op> threshold。

--- a/internal/anomaly/anomaly_test.go
+++ b/internal/anomaly/anomaly_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/huangchengsir/pipewright/internal/storetest"
 	_ "modernc.org/sqlite"
@@ -209,6 +210,93 @@ func TestListAlertsFilterAndLimit(t *testing.T) {
 	lim, _ := svc.ListAlerts(ctx, "", 1)
 	if len(lim) != 1 {
 		t.Fatalf("limit 1 wrong: %d", len(lim))
+	}
+}
+
+// stubNotifier 记录收到的告警(校验通知触发 + 去重)。
+type stubNotifier struct{ got []*Alert }
+
+func (n *stubNotifier) NotifyAlert(_ context.Context, a *Alert) { n.got = append(n.got, a) }
+
+// TestCheckNotifierInvokedOnNewAlert:命中新告警 → 通知器收到一次(带正确字段)。
+func TestCheckNotifierInvokedOnNewAlert(t *testing.T) {
+	disk := 92.3
+	col := stubCollector{snaps: []ServerMetricsSnapshot{
+		{ServerID: "s1", ServerName: "web-1", Available: true, DiskPercent: &disk},
+	}}
+	nf := &stubNotifier{}
+	svc := New(testDB(t), col, WithNotifier(nf), WithCooldown(time.Hour))
+	ctx := context.Background()
+	_, _ = svc.CreateRule(ctx, CreateRuleInput{Metric: "disk", Operator: "gt", Threshold: 1, Enabled: true})
+	if _, err := svc.Check(ctx); err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if len(nf.got) != 1 {
+		t.Fatalf("want notifier called once, got %d", len(nf.got))
+	}
+	if nf.got[0].ServerID != "s1" || nf.got[0].Metric != "disk" {
+		t.Fatalf("notified alert wrong: %+v", nf.got[0])
+	}
+}
+
+// TestCheckCooldownDedup:cooldown 窗口内同「服务器×规则条件」重复命中 → 不再产告警/不再通知。
+func TestCheckCooldownDedup(t *testing.T) {
+	disk := 92.3
+	col := stubCollector{snaps: []ServerMetricsSnapshot{
+		{ServerID: "s1", ServerName: "web-1", Available: true, DiskPercent: &disk},
+	}}
+	nf := &stubNotifier{}
+	svc := New(testDB(t), col, WithNotifier(nf), WithCooldown(time.Hour))
+	ctx := context.Background()
+	_, _ = svc.CreateRule(ctx, CreateRuleInput{Metric: "disk", Operator: "gt", Threshold: 1, Enabled: true})
+
+	first, _ := svc.Check(ctx)
+	second, _ := svc.Check(ctx) // 立即再检测:在 cooldown 内 → 跳过
+
+	if len(first) != 1 {
+		t.Fatalf("first check want 1, got %d", len(first))
+	}
+	if len(second) != 0 {
+		t.Fatalf("second check within cooldown want 0, got %d", len(second))
+	}
+	stored, _ := svc.ListAlerts(ctx, "", 0)
+	if len(stored) != 1 {
+		t.Fatalf("dedup should keep a single alert, got %d", len(stored))
+	}
+	if len(nf.got) != 1 {
+		t.Fatalf("notifier should fire once across cooldown, got %d", len(nf.got))
+	}
+}
+
+// TestCheckRefiresAfterCooldown:窗口外(把已存告警时间改老)→ 再次命中重新产告警 + 通知。
+func TestCheckRefiresAfterCooldown(t *testing.T) {
+	disk := 92.3
+	col := stubCollector{snaps: []ServerMetricsSnapshot{
+		{ServerID: "s1", ServerName: "web-1", Available: true, DiskPercent: &disk},
+	}}
+	nf := &stubNotifier{}
+	db := testDB(t)
+	svc := New(db, col, WithNotifier(nf), WithCooldown(time.Hour))
+	ctx := context.Background()
+	_, _ = svc.CreateRule(ctx, CreateRuleInput{Metric: "disk", Operator: "gt", Threshold: 1, Enabled: true})
+
+	if _, err := svc.Check(ctx); err != nil {
+		t.Fatalf("check1: %v", err)
+	}
+	// 把已存告警的 created_at 改到 2 小时前(> cooldown 窗口),模拟冷却已过。
+	old := time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339)
+	if _, err := db.ExecContext(ctx, `UPDATE anomaly_alerts SET created_at = ?`, old); err != nil {
+		t.Fatalf("age alert: %v", err)
+	}
+	again, err := svc.Check(ctx)
+	if err != nil {
+		t.Fatalf("check2: %v", err)
+	}
+	if len(again) != 1 {
+		t.Fatalf("after cooldown should refire, got %d", len(again))
+	}
+	if len(nf.got) != 2 {
+		t.Fatalf("notifier should fire twice (once per window), got %d", len(nf.got))
 	}
 }
 

--- a/internal/httpapi/anomaly.go
+++ b/internal/httpapi/anomaly.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"strconv"
 	"sync"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/huangchengsir/pipewright/internal/anomaly"
+	"github.com/huangchengsir/pipewright/internal/notify"
 	"github.com/huangchengsir/pipewright/internal/target"
 )
 
@@ -33,6 +35,38 @@ import (
 // servers 为已装配的 target.Service(4-1);检测时经 collectServerMetrics 逐台采集再归一为百分比快照。
 func NewAnomalyCollector(servers target.Service) anomaly.MetricsCollector {
 	return metricsCollector{servers: servers}
+}
+
+// NewAnomalyNotifier 构造 anomaly.Notifier:每条新告警 → 通知事件 anomaly_detected,经 notify
+// **全局路由**(projectID 空,异常非 run/项目维度)发到各配置渠道。让 anomaly 包不 import notify
+// (仿 NewAnomalyCollector 解耦);未配置任何路由 → RouteEventForProject 内部 best-effort 不发。
+func NewAnomalyNotifier(notifySvc notify.Service) anomaly.Notifier {
+	return anomalyNotifier{notify: notifySvc}
+}
+
+// anomalyNotifier 把 anomaly.Alert 映射为通知事件并经渠道发送。
+type anomalyNotifier struct{ notify notify.Service }
+
+// NotifyAlert 异步发一次告警通知(fire-and-forget):不阻塞检测主流程(手动检测的 HTTP 响应 /
+// 定时检测的 goroutine 都不等慢渠道)。用独立 ctx + 超时,失败仅记日志(best-effort,NFR-10)。
+func (n anomalyNotifier) NotifyAlert(ctx context.Context, a *anomaly.Alert) {
+	if n.notify == nil || a == nil {
+		return
+	}
+	// TemplateVars 复用既有占位:Project=服务器名(标题渲染为「[<服务器>] 异常检测」),
+	// Status=人读告警文案(如「磁盘使用率 92.3% > 1%」,正文/字段透出)。
+	vars := notify.TemplateVars{
+		Project: a.ServerName,
+		Status:  a.Message,
+		Event:   notify.EventAnomalyDetected,
+	}
+	go func() {
+		sendCtx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+		defer cancel()
+		if err := n.notify.RouteEventForProject(sendCtx, "", notify.EventAnomalyDetected, vars); err != nil {
+			log.Printf("[anomaly] 告警 %s 通知 best-effort 失败:%v", a.ID, err)
+		}
+	}()
 }
 
 // metricsCollector 是 anomaly.MetricsCollector 的 httpapi 适配:复用 6-1 的 collectServerMetrics

--- a/internal/i18n/messages_notify.go
+++ b/internal/i18n/messages_notify.go
@@ -13,6 +13,7 @@ func init() {
 		"已回滚":    {"zh-TW": "已回滾", "en": "Rolled back", "ja": "ロールバック済み", "ko": "롤백됨", "es": "Revertido", "fr": "Annulé", "de": "Zurückgerollt"},
 		"健康检查失败": {"zh-TW": "健康檢查失敗", "en": "Health check failed", "ja": "ヘルスチェック失敗", "ko": "상태 점검 실패", "es": "Comprobación de estado fallida", "fr": "Échec de la vérification de santé", "de": "Health-Check fehlgeschlagen"},
 		"需要审批":   {"zh-TW": "需要審批", "en": "Approval required", "ja": "承認が必要です", "ko": "승인 필요", "es": "Se requiere aprobación", "fr": "Approbation requise", "de": "Genehmigung erforderlich"},
+		"异常检测":   {"zh-TW": "異常偵測", "en": "Anomaly detected", "ja": "異常を検出", "ko": "이상 감지", "es": "Anomalía detectada", "fr": "Anomalie détectée", "de": "Anomalie erkannt"},
 
 		// Field labels (notification body + feishu card field list).
 		"项目":     {"zh-TW": "專案", "en": "Project", "ja": "プロジェクト", "ko": "프로젝트", "es": "Proyecto", "fr": "Projet", "de": "Projekt"},

--- a/internal/notify/feishu.go
+++ b/internal/notify/feishu.go
@@ -280,6 +280,8 @@ func feishuTitleIcon(p Payload) string {
 	event := strings.ToLower(strings.TrimSpace(p.Fields["event"]))
 	status := strings.ToLower(strings.TrimSpace(p.Fields["status"]))
 	switch {
+	case strings.Contains(event, "anomaly"):
+		return "🚨"
 	case strings.Contains(event, "approval"):
 		return "🔔"
 	case strings.Contains(event, "rollback") || strings.Contains(status, "rolled_back") || strings.Contains(status, "rollback"):
@@ -358,6 +360,10 @@ func feishuHeaderColor(p Payload) string {
 	event := strings.ToLower(strings.TrimSpace(p.Fields["event"]))
 	status := strings.ToLower(strings.TrimSpace(p.Fields["status"]))
 
+	// 异常检测:警示红(指标越限)。
+	if strings.Contains(event, "anomaly") {
+		return "red"
+	}
 	// 回滚单独橙色(既非成功也非纯失败)。
 	if strings.Contains(event, "rollback") || strings.Contains(status, "rolled_back") || strings.Contains(status, "rollback") {
 		return "orange"

--- a/internal/notify/feishu_test.go
+++ b/internal/notify/feishu_test.go
@@ -234,6 +234,7 @@ func TestFeishuHeaderColor(t *testing.T) {
 		{"回滚 status→橙", map[string]string{"status": "rolled_back"}, "orange"},
 		{"构建成功事件→绿", map[string]string{"event": "build_succeeded"}, "green"},
 		{"成功 status→绿", map[string]string{"status": "success"}, "green"},
+		{"异常检测事件→红", map[string]string{"event": "anomaly_detected"}, "red"},
 		{"未知→中性蓝", map[string]string{"kind": "test"}, "blue"},
 	}
 	for _, c := range cases {
@@ -242,5 +243,26 @@ func TestFeishuHeaderColor(t *testing.T) {
 				t.Fatalf("want %q got %q (fields=%v)", c.want, got, c.fields)
 			}
 		})
+	}
+}
+
+// TestAnomalyEventWiring:新增「异常检测」事件 = 合法枚举、有本地化标签、飞书标题图标 🚨。
+func TestAnomalyEventWiring(t *testing.T) {
+	if !validEvent(EventAnomalyDetected) {
+		t.Fatalf("anomaly_detected should be a valid event")
+	}
+	if got := eventLabel(EventAnomalyDetected, "zh-CN"); got != "异常检测" {
+		t.Fatalf("zh-CN label want 异常检测, got %q", got)
+	}
+	if got := eventLabel(EventAnomalyDetected, "en"); got != "Anomaly detected" {
+		t.Fatalf("en label want 'Anomaly detected', got %q", got)
+	}
+	if got := feishuTitleIcon(Payload{Fields: map[string]string{"event": EventAnomalyDetected}}); got != "🚨" {
+		t.Fatalf("anomaly title icon want 🚨, got %q", got)
+	}
+	// 标题随服务器名(Project)渲染为「[<服务器>] 异常检测」。
+	p := EventPayload("zh-CN", EventAnomalyDetected, "香港服务器", "", "", "磁盘使用率 92.3% > 1%", 0)
+	if p.Title != "[香港服务器] 异常检测" {
+		t.Fatalf("title want [香港服务器] 异常检测, got %q", p.Title)
 	}
 }

--- a/internal/notify/router.go
+++ b/internal/notify/router.go
@@ -31,6 +31,8 @@ const (
 	EventHealthCheckFailed = "health_check_failed"
 	// EventApprovalRequired 需要人工审批(run 进入 waiting_approval 时发,携带签名审批链接)。
 	EventApprovalRequired = "approval_required"
+	// EventAnomalyDetected 服务器指标异常(异常检测命中阈值规则;非 run 维度,projectID 空=全局路由)。
+	EventAnomalyDetected = "anomaly_detected"
 )
 
 // 路由领域错误。
@@ -47,7 +49,8 @@ var (
 func validEvent(e string) bool {
 	switch e {
 	case EventBuildSucceeded, EventBuildFailed, EventDeploySucceeded,
-		EventDeployFailed, EventRollback, EventHealthCheckFailed, EventApprovalRequired:
+		EventDeployFailed, EventRollback, EventHealthCheckFailed, EventApprovalRequired,
+		EventAnomalyDetected:
 		return true
 	default:
 		return false
@@ -60,7 +63,7 @@ func Events() []string {
 		EventBuildSucceeded, EventBuildFailed,
 		EventDeploySucceeded, EventDeployFailed,
 		EventRollback, EventHealthCheckFailed,
-		EventApprovalRequired,
+		EventApprovalRequired, EventAnomalyDetected,
 	}
 }
 
@@ -482,6 +485,8 @@ func eventLabel(event, lang string) string {
 		return i18n.T(lang, "健康检查失败")
 	case EventApprovalRequired:
 		return i18n.T(lang, "需要审批")
+	case EventAnomalyDetected:
+		return i18n.T(lang, "异常检测")
 	default:
 		return event
 	}

--- a/web/src/api/notifications.ts
+++ b/web/src/api/notifications.ts
@@ -134,6 +134,7 @@ export type NotificationEvent =
   | 'rollback'
   | 'health_check_failed'
   | 'approval_required'
+  | 'anomaly_detected'
 
 /** GET response item — an event→channel mapping. */
 export interface NotificationRoute {

--- a/web/src/i18n/locales/de/settingsNotifications.ts
+++ b/web/src/i18n/locales/de/settingsNotifications.ts
@@ -131,6 +131,8 @@ export default {
   evHealthCheckFailedDesc: 'Der Health-Check nach dem Deployment ist nicht bestanden',
   evApprovalRequired: 'Genehmigung erforderlich',
   evApprovalRequiredDesc: 'Ein Lauf hat ein manuelles Genehmigungs-Gate erreicht und wartet auf Genehmigung oder Ablehnung',
+  evAnomalyDetected: 'Anomalie erkannt',
+  evAnomalyDetectedDesc: 'Eine Servermetrik (CPU/Speicher/Festplatte) hat eine Schwellenwertregel überschritten',
 
   routesTitle: 'Ereignisrouten',
   routesDescPre: 'Konfigurieren Sie, welche Ereignisse über welche Kanäle benachrichtigen. ',

--- a/web/src/i18n/locales/en/settingsNotifications.ts
+++ b/web/src/i18n/locales/en/settingsNotifications.ts
@@ -131,6 +131,8 @@ export default {
   evHealthCheckFailedDesc: 'Post-deploy health check did not pass',
   evApprovalRequired: 'Approval Required',
   evApprovalRequiredDesc: 'A run reached a manual approval gate and awaits approve or reject',
+  evAnomalyDetected: 'Anomaly Detected',
+  evAnomalyDetectedDesc: 'A server metric (CPU/memory/disk) crossed a threshold rule',
 
   routesTitle: 'Event Routes',
   routesDescPre: 'Configure which events notify which channels. ',

--- a/web/src/i18n/locales/es/settingsNotifications.ts
+++ b/web/src/i18n/locales/es/settingsNotifications.ts
@@ -131,6 +131,8 @@ export default {
   evHealthCheckFailedDesc: 'La comprobación de estado posterior al despliegue no pasó',
   evApprovalRequired: 'Se requiere aprobación',
   evApprovalRequiredDesc: 'Una ejecución llegó a una puerta de aprobación manual y espera aprobación o rechazo',
+  evAnomalyDetected: 'Anomalía detectada',
+  evAnomalyDetectedDesc: 'Una métrica del servidor (CPU/memoria/disco) cruzó una regla de umbral',
 
   routesTitle: 'Rutas de eventos',
   routesDescPre: 'Configura qué eventos notifican por qué canales. ',

--- a/web/src/i18n/locales/fr/settingsNotifications.ts
+++ b/web/src/i18n/locales/fr/settingsNotifications.ts
@@ -131,6 +131,8 @@ export default {
   evHealthCheckFailedDesc: 'Le contrôle de santé après déploiement n’a pas réussi',
   evApprovalRequired: 'Approbation requise',
   evApprovalRequiredDesc: 'Une exécution a atteint une porte d’approbation manuelle et attend approbation ou refus',
+  evAnomalyDetected: 'Anomalie détectée',
+  evAnomalyDetectedDesc: 'Une métrique serveur (CPU/mémoire/disque) a franchi une règle de seuil',
 
   routesTitle: 'Routes d’événements',
   routesDescPre: 'Configurez quels événements notifient quels canaux. ',

--- a/web/src/i18n/locales/ja/settingsNotifications.ts
+++ b/web/src/i18n/locales/ja/settingsNotifications.ts
@@ -131,6 +131,8 @@ export default {
   evHealthCheckFailedDesc: 'デプロイ後のヘルスチェックが通過しませんでした',
   evApprovalRequired: '承認が必要です',
   evApprovalRequiredDesc: '実行が手動承認ゲートに到達し、承認または却下を待っています',
+  evAnomalyDetected: '異常を検出',
+  evAnomalyDetectedDesc: 'サーバー指標(CPU/メモリ/ディスク)がしきい値ルールに該当したとき通知',
 
   routesTitle: 'イベントルート',
   routesDescPre: '「どのイベントをどのチャンネルで通知するか」を設定します。',

--- a/web/src/i18n/locales/ko/settingsNotifications.ts
+++ b/web/src/i18n/locales/ko/settingsNotifications.ts
@@ -131,6 +131,8 @@ export default {
   evHealthCheckFailedDesc: '배포 후 상태 점검을 통과하지 못함',
   evApprovalRequired: '승인 필요',
   evApprovalRequiredDesc: '실행이 수동 승인 게이트에 도달하여 승인 또는 거부를 기다리는 중',
+  evAnomalyDetected: '이상 감지',
+  evAnomalyDetectedDesc: '서버 지표(CPU/메모리/디스크)가 임계값 규칙에 도달하면 알림',
 
   routesTitle: '이벤트 라우트',
   routesDescPre: '"어떤 이벤트를 어떤 채널로 알릴지"를 구성합니다. ',

--- a/web/src/i18n/locales/zh-CN/settingsNotifications.ts
+++ b/web/src/i18n/locales/zh-CN/settingsNotifications.ts
@@ -135,6 +135,8 @@ export default {
   evHealthCheckFailedDesc: '部署后健康检查未通过',
   evApprovalRequired: '需要审批',
   evApprovalRequiredDesc: '运行进入人工审批门,等待批准或拒绝',
+  evAnomalyDetected: '异常检测',
+  evAnomalyDetectedDesc: '服务器指标(CPU/内存/磁盘)命中阈值规则时告警',
 
   // 事件路由区
   routesTitle: '事件路由',

--- a/web/src/i18n/locales/zh-TW/settingsNotifications.ts
+++ b/web/src/i18n/locales/zh-TW/settingsNotifications.ts
@@ -130,6 +130,8 @@ export default {
   evHealthCheckFailedDesc: '部署後健康檢查未通過',
   evApprovalRequired: '需要審批',
   evApprovalRequiredDesc: '執行進入人工審批門,等待批准或拒絕',
+  evAnomalyDetected: '異常偵測',
+  evAnomalyDetectedDesc: '伺服器指標(CPU/記憶體/磁碟)命中閾值規則時告警',
 
   routesTitle: '事件路由',
   routesDescPre: '設定「哪些事件經哪些管道通知」。',

--- a/web/src/views/settings/SettingsNotifications.vue
+++ b/web/src/views/settings/SettingsNotifications.vue
@@ -449,6 +449,7 @@ const EVENTS = computed<EventMeta[]>(() => [
   { id: 'rollback', label: t('settingsNotifications.evRollback'), desc: t('settingsNotifications.evRollbackDesc') },
   { id: 'health_check_failed', label: t('settingsNotifications.evHealthCheckFailed'), desc: t('settingsNotifications.evHealthCheckFailedDesc') },
   { id: 'approval_required', label: t('settingsNotifications.evApprovalRequired'), desc: t('settingsNotifications.evApprovalRequiredDesc') },
+  { id: 'anomaly_detected', label: t('settingsNotifications.evAnomalyDetected'), desc: t('settingsNotifications.evAnomalyDetectedDesc') },
 ])
 
 const routesLoadState = ref<LoadState>('loading')


### PR DESCRIPTION
## 背景
异常检测此前是半成品:规则只能手动点「立即检测」,命中仅写库展示,**完全不发通知**。本 PR 补齐为可用闭环。

## 改动
- **定时自动检测**:后台 ticker 周期跑 `Check`(`PIPEWRIGHT_ANOMALY_INTERVAL` 秒,默认 60;置 `0` 关闭)。无 enabled 规则时 `Check` 提前返回 → 空载零开销;随 ctx 停机退出。
- **命中走通知渠道**:新增通知事件 `anomaly_detected`;`anomaly.Service` 注入 `Notifier`(`httpapi.NewAnomalyNotifier` 适配,anomaly 包不反向 import notify),每条**新**告警经 notify 全局路由(projectID 空)发到配置渠道。飞书卡片标题 🚨 + 头部红。
- **冷却去重**:同「服务器 × 规则条件(metric+operator+threshold)」在 cooldown 窗口内(`PIPEWRIGHT_ANOMALY_COOLDOWN` 秒,默认 600)只产一次告警/通知,避免持续越限每周期刷屏。
- **设置页**加 `anomaly_detected` 事件项(可独立开关/选渠道),i18n ×8。

## 测试
- 后端:anomaly 去重/通知触发/冷却后重发;notify 事件枚举+标签+飞书图标/头色。`go build/vet/test` 全绿,gofmt 干净。
- 前端:`lint`(0 error)/`typecheck`/`test`(330 passed)全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)