### PR TITLE
docs: README 同步至当前能力(反代/预览环境/AI/复用库 + 全量环境变量 + 43 包架构)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,21 @@ English | [简体中文](README.zh-CN.md)
 
 Mainstream options are either heavy (Jenkins with a pile of plugins + JVM) or a three-tool assembly (Woodpecker/Drone + Ansible/Kamal + Portainer). Pipewright packs "continuous integration, multi-server deployment, and server/container ops" into **one static binary**: download, start, open the browser — that's the entire install.
 
+It has since grown past that trio: publishing a deployed service on an HTTPS domain (the nginx + certbot step) and giving every pull request its own live preview URL are built in too.
+
 | | Pipewright | Jenkins | Drone + Ansible + Portainer |
 |---|:---:|:---:|:---:|
 | Single-binary deploy | ✅ | ❌ JVM + plugins | ❌ three-tool assembly |
 | Visual pipeline orchestration (DAG) | ✅ built-in canvas | plugin | hand-written YAML |
+| Pipeline as code (per-branch YAML) | ✅ | plugin | ✅ |
 | Isolated builds | ✅ | ✅ | ✅ |
 | Multi-server deploy (SSH, agentless) | ✅ built-in | plugin | Ansible |
 | Server / container ops | ✅ built-in | ❌ | Portainer |
 | Zero-downtime + failure rollback | ✅ | plugin | DIY |
+| Auto HTTPS + domain reverse proxy | ✅ built-in | ❌ | ❌ |
+| Per-PR preview environments | ✅ built-in | ❌ | ❌ |
+| DORA metrics | ✅ built-in | plugin | ❌ |
+| AI failure diagnosis | ✅ optional | ❌ | ❌ |
 | One-click self-update | ✅ | ❌ | ❌ |
 
 ## Screenshots
@@ -50,13 +57,18 @@ Mainstream options are either heavy (Jenkins with a pile of plugins + JVM) or a 
 
 ## Feature Overview
 
