### PR TITLE
fix(storetest): 迁移计数断言 41→42(修复 master 红)

### DIFF
--- a/internal/storetest/dialect_integration_test.go
+++ b/internal/storetest/dialect_integration_test.go
@@ -19,8 +19,8 @@ func TestMigrationsApplied(t *testing.T) {
 		if err := st.DB.QueryRowContext(ctx, `SELECT COUNT(1) FROM schema_migrations`).Scan(&n); err != nil {
 			t.Fatalf("count migrations: %v", err)
 		}
-		if n != 41 {
-			t.Fatalf("应用迁移数 = %d, 期望 41", n)
+		if n != 42 {
+			t.Fatalf("应用迁移数 = %d, 期望 42", n)
 		}
 		// 核心领域表存在(随手验一张)。
 		if _, err := st.DB.ExecContext(ctx, `SELECT 1 FROM audit_log WHERE 1=0`); err != nil {


### PR DESCRIPTION
## 背景
`#130` 加了迁移 `0043_metric_samples`,但漏改 `TestMigrationsApplied` 的硬编码期望计数(41),导致 master 的 `go test ./...` 一直失败。`--admin` squash 合并绕过了 CI 才没拦住。

**这个回归是新建的「发版流水线」自检阶段在容器里跑全量 `go test` 时抓到的**——正好印证了流水线 + 人工审核的价值。

## 改动
`internal/storetest/dialect_integration_test.go`:期望迁移数 41 → 42(现有 42 个迁移文件)。

## 验证
本地 `go test ./...` 全绿(全量,非局部)。

## 教训
- 加迁移必同步 bump 此断言。
- 别 `--admin` 绕 CI 合不确定改动。
- 本地自检跑全量 `go test ./...`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)