### PR TITLE
fix(pipeline): 流水线即代码/PR 状态检查卡仅在编排 tab 显示

### DIFF
--- a/web/src/views/ProjectPipeline.vue
+++ b/web/src/views/ProjectPipeline.vue
@@ -541,6 +541,11 @@ async function togglePrStatus(next: boolean): Promise<void> {
       >{{ tab.label }}</button>
     </nav>
 
+    <!--
+      Source-of-truth bars (PaC + PR status) are pipeline-definition concerns,
+      so they belong to the 编排/canvas tab only — not above every tab body.
+    -->
+    <template v-if="activeTab === 'canvas'">
     <!-- ─── Pipeline-as-code (GitOps) toggle (FR-8-12) ─────────────────────── -->
     <div class="pac-bar" :class="{ 'pac-bar--on': pacEnabled }">
       <div class="pac-bar-text">
@@ -610,6 +615,7 @@ async function togglePrStatus(next: boolean): Promise<void> {
         <span class="pac-switch-knob" aria-hidden="true"/>
       </button>
     </div>
+    </template>
 
     <!-- ─── Tab body: panels + optional validation side-drawer ─────────────── -->
     <!--


### PR DESCRIPTION
## 问题
流水线配置页的两张「配置来源」卡——**流水线即代码**(`.pipewright.yml` PaC 开关)与 **PR 状态检查**开关——自 #118/#120 起一直渲染在 `tab-body` **之外**,导致切到 `变量与缓存`/`触发设置`/`环境与凭据` 任意 tab 都会显示(见用户截图 `?tab=vars`)。它们是流水线**定义层面**的设置,应只属于「流水线编排」tab。

## 修复
用 `<template v-if="activeTab === 'canvas'">` 包裹两张卡,仅 canvas(编排)tab 渲染。纯前端模板条件,无逻辑/接口改动。

## 验证(vite dev 代理到 104 真数据)
- 编排 tab:两张卡 ✅ 显示
- 变量与缓存 / 触发设置 / 环境与凭据:0 张卡 ✅
- 前端 lint(0 err)/ typecheck / test(339 passed)全绿