### PR TITLE
feat(notify): 审批卡片展示发版汇总(版本/参数 + 分支/提交)

### DIFF
--- a/cmd/pipewright/main.go
+++ b/cmd/pipewright/main.go
@@ -339,7 +339,7 @@ func main() {
 		var dagOpts []dagrun.Option
 		// 审批门 hook(Story 8-4):Gate 阶段阻塞等待人工批准/拒绝。进入等待态后 best-effort 发
 		// 「需要审批」通知 + 签名审批链接(signer/PUBLIC_URL 未配则跳过通知,门行为不变)。
-		approvalNotifier := httpapi.NewApprovalNotifier(notifySvc, approvalSigner, strings.TrimSpace(os.Getenv("PIPEWRIGHT_PUBLIC_URL")))
+		approvalNotifier := httpapi.NewApprovalNotifier(notifySvc, approvalSigner, strings.TrimSpace(os.Getenv("PIPEWRIGHT_PUBLIC_URL")), runSvc)
 		dagOpts = append(dagOpts, dagrun.WithGate(httpapi.NewApprovalGate(runSvc, approvalCoord, approvalStore, approvalNotifier)))
 		if b, berr := build.NewBuilder(projectSvc, pipelineSettingsSvc, credVault, build.WithArtifactStore(artStore), build.WithArtifactLister(runSvc.ListArtifacts), build.WithImageGC(os.Getenv("PIPEWRIGHT_NO_IMAGE_GC") != "1"), build.WithCommitRecorder(func(ctx context.Context, runID, commit string) { _ = runSvc.SetCommit(ctx, runID, commit) }), build.WithStageDeployer(deploySvc), build.WithStageNotifier(notifySvc), clonerOpt, buildCacheOpt); berr == nil {
 			// runSvc 作测试报告持久层注入(Story 8-6 / FR-8-6):script 步骤产报告 → 解析 →

--- a/internal/httpapi/notify_hook.go
+++ b/internal/httpapi/notify_hook.go
@@ -94,7 +94,7 @@ const approvalLinkTTL = 24 * time.Hour
 //     绝不阻塞门。
 //   - 自带超时(防慢渠道挂死 goroutine);RouteEventForProject 内部已 best-effort(未配路由不发)。
 //   - 链接、token 绝不写日志。
-func NewApprovalNotifier(notifySvc notify.Service, signer *approval.Signer, publicURL string) ApprovalNotifier {
+func NewApprovalNotifier(notifySvc notify.Service, signer *approval.Signer, publicURL string, runs run.Service) ApprovalNotifier {
 	base := strings.TrimRight(strings.TrimSpace(publicURL), "/")
 	if notifySvc == nil || signer == nil || !signer.Enabled() || base == "" {
 		// 依赖不全:返回 nil,门据此跳过通知(功能优雅关闭)。
@@ -113,6 +113,17 @@ func NewApprovalNotifier(notifySvc notify.Service, signer *approval.Signer, publ
 			Event:     notify.EventApprovalRequired,
 			RunID:     runID,
 			ActionURL: link,
+		}
+		// 取运行元数据,让审批卡片展示「审什么」:分支 / 提交 / 运行参数(发版的 VERSION 等)。
+		// best-effort:取不到就用基础 vars(仍发审批链接,绝不阻塞门)。
+		if runs != nil {
+			if r, err := runs.Get(ctx, runID); err == nil && r != nil {
+				vars.Branch = r.Trigger.Branch
+				vars.Commit = notify.ShortCommit(r.Trigger.Commit)
+				if len(r.Trigger.Params) > 0 {
+					vars.Params = r.Trigger.Params
+				}
+			}
 		}
 
 		// 异步发:门随后阻塞在 coord.Wait 上等待决定,通知不应拖慢进入等待。脱离父 ctx

--- a/internal/i18n/messages_notify.go
+++ b/internal/i18n/messages_notify.go
@@ -14,6 +14,7 @@ func init() {
 		"健康检查失败": {"zh-TW": "健康檢查失敗", "en": "Health check failed", "ja": "ヘルスチェック失敗", "ko": "상태 점검 실패", "es": "Comprobación de estado fallida", "fr": "Échec de la vérification de santé", "de": "Health-Check fehlgeschlagen"},
 		"需要审批":   {"zh-TW": "需要審批", "en": "Approval required", "ja": "承認が必要です", "ko": "승인 필요", "es": "Se requiere aprobación", "fr": "Approbation requise", "de": "Genehmigung erforderlich"},
 		"异常检测":   {"zh-TW": "異常偵測", "en": "Anomaly detected", "ja": "異常を検出", "ko": "이상 감지", "es": "Anomalía detectada", "fr": "Anomalie détectée", "de": "Anomalie erkannt"},
+		"运行参数":   {"zh-TW": "執行參數", "en": "Parameters", "ja": "実行パラメータ", "ko": "실행 매개변수", "es": "Parámetros", "fr": "Paramètres", "de": "Parameter"},
 
 		// Field labels (notification body + feishu card field list).
 		"项目":     {"zh-TW": "專案", "en": "Project", "ja": "プロジェクト", "ko": "프로젝트", "es": "Proyecto", "fr": "Projet", "de": "Projekt"},

--- a/internal/notify/approval_event_test.go
+++ b/internal/notify/approval_event_test.go
@@ -37,6 +37,28 @@ func TestApprovalRequiredEventPayload(t *testing.T) {
 }
 
 // defaultPayload 携带 ActionURL 时,链接透出到 Fields[actionUrl] 与正文。
+// 审批卡片携带运行参数(如发版 VERSION):透出到 Fields + 正文,让审批人看到「要发什么」。
+func TestApprovalRequiredPayloadCarriesParams(t *testing.T) {
+	s, _, _ := newSvc(t, http.DefaultClient)
+	p := s.defaultPayload(ctx(), EventApprovalRequired, TemplateVars{
+		Project: "pipewright-release",
+		Branch:  "master",
+		Commit:  "abc1234",
+		Event:   EventApprovalRequired,
+		RunID:   "run-1",
+		Params:  map[string]string{"VERSION": "v1.3.9"},
+	})
+	if p.Fields["VERSION"] != "v1.3.9" {
+		t.Fatalf("VERSION param not in fields: %+v", p.Fields)
+	}
+	if !strings.Contains(p.Body, "VERSION=v1.3.9") {
+		t.Fatalf("VERSION not summarized in body: %q", p.Body)
+	}
+	if p.Fields["branch"] != "master" || p.Fields["commit"] != "abc1234" {
+		t.Fatalf("branch/commit missing: %+v", p.Fields)
+	}
+}
+
 func TestApprovalRequiredPayloadCarriesActionURL(t *testing.T) {
 	s, _, _ := newSvc(t, http.DefaultClient)
 	link := "https://ci.example.com/approvals?token=abc.def"

--- a/internal/notify/template.go
+++ b/internal/notify/template.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -71,6 +72,9 @@ type TemplateVars struct {
 	// ActionURL 是一次性操作链接(目前用于 approval_required 事件的签名审批链接);
 	// 空 = 该事件无操作链接。渲染时占位名 {{actionUrl}};并透出到 Payload.Fields["审批链接"]/正文。
 	ActionURL string
+	// Params 是本次运行的参数(如发版审批的 VERSION);非空时透出到 Payload.Fields + 正文,
+	// 让审批卡片展示「要发哪个版本」等汇总信息(审批人据此审核)。键原样、值已是明文非 secret。
+	Params map[string]string
 }
 
 // asMap 把 TemplateVars 展开为占位名 → 值的映射(冻结占位名)。
@@ -289,6 +293,30 @@ func (s *service) defaultPayload(ctx context.Context, event string, vars Templat
 	}
 	lang := s.notifyLanguage(ctx)
 	p := EventPayload(lang, event, vars.Project, vars.Branch, vars.Commit, vars.Status, durationMs)
+	// 运行参数(如发版审批的 VERSION)透出到字段 + 正文,让审批卡片展示「要发什么」的汇总。
+	if len(vars.Params) > 0 {
+		if p.Fields == nil {
+			p.Fields = map[string]string{}
+		}
+		keys := make([]string, 0, len(vars.Params))
+		for k := range vars.Params {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys) // 稳定顺序(字段渲染与正文一致)
+		parts := make([]string, 0, len(keys))
+		for _, k := range keys {
+			v := strings.TrimSpace(vars.Params[k])
+			if v == "" {
+				continue
+			}
+			p.Fields[k] = v
+			parts = append(parts, k+"="+v)
+		}
+		if len(parts) > 0 {
+			label := i18n.T(lang, "运行参数")
+			p.Body = strings.TrimRight(p.Body, "。.") + bodySeparator(lang) + label + bodySeparator(lang) + strings.Join(parts, bodyComma(lang))
+		}
+	}
 	if url := strings.TrimSpace(vars.ActionURL); url != "" {
 		if p.Fields == nil {
 			p.Fields = map[string]string{}


### PR DESCRIPTION
## 背景
发版审批门的飞书卡片只有泛泛的「需要审批 + 链接」,审批人看不到**要发哪个版本、改在哪个提交**,无从审核(用户原话:「不然审核什么东西」)。

## 改动
- `notify.TemplateVars` 增 `Params`;`defaultPayload` 把运行参数透出到卡片 `Fields` + 正文(字母序稳定),如 `VERSION=v1.3.9`。i18n「运行参数」×8。
- `ApprovalNotifier` 注入 `run.Service`:进入 `waiting_approval` 时取运行元数据,填 **分支 / 提交 / 运行参数**(best-effort,取不到仍发链接、不阻塞门)。
- `main` 给 `NewApprovalNotifier` 注入 `runSvc`。

## 测试
审批卡片携带 VERSION 参数 + 分支 + 提交;`go test ./...` 全绿(全量)、前端 test 绿、gofmt 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)