### PR TITLE
feat(deploy): 命令型部署(无产物)+ restartCommand 运行参数插值

### DIFF
--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -290,7 +290,7 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 				}
 				_ = rep.JobRunning(ctx, jb.ID)
 				jrep := rep.JobReporter(jb.ID)
-				if err := b.runDeployJob(ctx, jrep, jb, r.ID); err != nil {
+				if err := b.runDeployJob(ctx, jrep, jb, r.ID, r.Trigger.Params); err != nil {
 					_ = rep.JobDone(ctx, jb.ID, run.StepFailed)
 					return err
 				}
@@ -416,7 +416,7 @@ func (b *Builder) runStageJobsDAG(
 			case isBuildImageJob(jb.Type):
 				return b.runBuildImageJobIsolated(ctx, jsink, jrep, r, jb, stage, proj, settings, hasPushJob)
 			case isDeployJob(jb.Type):
-				return b.runDeployJob(ctx, jrep, jb, r.ID)
+				return b.runDeployJob(ctx, jrep, jb, r.ID, r.Trigger.Params)
 			case strings.TrimSpace(jb.Type) == "push_image":
 				// 推送随构建镜像节点完成(hasPushJob);本节点仅用于在 DAG 中编排顺序/展示。
 				_ = jrep.Log(ctx, streamStdout, fmt.Sprintf("· 推送镜像「%s」:已随构建镜像节点完成推送(本节点用于编排顺序)", jb.Name))
@@ -572,7 +572,7 @@ func (b *Builder) runBuildImageJobIsolated(
 
 // runDeployJob 执行一个 deploy_ssh 节点:把本 run 已产出的产物经 SSH 部署到节点配置的目标机
 // (复用 deploy.Service.DeployForStage 中途部署,不动 run 终态)。任一目标失败 → 阶段失败、阻断下游。
-func (b *Builder) runDeployJob(ctx context.Context, rep dagrun.StageReporter, jb pipeline.Job, runID string) error {
+func (b *Builder) runDeployJob(ctx context.Context, rep dagrun.StageReporter, jb pipeline.Job, runID string, params map[string]string) error {
 	if b.deployer == nil {
 		_ = rep.Log(ctx, streamStdout, "· 部署节点:部署服务未注入,跳过")
 		return nil
@@ -583,10 +583,12 @@ func (b *Builder) runDeployJob(ctx context.Context, rep dagrun.StageReporter, jb
 		return ErrBuildFailed
 	}
 	cfg := map[string]string{}
-	if dp := cfgString(jb.Config, "deployPath"); dp != "" {
+	// deployPath / restartCommand 支持 {{param}} 占位:用本次运行参数渲染(命令型部署据此让
+	// 「本地端口 / 穿透端口」等随运行参数变化;非配置类部署不写占位 → renderTemplate 零开销直返)。
+	if dp := renderTemplate(cfgString(jb.Config, "deployPath"), params); dp != "" {
 		cfg["releaseBase"] = dp
 	}
-	if rc := cfgString(jb.Config, "restartCommand"); rc != "" {
+	if rc := renderTemplate(cfgString(jb.Config, "restartCommand"), params); rc != "" {
 		cfg["restartCommand"] = rc
 	}
 	// 镜像产物部署参数(#51)透传:deploy.DeployForStage 经这些键挑镜像产物并组装

--- a/internal/build/dag_stage_exec_test.go
+++ b/internal/build/dag_stage_exec_test.go
@@ -546,7 +546,7 @@ func TestRunDeployJobPassesImageParams(t *testing.T) {
 		"strategy":      "blue_green",
 		"deployPath":    "/opt/app", // 文件态键仍应透传,不互斥
 	}}
-	if err := b.runDeployJob(context.Background(), rep, jb, "run-1"); err != nil {
+	if err := b.runDeployJob(context.Background(), rep, jb, "run-1", nil); err != nil {
 		t.Fatalf("runDeployJob err: %v", err)
 	}
 	for k, want := range map[string]string{

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -317,6 +317,12 @@ func (s *service) DeployForStage(ctx context.Context, runID string, serverIDs []
 	if len(serverIDs) == 0 {
 		return nil, ErrNoServers
 	}
+	// 「命令型」部署(artifactType=command):不取构建产物,直接在目标机执行 cfg["restartCommand"]。
+	// 供「配置类」流水线用(如 frp 隧道:就地 upsert frpc.ini + reload)。与产物发布完全隔离——
+	// **真实产物部署(artifactType != command)绝不进此分支**,既有部署/策略/健康检查路径零影响。
+	if strings.TrimSpace(cfg["artifactType"]) == "command" {
+		return s.runCommandOnly(ctx, runID, serverIDs, cfg)
+	}
 	// 取该 run 已产出的可部署产物。dist/jar/archive 走文件发布;image 走容器 pull→停旧起新→
 	// 健康→回滚(复用 image_release.go)。二者都在时按节点 cfg["artifactType"] 选(空 → 默认优先
 	// 文件发布,保持既有行为;显式 image → 选镜像)。选定后由 deployWithStrategy 据产物类型自动路由。
@@ -344,6 +350,53 @@ func (s *service) DeployForStage(ctx context.Context, runID string, serverIDs []
 	results := s.deployWithStrategy(ctx, servers, *artifact, cfg, nil, NormalizeStrategy(strategy))
 
 	// 持久化每机结果(填 run-detail targets slot);**不置 run 终态**(dag 调度器控制)。
+	dts := make([]run.DeployTarget, 0, len(results))
+	for _, r := range results {
+		dts = append(dts, run.DeployTarget{
+			RunID: runID, ServerID: r.ServerID, ServerName: r.ServerName,
+			Status: r.Status, Message: r.Message, StartedAt: r.StartedAt, FinishedAt: r.FinishedAt,
+		})
+	}
+	if err := s.runs.SaveDeployTargets(ctx, runID, dts); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// runCommandOnly 执行「命令型」部署:在每台目标机直接跑 cfg["restartCommand"](无构建产物)。
+// 命令文本里的 {{param}} 已在 build 层(runDeployJob)用本次运行参数渲染好;此处只逐机执行 +
+// 经 s.exec 把命令/输出实时回流步骤日志(脱敏由 sink Masker 兜底)+ 持久化每机结果。
+func (s *service) runCommandOnly(ctx context.Context, runID string, serverIDs []string, cfg map[string]string) ([]TargetResult, error) {
+	command := strings.TrimSpace(cfg["restartCommand"])
+	if command == "" {
+		return nil, fmt.Errorf("deploy: 命令型部署缺少 restartCommand")
+	}
+	results := make([]TargetResult, 0, len(serverIDs))
+	for _, sid := range serverIDs {
+		srv, gerr := s.targets.Get(ctx, sid)
+		if gerr != nil {
+			if errors.Is(gerr, target.ErrNotFound) {
+				return nil, ErrServerNotFound
+			}
+			return nil, gerr
+		}
+		started := time.Now().UTC()
+		out, err := s.exec(ctx, sid, []string{"sh", "-c", command})
+		fin := time.Now().UTC()
+		tr := TargetResult{ServerID: sid, ServerName: srv.Name, StartedAt: started, FinishedAt: &fin}
+		switch {
+		case err != nil:
+			tr.Status = run.TargetFailed
+			tr.Message = humanExecError(err)
+		case out != nil && out.ExitCode != 0:
+			tr.Status = run.TargetFailed
+			tr.Message = fmt.Sprintf("命令退出码 %d", out.ExitCode)
+		default:
+			tr.Status = run.TargetSuccess
+			tr.Message = "命令执行成功"
+		}
+		results = append(results, tr)
+	}
 	dts := make([]run.DeployTarget, 0, len(results))
 	for _, r := range results {
 		dts = append(dts, run.DeployTarget{

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -130,6 +130,70 @@ func seedServer(t *testing.T, st *stubTarget, name string) *target.Server {
 
 // ---- 用例 -------------------------------------------------------------------
 
+// TestDeployForStageCommandOnly 验证「命令型」部署(artifactType=command):不取构建产物,
+// 直接在目标机经 sh -c 跑 restartCommand;成功 → TargetSuccess。
+func TestDeployForStageCommandOnly(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	var gotCmd []string
+	tgt := &stubTarget{execFn: func(_ string, cmd []string) (*target.ExecResult, error) {
+		gotCmd = cmd
+		return &target.ExecResult{ExitCode: 0, Stdout: "configured"}, nil
+	}}
+	srv := seedServer(t, tgt, "frpc-client")
+	// 复用 seed:有产物在库,但命令型分支应**完全不碰产物**(在 ListArtifacts 之前提前返回)。
+	runID, _ := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactDist, "dist/unused")
+
+	res, err := svcCmdOnly(tgt, rsvc).DeployForStage(context.Background(), runID, []string{srv.ID},
+		map[string]string{"artifactType": "command", "restartCommand": "echo configuring frp tunnel"}, "")
+	if err != nil {
+		t.Fatalf("command-only DeployForStage: %v", err)
+	}
+	if len(res) != 1 || res[0].Status != run.TargetSuccess {
+		t.Fatalf("want 1 success, got %+v", res)
+	}
+	// 证明走的是命令型分支(sh -c <命令>),而非产物部署(那会跑 readlink/mkdir/tar…)。
+	if len(gotCmd) != 3 || gotCmd[0] != "sh" || gotCmd[1] != "-c" || gotCmd[2] != "echo configuring frp tunnel" {
+		t.Fatalf("command not run as `sh -c <cmd>`: %v", gotCmd)
+	}
+}
+
+// TestDeployForStageCommandOnlyNonZero 验证命令非零退出 → 该机 failed。
+func TestDeployForStageCommandOnlyNonZero(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	tgt := &stubTarget{execFn: func(_ string, _ []string) (*target.ExecResult, error) {
+		return &target.ExecResult{ExitCode: 2, Stderr: "boom"}, nil
+	}}
+	srv := seedServer(t, tgt, "frpc-client")
+	runID, _ := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactDist, "dist/unused")
+	res, err := svcCmdOnly(tgt, rsvc).DeployForStage(context.Background(), runID, []string{srv.ID},
+		map[string]string{"artifactType": "command", "restartCommand": "false"}, "")
+	if err != nil {
+		t.Fatalf("DeployForStage: %v", err)
+	}
+	if res[0].Status != run.TargetFailed {
+		t.Fatalf("want failed, got %+v", res[0])
+	}
+}
+
+// TestDeployForStageCommandOnlyMissingCmd 验证 command 型但缺 restartCommand → 报错。
+func TestDeployForStageCommandOnlyMissingCmd(t *testing.T) {
+	db := testDB(t)
+	rsvc := run.New(db)
+	tgt := &stubTarget{}
+	srv := seedServer(t, tgt, "frpc-client")
+	runID, _ := seedSuccessRunWithArtifact(t, db, rsvc, run.ArtifactDist, "dist/unused")
+	_, err := svcCmdOnly(tgt, rsvc).DeployForStage(context.Background(), runID, []string{srv.ID},
+		map[string]string{"artifactType": "command"}, "")
+	if err == nil {
+		t.Fatalf("want error for missing restartCommand")
+	}
+}
+
+// svcCmdOnly 构造一个 deploy.Service(便于命令型用例复用)。
+func svcCmdOnly(tgt *stubTarget, rsvc run.Service) Service { return New(tgt, rsvc) }
+
 // TestDeployDistSuccess 验证 dist 产物部署:命令 array 化、每机 success、run 终态保持 success。
 func TestDeployDistSuccess(t *testing.T) {
 	db := testDB(t)


### PR DESCRIPTION
## 背景
要做「自动配置 frp 穿透」流水线:运行时填本地端口/穿透端口 → 在 frpc 客户端机上 upsert frpc.ini + reload。frpc.ini 在**宿主机**、frpc 是**宿主机 systemd 服务**,容器化的 script 节点够不着;唯一在宿主机经 SSH 跑命令的是 deploy 节点,但它强制要构建产物。本 PR 补上「命令型部署」这一缺失能力。

## 改动(小、隔离)
- **命令型部署**:deploy config `artifactType=command` → `DeployForStage` 走最顶端的提前返回 `runCommandOnly`:不取产物,直接在目标机 `sh -c` 跑 `restartCommand`,逐机记结果 + 命令/输出经 `s.exec` 实时回流(sink 脱敏)。**真实产物部署(artifactType != command)绝不进此分支,既有部署/策略/健康检查路径零影响。**
- **`{{param}}` 插值**:`restartCommand`/`deployPath` 用本次运行参数渲染(`runDeployJob` → `renderTemplate`),实现「运行时按流水线变量配端口」。非配置类不写占位 → 零开销。

## 测试
命令型成功/非零退出失败/缺 restartCommand 报错;既有产物部署用例全绿。`go build/vet/test` 通过,gofmt 干净。

## 后续(本 PR 不含)
用此能力配置一条「frp 隧道」流水线(项目+参数+命令型部署节点),真机验证 —— 紧随其后。

🤖 Generated with [Claude Code](https://claude.com/claude-code)