-- **🔐 Security foundation** — single-admin auth (argon2id + CSRF) · encrypted credential vault (NaCl secretbox, masked display, never plaintext) · append-only audit · end-to-end secret redaction.
-- **🧩 Projects & pipelines** — visual orchestration canvas (stage DAG + intra-stage job-level DAG) · matrix builds · manual approval gates · sidecar services (attach DB/Redis for tests) · trigger rules + branch→environment mapping · server-authoritative validation.
-- **🏗 Isolated builds & artifacts** — version-pinned isolated builds inside containers · build dependency caching · multiple artifact types (image/JAR/dist) + push to private registries · live terminal logs (SSE) + history replay · read-only code browsing (Monaco).
-- **🚀 Multi-server deployment** — agentless deploy over SSH · health gating · zero-downtime cutover + failure rollback · parallel fan-out across hosts + visible partial failures · environment deployment history and rollback.
-- **📣 Notifications** — WeCom / DingTalk / Lark (Feishu) / email / custom webhook · fine-grained event→channel routing · templates + custom variables · in-pipeline notification nodes.
-- **🖥 Server & container ops** — multi-host status overview (CPU/memory/disk) · container/image/Stacks/volume/network management · live + historical service logs · interactive container terminal · web ops terminal (host shell, full copy-paste/signal support) · anomaly detection alerts.
-- **📈 Metrics** — the four DORA metrics (deployment frequency / lead time for changes / change failure rate / mean time to restore) out of the box.
+- **🔐 Security foundation** — single-admin auth (argon2id + CSRF) · encrypted credential vault (NaCl secretbox, masked display, never plaintext) · OAuth app onboarding for Gitee / GitHub / GitLab / self-hosted instances (the access token lands straight in the vault as a reusable credential) · append-only audit (SQLite triggers hard-block UPDATE/DELETE) with an optional remote sink · per-run secret redaction across logs, diagnostics, and notifications.
+- **🧩 Projects & pipelines** — visual orchestration canvas (stage DAG + intra-stage job-level DAG) · matrix builds · manual approval gates (approve straight from a notification via signed link) · sidecar services (attach DB/Redis for tests) · stage `when` conditions + post-stage steps · typed run parameters (enum/bool/number, validated at trigger time) · triggers: webhook, branch→environment mapping, 5-field cron, and upstream→downstream pipeline chaining (loop-safe by depth + path guards) · per-project concurrency caps with FIFO queueing · a reuse library of pipeline templates, variable groups, and custom nodes · server-authoritative validation.
+- **📝 Pipeline as code** — commit the pipeline structure to `.pipewright.yml` and let it evolve per branch, with the canvas as the always-available fallback ([details below](#pipeline-as-code-gitops)).
+- **🏗 Isolated builds & artifacts** — version-pinned isolated builds inside containers (docker/nerdctl/podman) · a local bare-mirror repo cache (incremental fetch, then a workspace in seconds) · build dependency caching keyed by branch + lockfile hash · a content-addressed artifact store that keeps the **real bytes** of jar/dist for deployment (not just a placeholder reference) · image build + push to private registries with image GC · an optional remote build machine per project (build is offloaded over SSH; tokens stay on the control node) · JUnit + Cobertura test reports feeding quality gates that fail the stage and block downstream deploys · live terminal logs (SSE) + history replay · read-only code browsing (Monaco).
+- **🚀 Multi-server deployment** — agentless deploy over SSH · health gating · zero-downtime cutover + failure rollback · parallel fan-out across hosts + visible partial failures · command-style deploys (restart a service with no artifact) · **environments as first-class objects**: per-environment deployment timeline, current active version, and one-click rollback to the last fully successful deploy · environment promotion chains (dev→staging→prod) with per-environment variables/secrets and approval gates.
+- **🌐 Auto HTTPS + domain reverse proxy** — one managed Caddy container per target host, orchestrated over the same SSH + docker path as container ops (render Caddyfile → `docker cp` → graceful reload). Certificates are issued and renewed automatically by Let's Encrypt over HTTP-01, or over **DNS-01 with Cloudflare / DNSPod / Alibaba Cloud DNS** for wildcards. Plus: multi-domain aliases, path routing (`/api`→A, `/`→B), redirects, access control (basic auth, IP allow/deny CIDR), HSTS / security headers / compression, load balancing across upstreams with active health-check failover, WebSocket / gRPC (h2c) / TCP passthrough (caddy-l4), a certificate dashboard that probes the real 443 handshake, and one-click subdomain allocation.
+- **🔎 Per-PR preview environments** — when a PR's run deploys successfully, it automatically gets a throwaway `pr-<n>-<proj>.<base>` domain with its own certificate and route, so reviewers open one link and see that PR actually running. Idempotent per PR, and reclaimed automatically — but **only** once the PR is provably closed or merged.
+- **📣 Notifications** — WeCom / DingTalk / Lark (Feishu) / Slack / email / custom webhook · fine-grained event→channel routing · templates + custom variables · rich Lark cards with approve/detail action buttons and a release summary · in-pipeline notification nodes.
+- **🖥 Server & container ops** — multi-host status overview (CPU/memory/disk) plus time-series trend charts · container/image/Stacks/volume/network management · container create/inspect/prune · live + historical service logs · live stats · interactive container terminal · web ops terminal (host shell, full copy-paste/signal support) · configurable anomaly detection that runs on a timer, dedupes by cooldown, and routes alerts to your notification channels.
+- **🤖 AI assist (optional, fully degradable)** — bring your own Claude / OpenAI / Ollama endpoint (API key encrypted in the vault). Automatic root-cause diagnosis when a build or deploy fails, with a 👍/👎 feedback loop and accuracy stats · repo analysis → generated pipeline draft · success-vs-failure commit diff · script risk annotation · natural-language→shell assistant and container diagnosis in the ops terminal. The core CI/CD path never depends on any of it (NFR-10).
+- **📈 Metrics** — the four DORA metrics (deployment frequency / lead time for changes / change failure rate / mean time to restore) out of the box, with Elite/High/Medium/Low performance bands.
+- **🧹 Housekeeping & platform** — configurable run-data retention sweeper (off by default; never touches in-flight runs) · SQLite (pure Go) or MySQL · 8 UI languages (zh-CN / zh-TW / en / ja / ko / de / fr / es) including server-side localization of API error messages.
 - **🔄 Update check + one-click self-update** — Settings → System checks GitHub for the latest release with semantic comparison; binary deployments can **auto-update with one click** from the UI (download + checksum verification + atomic replace + self-restart), while Docker deployments get the exact upgrade command.
 
 > Security is non-negotiable: credentials stored as ciphertext only, commands arrayified against injection, outbound SSRF locked down, logs redacted.
@@ -133,17 +145,64 @@ Open **Settings → System** and click "Check for updates" to query the latest r
 
 ### Configuration (environment variables)
 
+A normal install only needs the first two (plus `PIPEWRIGHT_PUBLIC_URL` if you run behind a reverse proxy); everything else has a sane default.
+
+**Core**
+
 | Variable | Description | Default |
 |---|---|---|
+| `PIPEWRIGHT_ADMIN_PASSWORD` | Admin password on first launch | none (must be set) |
+| `PIPEWRIGHT_MASTER_KEY` | Credential vault master key (base64-encoded 32 bytes); or use `PIPEWRIGHT_MASTER_KEY_FILE` to point to a file | vault disabled if unset |
 | `PIPEWRIGHT_ADDR` | HTTP listen address | `:8080` |
+| `PIPEWRIGHT_PUBLIC_URL` | Externally reachable base URL (e.g. `https://ci.example.com`). Required for webhook callbacks, OAuth redirects, signed approval links in notifications, and PR status links | none |
+| `PIPEWRIGHT_ADMIN_USERNAME` | Admin username on first launch | `admin` |
+| `PIPEWRIGHT_TRUST_PROXY` | Trust the first `X-Forwarded-For` hop as the audit client IP (`1`/`true`/`yes`/`on`). Leave off unless a trusted reverse proxy sits in front — otherwise anyone can forge audit source IPs | off |
 | `PIPEWRIGHT_RELEASE_REPO` | GitHub repo queried for update checks (change it for a fork) | `huangchengsir/pipewright` |
+| `PIPEWRIGHT_RUNTIME` | Set `docker` to declare a container deployment (affects self-update mode); otherwise auto-detected via `/.dockerenv` | auto-detect |
+| `PIPEWRIGHT_AUDIT_SINK` | Remote audit sink: an `http(s)://` endpoint, or any other value as a second local JSON Lines file path. Keeps audit records complete even if the local DB is wiped | none |
+
+**Database**
+
+| Variable | Description | Default |
+|---|---|---|
 | `PIPEWRIGHT_DB_DRIVER` | Database driver: `sqlite` or `mysql` | `sqlite` |
 | `PIPEWRIGHT_DB` | SQLite database path (when driver=sqlite) | `pipewright.db` |
 | `PIPEWRIGHT_DB_DSN` | MySQL DSN (required when driver=mysql) | none |
-| `PIPEWRIGHT_MASTER_KEY` | Credential vault master key (base64-encoded 32 bytes); or use `_FILE` to point to a file | vault disabled if unset |
-| `PIPEWRIGHT_ADMIN_USERNAME` | Admin username on first launch | `admin` |
-| `PIPEWRIGHT_ADMIN_PASSWORD` | Admin password on first launch | none (must be set) |
+
+**Runs & builds**
+
+| Variable | Description | Default |
+|---|---|---|
 | `PIPEWRIGHT_RUNNER` | Run executor: default DAG (orchestrates stages/script/deploy_ssh/notify per the canvas); set `legacy` to fall back to the old fixed flow | `dag` |
+| `PIPEWRIGHT_BUILDER` | `auto` uses a real container build when docker/nerdctl/podman is found and falls back to a stub otherwise; `real` refuses to start without a container CLI; `stub` never touches containers | `auto` |
+| `PIPEWRIGHT_MAX_CONCURRENT` | Global cap on simultaneously running runs (excess stays queued, FIFO). Per-project caps are configured in the UI | worker count (4) |
+| `PIPEWRIGHT_ARTIFACT_DIR` | Artifact store directory (real jar/dist bytes) | `<db dir>/artifacts` |
+| `PIPEWRIGHT_REPO_CACHE_DIR` | Local bare-mirror repo cache directory | `<db dir>/repos` |
+| `PIPEWRIGHT_NO_REPO_CACHE` | `1` disables the repo cache (every build clones over the network) | off |
+| `PIPEWRIGHT_CACHE_DIR` | Build dependency cache directory | `<db dir>/cache` |
+| `PIPEWRIGHT_NO_BUILD_CACHE` | `1` disables build dependency caching (always a cold build) | off |
+| `PIPEWRIGHT_NO_IMAGE_GC` | `1` keeps built images instead of garbage-collecting them | off |
+| `PIPEWRIGHT_PAC_RUNTIME` | `1` forces pipeline-as-code on for **all** projects, ignoring the per-project toggle | off |
+| `PIPEWRIGHT_CHAIN_MAX_DEPTH` | Max pipeline-chaining depth (hard stop against runaway chains) | `5` |
+
+**Integrations**
+
+| Variable | Description | Default |
+|---|---|---|
+| `PIPEWRIGHT_PR_STATUS` | `1` forces PR status reporting on for **all** projects, ignoring the per-project toggle | off |
+| `PIPEWRIGHT_PR_STATUS_GITHUB_BASE` | GitHub API base URL (for GitHub Enterprise) | public GitHub |
+| `PIPEWRIGHT_PR_STATUS_GITEE_BASE` | Gitee API base URL (for self-hosted Gitee) | public Gitee |
+| `PIPEWRIGHT_CADDY_IMAGE` | Reverse-proxy image. The default is a self-built Caddy bundling the DNS-01, ratelimit, and layer4 plugins; stock `caddy:2` works but loses DNS-01/wildcard/TCP support | `ghcr.io/huangchengsir/pipewright-caddy:latest` |
+| `PIPEWRIGHT_PREVIEW_SWEEP_INTERVAL` | How often to check whether preview environments can be reclaimed (Go duration, e.g. `10m`) | `5m` |
+
+**Ops monitoring**
+
+| Variable | Description | Default |
+|---|---|---|
+| `PIPEWRIGHT_ANOMALY_INTERVAL` | Anomaly detection interval in seconds; `0` disables the timer (manual checks still work) | `60` |
+| `PIPEWRIGHT_ANOMALY_COOLDOWN` | Minimum seconds between repeat alerts for the same server×rule | `600` |
+| `PIPEWRIGHT_METRICS_SAMPLE_INTERVAL` | Server metrics sampling interval in seconds (source of the trend charts); `0` disables sampling | `60` |
+| `PIPEWRIGHT_METRICS_RETENTION_DAYS` | How many days of metric samples to keep | `7` |
 
 ## Pipeline as code (GitOps)
 
@@ -154,6 +213,7 @@ Commit your pipeline structure to `.pipewright.yml` in the repo — **same sourc
 - **Never breaks a run**: if the file is **missing** → falls back to the pipeline configured in the canvas (UI); if it exists but is **invalid YAML** → also falls back to the stored canvas config.
 - **Scope**: the YAML controls **pipeline structure only** (stages / jobs / `needs` / DAG layout). **Variables & cache, environments & credentials, and trigger rules** still come from the canvas (UI) settings — they are **not** in the YAML.
 - **Schema** is the same one used by the platform's "Import from YAML" (`version` + `stages` → `jobs`; a job uses a nested `script:` block for `image`/`commands`/`env`/`workdir`).
+- **Job types** available in both the canvas and the YAML: `git_source`, `script`, `build_backend`, `build_frontend`, `build_image`, `push_image`, `deploy_ssh`, `deploy_frontend`, `health_check`, `notify`, `templated`, `custom`.
 
 ```yaml
 version: 1
@@ -197,27 +257,72 @@ stages:
 
 ## Tech Stack
 
-- **Backend**: Go · Chi (routing) · modernc/sqlite (pure Go, no CGO) · go-git · NaCl secretbox (vault) · argon2id · golang.org/x/crypto/ssh (agentless deployment)
-- **Frontend**: Vue 3 `<script setup>` · Vite · naive-ui · OKLCH dual theme · Monaco (read-only code browsing) · embedded into the binary via `go:embed`
+- **Backend**: Go · Chi (routing) · modernc/sqlite (pure Go, no CGO) + go-sql-driver/mysql · go-git (no host git dependency) · NaCl secretbox (vault) · argon2id + bcrypt · golang.org/x/crypto/ssh (agentless deployment) · coder/websocket (terminals) · Caddy (orchestrated on target hosts for auto HTTPS)
+- **Frontend**: Vue 3 `<script setup>` · Vite · naive-ui · OKLCH dual theme · Monaco (read-only code browsing) · Vitest + Playwright · embedded into the binary via `go:embed`
+
+Deliberately dependency-lean: the cron parser, DAG engine, DNS provider clients, artifact/build caches, and Caddyfile renderer are all in-tree rather than pulled in as libraries.
 
 ## Architecture
 
+One process, ~45 domain packages. `internal/httpapi` is the only package that touches HTTP; every domain package is injected into it, and `cmd/pipewright/main.go` is the single wiring layer (including the adapters that keep otherwise-circular packages pointing one way).
+
 ```
 single static binary (cmd/pipewright)
-├── internal/auth        auth + sessions + CSRF
-├── internal/vault       encrypted credential vault (secretbox)
-├── internal/audit       append-only audit + redaction
-├── internal/project     project onboarding + repo detection
-├── internal/pipeline    pipeline spec + build/deploy config + validation
-├── internal/trigger     webhook + branch-mapping triggers
-├── internal/run         run model + worker pool + logs + artifacts
-├── internal/dagrun      DAG scheduling (stage-level + job-level, matrix expansion)
-├── internal/build       isolated builds + image/artifacts + dependency caching
-├── internal/target      generic SSH exec/session layer (shared by deploy + ops)
-├── internal/deploy      SSH deploy execution + health gating + rollback
-├── internal/notify      multi-channel notifications + event routing + templates
-├── internal/httpapi     the sole outward HTTP surface (domain packages never touch HTTP)
-└── web/                 Vue 3 frontend (embedded via go:embed)
+│
+├─ foundation
+│  ├── internal/config        env config + master key loading
+│  ├── internal/store         DB open + migrations (sqlite / mysql dialects)
+│  ├── internal/auth          auth + sessions + CSRF
+│  ├── internal/vault         encrypted credential vault (secretbox)
+│  ├── internal/oauth         OAuth app onboarding → token stored as a vault credential
+│  ├── internal/audit         append-only audit + optional remote sink
+│  ├── internal/mask          secret redaction (logs / diagnostics / notifications)
+│  ├── internal/i18n          server-side localization of user-facing messages
+│  └── internal/version       release check + one-click self-update
+│
+├─ pipelines
+│  ├── internal/project       project onboarding + repo detection
+│  ├── internal/pipeline      pipeline spec + build/deploy config + validation
+│  ├── internal/pipelineyaml  YAML ↔ spec round-trip (import / export)
+│  ├── internal/pacloader     pipeline-as-code loader (.pipewright.yml, per branch)
+│  ├── internal/library       reusable templates + variable groups + custom nodes
+│  ├── internal/trigger       webhook + branch→environment mapping
+│  ├── internal/cron          5-field cron parser + minute-granularity scheduler
+│  └── internal/chain         upstream→downstream chaining (loop-safe)
+│
+├─ execution
+│  ├── internal/run           run model + worker pool + logs + artifacts + parameters
+│  ├── internal/dag           pure DAG scheduling kernel (no I/O)
+│  ├── internal/dagrun        DAG run orchestration (stage + job level, matrix expansion)
+│  ├── internal/build         isolated container builds + images + stage executor
+│  ├── internal/runner        per-project remote build machine config
+│  ├── internal/repocache     local bare-mirror repo cache (incremental fetch)
+│  ├── internal/buildcache    build dependency cache (branch + lockfile keyed)
+│  ├── internal/artifactstore content-addressed artifact bytes
+│  ├── internal/testreport    JUnit + Cobertura parsing
+│  ├── internal/qualitygate   pure quality-gate evaluation
+│  ├── internal/approval      manual approval gates (coordinator + persistence)
+│  └── internal/retention     run data retention sweeper
+│
+├─ delivery
+│  ├── internal/target        generic SSH exec/session layer (shared by deploy + ops)
+│  ├── internal/deploy        SSH deploy execution + health gating + rollback
+│  ├── internal/environments  environments as first-class objects + rollback targets
+│  ├── internal/promotion     environment promotion chains + per-env vars
+│  ├── internal/prstatus      PR / commit status reporting (GitHub / Gitee)
+│  ├── internal/proxy         auto HTTPS + domain reverse proxy (Caddy orchestration)
+│  ├── internal/dnsprovider   Cloudflare / DNSPod / Alibaba DNS (DNS-01 + subdomains)
+│  └── internal/previewenv    per-PR preview environments + auto reclamation
+│
+├─ observability
+│  ├── internal/notify        multi-channel notifications + event routing + templates
+│  ├── internal/anomaly       configurable threshold detection + alerts
+│  ├── internal/metrics       server metric time series (trend charts)
+│  ├── internal/dora          DORA metrics + performance bands
+│  └── internal/ai            optional AI: diagnosis, repo analysis, run diff, risk
+│
+├── internal/httpapi          the sole outward HTTP surface (~188 routes)
+└── web/                      Vue 3 frontend (embedded via go:embed)
 ```
 
 ## Project Status

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,14 +20,21 @@
 
 主流方案要么重(Jenkins 一堆插件 + JVM),要么是三个工具拼装(Woodpecker/Drone + Ansible/Kamal + Portainer)。Pipewright 把「持续集成、多服务器部署、服务器/容器运维」装进**一个静态二进制**:下载、启动、打开浏览器,就是全部安装过程。
 
+如今它已长过那三件套:把部署好的服务挂上 HTTPS 域名(原本的 nginx + certbot 那一步)、给每个 PR 一个能点开的预览地址,也都内置了。
+
 | | Pipewright | Jenkins | Drone + Ansible + Portainer |
 |---|:---:|:---:|:---:|
 | 单二进制部署 | ✅ | ❌ JVM + 插件 | ❌ 三套拼装 |
 | 可视化流水线编排(DAG) | ✅ 内置画布 | 插件 | YAML 手写 |
+| 流水线即代码(按分支演进) | ✅ | 插件 | ✅ |
 | 隔离构建 | ✅ | ✅ | ✅ |
 | 多服务器部署(SSH,免 Agent) | ✅ 内置 | 插件 | Ansible |
 | 服务器 / 容器运维 | ✅ 内置 | ❌ | Portainer |
 | 零停机 + 失败回滚 | ✅ | 插件 | 自己写 |
+| 自动 HTTPS + 域名反向代理 | ✅ 内置 | ❌ | ❌ |
+| Per-PR 预览环境 | ✅ 内置 | ❌ | ❌ |
+| DORA 指标 | ✅ 内置 | 插件 | ❌ |
+| AI 失败诊断 | ✅ 可选 | ❌ | ❌ |
 | 一键自更新 | ✅ | ❌ | ❌ |
 
 ## 界面预览
@@ -50,13 +57,18 @@
 
 ## 能力总览
 
-- **🔐 安全地基** —— 单管理员认证(argon2id + CSRF)· 凭据加密保险库(NaCl secretbox,掩码呈现,绝无明文)· append-only 审计 · 全链路 secret 脱敏。
-- **🧩 项目与流水线** —— 可视化编排画布(阶段 DAG + 阶段内任务级 DAG)· 矩阵构建 · 人工审批门 · 旁挂服务(测试挂 DB/Redis)· 触发规则 + 分支→环境映射 · 服务端权威合法性校验。
-- **🏗 隔离构建与产物** —— 版本钉死的容器内隔离构建 · 构建依赖缓存 · 多类型产物(镜像/JAR/dist)+ 推送私有镜像仓库 · 实时终端日志(SSE)+ 历史回放 · 只读代码浏览(Monaco)。
-- **🚀 多服务器部署** —— 经 SSH 免 Agent 部署 · 健康门控 · 零停机切换 + 失败回滚 · 多机并行扇出 + 部分失败可见 · 环境部署历史与回滚。
-- **📣 通知** —— 企业微信 / 钉钉 / 飞书 / 邮件 / 自定义 webhook · 事件→渠道细粒度路由 · 模板 + 变量自定义 · 流水线内通知节点。
-- **🖥 服务器与容器运维** —— 多机状态总览(CPU/内存/磁盘)· 容器/镜像/Stacks/卷/网络管理 · 实时 + 历史服务日志 · 容器交互终端 · Web 运维终端(主机 shell,完整复制粘贴/信号支持)· 异常检测告警。
-- **📈 度量** —— DORA 四指标(部署频率/变更前置时长/变更失败率/平均恢复时长)开箱即用。
+- **🔐 安全地基** —— 单管理员认证(argon2id + CSRF)· 凭据加密保险库(NaCl secretbox,掩码呈现,绝无明文)· OAuth 应用接入 Gitee / GitHub / GitLab / 自建实例(拿到的 access token 直接存成可复用的保险库凭据)· append-only 审计(SQLite trigger 硬拦 UPDATE/DELETE)+ 可选远端 sink · 按 run 解析真实凭据后对日志 / 诊断 / 通知全链路脱敏。
+- **🧩 项目与流水线** —— 可视化编排画布(阶段 DAG + 阶段内任务级 DAG)· 矩阵构建 · 人工审批门(可直接在通知里点签名链接审批)· 旁挂服务(测试挂 DB/Redis)· 阶段 `when` 条件 + 阶段后置步骤 · 类型化运行参数(枚举/布尔/数字,触发时即校验)· 触发方式:webhook、分支→环境映射、5 字段 cron 定时、上游→下游流水线串联(深度门 + 路径门防环)· 项目级并发上限 + 超限 FIFO 排队 · 复用库:流水线模板 / 变量组 / 自定义节点 · 服务端权威合法性校验。
+- **📝 流水线即代码** —— 把流水线结构写进 `.pipewright.yml`、按分支各自演进,画布配置始终作为兜底回退([详见下文](#流水线即代码gitops))。
+- **🏗 隔离构建与产物** —— 版本钉死的容器内隔离构建(docker/nerdctl/podman)· 代码管理区:本地 bare 镜像 + 增量 fetch,秒级出工作区 · 构建依赖缓存(按分支 + lockfile hash 寻址)· 内容寻址制品库,jar/dist 存**真字节**供部署(而非占位 reference)· 镜像构建 + 推送私有仓库 + 镜像 GC · 每项目可指定远程构建机(构建经 SSH 下沉到远程,token 只留控制机)· JUnit + Cobertura 测试报告喂质量门禁,不过则阶段失败、阻断下游部署 · 实时终端日志(SSE)+ 历史回放 · 只读代码浏览(Monaco)。
+- **🚀 多服务器部署** —— 经 SSH 免 Agent 部署 · 健康门控 · 零停机切换 + 失败回滚 · 多机并行扇出 + 部分失败可见 · 命令型部署(无产物,直接重启服务)· **环境一等公民**:逐环境部署时间线、当前活跃版本、一键回滚到上一次全成功部署 · 环境晋级流(dev→staging→prod)+ 逐环境变量/密钥 + 审批门。
+- **🌐 自动 HTTPS + 域名反向代理** —— 每台目标主机一个托管 Caddy 容器,复用与容器运维同一套 SSH + docker 手法编排(渲染 Caddyfile → `docker cp` → 优雅 reload)。证书经 Let's Encrypt 自动签发/续期:HTTP-01,或**经 Cloudflare / DNSPod / 阿里云 DNS 走 DNS-01**(通配符必需)。另有:多域名别名、路径路由(`/api`→A、`/`→B)、重定向、访问控制(basic auth、IP 允许/拒绝 CIDR)、HSTS / 安全头 / 压缩、多上游负载均衡 + 主动健康检查故障转移、WebSocket / gRPC(h2c) / TCP 透传(caddy-l4)、按真实 443 握手探测的证书大盘、一键子域名。
+- **🔎 Per-PR 预览环境** —— 某 PR 的运行成功部署后,自动分配一次性域名 `pr-<n>-<proj>.<base>`(带自己的证书与路由),评审者点开链接就能看到这条 PR 真实跑起来的样子。同一 PR 幂等复用;自动回收,但**仅在**确证 PR 已关闭/合并时才回收。
+- **📣 通知** —— 企业微信 / 钉钉 / 飞书 / Slack / 邮件 / 自定义 webhook · 事件→渠道细粒度路由 · 模板 + 变量自定义 · 飞书富卡片(审批/详情行动按钮 + 发版汇总)· 流水线内通知节点。
+- **🖥 服务器与容器运维** —— 多机状态总览(CPU/内存/磁盘)+ 指标时序趋势图 · 容器/镜像/Stacks/卷/网络管理 · 容器创建/inspect/prune · 实时 + 历史服务日志 · 实时 stats · 容器交互终端 · Web 运维终端(主机 shell,完整复制粘贴/信号支持)· 可配置异常检测:定时自动跑、冷却去重、命中走通知渠道。
+- **🤖 AI 辅助(可选,完全可降级)** —— 自带 Claude / OpenAI / Ollama 端点(apiKey 密文入保险库)。构建/部署失败自动根因诊断 + 👍/👎 反馈飞轮与准确率统计 · 仓库分析 → 生成流水线草案 · 成功/失败提交差异 · 脚本风险标注 · 运维终端的自然语言→shell 助手与容器诊断。核心 CI/CD 路径完全不依赖它(NFR-10)。
+- **📈 度量** —— DORA 四指标(部署频率/变更前置时长/变更失败率/平均恢复时长)开箱即用,并给 Elite/High/Medium/Low 绩效分档。
+- **🧹 数据与平台** —— 运行数据保留清理器(默认关;绝不动在跑的运行)· SQLite(纯 Go)或 MySQL · 8 种界面语言(简中 / 繁中 / 英 / 日 / 韩 / 德 / 法 / 西),API 错误信息亦服务端本地化。
 - **🔄 检查 + 一键自更新** —— 设置→系统 一键查 GitHub 最新发布并语义比对;二进制部署可页面**一键自动更新**(下载 + 校验和核验 + 原子替换 + 自重启),Docker 部署给出精确升级命令。
 
 > 安全不可妥协:凭据仅以密文存储、命令 array 化防注入、出网 SSRF 收口、日志脱敏。
@@ -133,17 +145,64 @@ make build          # 前端构建 → go:embed → 单个静态二进制 ./pipe
 
 ### 配置(环境变量)
 
+正常安装只需前两个(若跑在反代后面再加 `PIPEWRIGHT_PUBLIC_URL`),其余都有合理默认值。
+
+**核心**
+
 | 变量 | 说明 | 默认 |
 |---|---|---|
+| `PIPEWRIGHT_ADMIN_PASSWORD` | 首次启动管理员口令 | 无(须设置) |
+| `PIPEWRIGHT_MASTER_KEY` | 凭据保险库主密钥(base64 的 32 字节);或用 `PIPEWRIGHT_MASTER_KEY_FILE` 指文件 | 未配则保险库禁用 |
 | `PIPEWRIGHT_ADDR` | HTTP 监听地址 | `:8080` |
+| `PIPEWRIGHT_PUBLIC_URL` | 外部可访问的基址(如 `https://ci.example.com`)。webhook 回调、OAuth 回跳、通知里的签名审批链接、PR 状态跳转链接都需要它 | 无 |
+| `PIPEWRIGHT_ADMIN_USERNAME` | 首次启动管理员用户名 | `admin` |
+| `PIPEWRIGHT_TRUST_PROXY` | 采信 `X-Forwarded-For` 首段作为审计来源 IP(`1`/`true`/`yes`/`on`)。除非前面确有可信反代,否则别开 —— 否则任意客户端都能伪造审计来源 IP | 关 |
 | `PIPEWRIGHT_RELEASE_REPO` | 检查更新所查的 GitHub 仓库(fork 可改) | `huangchengsir/pipewright` |
+| `PIPEWRIGHT_RUNTIME` | 设 `docker` 显式声明容器部署形态(影响自更新方式);否则经 `/.dockerenv` 自动探测 | 自动探测 |
+| `PIPEWRIGHT_AUDIT_SINK` | 远端审计 sink:`http(s)://` 端点,或填其它值作为第二份本地 JSON Lines 文件路径。本地库被删后审计仍完整 | 无 |
+
+**数据库**
+
+| 变量 | 说明 | 默认 |
+|---|---|---|
 | `PIPEWRIGHT_DB_DRIVER` | 数据库驱动:`sqlite` 或 `mysql` | `sqlite` |
 | `PIPEWRIGHT_DB` | SQLite 数据库路径(driver=sqlite 时) | `pipewright.db` |
 | `PIPEWRIGHT_DB_DSN` | MySQL DSN(driver=mysql 时必填) | 无 |
-| `PIPEWRIGHT_MASTER_KEY` | 凭据保险库主密钥(base64 的 32 字节);或用 `_FILE` 指文件 | 未配则保险库禁用 |
-| `PIPEWRIGHT_ADMIN_USERNAME` | 首次启动管理员用户名 | `admin` |
-| `PIPEWRIGHT_ADMIN_PASSWORD` | 首次启动管理员口令 | 无(须设置) |
+
+**运行与构建**
+
+| 变量 | 说明 | 默认 |
+|---|---|---|
 | `PIPEWRIGHT_RUNNER` | 运行执行器:默认 DAG(按画布 stages/script/deploy_ssh/notify 编排执行);设 `legacy` 回退旧版固定流程 | `dag` |
+| `PIPEWRIGHT_BUILDER` | `auto` 探测到 docker/nerdctl/podman 用真实构建、否则回退桩;`real` 无容器 CLI 直接启动失败;`stub` 完全不碰容器 | `auto` |
+| `PIPEWRIGHT_MAX_CONCURRENT` | 全局同时运行上限(超出保持 queued 排队,FIFO)。项目级上限在界面里配 | worker 数(4) |
+| `PIPEWRIGHT_ARTIFACT_DIR` | 制品库目录(jar/dist 真字节) | `<DB 同级>/artifacts` |
+| `PIPEWRIGHT_REPO_CACHE_DIR` | 代码管理区(本地 bare 镜像)目录 | `<DB 同级>/repos` |
+| `PIPEWRIGHT_NO_REPO_CACHE` | `1` 关闭代码管理区(每次构建直连网络克隆) | 关 |
+| `PIPEWRIGHT_CACHE_DIR` | 构建依赖缓存目录 | `<DB 同级>/cache` |
+| `PIPEWRIGHT_NO_BUILD_CACHE` | `1` 关闭构建依赖缓存(每次冷构建) | 关 |
+| `PIPEWRIGHT_NO_IMAGE_GC` | `1` 保留构建出的镜像,不做垃圾回收 | 关 |
+| `PIPEWRIGHT_PAC_RUNTIME` | `1` 对**所有项目**强开流水线即代码,无视各项目开关 | 关 |
+| `PIPEWRIGHT_CHAIN_MAX_DEPTH` | 流水线串联深度上限(防无限链的硬兜底) | `5` |
+
+**集成**
+
+| 变量 | 说明 | 默认 |
+|---|---|---|
+| `PIPEWRIGHT_PR_STATUS` | `1` 对**所有项目**强开 PR 状态回写,无视各项目开关 | 关 |
+| `PIPEWRIGHT_PR_STATUS_GITHUB_BASE` | GitHub API 基址(GitHub Enterprise 用) | 公有 GitHub |
+| `PIPEWRIGHT_PR_STATUS_GITEE_BASE` | Gitee API 基址(自建 Gitee 用) | 公有 Gitee |
+| `PIPEWRIGHT_CADDY_IMAGE` | 反代镜像。默认是自构建的 Caddy(含 DNS-01 / ratelimit / layer4 插件);用原版 `caddy:2` 也能跑,但会失去 DNS-01/通配符/TCP 能力 | `ghcr.io/huangchengsir/pipewright-caddy:latest` |
+| `PIPEWRIGHT_PREVIEW_SWEEP_INTERVAL` | 预览环境回收扫描间隔(Go duration,如 `10m`) | `5m` |
+
+**运维监控**
+
+| 变量 | 说明 | 默认 |
+|---|---|---|
+| `PIPEWRIGHT_ANOMALY_INTERVAL` | 异常检测间隔(秒);`0` 关闭定时(仍可手动「立即检测」) | `60` |
+| `PIPEWRIGHT_ANOMALY_COOLDOWN` | 同「服务器×规则」重复告警的最小间隔(秒) | `600` |
+| `PIPEWRIGHT_METRICS_SAMPLE_INTERVAL` | 服务器指标采样间隔(秒,趋势图数据源);`0` 关闭采样 | `60` |
+| `PIPEWRIGHT_METRICS_RETENTION_DAYS` | 指标样本保留天数 | `7` |
 
 ## 流水线即代码(GitOps)
 
@@ -154,6 +213,7 @@ make build          # 前端构建 → go:embed → 单个静态二进制 ./pipe
 - **永不卡住运行的回退**:文件**缺失** → 回退到画布(UI)里已配置的流水线;文件存在但 **YAML 非法** → 同样回退到已存的画布配置。
 - **作用范围**:YAML 只管**流水线结构**(阶段 / 任务 / `needs` / DAG 编排);**变量与缓存、环境与凭据、触发规则**仍来自画布(UI)设置,**不写在 YAML 里**。
 - **schema** 与平台「从 YAML 导入」用的是同一套(`version` + `stages` → `jobs`,job 用嵌套 `script:` 块写 `image`/`commands`/`env`/`workdir`)。
+- **节点类型**(画布与 YAML 通用):`git_source`、`script`、`build_backend`、`build_frontend`、`build_image`、`push_image`、`deploy_ssh`、`deploy_frontend`、`health_check`、`notify`、`templated`、`custom`。
 
 ```yaml
 version: 1
@@ -197,27 +257,72 @@ stages:
 
 ## 技术栈
 
-- **后端**:Go · Chi(路由)· modernc/sqlite(纯 Go,无 CGO)· go-git · NaCl secretbox(保险库)· argon2id · golang.org/x/crypto/ssh(免 Agent 部署)
-- **前端**:Vue 3 `<script setup>` · Vite · naive-ui · OKLCH 双主题 · Monaco(只读代码浏览)· 经 `go:embed` 内嵌进二进制
+- **后端**:Go · Chi(路由)· modernc/sqlite(纯 Go,无 CGO)+ go-sql-driver/mysql · go-git(不依赖宿主 git)· NaCl secretbox(保险库)· argon2id + bcrypt · golang.org/x/crypto/ssh(免 Agent 部署)· coder/websocket(终端)· Caddy(在目标主机上编排,提供自动 HTTPS)
+- **前端**:Vue 3 `<script setup>` · Vite · naive-ui · OKLCH 双主题 · Monaco(只读代码浏览)· Vitest + Playwright · 经 `go:embed` 内嵌进二进制
+
+依赖刻意保持精简:cron 解析器、DAG 引擎、DNS 厂商客户端、制品库/构建缓存、Caddyfile 渲染器全部自己实现,不引三方库。
 
 ## 架构
 
+一个进程,约 45 个领域包。`internal/httpapi` 是唯一碰 HTTP 的包,所有领域包注入其中;`cmd/pipewright/main.go` 是唯一的装配层(包内互引经这里的适配器晚绑,保持包间单向依赖)。
+
 ```
 单静态二进制 (cmd/pipewright)
-├── internal/auth        认证 + 会话 + CSRF
-├── internal/vault       凭据加密保险库(secretbox)
-├── internal/audit       append-only 审计 + 脱敏
-├── internal/project     项目接入 + 仓库探测
-├── internal/pipeline    流水线 spec + 构建/部署配置 + 校验
-├── internal/trigger     webhook + 分支映射触发
-├── internal/run         运行模型 + worker pool + 日志 + 产物
-├── internal/dagrun      DAG 调度(阶段级 + 任务级,矩阵展开)
-├── internal/build       隔离构建 + 镜像/产物 + 依赖缓存
-├── internal/target      通用 SSH exec/session 层(部署 + 运维共享)
-├── internal/deploy      SSH 部署执行 + 健康门控 + 回滚
-├── internal/notify      多渠道通知 + 事件路由 + 模板
-├── internal/httpapi     唯一对外 HTTP 面(领域包不碰 HTTP)
-└── web/                 Vue3 前端(go:embed 内嵌)
+│
+├─ 地基
+│  ├── internal/config        env 配置 + master key 加载
+│  ├── internal/store         开库 + 迁移(sqlite / mysql 双方言)
+│  ├── internal/auth          认证 + 会话 + CSRF
+│  ├── internal/vault         凭据加密保险库(secretbox)
+│  ├── internal/oauth         OAuth 应用接入 → token 存成保险库凭据
+│  ├── internal/audit         append-only 审计 + 可选远端 sink
+│  ├── internal/mask          secret 脱敏(日志 / 诊断 / 通知)
+│  ├── internal/i18n          用户可见信息的服务端本地化
+│  └── internal/version       版本检查 + 一键自更新
+│
+├─ 流水线
+│  ├── internal/project       项目接入 + 仓库探测
+│  ├── internal/pipeline      流水线 spec + 构建/部署配置 + 校验
+│  ├── internal/pipelineyaml  YAML ↔ spec 双向往返(导入 / 导出)
+│  ├── internal/pacloader     流水线即代码加载(.pipewright.yml,按分支)
+│  ├── internal/library       可复用模板 + 变量组 + 自定义节点
+│  ├── internal/trigger       webhook + 分支→环境映射
+│  ├── internal/cron          5 字段 cron 解析器 + 分钟粒度调度器
+│  └── internal/chain         上游→下游串联(防环)
+│
+├─ 执行
+│  ├── internal/run           运行模型 + worker pool + 日志 + 产物 + 参数
+│  ├── internal/dag           纯 DAG 调度内核(零 I/O)
+│  ├── internal/dagrun        DAG 运行编排(阶段级 + 任务级,矩阵展开)
+│  ├── internal/build         容器内隔离构建 + 镜像 + 阶段执行器
+│  ├── internal/runner        每项目远程构建机配置
+│  ├── internal/repocache     代码管理区(本地 bare 镜像 + 增量 fetch)
+│  ├── internal/buildcache    构建依赖缓存(分支 + lockfile 寻址)
+│  ├── internal/artifactstore 内容寻址的产物字节存储
+│  ├── internal/testreport    JUnit + Cobertura 解析
+│  ├── internal/qualitygate   纯质量门禁评估
+│  ├── internal/approval      人工审批门(协调器 + 持久化)
+│  └── internal/retention     运行数据保留清理
+│
+├─ 交付
+│  ├── internal/target        通用 SSH exec/session 层(部署 + 运维共享)
+│  ├── internal/deploy        SSH 部署执行 + 健康门控 + 回滚
+│  ├── internal/environments  环境一等公民 + 回滚目标定位
+│  ├── internal/promotion     环境晋级流 + 逐环境变量
+│  ├── internal/prstatus      PR / 提交状态回写(GitHub / Gitee)
+│  ├── internal/proxy         自动 HTTPS + 域名反向代理(Caddy 编排)
+│  ├── internal/dnsprovider   Cloudflare / DNSPod / 阿里云 DNS(DNS-01 + 子域名)
+│  └── internal/previewenv    Per-PR 预览环境 + 自动回收
+│
+├─ 可观测
+│  ├── internal/notify        多渠道通知 + 事件路由 + 模板
+│  ├── internal/anomaly       可配置阈值检测 + 告警
+│  ├── internal/metrics       服务器指标时序(趋势图)
+│  ├── internal/dora          DORA 指标 + 绩效分档
+│  └── internal/ai            可选 AI:诊断 / 仓库分析 / 差异 / 风险标注
+│
+├── internal/httpapi          唯一对外 HTTP 面(约 188 条路由)
+└── web/                      Vue3 前端(go:embed 内嵌)
 ```
 
 ## 开发状态


### PR DESCRIPTION
## 背景

README 的能力总览、架构树与环境变量表停留在早期骨架:R1–R4 反向代理专题、Epic 8 编排增强、AI 辅助等成果在文档里完全不可见;环境变量只列了 7 个(代码里实际约 30 个非测试变量),自托管用户配不出 `PIPEWRIGHT_PUBLIC_URL` 这类关键项。

本次按代码逐条核对后同步中英文两份 README,**仅文档改动,不涉及代码**。

## 改动

- **对比表**:补 流水线即代码 / 自动 HTTPS 反代 / Per-PR 预览环境 / DORA / AI 诊断
- **能力总览**:8 → 13 条
  - 新增「自动 HTTPS + 域名反向代理」「Per-PR 预览环境」「AI 辅助」「流水线即代码」「数据与平台」
  - 既有条目补:OAuth 接入四平台、审计远端 sink、通知内签名链接审批、cron 定时、流水线串联、并发上限 + FIFO 排队、复用库(模板/变量组/自定义节点)、类型化运行参数、代码管理区、构建依赖缓存、真字节制品库、远程构建机、JUnit+Cobertura 质量门禁、环境一等公民 + 晋级流、命令型部署、指标时序趋势、Slack 渠道
- **环境变量**:7 → 31 个,按 核心 / 数据库 / 运行与构建 / 集成 / 运维监控 分五张表;默认值逐一对齐代码(worker 4、异常检测 60s、冷却 600s、指标保留 7 天、串联深度 5、预览回收 5m)
- **架构**:13 → 43 个包,按 地基 / 流水线 / 执行 / 交付 / 可观测 分组,并说明 `httpapi` 为唯一 HTTP 面、`main.go` 为唯一装配层(含打破包间环引用的适配器)
- **技术栈**:补 go-sql-driver/mysql、coder/websocket、bcrypt、Caddy、Vitest + Playwright,并说明 cron 解析器 / DAG 引擎 / DNS 客户端 / 缓存层 / Caddyfile 渲染器均为自实现
- **流水线即代码**:补 12 种节点类型清单

## 核对方式

每条描述均对照代码确认:包 doc 注释、`proxy.RouteConfig` 字段、`jobConfigSchema.ts`、`main.go` 装配逻辑、`web/src/i18n/locales` 语言目录、`go.mod`。未写入任何推测性描述。

## 已知未同步项(本 PR 不含)

- `docs/screenshots/` 仅 4 张图,反代大盘与预览环境无截图,故「界面预览」一节未动
- `.env.example` 仍只列 6 个变量,与新增环境变量表尚未同步

🤖 Generated with [Claude Code](https://claude.com/claude-code)