### PR TITLE
fix(ci): 修正 caddy-image 工作流中无效的 build-push-action SHA

### DIFF
--- a/.github/workflows/caddy-image.yml
+++ b/.github/workflows/caddy-image.yml
@@ -48,7 +48,7 @@ jobs:
             type=ref,event=tag
             type=raw,value=latest
 
-      - uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcd730101868b # v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: deploy/caddy/Dockerfile


### PR DESCRIPTION
## 问题
master HEAD 显示 CI 红叉。根因是 `caddy-image` 工作流引用的 `docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcd730101868b # v6` **这个 commit SHA 在该 action 仓库里根本不存在**(`gh api` 返回 422 No commit found)。

这是 #146(dbbe4a5 "pin GitHub Actions to commit SHA" 供应链加固)钉 SHA 时把 build-push-action 钉成了无效值。后果:每次打 tag(v*)随发版构建自构建 Caddy 镜像推 ghcr 时,Actions 在 `Getting action download info` 阶段就 `Unable to resolve action` 直接失败——**自 #146 起这条镜像推送线一直是坏的**。

## 修复
改钉到真实存在的 `docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2`。

## 验证
- ✅ YAML 语法校验通过
- ✅ 全仓所有工作流(ci/release/caddy-image/mem-budget)的 action SHA 逐个 `gh api` 核验,**均真实可解析**(仅此一处曾无效)

🤖 Generated with [Claude Code](https://claude.com/claude-code)