### PR TITLE
fix(caddy-image): 修复插件升级致 caddy 镜像构建失败 (GOTOOLCHAIN=auto + Caddy 2.11.4)

### DIFF
--- a/deploy/caddy/Dockerfile
+++ b/deploy/caddy/Dockerfile
@@ -15,6 +15,10 @@ ARG CADDY_VERSION=2.8.4
 FROM caddy:${CADDY_VERSION}-builder AS builder
 
 # 插件版本不钉到具体 tag(xcaddy 默认拉各插件最新兼容版);如需完全可复现可在此加 @vX.Y.Z。
+# GOTOOLCHAIN=auto:builder 镜像自带的 Go 版本可能低于某些「拉最新」插件的 go.mod 要求
+# (如 caddy-dns/tencentcloud v0.4.3 要 go>=1.25),auto 允许 go 按需自动下载对应工具链,
+# 避免插件升级把构建卡在 builder 镜像的固定 Go 版本上(默认 local 会直接 FATAL)。
+ENV GOTOOLCHAIN=auto
 RUN xcaddy build \
     --with github.com/caddy-dns/cloudflare \
     --with github.com/caddy-dns/alidns \

--- a/deploy/caddy/Dockerfile
+++ b/deploy/caddy/Dockerfile
@@ -11,7 +11,7 @@
 # 版本钉死(可复现构建);升级时同步改 CADDY_VERSION 并跑一次镜像 CI。
 
 # --- 构建阶段:xcaddy 编译自定义 caddy 二进制 ---
-ARG CADDY_VERSION=2.8.4
+ARG CADDY_VERSION=2.11.4
 FROM caddy:${CADDY_VERSION}-builder AS builder
 
 # 插件版本不钉到具体 tag(xcaddy 默认拉各插件最新兼容版);如需完全可复现可在此加 @vX.Y.Z。


### PR DESCRIPTION
## 背景

master 上 `caddy-image` 工作流自 #146 起一直红叉。#153 (a7bd511) 已修掉第一层 bug(build-push-action 钉到不存在的 SHA)。本 PR 修第二层根因。

## 根因

`deploy/caddy/Dockerfile` 用 xcaddy 编译自定义 caddy,插件不钉版本(拉各插件最新兼容版)。上游插件 `caddy-dns/tencentcloud` v0.4.3 把 go.mod 要求抬到 go>=1.25,且要求 Caddy>=2.10.2,与 builder 镜像固定的 Go 版本 / 旧 CADDY_VERSION 2.8.4 冲突,导致构建直接 FATAL。

## 修复(2 处)

1. `ENV GOTOOLCHAIN=auto` —— 允许 go 按需自动下载插件 go.mod 要求的工具链,不再被 builder 镜像固定 Go 版本卡住(默认 `local` 会直接报错退出)。
2. `CADDY_VERSION 2.8.4 -> 2.11.4` —— 跟上插件要求的 Caddy 版本下界。

## 验证

分支上 `workflow_dispatch` 手动触发 caddy-image 工作流,run `27964961765` 构建成功(19m51s,完整跨越此前的失败点)。本地 docker 不可用,故用 workflow_dispatch 在分支上实测。

合并后 master 的 caddy-image 工作流即可转绿。