### PR TITLE
fix(run-diff): 短 SHA 解析,修代码变更卡恒「提交不可达」

### DIFF
--- a/internal/ai/diff.go
+++ b/internal/ai/diff.go
@@ -203,7 +203,7 @@ func (d goGitDiffer) DiffCommit(ctx context.Context, repoURL, token, commit stri
 		return RunDiff{Available: false, Reason: "仓库克隆失败,暂时无法计算差异", Files: []FileDiff{}}, ""
 	}
 
-	curCommit, cerr := repo.CommitObject(plumbing.NewHash(commit))
+	curCommit, cerr := resolveCommit(repo, commit)
 	if cerr != nil {
 		return RunDiff{Available: false, Reason: "提交在仓库中不可达,无法计算差异", Files: []FileDiff{}}, ""
 	}
@@ -231,14 +231,24 @@ func (d goGitDiffer) DiffCommit(ctx context.Context, repoURL, token, commit stri
 	return buildRunDiff(cctx, changes), parentSHA
 }
 
-// commitTree 解析 commit sha 并返回其 tree;sha 不可达/解析失败返回错误。
+// commitTree 解析 commit 引用并返回其 tree;不可达/解析失败返回错误。
 func commitTree(repo *gogit.Repository, sha string) (*object.Tree, error) {
-	hash := plumbing.NewHash(sha)
-	commit, err := repo.CommitObject(hash)
+	commit, err := resolveCommit(repo, sha)
 	if err != nil {
 		return nil, err
 	}
 	return commit.Tree()
+}
+
+// resolveCommit 把 commit 引用解析为提交对象。**关键**:go-git 的 CommitObject 只认 40 位全 SHA,
+// 而生产里 run 存的是**短 SHA**(SetCommit 回写 7 位短 SHA);故先用 ResolveRevision 把短 SHA /
+// 分支名 / tag 等解析成全 hash,再取提交对象。否则短 SHA 一律「提交不可达」降级(本功能曾踩此坑)。
+func resolveCommit(repo *gogit.Repository, rev string) (*object.Commit, error) {
+	h, err := repo.ResolveRevision(plumbing.Revision(rev))
+	if err != nil {
+		return nil, err
+	}
+	return repo.CommitObject(*h)
 }
 
 // buildRunDiff 把 go-git Changes 折算为文件级 RunDiff(状态 + 增删行数 + 截断 + summary)。

--- a/internal/ai/diff_test.go
+++ b/internal/ai/diff_test.go
@@ -153,6 +153,27 @@ func TestDiffCommitSelf(t *testing.T) {
 	}
 }
 
+// TestDiffCommitShortSHA 验证用**短 SHA**(生产里 run 存的就是 7 位短 SHA)也能解析出提交并算 diff。
+// 回归守护:go-git CommitObject 只认 40 位全 SHA,必须先 ResolveRevision 解析短 SHA(本功能曾踩此坑)。
+func TestDiffCommitShortSHA(t *testing.T) {
+	url, shas := makeMultiCommitRepo(t,
+		commitSpec{"app.txt": "a\n"},
+		commitSpec{"app.txt": "a\nb\n"},
+	)
+	d := newInsecureRunDiffer()
+	short := shas[1][:7]
+	res, parent := d.DiffCommit(context.Background(), url, "", short)
+	if !res.Available {
+		t.Fatalf("short SHA %q should resolve, got degraded: %s", short, res.Reason)
+	}
+	if parent != shas[0] {
+		t.Fatalf("parent=%q want full parent %q", parent, shas[0])
+	}
+	if _, ok := findFile(res.Files, "app.txt"); !ok {
+		t.Fatalf("app.txt missing: %+v", res.Files)
+	}
+}
+
 // TestDiffCommitRoot 验证根提交(无父)→ 全部文件视为新增,父 SHA 空。
 func TestDiffCommitRoot(t *testing.T) {
 	url, shas := makeMultiCommitRepo(t,


### PR DESCRIPTION
## 问题
v1.4.0 上线后,运行详情「代码变更」卡对真实运行恒显示空(available:false / 提交不可达)。根因:`run.Trigger.Commit` 存的是 **7 位短 SHA**,而 go-git 的 `repo.CommitObject` 只认 **40 位全 SHA**,短 SHA 解析失败 → `DiffCommit` 降级。(测试用 `git rev-parse` 的全 SHA 所以没暴露。)

## 修复
新增 `resolveCommit`:先 `repo.ResolveRevision`(短 SHA / 分支名 / tag → 全 hash)再取提交对象;`DiffCommit` 与 `commitTree`(baseline 路径)都改走它。新增 `TestDiffCommitShortSHA` 回归守护。

## 自检
`go build/vet/test ./...` 绿、`gofmt` 净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)