### PR TITLE
fix(run-diff): 「代码变更」卡补挂成功运行详情页(#137 漏挂修复)

### DIFF
--- a/web/src/views/RunDetail.vue
+++ b/web/src/views/RunDetail.vue
@@ -1103,6 +1103,13 @@ function nodeClass(status: StepStatus): string {
             </div>
             <!-- END SLOT: SSH 部署执行 -->
 
+            <!-- 代码变更(run-diff;#137)。成功运行恒可见 —— 展示「本次提交自身」相对父提交的
+                 文件级 diff(git show),回答「这次部署改了啥」。后端按 commit-self 语义返回,
+                 不依赖 baseline 运行;无 commit / 克隆失败时组件自身降级。与 failed 分支同一组件。 -->
+            <div class="diff-section" role="region" :aria-label="t('runDetail.diffAria')">
+              <SuccessFailDiff :run-id="run.id" />
+            </div>
+
           </div>
         </template>
 


### PR DESCRIPTION
## 问题

#137 把「代码变更」卡改为 commit-self(git show)语义并在提交说明里写「成功运行也恒可见」「前端 SuccessFailDiff 无需改渲染」。但实测 104 上的 aireboot **成功** run 详情页**根本没有这张卡**。

根因:`SuccessFailDiff` 组件在 `RunDetail.vue` 里**只挂在 `failed` 分支**(L1163,`v-else-if="run.status === 'failed'"` 内),`success` 分支(806–1109)从未渲染过它。这张卡此前一直只活在失败分支,#137 误判「前端无需改渲染」。净结果:#137 想解决的核心场景「部署成功想看这次改了啥」恰恰还是看不到。

后端 `DiffCommit`(#137)+ 短 SHA `ResolveRevision`(#138)都正常 —— `/api/runs/{id}/diff` 对该成功 run 只读 GET 返回 `available:true`、`current:0bc95f3`、`baseline:8308a769`(父提交)、`README.md modified` 带 patch。问题纯在前端漏挂。

## 改动

把同一个 `SuccessFailDiff`(连同 `diff-section` 包装 + `diffAria`)补进 `success` 分支末尾(SSH 部署 slot 之后)。纯前端、纯加法,无后端改动;组件无 commit/克隆失败时自身降级。

## 验证

- **真机端到端**:104 真实 aireboot 成功 run `#ccb2317a`(main/`0bc95f3`),经 vite dev 代理渲染本次前端 —— 卡正常显示「父提交 `8308a769` → 本次 `0bc95f3`」「1 文件改动(+2/-0)」,README.md 可展开看 +/- 着色正文。
- **后端**:`/diff` 接口只读 GET 验证 `available:true`(短 SHA 已解析,无「提交不可达」)。
- **自检**:`npm run lint`(0 error)/`typecheck`/`test`(330 全过)全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)