### PR TITLE
fix(run): 取消恰落在 worker 取活与转 running 之间时,run 永久卡 queued

### DIFF
--- a/internal/run/pool.go
+++ b/internal/run/pool.go
@@ -415,6 +415,18 @@ func (p *WorkerPool) execute(runID string) {
 			return // 已被取消/非队列态:跳过。
 		}
 		log.Printf("[run] run %s: to running failed: %v", runID, err)
+		// 非 ErrInvalidTransition 的失败意味着 run **仍是 queued**,而本 worker 已接手它、
+		// 其它 worker 不会再取——就此返回会让它永久卡在 queued(僵尸运行,页面上永不终结;
+		// FailOrphanedRuns 只在进程启动时扫一次,不重启则一直挂着)。
+		//
+		// 最典型触发:用户取消恰落在上方「注册取消句柄」与本转移之间。Cancel 见句柄已注册,
+		// 于是走「cancel() 后由 worker 落终态」那条路;而本转移拿到的 runCtx 已废,报的是
+		// context canceled(**不是** ErrInvalidTransition),于是两边都不落终态。
+		//
+		// 故此处落终态兜底,与下方 Get 失败分支一致。failToTerminal / reconcile 均用
+		// background ctx,不受已取消的 runCtx 影响。
+		p.svc.failToTerminal(runID)
+		sink.reconcile(StatusFailed)
 		return
 	}
 

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -209,6 +209,53 @@ func TestCancelRunning(t *testing.T) {
 	}
 }
 
+// TestCancelBetweenPickupAndRunning 覆盖 TestCancelQueued(worker 取走**前**取消)与
+// TestCancelRunning(已 running 时取消)之间的窗口:worker 已注册取消句柄、但尚未做
+// queued→running 时被取消。
+//
+// 该窗口曾使两边都不落终态:Cancel 见句柄已注册 → 走 cancel() 交由 worker 落终态;
+// 而 worker 的 queued→running 拿到已废的 runCtx,报 context canceled(非
+// ErrInvalidTransition),旧代码只记日志便返回 → run 永久卡在 queued(僵尸)。
+//
+// 用「已取消的池 ctx」直调 execute 确定性复现:runCtx 派生自池 ctx,故一出生即已取消,
+// queued→running 必报 context canceled,与真实竞态命中同一分支。
+func TestCancelBetweenPickupAndRunning(t *testing.T) {
+	db := testDB(t)
+	svc := New(db)
+	// runner 不应被触达(转 running 就失败了);若被调用则说明分支走错。
+	pool := NewWorkerPool(svc, WithRunner(&failIfCalledRunner{t: t}))
+	projID := seedProject(t, db)
+
+	r, err := svc.Create(context.Background(), projID, Trigger{Type: TriggerManual})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	pool.ctx = ctx // 不 Start():直接以已取消的池 ctx 执行
+	pool.execute(r.ID)
+
+	got, err := svc.Get(context.Background(), r.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !IsTerminal(got.Status) {
+		t.Fatalf("被取消的 run 必须落终态,got %q(僵尸:永久卡 queued,不重启不会被清)", got.Status)
+	}
+	if got.Status != StatusFailed {
+		t.Fatalf("取消复用 failed(无独立 canceled 态), got %q", got.Status)
+	}
+}
+
+// failIfCalledRunner 在被调用时让测试失败,用于断言某分支不该执行到 runner。
+type failIfCalledRunner struct{ t *testing.T }
+
+func (r *failIfCalledRunner) Run(context.Context, *Run, StepSink) error {
+	r.t.Error("runner 不应被调用:queued→running 失败后应直接落终态")
+	return nil
+}
+
 // blockingRunner 在第一步后阻塞直到 ctx 取消或 gate 关闭,用于测试运行中取消。
 type blockingRunner struct{ gate chan struct{} }
 


### PR DESCRIPTION
## 症状

`internal/httpapi` 的 `TestDeployNonSuccessRun422` 在 CI 上**稳定失败**(同一 SHA 上连挂两次,见 #158 的 backend job):测试建 run → 立刻取消 → 等 `failed`,但 run 停在 `queued` 直到超时。伴随日志:

```
[run] run <id>: to running failed: run: transition: context canceled
```

## 根因

`pool.execute` 先注册取消句柄、后做状态转移:

```
pool.go:382   p.svc.cancels[runID] = cancel        ← 先注册
pool.go:413   transition(runCtx, queued→running)   ← 后转移
```

`Service.Cancel`(`service.go:472`)分两条路:句柄**已注册** → `cancel()` 后交由 worker 落终态;**未注册**(仍 queued)→ 自己直接 `queued→failed`。

取消恰落在上述两行之间时,两条路都不落终态:

1. Cancel 见句柄已注册 → 调 `cancel()`,runCtx 作废,返回快照(仍 `queued`)
2. worker 随后拿**已作废的 runCtx** 做 `queued→running`,得到的是 `context canceled` —— **不是** `ErrInvalidTransition`
3. 旧代码在该分支只记一行日志便 `return`,未落任何终态

→ run **永久停在 `queued`**。页面上永不终结;`FailOrphanedRuns`(`service.go:701`)虽覆盖 queued,但只在**进程启动时**扫一次,不重启则一直挂着。

**这是产品级 bug,不只是测试问题** —— 真实用户在该窗口取消运行会留下僵尸运行。

## 修法

在该分支落终态兜底(`failToTerminal` + `sink.reconcile`),与**紧邻的 `Get` 失败分支**(`pool.go:421-427`)保持一致 —— 那里本就这么做了,413 分支只是漏了。两者均用 background ctx,不受已作废的 runCtx 影响;`failToTerminal` 自身幂等(已终态直接返回)。

刻意**不**调整注册与转移的先后顺序:把注册挪到转移之后会换来更坏的洞 —— 取消若落在新窗口,Cancel 走「未注册 → `queued→failed`」而此时已是 `running`,转移失败后静默返回,表现为「点了取消、返回 200、运行却继续跑」。保持注册在前可确保取消总能传播。

## 测试

新增 `TestCancelBetweenPickupAndRunning`,补上既有 `TestCancelQueued`(取走**前**取消)与 `TestCancelRunning`(**已 running** 时取消)之间的覆盖空隙 —— 正是这个空隙让 bug 溜了进来。

以「已取消的池 ctx」直调 `execute` **确定性**复现:runCtx 派生自池 ctx,故一出生即已取消,`queued→running` 必报 context canceled,命中同一分支。断言 run 必须落终态。

## 验证

本机未装 Go 工具链,故未跑本地测试,验证靠 CI —— 这次有干净的前后对照:

- **修复前**:`backend` job 在同一 SHA 上连挂 2 次(attempt 1 + 2),均为 `TestDeployNonSuccessRun422` 卡在 `queued`
- **修复后**:期望 `backend` 转绿,且新增的 `TestCancelBetweenPickupAndRunning` 通过

若 CI 仍红,说明诊断有误,我会继续查。

🤖 Generated with [Claude Code](https://claude.com/claude-code)