### PR TITLE
fix(build): 串行 script 路径也注入流水线级变量(补 #134)

### DIFF
--- a/internal/build/dag_stage_exec.go
+++ b/internal/build/dag_stage_exec.go
@@ -242,8 +242,12 @@ func NewStageExecutor(b *Builder, reportSink TestReportSink) dagrun.StageExecuto
 						_ = rep.JobDone(ctx, jb.ID, run.StepFailed)
 						return ErrBuildFailed
 					}
-					// 注入顺序:运行参数 → 上游 job 输出(carriedEnv)→ job 自身 env(后者覆盖同名)→ PIPEWRIGHT_ENV(系统,末位防覆盖)。
+					// 注入顺序:运行参数 → 上游 job 输出(carriedEnv)→ 流水线级变量(「变量与缓存」,
+					// 含 secret,vault 即取即用)→ job 自身 env(后者覆盖同名)→ PIPEWRIGHT_ENV(系统,末位防覆盖)。
 					base := append(runParamsAsEnv(r.Trigger.Params), carriedEnv...)
+					if settings != nil && len(settings.Build.Vars) > 0 {
+						base = append(base, settings.Build.Vars...)
+					}
 					step.Env = append(base, step.Env...)
 					step.Env = append(step.Env, pipewrightEnvVar())
 					// 旁挂服务网络:脚本容器加入,按服务名互访。


### PR DESCRIPTION
#134 只修了 job-DAG 隔离路径;无 job-needs 的阶段走**串行 script 路径**,同样漏注入 `settings.Build.Vars`。发版流水线(YAML 导入、无 needs)走串行路径,打 tag 的 script 拿不到 GITHUB_TOKEN。本次补齐串行路径,两路径一致。`go test ./...` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)