### PR TITLE
fix(build): 流水线级变量(含 secret)注入 script 步骤

### DIFF
--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -518,7 +518,6 @@ func (b *Builder) runScriptJobIsolated(
 	upstreamEnv []pipeline.BuildVar,
 	reportSink TestReportSink,
 ) ([]pipeline.BuildVar, error) {
-	_ = settings // 与既有 script 路径签名对齐;script 执行不直接用 settings
 	ws, _, cleanup, err := b.cloneJobWorkspace(ctx, r, proj, rep)
 	if err != nil {
 		return nil, err
@@ -530,7 +529,13 @@ func (b *Builder) runScriptJobIsolated(
 		_ = rep.Log(ctx, streamStderr, fmt.Sprintf("script job「%s」配置无效:%v", jb.Name, verr))
 		return nil, ErrBuildFailed
 	}
+	// 注入顺序:运行参数 → 上游 job 输出 → 流水线级变量(「变量与缓存」,含 secret,vault 即取即用)
+	// → job 自身 env(后者覆盖同名)。此前流水线级变量只注入镜像构建路径、不到 script 步骤(漏),
+	// 导致脚本节点拿不到「变量与缓存」里配的 secret(如发版的 GITHUB_TOKEN)。本修复补齐。
 	base := append(runParamsAsEnv(r.Trigger.Params), upstreamEnv...)
+	if settings != nil && len(settings.Build.Vars) > 0 {
+		base = append(base, settings.Build.Vars...)
+	}
 	step.Env = append(base, step.Env...)
 	step.Env = append(step.Env, pipewrightEnvVar())
 	if svcNetwork != "" {


### PR DESCRIPTION
## 背景
「变量与缓存」里配的变量(含保险库 secret 引用)此前只注入**镜像构建**路径,画布 **script 节点拿不到**(`runScriptJobIsolated` 里 `_ = settings` 丢弃)。发版流水线打 tag 的 script 节点因此拿不到 `GITHUB_TOKEN`,`git push` 报 `Invalid username or token`。

## 修复
script 步骤 env 注入序补上 `settings.Build.Vars`:运行参数 → 上游产出 → **流水线级变量** → job 自身 env。secret 由既有 `runScriptStep` 的 `buildArgs` 经 `vault.Reveal` 即取即用、sink Masker 脱敏(与镜像构建同款)。

## 验证
`go test ./...` 全绿、gofmt 干净。随后发版流水线打 tag 步骤真机验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)