### PR TITLE
fix(terminal): 运维终端按钮按连接态切换(LIVE 时给「断开」)

### DIFF
--- a/web/src/views/ServerTerminal.vue
+++ b/web/src/views/ServerTerminal.vue
@@ -655,10 +655,21 @@ onBeforeUnmount(() => {
       <span v-else-if="connState === 'connecting'" class="conn-state">{{ tg('serverTerminal.connecting') }}</span>
       <span v-else-if="connState === 'error'" class="conn-state err">{{ tg('serverTerminal.connectFailed') }}</span>
 
-      <button class="tbtn" type="button" :disabled="connState === 'connecting'" @click="connect">
-        {{ connState === 'connected' ? tg('serverTerminal.reconnect') : tg('serverTerminal.connect') }}
+      <button
+        v-if="connState === 'connected'"
+        class="tbtn danger"
+        type="button"
+        @click="disconnect"
+      >{{ tg('serverTerminal.disconnect') }}</button>
+      <button
+        v-else
+        class="tbtn"
+        type="button"
+        :disabled="connState === 'connecting'"
+        @click="connect"
+      >
+        {{ connState === 'closed' || connState === 'error' ? tg('serverTerminal.reconnect') : tg('serverTerminal.connect') }}
       </button>
-      <button class="tbtn danger" type="button" :disabled="connState !== 'connected'" @click="disconnect">{{ tg('serverTerminal.disconnect') }}</button>
       <button class="tbtn" type="button" @click="closePage">{{ tg('serverTerminal.close') }}</button>
     </header>
 


### PR DESCRIPTION
## 问题
运维终端页(`ServerTerminal.vue`)右上角同时渲染「连接/重连」与「断开」两个按钮,且「连接/重连」按钮在已连接(`● LIVE`)状态下显示为**「重连」**——用户反馈:明明已连上,却提示「重连」,应当是「断开」,断开后才出现「重连」。

## 改动
把两个并存按钮合并为**单一状态驱动按钮**:

| connState | 按钮 |
|---|---|
| `connected` | 「断开」(danger) |
| `closed` / `error` | 「重连」 |
| `idle` | 「连接」 |
| `connecting` | 「连接」(禁用) |

状态标签(LIVE / 连接中 / 连接失败)保持不变;`connect()`/`disconnect()` 行为不变。

## 自检
- `npm run lint` 0 errors(8 个既有 warning,非本次引入)
- `npm run typecheck` 通过
- `npm run test` 330 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)